### PR TITLE
game: add persistent xp save for campaign, refs #1410

### DIFF
--- a/src/db/db_sqlite3.c
+++ b/src/db/db_sqlite3.c
@@ -81,6 +81,7 @@ const char *sql_Version_Statements[SQL_DBMS_SCHEMA_VERSION] =
 		"CREATE TABLE IF NOT EXISTS rating_maps (mapname TEXT PRIMARY KEY NOT NULL, win_axis INT, win_allies INT, UNIQUE (mapname));",                  // server table
 		// version 2
 		"CREATE TABLE IF NOT EXISTS prestige_users (guid TEXT PRIMARY KEY NOT NULL, prestige INT, streak INT, skill0 INT, skill1 INT, skill2 INT, skill3 INT, skill4 INT, skill5 INT, skill6 INT, created TEXT, updated TEXT, UNIQUE (guid));" // server table
+		"CREATE TABLE IF NOT EXISTS xpsave_users (guid TEXT PRIMARY KEY NOT NULL, skills BLOB NOT NULL, medals BLOB NOT NULL, created TEXT, updated TEXT, UNIQUE (guid));" // server table
 
 		"CREATE TABLE IF NOT EXISTS client_servers (profile TEXT NOT NULL, source INT NOT NULL, address TEXT NOT NULL, name TEXT NOT NULL, mod TEXT NOT NULL, updated DATETIME, created DATETIME);"
 		"CREATE INDEX IF NOT EXISTS client_servers_profile_idx ON client_servers(profile);"

--- a/src/game/g_active.c
+++ b/src/game/g_active.c
@@ -1730,8 +1730,9 @@ void SpectatorClientEndFrame(gentity_t *ent)
 		int i;
 		ent->client->ps.stats[STAT_XP] = 0;
 
-		if ((g_gametype.integer == GT_WOLF_CAMPAIGN && (g_campaigns[level.currentCampaign].current != 0 && !level.newCampaign)) ||
-		    (g_gametype.integer == GT_WOLF_LMS && g_currentRound.integer != 0))
+		if ((g_gametype.integer == GT_WOLF_CAMPAIGN && g_xpSaver.integer) ||
+			(g_gametype.integer == GT_WOLF_CAMPAIGN && (g_campaigns[level.currentCampaign].current != 0 && !level.newCampaign)) ||
+			(g_gametype.integer == GT_WOLF_LMS && g_currentRound.integer != 0))
 		{
 			for (i = 0; i < SK_NUM_SKILLS; ++i)
 			{
@@ -2155,7 +2156,8 @@ void ClientEndFrame(gentity_t *ent)
 	}
 
 	ent->client->ps.stats[STAT_XP] = 0;
-	if ((g_gametype.integer == GT_WOLF_CAMPAIGN && (g_campaigns[level.currentCampaign].current != 0 && !level.newCampaign)) ||
+	if ((g_gametype.integer == GT_WOLF_CAMPAIGN && g_xpSaver.integer) ||
+		(g_gametype.integer == GT_WOLF_CAMPAIGN && (g_campaigns[level.currentCampaign].current != 0 && !level.newCampaign)) ||
 	    (g_gametype.integer == GT_WOLF_LMS && g_currentRound.integer != 0))
 	{
 		for (i = 0; i < SK_NUM_SKILLS; ++i)

--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -2308,8 +2308,18 @@ char *ClientConnect(int clientNum, qboolean firstTime, qboolean isBot)
 		{
 			G_SetPlayerSkill(client, i);
 		}
-	}
+	} else
 #endif
+	if (firstTime && g_xpSaver.integer && g_gametype.integer == GT_WOLF_CAMPAIGN)
+	{
+		int i;
+		G_XPSaver_Load(client);
+
+		for (i = 0; i < SK_NUM_SKILLS; i++)
+		{
+			G_SetPlayerSkill(client, i);
+		}
+	}
 
 	ClientUserinfoChanged(clientNum);
 
@@ -3168,8 +3178,12 @@ void ClientDisconnect(int clientNum)
 	if (g_prestige.integer && !level.intermissiontime)
 	{
 		G_SetClientPrestige(ent->client, qfalse);
-	}
+	} else
 #endif
+	if (g_xpSaver.integer && g_gametype.integer == GT_WOLF_CAMPAIGN && !level.intermissiontime)
+	{
+		G_XPSaver_Store(ent->client);
+	}
 
 #ifdef FEATURE_LUA
 	// LUA API callbacks

--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -361,7 +361,8 @@ qboolean G_SendScore_Add(gentity_t *ent, int i, char *buf, int bufsize)
 	{
 		int j;
 
-		if ((g_gametype.integer == GT_WOLF_CAMPAIGN && (g_campaigns[level.currentCampaign].current != 0 && !level.newCampaign)) ||
+		if ((g_gametype.integer == GT_WOLF_CAMPAIGN && g_xpSaver.integer) ||
+			(g_gametype.integer == GT_WOLF_CAMPAIGN && (g_campaigns[level.currentCampaign].current != 0 && !level.newCampaign)) ||
 		    (g_gametype.integer == GT_WOLF_LMS && g_currentRound.integer != 0))
 		{
 			for (j = SK_BATTLE_SENSE; j < SK_NUM_SKILLS; j++)

--- a/src/game/g_db.c
+++ b/src/game/g_db.c
@@ -84,7 +84,10 @@ int G_DB_Init()
 		return 1;
 	}
 #endif
-
+	if (G_XPSaver_CheckDB(level.database.path, db_mode))
+	{
+		return 1;
+	}
 	// open db
 	if (db_mode == 1)
 	{

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -2101,6 +2101,7 @@ extern vmCvar_t g_multiview;
 #define STICKYCHARGE_SELFKILL 1 // keep charge after selfkill, mortal self damage, teamkill, mortal world damage
 #define STICKYCHARGE_ANYDEATH 2 // keep charge after any death (for eg. death by enemy)
 extern vmCvar_t g_stickyCharge;
+extern vmCvar_t g_xpSaver;
 
 /**
  * @struct GeoIPTag
@@ -2455,6 +2456,11 @@ void G_SetClientPrestige(gclient_t *cl, qboolean streakUp);
 int G_ReadPrestige(prData_t *pr_data);
 int G_WritePrestige(prData_t *pr_data);
 #endif
+
+int G_XPSaver_CheckDB(char *db_path, int db_mode);
+void G_XPSaver_Load(gclient_t *cl);
+void G_XPSaver_Store(gclient_t *cl);
+int G_XPSaver_Clear();
 
 // g_stats.c
 void G_UpgradeSkill(gentity_t *ent, skillType_t skill);

--- a/src/game/g_match.c
+++ b/src/game/g_match.c
@@ -449,7 +449,8 @@ char *G_createStats(gentity_t *ent)
 	}
 
 	// Add skillpoints as necessary
-	if ((g_gametype.integer == GT_WOLF_CAMPAIGN && (g_campaigns[level.currentCampaign].current != 0 && !level.newCampaign)) ||
+	if ((g_gametype.integer == GT_WOLF_CAMPAIGN && g_xpSaver.integer) ||
+		(g_gametype.integer == GT_WOLF_CAMPAIGN && (g_campaigns[level.currentCampaign].current != 0 && !level.newCampaign)) ||
 	    (g_gametype.integer == GT_WOLF_LMS && g_currentRound.integer != 0))
 	{
 		for (i = SK_BATTLE_SENSE; i < SK_NUM_SKILLS; i++)

--- a/src/game/g_xp_saver.c
+++ b/src/game/g_xp_saver.c
@@ -1,0 +1,400 @@
+/*
+ * ET: Legacy
+ * Copyright (C) 2012-2020 ET:Legacy team <mail@etlegacy.com>
+ *
+ * This file is part of ET: Legacy - http://www.etlegacy.com
+ *
+ * ET: Legacy is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ET: Legacy is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ET: Legacy. If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * @file g_xp_saver.c
+ * @brief Stores, loads and resets XP
+ */
+
+#include "g_local.h"
+
+#ifdef FEATURE_DBMS
+#include <sqlite3.h>
+#endif
+
+#ifndef _MSC_VER
+#define __FUNCTION__ __func__
+#endif
+
+#define bf_write(bf, T, input) *((T*)bf++) = (T)input;
+#define bf_read(bf, T, output) output = *((T*)bf++);
+#define assert_return(cond, status, msg) \
+	if (!(cond)) { \
+		if (msg) { \
+			G_Printf("^1%s (%i): failed: %s\n", __func__, __LINE__, msg); \
+		} \
+		return status; \
+	}
+
+typedef struct xpData_s
+{
+	const unsigned char *guid;
+	int skillpoints[SK_NUM_SKILLS];
+	int medals[SK_NUM_SKILLS];
+} xpData_t;
+
+static int G_XPSaver_Read(xpData_t *xp_data);
+static int G_XPSaver_Write(xpData_t *xp_data);
+
+#define XPCHECK_SQLWRAP_TABLES "SELECT * FROM xpsave_users;"
+#define XPCHECK_SQLWRAP_SCHEMA "SELECT guid, skills, medals, created, updated FROM xpsave_users;"
+#define XPUSERS_SQLWRAP_SELECT "SELECT * FROM xpsave_users WHERE guid = '%s';"
+#define XPUSERS_SQLWRAP_INSERT "INSERT INTO xpsave_users (guid, skills, medals, created, updated) VALUES ('%s', ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);"
+#define XPUSERS_SQLWRAP_UPDATE "UPDATE xpsave_users SET skills = ?, medals = ?, updated = CURRENT_TIMESTAMP WHERE guid = '%s';"
+#define XPUSERS_SQLWRAP_DELETE "DELETE FROM xpsave_users"
+
+/**
+ * @brief Checks if database exists, if tables exist and if schemas are correct
+ * @param[in] db_path
+ * @param[in] db_mode
+ * @return 0 if database check is successful, 1 otherwise.
+ */
+int G_XPSaver_CheckDB(char *db_path, int db_mode)
+{
+	int     result;
+	sqlite3 *db;
+
+	if (!db_path || db_path[0] == '\0')
+	{
+		G_Printf("G_XPSaver_CheckDB: invalid path specified\n");
+		return 1;
+	}
+
+	// check if database can be opened
+	if (db_mode == 1)
+	{
+		result = sqlite3_open_v2(db_path, &db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_MEMORY | SQLITE_OPEN_SHAREDCACHE, NULL);
+	}
+	else // db_mode 2
+	{
+		result = sqlite3_open_v2(db_path, &db, SQLITE_OPEN_READWRITE, NULL);
+	}
+
+	if (result != SQLITE_OK)
+	{
+		G_Printf("G_XPSaver_CheckDB: sqlite3_open_v2 failed: %s\n", sqlite3_errstr(result));
+		return 1;
+	}
+
+	// check if tables exist
+	result = sqlite3_exec(db, XPCHECK_SQLWRAP_TABLES, NULL, NULL, NULL);
+
+	if (result != SQLITE_OK)
+	{
+		G_Printf("G_XPSaver_CheckDB: sqlite3_exec XPCHECK_SQLWRAP_TABLES failed: %s\n", sqlite3_errstr(result));
+
+		result = sqlite3_close(db);
+
+		if (result != SQLITE_OK)
+		{
+			G_Printf("G_XPSaver_CheckDB: sqlite3_close failed: %s\n", sqlite3_errstr(result));
+			return 1;
+		}
+		return 1;
+	}
+
+	// check schema
+	result = sqlite3_exec(db, XPCHECK_SQLWRAP_SCHEMA, NULL, NULL, NULL);
+
+	if (result != SQLITE_OK)
+	{
+		G_Printf("G_XPSaver_CheckDB: sqlite3_exec XPCHECK_SQLWRAP_SCHEMA failed: %s\n", sqlite3_errstr(result));
+
+		result = sqlite3_close(db);
+
+		if (result != SQLITE_OK)
+		{
+			G_Printf("G_XPSaver_CheckDB: sqlite3_close failed: %s\n", sqlite3_errstr(result));
+			return 1;
+		}
+		return 1;
+	}
+
+	// all ok
+	result = sqlite3_close(db);
+
+	if (result != SQLITE_OK)
+	{
+		G_Printf("G_XPSaver_CheckDB: sqlite3_close failed: %s\n", sqlite3_errstr(result));
+		return 1;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Retrieves xp for a client
+ * @param[in] cl
+ */
+void G_XPSaver_Load(gclient_t *cl)
+{
+	char      userinfo[MAX_INFO_STRING];
+	char      *guid;
+	int       clientNum, i;
+	xpData_t  xp_data;
+	gentity_t *ent;
+
+	if (!level.database.initialized)
+	{
+		G_Printf("G_XPSaver_Load: access to non-initialized database\n");
+		return;
+	}
+
+	if (!cl)
+	{
+		return;
+	}
+
+	clientNum = cl - level.clients;
+
+	// ignore bots
+	ent = g_entities + clientNum;
+
+	if (ent->r.svFlags & SVF_BOT)
+	{
+		return;
+	}
+
+	// retrieve guid
+	trap_GetUserinfo(clientNum, userinfo, sizeof(userinfo));
+	guid = Info_ValueForKey(userinfo, "cl_guid");
+
+	// assign guid
+	xp_data.guid = (const unsigned char *)guid;
+
+	// retrieve current xp or assign default values
+	if (G_XPSaver_Read(&xp_data))
+	{
+		return;
+	}
+
+	// assign user data to session
+	cl->sess.startxptotal = 0;
+	for (i = 0; i < SK_NUM_SKILLS; i++)
+	{
+		cl->sess.skillpoints[i]      = xp_data.skillpoints[i];
+		cl->sess.startskillpoints[i] = xp_data.skillpoints[i];
+		cl->sess.startxptotal       += xp_data.skillpoints[i];
+		cl->sess.medals[i]          += xp_data.medals[i];
+	}
+}
+
+/**
+ * @brief Updates xp stats and timestamp for client
+ * @param[in] cl
+ */
+void G_XPSaver_Store(gclient_t *cl)
+{
+	char      userinfo[MAX_INFO_STRING];
+	char      *guid;
+	int       clientNum, i;
+	xpData_t  xp_data;
+	gentity_t *ent;
+	qboolean  hasMapXPs = qfalse;
+
+	if (!level.database.initialized)
+	{
+		G_Printf("G_XPSaver_Store: access to non-initialized database\n");
+		return;
+	}
+
+	if (!cl)
+	{
+		return;
+	}
+
+	// don't record any data in warmup
+	if (level.warmupTime)
+	{
+		return;
+	}
+
+	clientNum = cl - level.clients;
+
+	// ignore bots
+	ent = g_entities + clientNum;
+
+	if (ent->r.svFlags & SVF_BOT)
+	{
+		return;
+	}
+
+	// retrieve guid
+	trap_GetUserinfo(clientNum, userinfo, sizeof(userinfo));
+	guid = Info_ValueForKey(userinfo, "cl_guid");
+
+	xp_data.guid = (const unsigned char *)guid;
+
+	for (i = 0; i < SK_NUM_SKILLS; i++)
+	{
+		xp_data.skillpoints[i] = (int)cl->sess.skillpoints[i];
+		xp_data.medals[i] = (int)cl->sess.medals[i];
+	}
+
+	// save or update xp
+	if (G_XPSaver_Write(&xp_data))
+	{
+		return;
+	}
+}
+
+/**
+ * @brief Retrieves XP from the xpsave_users table
+ * @param[in] xp_data
+ * @return 0 if successful, 1 otherwise.
+ */
+static int G_XPSaver_Read(xpData_t *xp_data)
+{
+	int          result, i;
+	const char   *err;
+	sqlite3_stmt *sqlstmt;
+	const int    *pSkills;
+	const int    *pMedals;
+
+	Com_Memset(xp_data->skillpoints, 0, sizeof(xp_data->skillpoints));
+	Com_Memset(xp_data->medals, 0, sizeof(xp_data->medals));
+
+	if (!level.database.initialized)
+	{
+		G_Printf("G_XPSaver_Read: access to non-initialized database\n");
+		return 1;
+	}
+
+	result = sqlite3_prepare(level.database.db, va(XPUSERS_SQLWRAP_SELECT, xp_data->guid), -1, &sqlstmt, NULL);
+	assert_return(result == SQLITE_OK, 1, sqlite3_errmsg(level.database.db));
+
+	result = sqlite3_step(sqlstmt);
+
+	if (result == SQLITE_ROW)
+	{	
+		/* retrieve skills */
+		pSkills = (int*)sqlite3_column_blob(sqlstmt, 1);
+		assert_return(pSkills, 1, sqlite3_errmsg(level.database.db));
+
+		pMedals = (int*)sqlite3_column_blob(sqlstmt, 2);
+		assert_return(pMedals, 2, sqlite3_errmsg(level.database.db));
+
+		for (i = 0; i < SK_NUM_SKILLS; i++)
+		{
+			bf_read(pSkills, int, xp_data->skillpoints[i]);
+			bf_read(pMedals, int, xp_data->medals[i]);
+		}
+	}
+	// no entry found or other failure
+	else if (result != SQLITE_DONE)
+	{
+		err = sqlite3_errmsg(level.database.db);
+		if (err) 
+		{
+			G_Printf("^3%s (%i): failed: %s\n", __func__, __LINE__, err);
+		}
+		sqlite3_finalize(sqlstmt);
+		return 1;
+	}
+
+	result = sqlite3_finalize(sqlstmt);
+	assert_return(result == SQLITE_OK, 1, sqlite3_errmsg(level.database.db));	
+
+	return 0;
+}
+
+/**
+ * @brief Sets or updates skills and medals
+ * @param[in] xp_data
+ * @return 0 if successful, 1 otherwise.
+ */
+static int G_XPSaver_Write(xpData_t *xp_data)
+{
+	int          i;
+	int          result;
+	sqlite3_stmt *sqlstmt;
+	int          buffer[SK_NUM_SKILLS * 2];
+	int          *pSkills;
+	int          *pMedals;
+
+	if (!level.database.initialized)
+	{
+		G_Printf("G_XPSaver_Write: access to non-initialized database\n");
+		return 1;
+	}
+
+	result = sqlite3_prepare(level.database.db, va(XPUSERS_SQLWRAP_SELECT, xp_data->guid), -1, &sqlstmt, NULL);
+	assert_return(result == SQLITE_OK, 1, sqlite3_errmsg(level.database.db));
+
+	result = sqlite3_step(sqlstmt);
+
+	pSkills = buffer;
+	pMedals = buffer + SK_NUM_SKILLS;
+	for (i = 0; i < SK_NUM_SKILLS; i++) 
+	{
+		bf_write(pSkills, int, xp_data->skillpoints[i]);
+		bf_write(pMedals, int, xp_data->medals[i]);
+	}
+
+	if (result == SQLITE_DONE)
+	{
+		result = sqlite3_prepare(level.database.db, va(XPUSERS_SQLWRAP_INSERT, xp_data->guid), -1, &sqlstmt, NULL);
+	}
+	else
+	{
+		result = sqlite3_prepare(level.database.db, va(XPUSERS_SQLWRAP_UPDATE, xp_data->guid), -1, &sqlstmt, NULL);
+	}
+	assert_return(result == SQLITE_OK, 1, sqlite3_errmsg(level.database.db));
+
+	result = sqlite3_bind_blob(sqlstmt, 1, buffer, sizeof(int) * SK_NUM_SKILLS, SQLITE_STATIC);
+	assert_return(result == SQLITE_OK, 1, sqlite3_errmsg(level.database.db));
+
+	result = sqlite3_bind_blob(sqlstmt, 2, buffer + SK_NUM_SKILLS, sizeof(int) * SK_NUM_SKILLS, SQLITE_STATIC);        
+	assert_return(result == SQLITE_OK, 1, sqlite3_errmsg(level.database.db));
+
+	result = sqlite3_step(sqlstmt);
+	assert_return(result == SQLITE_DONE, 1, sqlite3_errmsg(level.database.db));
+
+	result = sqlite3_finalize(sqlstmt);
+	assert_return(result == SQLITE_OK, 1, sqlite3_errmsg(level.database.db));
+
+	return 0;
+}
+
+/**
+ * @brief Clears any xp data from the table
+ * @return 0 if successful, 1 otherwise.
+ */
+int G_XPSaver_Clear()
+{
+	int          result;
+	char         *err_msg = NULL;
+
+	if (!level.database.initialized)
+	{
+		G_Printf("G_XPSaver_Clear: access to non-initialized database\n");
+		return 1;
+	}
+
+	result = sqlite3_exec(level.database.db, XPUSERS_SQLWRAP_DELETE, 0, 0, &err_msg);
+
+	if (result != SQLITE_OK)
+	{
+		G_Printf("G_XPSaver_Clear: sqlite3_prepare failed: %s\n", err_msg);
+		sqlite3_free(err_msg);
+		return 1;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
* Backs xp save with database support.
* Adds `g_xpSaver` cvar to toggle behavior.

This allows players during single campaign to disconnect and then come back later still retaining their skills and xp.