### PR TITLE
League config patches: Add stopwatch gamemode

### DIFF
--- a/etmain/configs/legacy1.config
+++ b/etmain/configs/legacy1.config
@@ -12,6 +12,7 @@ init
   setl sv_pure "1"
   setl sv_cheats "0"
 
+  setl g_gameType "3"
   setl g_warmup "15"
   setl g_doWarmup "1"
   setl g_voiceChatsAllowed "5"

--- a/etmain/configs/legacy3.config
+++ b/etmain/configs/legacy3.config
@@ -12,6 +12,7 @@ init
   setl sv_pure "1"
   setl sv_cheats "0"
 
+  setl g_gameType "3"
   setl g_warmup "15"
   setl g_doWarmup "1"
   setl g_voiceChatsAllowed "5"

--- a/etmain/configs/legacy5.config
+++ b/etmain/configs/legacy5.config
@@ -12,6 +12,7 @@ init
   setl sv_pure "1"
   setl sv_cheats "0"
 
+  setl g_gameType "3"
   setl g_warmup "15"
   setl g_doWarmup "1"
   setl g_voiceChatsAllowed "5"

--- a/etmain/configs/legacy6.config
+++ b/etmain/configs/legacy6.config
@@ -12,6 +12,7 @@ init
   setl sv_pure "1"
   setl sv_cheats "0"
 
+  setl g_gameType "3"
   setl g_warmup "15"
   setl g_doWarmup "1"
   setl g_voiceChatsAllowed "5"


### PR DESCRIPTION
This is a pull request to add the stopwatch gametype (g_gameType "3") to the current competitive configurations associated with player limitations. This will make them work the same way as the competitive configs being used on ETPRO: https://github.com/msh100/ETPro-configs/tree/master/configs

This change shouldn't be made for the unrestricted default comp configuration: https://github.com/etlegacy/etlegacy/blob/master/etmain/configs/defaultcomp.config