### PR TITLE
Slow/fast reload sound is now determined based on the player that's reloading

### DIFF
--- a/src/cgame/cg_event.c
+++ b/src/cgame/cg_event.c
@@ -2144,7 +2144,7 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 		break;
 	case EV_FILL_CLIP:
 		// IS_VALID_WEAPON(es->weapon) ?
-		if (cgs.clientinfo[cg.clientNum].skill[SK_LIGHT_WEAPONS] >= 2 && (GetWeaponTableData(es->weapon)->attributes & WEAPON_ATTRIBUT_FAST_RELOAD) && cg_weapons[es->weapon].reloadFastSound)
+		if (cgs.clientinfo[es->clientNum].skill[SK_LIGHT_WEAPONS] >= 2 && (GetWeaponTableData(es->weapon)->attributes & WEAPON_ATTRIBUT_FAST_RELOAD) && cg_weapons[es->weapon].reloadFastSound)
 		{
 			trap_S_StartSound(NULL, es->number, CHAN_WEAPON, cg_weapons[es->weapon].reloadFastSound);
 		}


### PR DESCRIPTION
Steps to reproduce the problem:

1. Have two players. Player one has Light Weapons >= 2 and player two has Light Weapons < 2.
2. Player one reloads while player two hears it. Player one reloads fast, but player two hears the slow reload sound.
3. The opposite also happens. Player two reloads while player one hears it. Player two reloads slow, but player one hears the fast sound.

Explained simply, the reload sound is based on *your* Light Weapons skill instead of the skill of the player that is actually reloading.

This happens when:
* Spectating
* Playing