### PR TITLE
Fix being unable to spec lock an empty team

### DIFF
--- a/src/game/g_referee.c
+++ b/src/game/g_referee.c
@@ -450,9 +450,9 @@ void G_refSpeclockTeams_cmd(gentity_t *ent, qboolean fLock)
 {
 	char *status;
 
-	// Ensure proper locking
-	G_updateSpecLock(TEAM_AXIS, (TeamCount(-1, TEAM_AXIS)) ? fLock : qfalse);
-	G_updateSpecLock(TEAM_ALLIES, (TeamCount(-1, TEAM_ALLIES)) ? fLock : qfalse);
+	// Both teams are spec locked
+	G_updateSpecLock(TEAM_AXIS, fLock);
+	G_updateSpecLock(TEAM_ALLIES, fLock);
 
 	status = va("Referee has ^3SPECTATOR %sLOCKED^7 teams", ((fLock) ? "" : "UN"));
 

--- a/src/game/g_team.c
+++ b/src/game/g_team.c
@@ -1919,7 +1919,7 @@ void G_verifyMatchState(team_t nTeam)
 				teamInfo[nTeam].team_lock = qfalse;
 			}
 
-			G_teamReset(nTeam, qtrue);
+			G_teamReset(nTeam, qfalse);
 		}
 	}
 
@@ -1940,7 +1940,7 @@ qboolean G_teamJoinCheck(team_t nTeam, gentity_t *ent)
 	// Sanity check
 	if (cnt == 0)
 	{
-		G_teamReset(nTeam, qtrue);
+		G_teamReset(nTeam, qfalse);
 		teamInfo[nTeam].team_lock = qfalse;
 	}
 
@@ -2121,18 +2121,6 @@ qboolean G_allowFollow(gentity_t *ent, int nTeam)
 		    ent->client->sess.sessionTeam != nTeam)
 		{
 			return qfalse;
-		}
-	}
-
-	if (level.time - level.startTime > 2500)
-	{
-		if (TeamCount(-1, TEAM_AXIS) == 0)
-		{
-			teamInfo[TEAM_AXIS].spec_lock = qfalse;
-		}
-		if (TeamCount(-1, TEAM_ALLIES) == 0)
-		{
-			teamInfo[TEAM_ALLIES].spec_lock = qfalse;
 		}
 	}
 


### PR DESCRIPTION
Spec lock is also no longer removed from empty teams.