### PR TITLE
Changed/Added OSX build checks

### DIFF
--- a/cmake/ETLBuildMod.cmake
+++ b/cmake/ETLBuildMod.cmake
@@ -91,15 +91,17 @@ if(LIBM)
 endif()
 
 # Build both arhitectures on older xcode versions
-if(APPLE AND CMAKE_OSX_DEPLOYMENT_TARGET LESS_EQUAL "10.12" AND NOT OSX_NOX86)
-	set_target_properties(cgame${LIB_SUFFIX}${ARCH}
-		PROPERTIES
-		OSX_ARCHITECTURES "i386;x86_64"
-	)
-	set_target_properties(ui${LIB_SUFFIX}${ARCH}
-		PROPERTIES
-		OSX_ARCHITECTURES "i386;x86_64"
-	)
+if(APPLE)
+	if(CMAKE_OSX_DEPLOYMENT_TARGET LESS_EQUAL "10.14")
+		# Force universal mod on osx up to Mojave
+		set(OSX_MOD_ARCH "i386;x86_64")
+	else()
+		# 64bit mod only as of Catalina and higher
+		set(OSX_MOD_ARCH "x86_64")
+	endif()
+
+	set_target_properties(cgame${LIB_SUFFIX}${ARCH} PROPERTIES OSX_ARCHITECTURES "${OSX_MOD_ARCH}" )
+	set_target_properties(ui${LIB_SUFFIX}${ARCH} PROPERTIES OSX_ARCHITECTURES "${OSX_MOD_ARCH}" )
 endif()
 
 # install bins of cgame, ui and qgame

--- a/cmake/ETLPlatform.cmake
+++ b/cmake/ETLPlatform.cmake
@@ -81,8 +81,8 @@ if(UNIX)
 			set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12")
 		endif()
 
-		# After version 10.12 it's no longer possible to build 32 bit applications with this script
-		if(CMAKE_OSX_DEPLOYMENT_TARGET GREATER "10.12" AND CROSS_COMPILE32)
+		# After version 10.14 it's no longer possible to build 32 bit applications with this script
+		if(CMAKE_OSX_DEPLOYMENT_TARGET GREATER "10.14" AND CROSS_COMPILE32)
 			message(FATAL_ERROR "Can't build a 32bit build on this OSX version")
 		endif()
 

--- a/easybuild.sh
+++ b/easybuild.sh
@@ -135,6 +135,13 @@ detectos() {
 	elif [[ ${PLATFORMSYS} == "Darwin" ]]; then
 		PLATFORMSYS=`sw_vers -productName`
 		DISTRO=`sw_vers -productVersion`
+
+		# Check if x86_build is set and an osx vesion as of Catalina or higher is used
+		IFS='.' read -r -a ver <<< "$DISTRO"
+		if [ "${ver[1]}" -gt 14 ] && [ "${x86_build}" = true ]; then
+			einfo "You can't compile 32bit binaries with Mac OS 10.${ver[1]}. Use the flag \"-64\". Aborting."
+			exit 1
+		fi
 	else
 		DISTRO="Unknown"
 	fi


### PR DESCRIPTION
The previous check in cmake wasn't working, as OSX_NOX86 hasn't been initialized/set. So it has used 32+64 on Catalina, exiting in an error while compiling. I've adjusted Jacker's if statement in the first commit.

The second commit adds an additional check to easybuild.sh. The procedure has to end pretty early, otherwise easybuild would add `-m32` to the compiler flags. This would break cmake's compile tests again.