### PR TITLE
Load autoexec_<class>.cfg instead of autoexec_<Class>.cfg

### DIFF
--- a/src/game/bg_classes.c
+++ b/src/game/bg_classes.c
@@ -427,15 +427,15 @@ const char *BG_ClassnameForNumberFilename(int classNum)
 	switch (classNum)
 	{
 	case PC_SOLDIER:
-		return "Soldier";
+		return "soldier";
 	case PC_MEDIC:
-		return "Medic";
+		return "medic";
 	case PC_ENGINEER:
-		return "Engineer";
+		return "engineer";
 	case PC_FIELDOPS:
-		return "Fieldops";
+		return "fieldops";
 	case PC_COVERTOPS:
-		return "Covertops";
+		return "covertops";
 	default:
 		return "^1ERROR";
 	}


### PR DESCRIPTION
This small patch will have ET:L load `autoexec_<class>.cfg` (in lower case) whenever the player changes class, so as to mimic ETPro behavior.
