### PR TITLE
[client] Hide renderer warnings behind developer cvar (#1407)

### DIFF
--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -2481,7 +2481,7 @@ static __attribute__ ((format(printf, 2, 3))) void QDECL CL_RefPrintf(int print_
 	}
 	else if (print_level == PRINT_WARNING)
 	{
-		Com_Printf(S_COLOR_YELLOW "%s", msg); // yellow
+		Com_DPrintf(S_COLOR_YELLOW "%s", msg); // yellow
 	}
 	else if (print_level == PRINT_DEVELOPER)
 	{


### PR DESCRIPTION
Fixes #1407 

`Com_DPrintf` here is the one defined in `qcommon/common.c` which checks for developer cvar.

`CL_RefPrintf` is passed to the renderer which calls it via `Ren_Warning`
```
$ rg CL_RefPrintf src
src/client/cl_main.c
2462: * @brief CL_RefPrintf
2469:static __attribute__ ((format(printf, 2, 3))) void QDECL CL_RefPrintf(int print_level, const char *fmt, ...)
2673:	ri.Printf                  = CL_RefPrintf;
```
```
$ rg Ren_Warning src/renderercommon
(...)
src/renderercommon/tr_common.h
84:#define Ren_Warning(...) ri.Printf(PRINT_WARNING, __VA_ARGS__)
(...)
```