### PR TITLE
Fix container mount

### DIFF
--- a/src/client/cl_parse.c
+++ b/src/client/cl_parse.c
@@ -590,6 +590,20 @@ int cl_connectedToCheatServer;
 
 void CL_PurgeCache(void);
 
+static void CL_SetPurePaks(void)
+{
+	const char *s, *t;
+	char *systemInfo = cl.gameState.stringData + cl.gameState.stringOffsets[CS_SYSTEMINFO];
+	// check pure server string
+	s = Info_ValueForKey(systemInfo, "sv_paks");
+	t = Info_ValueForKey(systemInfo, "sv_pakNames");
+	FS_PureServerSetLoadedPaks(s, t);
+
+	s = Info_ValueForKey(systemInfo, "sv_referencedPaks");
+	t = Info_ValueForKey(systemInfo, "sv_referencedPakNames");
+	FS_PureServerSetReferencedPaks(s, t);
+}
+
 /**
  * @brief The systeminfo configstring has been changed, so parse new information out of it.
  * This will happen at every gamestate, and possibly during gameplay.
@@ -611,6 +625,11 @@ void CL_SystemInfoChanged(void)
 	// don't set any vars when playing a demo
 	if (clc.demoplaying)
 	{
+		// allow running demo in pure mode to simulate server environment
+		if (Cvar_VariableValue("sv_pure") != 0.f) 
+		{
+			CL_SetPurePaks();
+		}
 		return;
 	}
 
@@ -621,14 +640,7 @@ void CL_SystemInfoChanged(void)
 		Cvar_SetCheatState();
 	}
 
-	// check pure server string
-	s = Info_ValueForKey(systemInfo, "sv_paks");
-	t = Info_ValueForKey(systemInfo, "sv_pakNames");
-	FS_PureServerSetLoadedPaks(s, t);
-
-	s = Info_ValueForKey(systemInfo, "sv_referencedPaks");
-	t = Info_ValueForKey(systemInfo, "sv_referencedPakNames");
-	FS_PureServerSetReferencedPaks(s, t);
+	CL_SetPurePaks();
 
 	gameSet = qfalse;
 	// scan through all the variables in the systeminfo and locally set cvars to match

--- a/src/qcommon/files.c
+++ b/src/qcommon/files.c
@@ -5432,8 +5432,8 @@ void FS_InitWhitelist()
 
 	msec = Sys_Milliseconds();
 
-	Com_Memset(pakMetaEntries, 0, sizeof(pakMetaEntry_t) * WL_MAX_ENTRIES);
-	Com_Memset(pakMetaEntryMap, 0, sizeof(pakMetaEntry_t) * WL_MAX_ENTRIES);
+	Com_Memset(pakMetaEntries, 0, sizeof(pakMetaEntries));
+	Com_Memset(pakMetaEntryMap, 0, sizeof(pakMetaEntryMap));
 
 	fileListPath = va("%s%c%s", fs_homepath->string, PATH_SEP, WL_FILENAME);
 	file         = Sys_FOpen(fileListPath, "rb");


### PR DESCRIPTION
* Fixed bug where container mounting was always happening.
* Made demo replays to run in pure mode, effectively mounting the container and loading only server pak files. This behavior can be changed by setting `sv_pure 0`.
* Fixed incorrect size was used for memsetting the pak meta entries.