### PR TITLE
renderer: Allow setting multisample to 8x for increased visual quality

### DIFF
--- a/etmain/ui/options_system.menu
+++ b/etmain/ui/options_system.menu
@@ -77,7 +77,7 @@ menuDef {
 	// "GL_NEAREST" "GL_LINEAR" "GL_NEAREST_MIPMAP_NEAREST" "GL_LINEAR_MIPMAP_NEAREST" "GL_NEAREST_MIPMAP_LINEAR" "GL_LINEAR_MIPMAP_LINEAR"
 	MULTIACTION( 8, GRAPHICSADVANCED_Y+88, (SUBWINDOW_WIDTH_L)-4, 10, _("Texture Filter:"), .2, 8, "ui_r_texturemode", cvarStrList { "Bilinear"; "GL_LINEAR_MIPMAP_NEAREST"; "Trilinear"; "GL_LINEAR_MIPMAP_LINEAR" }, uiScript glCustom, _("Set the GL texture mode") )
 	MULTIACTION( 8, GRAPHICSADVANCED_Y+100, (SUBWINDOW_WIDTH_L)-4, 10, _("Anisotropic Filter:"), .2, 8, "ui_r_ext_texture_filter_anisotropic", cvarFloatList { "Disabled" 0 "Medium" 4 "High" 8 }, uiScript glCustom, _("Set anisotropic filtering") )
-	MULTIACTION( 8, GRAPHICSADVANCED_Y+112, (SUBWINDOW_WIDTH_L)-4, 10, _("Anti-Aliasing:"), .2, 8, "ui_r_ext_multisample", cvarFloatList { "Off" 0 "x2" 2 "x4" 4 }, uiScript glCustom, _("Set Anti-Aliasing") )
+	MULTIACTION( 8, GRAPHICSADVANCED_Y+112, (SUBWINDOW_WIDTH_L)-4, 10, _("Anti-Aliasing:"), .2, 8, "ui_r_ext_multisample", cvarFloatList { "Off" 0 "x2" 2 "x4" 4 "x8" 8 }, uiScript glCustom, _("Set Anti-Aliasing") )
 	MULTIACTION( 8, GRAPHICSADVANCED_Y+124, (SUBWINDOW_WIDTH_L)-4, 10, _("Color Depth:"), .2, 8, "ui_r_colorbits", cvarFloatList { "Desktop Default" 0 "16-bit" 16 "32-bit" 32 }, uiScript glCustom, _("Set color depth") )
 	YESNOACTION( 8, GRAPHICSADVANCED_Y+136, (SUBWINDOW_WIDTH_L)-4, 10, _("Detail Textures:"), .2, 8, "ui_r_detailtextures", uiScript glCustom, _("Toogles usage of high detail textures") )
 	MULTIACTION( 8, GRAPHICSADVANCED_Y+148, (SUBWINDOW_WIDTH_L)-4, 10, _("Depth Buffer:"), .2, 8, "ui_r_depthbits", cvarFloatList { "Default" 0 "16-bit" 16 "24-bit" 24 }, uiScript glCustom, _("Set the number of desired depth bits") )

--- a/src/sdl/sdl_glimp.c
+++ b/src/sdl/sdl_glimp.c
@@ -231,7 +231,7 @@ static void GLimp_InitCvars(void)
 	r_colorbits       = Cvar_Get("r_colorbits", "0", CVAR_ARCHIVE | CVAR_LATCH | CVAR_UNSAFE);
 	r_ignorehwgamma   = Cvar_Get("r_ignorehwgamma", "0", CVAR_ARCHIVE | CVAR_LATCH | CVAR_UNSAFE);
 	r_ext_multisample = Cvar_Get("r_ext_multisample", "0", CVAR_ARCHIVE | CVAR_LATCH | CVAR_UNSAFE);
-	Cvar_CheckRange(r_ext_multisample, 0, 4, qtrue);
+	Cvar_CheckRange(r_ext_multisample, 0, 8, qtrue);
 
 	// Old modes (these are used by the UI code)
 	Cvar_Get("r_oldFullscreen", "", CVAR_ARCHIVE);


### PR DESCRIPTION
We could go as far as to allow 16×, but it's even slower for little visual benefit (the difference between 4× and 8× isn't that large already). Also, graphics drivers tend to implement 16× MSAA in unusual ways, such as combining 8× MSAA with 2× SSAA. This could cause various issues if not accounted for in the renderer.