### PR TITLE
Use discord channel as contact in metainfo

### DIFF
--- a/misc/com.etlegacy.ETLegacy.metainfo.xml
+++ b/misc/com.etlegacy.ETLegacy.metainfo.xml
@@ -23,7 +23,7 @@
     <url type="help">https://github.com/etlegacy/etlegacy/wiki</url>
     <url type="donation">https://github.com/etlegacy/etlegacy</url>
     <url type="translate">https://www.transifex.com/projects/p/etlegacy/</url>
-    <url type="contact">mail@etlegacy.com</url>
+    <url type="contact">https://discord.gg/UBAZFys</url>
 
     <launchable type="desktop-id">com.etlegacy.ETLegacy.desktop</launchable>
 


### PR DESCRIPTION
URL should have mailto: prefix. But even with that it is not accepted by
appstream-util validate-relax. Use discord channel as a contact. Leave
mail only in update_contact.

Reported [error on RH bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=1893337), but until that is propagated, use non-mail contact only.