### PR TITLE
ui: Fixing permanently disabled buttons in vote menu, refs #1528

### DIFF
--- a/etmain/ui/ingame_vote_misc.menu
+++ b/etmain/ui/ingame_vote_misc.menu
@@ -44,13 +44,13 @@ menuDef {
 // Buttons //
 	BUTTON( 6, 32, .5*(WINDOW_WIDTH-18), 14, _("START MATCH"), .24, 11, exec "cmd callvote startmatch"; uiScript closeingame )
 	BUTTONEXT( 6, 50, .5*(WINDOW_WIDTH-18), 14, _("RESET MATCH"), .24, 11, exec "cmd callvote matchreset"; uiScript closeingame, voteFlag CV_SVF_MATCHRESET )
-	NAMEDBUTTONEXT( bttn_restmap, 6, 68, .5*(WINDOW_WIDTH-18), 14, _("RESTART MAP"), .24, 11, exec "cmd callvote maprestart"; uiScript closeingame, settingEnabled CV_SVF_MAPRESTART voteFlag CV_SVF_MAPRESTART )
-	NAMEDBUTTONEXT( bttn_restcampaign, 6, 68, .5*(WINDOW_WIDTH-18), 14, _("RESTART CAMPAIGN"), .24, 11, exec "cmd callvote restartcampaign"; uiScript closeingame, settingEnabled CV_SVF_RESTARTCAMPAIGN voteFlag CV_SVF_RESTARTCAMPAIGN )
+	NAMEDBUTTONEXT( bttn_restmap, 6, 68, .5*(WINDOW_WIDTH-18), 14, _("RESTART MAP"), .24, 11, exec "cmd callvote maprestart"; uiScript closeingame, voteFlag CV_SVF_MAPRESTART )
+	NAMEDBUTTONEXT( bttn_restcampaign, 6, 68, .5*(WINDOW_WIDTH-18), 14, _("RESTART CAMPAIGN"), .24, 11, exec "cmd callvote restartcampaign"; uiScript closeingame, voteFlag CV_SVF_RESTARTCAMPAIGN )
 	NAMEDBUTTONEXT( bttn_nextmap, 6, 86, .5*(WINDOW_WIDTH-18), 14, _("NEXT MAP"), .24, 11, exec "cmd callvote nextmap"; uiScript closeingame, settingEnabled CV_SVS_NEXTMAP voteFlag CV_SVF_NEXTMAP )
 	NAMEDBUTTONEXT( bttn_nextcampaign, 6, 86, .5*(WINDOW_WIDTH-18), 14, _("NEXT CAMPAIGN"), .24, 11, exec "cmd callvote nextmap"; uiScript closeingame, settingEnabled CV_SVS_NEXTMAP voteFlag CV_SVF_NEXTMAP )  //Replace CV_SVF_NEXTMAP with CV_SVF_NEXTCAMPAIGN //
 	BUTTONEXT( 6, 104, .5*(WINDOW_WIDTH-18), 14, _("ANTI-LAG ON"), .24, 11, exec "cmd callvote antilag 1"; uiScript closeingame, settingDisabled CV_SVS_ANTILAG voteFlag CV_SVF_ANTILAG )
 	BUTTONEXT( 6, 104, .5*(WINDOW_WIDTH-18), 14, _("ANTI-LAG OFF"), .24, 11, exec "cmd callvote antilag 0"; uiScript closeingame, settingEnabled CV_SVS_ANTILAG voteFlag CV_SVF_ANTILAG )
-	BUTTONEXT( 6, 122, .5*(WINDOW_WIDTH-18), 14, _("SURRENDER"), .24, 11, exec "cmd callvote surrender"; uiScript closeingame, settingEnabled CV_SVF_SURRENDER voteFlag CV_SVF_SURRENDER )
+	BUTTONEXT( 6, 122, .5*(WINDOW_WIDTH-18), 14, _("SURRENDER"), .24, 11, exec "cmd callvote surrender"; uiScript closeingame, voteFlag CV_SVF_SURRENDER )
 
 	BUTTONEXT( 6+.5*(WINDOW_WIDTH-18)+6, 32, .5*(WINDOW_WIDTH-18), 14, _("SHUFFLE"), .24, 11, exec "cmd callvote shuffleteams"; uiScript closeingame, voteFlag CV_SVF_SHUFFLETEAMS )
 	BUTTONEXT( 6+.5*(WINDOW_WIDTH-18)+6, 50, .5*(WINDOW_WIDTH-18), 14, _("NO RESTART SHUFFLE"), .24, 11, exec "cmd callvote shuffleteams_norestart"; uiScript closeingame, voteFlag CV_SVF_SHUFFLETEAMS_NORESTART )

--- a/etmain/ui/ingame_vote_misc_refrcon.menu
+++ b/etmain/ui/ingame_vote_misc_refrcon.menu
@@ -43,13 +43,13 @@ menuDef {
 // Buttons //
 	BUTTON( 6, 32, .5*(WINDOW_WIDTH-18), 14, _("START MATCH"), .24, 11, exec "cmd ref startmatch" ; uiScript closeingame )
 	BUTTONEXT( 6, 50, .5*(WINDOW_WIDTH-18), 14, _("RESET MATCH"), .24, 11, exec "cmd ref matchreset" ; uiScript closeingame, voteFlag CV_SVF_MATCHRESET )
-	NAMEDBUTTONEXT( bttn_restmap, 6, 68, .5*(WINDOW_WIDTH-18), 14, _("RESTART MAP"), .24, 11, exec "cmd ref maprestart" ; uiScript closeingame, settingEnabled CV_SVF_MAPRESTART voteFlag CV_SVF_MAPRESTART )
-	NAMEDBUTTONEXT( bttn_restcampaign, 6, 68, .5*(WINDOW_WIDTH-18), 14, _("RESTART CAMPAIGN"), .24, 11, exec "cmd ref restartcampaign" ; uiScript closeingame, settingEnabled CV_SVF_RESTARTCAMPAIGN voteFlag CV_SVF_RESTARTCAMPAIGN )
+	NAMEDBUTTONEXT( bttn_restmap, 6, 68, .5*(WINDOW_WIDTH-18), 14, _("RESTART MAP"), .24, 11, exec "cmd ref maprestart" ; uiScript closeingame, voteFlag CV_SVF_MAPRESTART )
+	NAMEDBUTTONEXT( bttn_restcampaign, 6, 68, .5*(WINDOW_WIDTH-18), 14, _("RESTART CAMPAIGN"), .24, 11, exec "cmd ref restartcampaign" ; uiScript closeingame, voteFlag CV_SVF_RESTARTCAMPAIGN )
 	NAMEDBUTTONEXT( bttn_nextmap, 6, 86, .5*(WINDOW_WIDTH-18), 14, _("NEXT MAP"), .24, 11, exec "cmd ref nextmap" ; uiScript closeingame, settingEnabled CV_SVS_NEXTMAP voteFlag CV_SVF_NEXTMAP )
 	NAMEDBUTTONEXT( bttn_nextcampaign, 6, 86, .5*(WINDOW_WIDTH-18), 14, _("NEXT CAMPAIGN"), .24, 11, exec "cmd ref nextmap" ; uiScript closeingame, settingEnabled CV_SVS_NEXTMAP voteFlag CV_SVF_NEXTMAP )
 	BUTTONEXT( 6, 104, .5*(WINDOW_WIDTH-18), 14, _("ANTI-LAG ON"), .24, 11, exec "cmd ref antilag 1" ; uiScript closeingame, settingDisabled CV_SVS_ANTILAG voteFlag CV_SVF_ANTILAG )
 	BUTTONEXT( 6, 104, .5*(WINDOW_WIDTH-18), 14, _("ANTI-LAG OFF"), .24, 11, exec "cmd ref antilag 0" ; uiScript closeingame, settingEnabled CV_SVS_ANTILAG voteFlag CV_SVF_ANTILAG )
-	BUTTONEXT( 6, 122, .5*(WINDOW_WIDTH-18), 14, _("SURRENDER"), .24, 11, exec "cmd ref surrender" ; uiScript closeingame, settingEnabled CV_SVF_SURRENDER voteFlag CV_SVF_SURRENDER )
+	BUTTONEXT( 6, 122, .5*(WINDOW_WIDTH-18), 14, _("SURRENDER"), .24, 11, exec "cmd ref surrender" ; uiScript closeingame, voteFlag CV_SVF_SURRENDER )
 
 	BUTTONEXT( 6+.5*(WINDOW_WIDTH-18)+6, 32, .5*(WINDOW_WIDTH-18), 14, _("SHUFFLE"), .24, 11, exec "cmd ref shuffleteams" ; uiScript closeingame, voteFlag CV_SVF_SHUFFLETEAMS )
 	BUTTONEXT( 6+.5*(WINDOW_WIDTH-18)+6, 50, .5*(WINDOW_WIDTH-18), 14, _("NO RESTART SHUFFLE"), .24, 11, exec "cmd ref shuffleteams_norestart" ; uiScript closeingame, voteFlag CV_SVF_SHUFFLETEAMS_NORESTART )


### PR DESCRIPTION
`settingEnabled` should only be used with `CS_SERVERTOGGLES` values (`CS_SVS_*`).

https://github.com/etlegacy/etlegacy/blob/master/src/ui/ui_menuitem.c#L3833-L3841
```
	if ((item->settingFlags & (SVS_ENABLED_SHOW | SVS_DISABLED_SHOW)) && !Item_SettingShow(item, qfalse))
	{
		return;
	}

	if (item->voteFlag != 0 && !Item_SettingShow(item, qtrue))
	{
		return;
	}
```

https://github.com/etlegacy/etlegacy/blob/master/src/ui/ui_menuitem.c#L199-L222
```
qboolean Item_SettingShow(itemDef_t *item, qboolean fVoteTest)
{
	char info[MAX_INFO_STRING];

	if (fVoteTest)
	{
		trap_Cvar_VariableStringBuffer("cg_ui_voteFlags", info, sizeof(info));
		return((atoi(info) & item->voteFlag) != item->voteFlag);
	}

	DC->getConfigString(CS_SERVERTOGGLES, info, sizeof(info));

	if (item->settingFlags & SVS_ENABLED_SHOW)
	{
		return(atoi(info) & item->settingTest);
	}

	if (item->settingFlags & SVS_DISABLED_SHOW)
	{
		return(!(atoi(info) & item->settingTest));
	}

	return qtrue;
}
```

	
If `settingEnabled` is set, the value it points to gets checked against `CS_SERVERTOGGLES` because of `fVoteTest == false`.

The values that were set for that 3 buttons correspond to `cg_ui_voteFlags`, which meant that the check for `voteFlags` was never reached as the buttons got already disabled(not drawn).

`item->settingFlags` = `settingEnabled` or `settingDisabled`
`item->settingTest` = `settingEnabled` value = `CS_SERVERTOGGLES` = various CVARS, fe. `g_friendlyFire`, `g_antilag`.
`item->voteFlag` = `voteFlag` value = `cg_ui_voteFlags` = `vote_allow_*` CVARS