### PR TITLE
Extend viewpos and setviewpos to include all angles

### DIFF
--- a/src/cgame/cg_consolecmds.c
+++ b/src/cgame/cg_consolecmds.c
@@ -41,9 +41,9 @@
  */
 static void CG_Viewpos_f(void)
 {
-	CG_Printf("(%i %i %i) : %i\n", (int)cg.refdef.vieworg[0],
+	CG_Printf("(%i %i %i) : %i %i %i\n", (int)cg.refdef.vieworg[0],
 	          (int)cg.refdef.vieworg[1], (int)cg.refdef.vieworg[2],
-	          (int)cg.refdefViewAngles[YAW]);
+	          (int)cg.refdefViewAngles[PITCH], (int)cg.refdefViewAngles[YAW], (int)cg.refdefViewAngles[ROLL]);
 }
 
 /**

--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -3622,21 +3622,23 @@ void Cmd_SetViewpos_f(gentity_t *ent)
 		trap_SendServerCommand(ent - g_entities, va("print \"Cheats are not enabled on this server.\n\""));
 		return;
 	}
-	if (trap_Argc() != 5)
+	if (trap_Argc() != 7)
 	{
-		trap_SendServerCommand(ent - g_entities, va("print \"usage: setviewpos x y z yaw\n\""));
+		trap_SendServerCommand(ent - g_entities, va("print \"usage: setviewpos x y z pitch yaw roll\n\""));
 		return;
 	}
 
-	VectorClear(angles);
 	for (i = 0 ; i < 3 ; i++)
 	{
 		trap_Argv(i + 1, buffer, sizeof(buffer));
 		origin[i] = atof(buffer);
 	}
 
-	trap_Argv(4, buffer, sizeof(buffer));
-	angles[YAW] = atof(buffer);
+	for (i = 0; i < 3; i++)
+	{
+		trap_Argv(i + 4, buffer, sizeof(buffer));
+		angles[i] = atof(buffer);
+	}
 
 	TeleportPlayer(ent, origin, angles);
 }

--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -3622,22 +3622,37 @@ void Cmd_SetViewpos_f(gentity_t *ent)
 		trap_SendServerCommand(ent - g_entities, va("print \"Cheats are not enabled on this server.\n\""));
 		return;
 	}
-	if (trap_Argc() != 7)
+
+	if (trap_Argc() == 5)
 	{
-		trap_SendServerCommand(ent - g_entities, va("print \"usage: setviewpos x y z pitch yaw roll\n\""));
+		VectorClear(angles);
+		for (i = 0; i < 3; i++)
+		{
+			trap_Argv(i + 1, buffer, sizeof(buffer));
+			origin[i] = atof(buffer);
+		}
+
+		trap_Argv(4, buffer, sizeof(buffer));
+		angles[YAW] = atof(buffer);
+	}
+	else if (trap_Argc() == 7)
+	{
+		for (i = 0; i < 3; i++)
+		{
+			trap_Argv(i + 1, buffer, sizeof(buffer));
+			origin[i] = atof(buffer);
+		}
+
+		for (i = 0; i < 3; i++)
+		{
+			trap_Argv(i + 4, buffer, sizeof(buffer));
+			angles[i] = atof(buffer);
+		}
+	}
+	else
+	{
+		trap_SendServerCommand(ent - g_entities, va("print \"usage: setviewpos x y z yaw\n       setviewpos x y z pitch yaw roll\n\""));
 		return;
-	}
-
-	for (i = 0 ; i < 3 ; i++)
-	{
-		trap_Argv(i + 1, buffer, sizeof(buffer));
-		origin[i] = atof(buffer);
-	}
-
-	for (i = 0; i < 3; i++)
-	{
-		trap_Argv(i + 4, buffer, sizeof(buffer));
-		angles[i] = atof(buffer);
 	}
 
 	TeleportPlayer(ent, origin, angles);


### PR DESCRIPTION
Extends `viewpos` and `setviewpos` commands to take 6 arguments instead of 4, so you can individually view and set all your view angles. The first argument is now pitch instead of yaw.

refs #1564 