### PR TITLE
game: Don't show health of invulnerable entities, fixes #1563

### DIFF
--- a/src/game/g_script_actions.c
+++ b/src/game/g_script_actions.c
@@ -3969,6 +3969,12 @@ qboolean G_ScriptAction_SetDamagable(gentity_t *ent, char *params)
 	while ((target = G_FindByTargetname(target, name)))
 	{
 		target->takedamage = canDamage;
+
+		// don't show health of target that can't be damaged
+		if (!canDamage)
+		{
+			target->s.effect1Time = 0;
+		}
 	}
 
 	return qtrue;


### PR DESCRIPTION
game: changed G_ScriptAction_SetDamagable so as to not show health of invulnerable entities, fixes #1563