### PR TITLE
qcommon: unhardcode patch plane optimization

### DIFF
--- a/src/qcommon/cm_load.c
+++ b/src/qcommon/cm_load.c
@@ -53,6 +53,7 @@ cvar_t *cm_noAreas;
 cvar_t *cm_noCurves;
 cvar_t *cm_playerCurveClip;
 cvar_t *cm_optimize;
+cvar_t *cm_optimizePatchPlanes;
 
 cmodel_t box_model;
 cplane_t *box_planes;
@@ -626,10 +627,11 @@ void CM_LoadMap(const char *name, qboolean clientload, unsigned int *checksum)
 		Com_Error(ERR_DROP, "CM_LoadMap: NULL name");
 	}
 
-	cm_noAreas         = Cvar_Get("cm_noAreas", "0", CVAR_CHEAT);
-	cm_noCurves        = Cvar_Get("cm_noCurves", "0", CVAR_CHEAT);
-	cm_playerCurveClip = Cvar_Get("cm_playerCurveClip", "1", CVAR_ARCHIVE | CVAR_CHEAT);
-	cm_optimize        = Cvar_Get("cm_optimize", "1", CVAR_CHEAT);
+	cm_noAreas             = Cvar_Get("cm_noAreas", "0", CVAR_CHEAT);
+	cm_noCurves            = Cvar_Get("cm_noCurves", "0", CVAR_CHEAT);
+	cm_playerCurveClip     = Cvar_Get("cm_playerCurveClip", "1", CVAR_ARCHIVE | CVAR_CHEAT);
+	cm_optimize            = Cvar_Get("cm_optimize", "1", CVAR_CHEAT);
+	cm_optimizePatchPlanes = Cvar_Get("cm_optimizePatchPlanes", "1", CVAR_CHEAT | CVAR_SERVERINFO | CVAR_LATCH);
 
 	Com_DPrintf("CM_LoadMap( %s, %i )\n", name, clientload);
 

--- a/src/qcommon/cm_load.c
+++ b/src/qcommon/cm_load.c
@@ -631,7 +631,7 @@ void CM_LoadMap(const char *name, qboolean clientload, unsigned int *checksum)
 	cm_noCurves            = Cvar_Get("cm_noCurves", "0", CVAR_CHEAT);
 	cm_playerCurveClip     = Cvar_Get("cm_playerCurveClip", "1", CVAR_ARCHIVE | CVAR_CHEAT);
 	cm_optimize            = Cvar_Get("cm_optimize", "1", CVAR_CHEAT);
-	cm_optimizePatchPlanes = Cvar_Get("cm_optimizePatchPlanes", "1", CVAR_CHEAT | CVAR_SERVERINFO | CVAR_LATCH);
+	cm_optimizePatchPlanes = Cvar_Get("cm_optimizePatchPlanes", "0", CVAR_CHEAT | CVAR_SERVERINFO);
 
 	Com_DPrintf("CM_LoadMap( %s, %i )\n", name, clientload);
 

--- a/src/qcommon/cm_local.h
+++ b/src/qcommon/cm_local.h
@@ -189,6 +189,7 @@ extern cvar_t    *cm_noAreas;
 extern cvar_t    *cm_noCurves;
 extern cvar_t    *cm_playerCurveClip;
 extern cvar_t    *cm_optimize;
+extern cvar_t    *cm_optimizePatchPlanes;
 
 // cm_test.c
 

--- a/src/qcommon/cm_patch.c
+++ b/src/qcommon/cm_patch.c
@@ -1020,7 +1020,7 @@ void CM_AddFacetBevels(facet_t *facet)
 			// see if the plane is already present
 			for (i = 0; i < facet->numBorders; i++)
 			{
-				if (cm_optimizePatchPlanes->integer)
+				if (!cm_optimizePatchPlanes->integer)
 				{
 					if (CM_PlaneEqual(&planes[facet->borderPlanes[i]], plane, &flipped))
 					{

--- a/src/qcommon/cm_patch.c
+++ b/src/qcommon/cm_patch.c
@@ -346,7 +346,7 @@ static void CM_SubdivideGridColumns(cGrid_t *grid)
 {
 	int i, j, k;
 
-	for (i = 0 ; i < grid->width - 2 ; )
+	for (i = 0 ; i < grid->width - 2 ;)
 	{
 		// grid->points[i][x] is an interpolating control point
 		// grid->points[i+1][x] is an aproximating control point
@@ -503,10 +503,10 @@ int CM_PlaneEqual(patchPlane_t *p, float plane[4], int *flipped)
 	float invplane[4];
 
 	if (
-	    Q_fabs(p->plane[0] - plane[0]) < NORMAL_EPSILON
-	    && Q_fabs(p->plane[1] - plane[1]) < NORMAL_EPSILON
-	    && Q_fabs(p->plane[2] - plane[2]) < NORMAL_EPSILON
-	    && Q_fabs(p->plane[3] - plane[3]) < DIST_EPSILON)
+		Q_fabs(p->plane[0] - plane[0]) < NORMAL_EPSILON
+		&& Q_fabs(p->plane[1] - plane[1]) < NORMAL_EPSILON
+		&& Q_fabs(p->plane[2] - plane[2]) < NORMAL_EPSILON
+		&& Q_fabs(p->plane[3] - plane[3]) < DIST_EPSILON)
 	{
 		*flipped = qfalse;
 		return qtrue;
@@ -516,10 +516,10 @@ int CM_PlaneEqual(patchPlane_t *p, float plane[4], int *flipped)
 	invplane[3] = -plane[3];
 
 	if (
-	    Q_fabs(p->plane[0] - invplane[0]) < NORMAL_EPSILON
-	    && Q_fabs(p->plane[1] - invplane[1]) < NORMAL_EPSILON
-	    && Q_fabs(p->plane[2] - invplane[2]) < NORMAL_EPSILON
-	    && Q_fabs(p->plane[3] - invplane[3]) < DIST_EPSILON)
+		Q_fabs(p->plane[0] - invplane[0]) < NORMAL_EPSILON
+		&& Q_fabs(p->plane[1] - invplane[1]) < NORMAL_EPSILON
+		&& Q_fabs(p->plane[2] - invplane[2]) < NORMAL_EPSILON
+		&& Q_fabs(p->plane[3] - invplane[3]) < DIST_EPSILON)
 	{
 		*flipped = qtrue;
 		return qtrue;
@@ -795,8 +795,8 @@ static int CM_EdgePlaneNum(cGrid_t *grid, int gridPlanes[MAX_GRID_SIZE][MAX_GRID
 	}
 
 	Com_Error(ERR_DROP, "CM_EdgePlaneNum: bad k");
-	
-	return -1;	
+
+	return -1;
 }
 
 /**
@@ -1020,9 +1020,29 @@ void CM_AddFacetBevels(facet_t *facet)
 			// see if the plane is already present
 			for (i = 0; i < facet->numBorders; i++)
 			{
-				if (CM_PlaneEqual(&planes[facet->borderPlanes[i]], plane, &flipped))
+				if (cm_optimizePatchPlanes->integer)
 				{
-					break;
+					if (CM_PlaneEqual(&planes[facet->borderPlanes[i]], plane, &flipped))
+					{
+						break;
+					}
+				}
+				else // Vanilla ET behavior, able to walk inside patch bevels on certain angles
+				{
+					if (dir > 0)
+					{
+						if (planes[facet->borderPlanes[i]].plane[axis] >= 0.9999f)
+						{
+							break;
+						}
+					}
+					else
+					{
+						if (planes[facet->borderPlanes[i]].plane[axis] <= -0.9999f)
+						{
+							break;
+						}
+					}
 				}
 			}
 


### PR DESCRIPTION
Unhardcode the patch optimization revert done in [this commit](https://github.com/etlegacy/etlegacy/commit/abd2d4d910a6376c3edc79b20db1b687c677c369?branch=abd2d4d910a6376c3edc79b20db1b687c677c369) and tie the optimization to `cm_optimizePatchPlanes` cvar. This is mainly meant for trickjump servers, where some maps require usage of this bug in order to be completed.