### PR TITLE
cgame: draw limbo times instead of warmup in reinforcement time HUD element

### DIFF
--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -2267,18 +2267,18 @@ static const char *CG_TimerWarmupString()
 	}
 	else                                              // draw limbotime periods otherwise 
 	{
-		int limbotime_own, limbotime_enemy;
+		int limbotimeOwn, limbotimeEnemy;
 		if (cgs.clientinfo[cg.snap->ps.clientNum].team == TEAM_AXIS)
 		{
-			limbotime_own   = cg_redlimbotime.integer;
-			limbotime_enemy = cg_bluelimbotime.integer;
+			limbotimeOwn   = cg_redlimbotime.integer;
+			limbotimeEnemy = cg_bluelimbotime.integer;
 		}
 		else
 		{
-			limbotime_own   = cg_bluelimbotime.integer;
-			limbotime_enemy = cg_redlimbotime.integer;
+			limbotimeOwn   = cg_bluelimbotime.integer;
+			limbotimeEnemy = cg_redlimbotime.integer;
 		}
-		return va("^1%2.0i ^$%2.0i", limbotime_enemy / 1000, limbotime_own / 1000);
+		return va("^1%2.0i ^$%2.0i", limbotimeEnemy / 1000, limbotimeOwn / 1000);
 	}
 }
 

--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -2253,6 +2253,36 @@ static float CG_DrawFPS(float y)
 }
 
 /**
+* @brief CG_TimerWarmupString string to be drawn in reinforcement time hud element
+* If gametype is Last Man Standing it returns just WARMUP, otherwise it returns colored limbotime periods:
+* If player or following player is axis, then it returns red allies limbotime and blue axis limbotime,
+* for allies or in freecam it returns red axis limbotime and blue allies limbotime.
+* @return
+*/
+static const char *CG_TimerWarmupString()
+{
+	if (cgs.gametype == GT_WOLF_LMS)
+	{
+		return va("^7%s", CG_TranslateString("WARMUP")); // don't draw reinforcement time in warmup mode for LMS
+	}
+	else                                              // draw limbotime periods otherwise 
+	{
+		int limbotime_own, limbotime_enemy;
+		if (cgs.clientinfo[cg.snap->ps.clientNum].team == TEAM_AXIS)
+		{
+			limbotime_own   = cg_redlimbotime.integer;
+			limbotime_enemy = cg_bluelimbotime.integer;
+		}
+		else
+		{
+			limbotime_own   = cg_bluelimbotime.integer;
+			limbotime_enemy = cg_redlimbotime.integer;
+		}
+		return va("^1%2.0i ^$%2.0i", limbotime_enemy / 1000, limbotime_own / 1000);
+	}
+}
+
+/**
  * @brief CG_DrawTimersAlt
  * @param[in] respawn
  * @param[in] spawntimer
@@ -2277,7 +2307,7 @@ static void CG_DrawTimersAlt(rectDef_t *respawn, rectDef_t *spawntimer, rectDef_
 
 	if (cgs.gamestate != GS_PLAYING)
 	{
-		s        = va("^7%s", CG_TranslateString("WARMUP")); // don't draw reinforcement time in warmup mode // ^*
+		s        = CG_TimerWarmupString();
 		color[3] = fabs(sin(cg.time * 0.002));
 	}
 	else if (msec < 0 && cgs.timelimit > 0.0f)
@@ -2412,7 +2442,7 @@ static float CG_DrawTimerNormal(float y)
 
 	if (cgs.gamestate != GS_PLAYING)
 	{
-		s        = va("^7%s", CG_TranslateString("WARMUP")); // don't draw reinforcement time in warmup mode // ^*
+		s        = CG_TimerWarmupString();
 		color[3] = fabs(sin(cg.time * 0.002));
 	}
 	else if (msec < 0 && cgs.timelimit > 0.0f)

--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -2415,6 +2415,7 @@ static void CG_DrawTimersAlt(rectDef_t *respawn, rectDef_t *spawntimer, rectDef_
 				s = va("%02i:%02i", time.tm_hour, time.tm_min);
 			}
 		}
+		color[3] = 1.f; // don't blink local time during warmup
 		CG_Text_Paint_Ext(localtime->x, localtime->y, 0.19f, 0.19f, color, s, 0, 0, ITEM_TEXTSTYLE_SHADOWED, &cgs.media.limboFont1);
 	}
 }


### PR DESCRIPTION
During warmup the reinforcement time HUD element only displays blinking WARMUP string, this information is redundant because its already displayed in the middle of screen:
![image](https://user-images.githubusercontent.com/4035800/107119566-cd0db280-6888-11eb-9551-302edbfd2bec.png)


So instead of WARMUP display limbo times of both teams with following logic:
- If player or following player is axis => red allies limbo time and blue axis limbo time
- For allies or in free cam => red axis limbo time and blue allies limbo time
- If the game type is Last Man Standing => WARMUP

I also sneaked in change to not blink local time for alternative timers.
I kept the blinking for the limbo times, can't decide whether that should be disabled too.

Preview:
- Normal timer:
![image](https://user-images.githubusercontent.com/4035800/107119064-6b981480-6885-11eb-8094-c8e8585827ad.png)

- Alternative timers position (cg_althudFlags & 1) + non-blinking local time:
![image](https://user-images.githubusercontent.com/4035800/107119071-7b175d80-6885-11eb-9130-dd9525f059d7.png)

refs #1414 