### PR TITLE
Auto spawn timer period refs: #1414

### DIFF
--- a/src/cgame/cg_consolecmds.c
+++ b/src/cgame/cg_consolecmds.c
@@ -1274,16 +1274,13 @@ static void CG_TimerSet_f(void)
  */
 static void CG_TimerReset_f(void)
 {
-	int msec;
-
 	if (cgs.gamestate != GS_PLAYING)
 	{
 		CG_Printf("You may only use this command during the match.\n");
 		return;
 	}
 
-	msec = (int)(cgs.timelimit * 60000.f) - (cg.time - cgs.levelStartTime); // 60.f * 1000.f
-	trap_Cvar_Set("cg_spawnTimer_set", va("%d", msec / 1000));
+	trap_Cvar_Set("cg_spawnTimer_set", va("%d", cg.time - cgs.levelStartTime));
 }
 
 /**

--- a/src/cgame/cg_consolecmds.c
+++ b/src/cgame/cg_consolecmds.c
@@ -1251,7 +1251,7 @@ static void CG_TimerSet_f(void)
 
 		if (spawnPeriod == 0)
 		{
-			trap_Cvar_Set("cg_spawnTimer_set", "-1");
+			trap_Cvar_Set("cg_spawnTimer_period", 0);
 		}
 		else if (spawnPeriod < 1 || spawnPeriod > 60)
 		{

--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -2330,13 +2330,14 @@ static void CG_DrawTimersAlt(rectDef_t *respawn, rectDef_t *spawntimer, rectDef_
 	CG_Text_Paint_Ext(respawn->x - w, respawn->y, 0.19f, 0.19f, color, s, 0, 0, ITEM_TEXTSTYLE_SHADOWED, &cgs.media.limboFont1);
 
 	// spawntimer
-	if (cg_spawnTimer_set.integer != -1 && cg_spawnTimer_period.integer > 0 && cgs.gamestate == GS_PLAYING && !cgs.clientinfo[cg.clientNum].shoutcaster)
+	if (cg_spawnTimer_set.integer != -1 && cgs.gamestate == GS_PLAYING && !cgs.clientinfo[cg.clientNum].shoutcaster)
 	{
 		if (cgs.clientinfo[cg.clientNum].team != TEAM_SPECTATOR || (cg.snap->ps.pm_flags & PMF_FOLLOW))
 		{
+			int period  = cg_spawnTimer_period.integer > 0 ? cg_spawnTimer_period.integer : (cgs.clientinfo[cg.snap->ps.clientNum].team == TEAM_AXIS ? cg_bluelimbotime.integer / 1000 : cg_redlimbotime.integer / 1000);
 			seconds     = msec / 1000;
 			secondsThen = ((cgs.timelimit * 60000.f) - cg_spawnTimer_set.integer) / 1000;
-			s           = va("^1%i ", cg_spawnTimer_period.integer + (seconds - secondsThen) % cg_spawnTimer_period.integer);
+			s           = va("^1%i ", period + (seconds - secondsThen) % period);
 			w           = CG_Text_Width_Ext(s, 0.19f, 0, &cgs.media.limboFont1) - ((msec < 0 && cgs.timelimit > 0.0f) ? CG_Text_Width_Ext("00:00", 0.19f, 0, &cgs.media.limboFont1) : 0);
 			CG_Text_Paint_Ext(spawntimer->x - w, spawntimer->y, 0.19f, 0.19f, color, s, 0, 0, ITEM_TEXTSTYLE_SHADOWED, &cgs.media.limboFont1);
 		}

--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -2335,11 +2335,14 @@ static void CG_DrawTimersAlt(rectDef_t *respawn, rectDef_t *spawntimer, rectDef_
 		if (cgs.clientinfo[cg.clientNum].team != TEAM_SPECTATOR || (cg.snap->ps.pm_flags & PMF_FOLLOW))
 		{
 			int period  = cg_spawnTimer_period.integer > 0 ? cg_spawnTimer_period.integer : (cgs.clientinfo[cg.snap->ps.clientNum].team == TEAM_AXIS ? cg_bluelimbotime.integer / 1000 : cg_redlimbotime.integer / 1000);
-			seconds     = msec / 1000;
-			secondsThen = ((cgs.timelimit * 60000.f) - cg_spawnTimer_set.integer) / 1000;
-			s           = va("^1%i ", period + (seconds - secondsThen) % period);
-			w           = CG_Text_Width_Ext(s, 0.19f, 0, &cgs.media.limboFont1) - ((msec < 0 && cgs.timelimit > 0.0f) ? CG_Text_Width_Ext("00:00", 0.19f, 0, &cgs.media.limboFont1) : 0);
-			CG_Text_Paint_Ext(spawntimer->x - w, spawntimer->y, 0.19f, 0.19f, color, s, 0, 0, ITEM_TEXTSTYLE_SHADOWED, &cgs.media.limboFont1);
+			if (period > 0) // prevent division by 0
+			{
+				seconds     = msec / 1000;
+				secondsThen = ((cgs.timelimit * 60000.f) - cg_spawnTimer_set.integer) / 1000;
+				s           = va("^1%i ", period + (seconds - secondsThen) % period);
+				w           = CG_Text_Width_Ext(s, 0.19f, 0, &cgs.media.limboFont1) - ((msec < 0 && cgs.timelimit > 0.0f) ? CG_Text_Width_Ext("00:00", 0.19f, 0, &cgs.media.limboFont1) : 0);
+				CG_Text_Paint_Ext(spawntimer->x - w, spawntimer->y, 0.19f, 0.19f, color, s, 0, 0, ITEM_TEXTSTYLE_SHADOWED, &cgs.media.limboFont1);
+			}
 		}
 	}
 	else if (cg_spawnTimer_set.integer != -1 && cg_spawnTimer_period.integer > 0 && cgs.gamestate != GS_PLAYING)

--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -2338,8 +2338,8 @@ static void CG_DrawTimersAlt(rectDef_t *respawn, rectDef_t *spawntimer, rectDef_
 			int  reinfTime  = CG_CalculateReinfTime(qfalse);
 			char *teamColor = (cgs.clientinfo[cg.clientNum].shoutcaster ? (cgs.clientinfo[cg.snap->ps.clientNum].team == TEAM_AXIS ? "^1" : "^$") : "^F");
 
-			rt = va("%s%d%s", (reinfTime <= 2 && cgs.clientinfo[cg.clientNum].health == 0 &&
-			                   !(cg.snap->ps.pm_flags & PMF_FOLLOW)) ? "^1" : teamColor, reinfTime, ((cgs.timelimit <= 0.0f) ? "" : " "));
+			rt = va("%s%d ", (reinfTime <= 2 && cgs.clientinfo[cg.clientNum].health == 0 &&
+			                   !(cg.snap->ps.pm_flags & PMF_FOLLOW)) ? "^1" : teamColor, reinfTime);
 		}
 		else
 		{
@@ -2477,7 +2477,7 @@ static float CG_DrawTimerNormal(float y)
 	// spawntimer
 	if (rt = CG_SpawnTimerText())
 	{
-		s = va("%s%s", rt, s);
+		s = va("%s%s%s", rt, (cgs.timelimit <= 0.0f) ? " " : "", s);
 	}
 
 	w  = CG_Text_Width_Ext(s, 0.19f, 0, &cgs.media.limboFont1);

--- a/src/cgame/cg_servercmds.c
+++ b/src/cgame/cg_servercmds.c
@@ -961,6 +961,7 @@ static void CG_ConfigStringModified(void)
 		break;
 	case CS_LEVEL_START_TIME:
 		cgs.levelStartTime = atoi(CG_ConfigString(num));
+		trap_Cvar_Set("cg_spawnTimer_set", "-1");
 		break;
 	case CS_INTERMISSION_START_TIME:
 		cgs.intermissionStartTime = atoi(CG_ConfigString(num));


### PR DESCRIPTION
Use spawnTimer period from `cg_red(blue)limbotime`, this relieves burden of setting the value manually or with `autoexec_<team>.cfg` and `autoexec_<mapname>.cfg` scripts.
Player now only has to execute `timerReset` or `resetTimer`.

timerSet behaviour:
- `timerSet <number>` - custom period
- `timerSet` - resets the stamp which disables the spawn timer
- `timerSet 0` to use the cg_red(blue)limbotime again - this is changed in this PR, behavior before would be same as `timerSet`

I extracted the logic of drawing spawn timer text into function that is used by both normal and alternative timer.

Note that `cycle cg_spawnTimer_set 0 60000 1000` and `cycle cg_spawnTimer_set 60000 0 1000` can be used to adjust the timer forward or backward in time. Could be added as bind in advanced controls menu? Or at least as a hint.

If spawn time periods are changed on server then the spawn timer isn't accurate anymore, but I think it could done too. 

This pull request contains also fix for timerReset/resetTimer command.
Also contains invalidation of spawn timer stamp when cgs.levelStartTime is changed - this fixes spawn timer being broken on map reset or map change.

Including preview because I did some adjustments when adding space character between spawn timer and reinforcement timer:

- before `timerReset` + positive timelimit + alternative timer:
![2021-02-07-174914-frostbite](https://user-images.githubusercontent.com/4035800/107154568-dcb5f580-6973-11eb-96fc-5d38096c7ae5.png)

- before `timerReset` + positive timelimit + normal timer:
![2021-02-07-174919-frostbite](https://user-images.githubusercontent.com/4035800/107154615-23a3eb00-6974-11eb-93ae-13012f020d01.png)

- after `timerReset` + positive timelimit + alternative timer:
![2021-02-07-174941-frostbite](https://user-images.githubusercontent.com/4035800/107154670-8e552680-6974-11eb-9e7e-1b9f37ef1a43.png)

- after `timerReset` + positive timelimit + normal timer:
![2021-02-07-175011-frostbite](https://user-images.githubusercontent.com/4035800/107154696-b17fd600-6974-11eb-977d-06048ae2d6d7.png)

- before `timerReset` + non-positive timelimit + normal timer:
![2021-02-07-175028-frostbite](https://user-images.githubusercontent.com/4035800/107154720-d8d6a300-6974-11eb-80df-ffb38b79b189.png)

- before `timerReset` + non-positive timelimit + alternative timer:
![2021-02-07-175033-frostbite](https://user-images.githubusercontent.com/4035800/107154732-e7bd5580-6974-11eb-96df-843b8a2f0783.png)

- after `timerReset` + non-positive timelimit + normal timer:
![2021-02-07-175114-frostbite](https://user-images.githubusercontent.com/4035800/107154804-26531000-6975-11eb-8e8a-7f4b8ded1a80.png)

- after `timerReset` + non-positive timelimit + alternative timer:
![2021-02-07-175046-frostbite](https://user-images.githubusercontent.com/4035800/107154748-f6a40800-6974-11eb-9fe3-2d05675b18da.png)

refs: #1414




