### PR TITLE
Shoutcast overlay fixes and changes.

### DIFF
--- a/etmain/ui/options_controls_advanced.menu
+++ b/etmain/ui/options_controls_advanced.menu
@@ -57,6 +57,18 @@ menuDef {
 	MULTI( 8, JOYSTICK_Y+40, (SUBWINDOW_WIDTH)-4, 10, _("Analog Joystick:"), .2, 8, "in_joystickUseAnalog", cvarFloatList { "No" 0 "Yes" 1 }, _("Use analog joystick?") )
 	EDITFIELD( 8, JOYSTICK_Y+52, (SUBWINDOW_WIDTH)-4, 10, _("Joystick Threshold:"), .2, 8, "in_joystickThreshold", 64, 18, _("Sets joystick threshold sensitivity") )
 
+// Shoutcast //
+#define SHOUTCAST_Y 32
+	SUBWINDOW( 6+(SUBWINDOW_WIDTH)+6, SHOUTCAST_Y, (SUBWINDOW_WIDTH), 112, _("SHOUTCAST") )
+	BIND( 6+(SUBWINDOW_WIDTH)+6+2, SHOUTCAST_Y+16, (SUBWINDOW_WIDTH)-4, 10, _("Shoutcast menu:"), .2, 8, "shoutcastmenu", "Used to follow players, use the same way like voice chat." )
+	MULTI( 6+(SUBWINDOW_WIDTH)+6+2, SHOUTCAST_Y+28, (SUBWINDOW_WIDTH)-4, 10, _("Show minimap:"), .2, 8, "cg_shoutcastDrawMinimap", cvarFloatList { "Off" 0 "On" 1 }, _("Displays minimap.") )
+	MULTI( 6+(SUBWINDOW_WIDTH)+6+2, SHOUTCAST_Y+40, (SUBWINDOW_WIDTH)-4, 10, _("Show player lists:"), .2, 8, "cg_shoutcastDrawPlayers", cvarFloatList { "Off" 0 "On" 1 }, _("Displays player lists.") )
+	MULTI( 6+(SUBWINDOW_WIDTH)+6+2, SHOUTCAST_Y+52, (SUBWINDOW_WIDTH)-4, 10, _("Show grenade trail:"), .2, 8, "cg_shoutcastGrenadeTrail", cvarFloatList { "Off" 0 "On" 1 }, _("Use special red trail for grenades.") )
+	MULTI( 6+(SUBWINDOW_WIDTH)+6+2, SHOUTCAST_Y+64, (SUBWINDOW_WIDTH)-4, 10, _("Show player health:"), .2, 8, "cg_shoutcastDrawHealth", cvarFloatList { "Off" 0 "As text" 1 "As health bar" 2 }, _("Displays player health above them.") )
+	MULTI( 6+(SUBWINDOW_WIDTH)+6+2, SHOUTCAST_Y+76, (SUBWINDOW_WIDTH)-4, 10, _("Show team names:"), .2, 8, "cg_shoutcastDrawTeamNames", cvarFloatList { "Off" 0 "On" 1 }, _("Displays team names.") )
+	EDITFIELD( 6+(SUBWINDOW_WIDTH)+6+2, SHOUTCAST_Y+88, (SUBWINDOW_WIDTH)-4, 10, _("Axis team name:"), .2, 8, "cg_shoutcastTeamName1", 64, 18, _("Sets axis team name (axis if empty).") )
+	EDITFIELD( 6+(SUBWINDOW_WIDTH)+6+2, SHOUTCAST_Y+100, (SUBWINDOW_WIDTH)-4, 10, _("Allies team name:"), .2, 8, "cg_shoutcastTeamName2", 64, 18, _("Sets allies team name (allies if empty).") )
+	
 // Buttons //
 	BUTTON( 6, WINDOW_HEIGHT-24, WINDOW_WIDTH-12, 18, _("BACK"), .3, 14, close options_controls_advanced ; open options_controls )
 }

--- a/src/cgame/cg_commandmap.c
+++ b/src/cgame/cg_commandmap.c
@@ -2148,6 +2148,11 @@ void CG_DrawAutoMapNew(float x, float y, float w, float h)
 		}
 	}
 
+	if (!cg_shoutcastDrawMinimap.integer)
+	{
+		return;
+	}
+
 #ifdef FEATURE_EDV
 	if (cgs.demoCamera.renderingFreeCam == qtrue || cgs.demoCamera.renderingWeaponCam == qtrue || !cg_drawCompass.integer)
 	{

--- a/src/cgame/cg_commandmap.c
+++ b/src/cgame/cg_commandmap.c
@@ -2898,7 +2898,6 @@ void CG_DrawMapNew(float x, float y, float w, float h, int mEntFilter, mapScisso
 
 	if (scissor)
 	{
-		//AUTOMAP_PLAYER_ICON_SIZE
 		icon_size = AUTOMAP_PLAYER_ICON_SIZE_NEW;
 
 		if (scissor->br[0] >= scissor->tl[0])

--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -3747,11 +3747,6 @@ static void CG_Draw2D(void)
 		CG_DrawOnScreenBars();
 	}
 
-	if (!CG_DrawScoreboard() && cgs.clientinfo[cg.clientNum].shoutcaster && cg_shoutcastDrawPlayers.integer)
-	{
-		CG_DrawShoutcastPlayerList();
-	}
-
 	// no longer cheat protected, we draw crosshair/reticle in non demoplayback
 	if (cg_draw2D.integer == 0)
 	{
@@ -3814,6 +3809,11 @@ static void CG_Draw2D(void)
 		CG_DrawBannerPrint();
 
 		CG_SetHud();
+
+		if (cgs.clientinfo[cg.clientNum].shoutcaster && cg_shoutcastDrawPlayers.integer)
+		{
+			CG_DrawShoutcastPlayerList();
+		}
 
 #ifdef FEATURE_EDV
 		if (cg.snap->ps.persistant[PERS_TEAM] != TEAM_SPECTATOR && !cgs.demoCamera.renderingFreeCam && !cgs.demoCamera.renderingWeaponCam)

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2819,6 +2819,7 @@ extern vmCvar_t cg_shoutcastTeamName1;
 extern vmCvar_t cg_shoutcastTeamName2;
 extern vmCvar_t cg_shoutcastDrawHealth;
 extern vmCvar_t cg_shoutcastGrenadeTrail;
+extern vmCvar_t cg_shoutcastDrawMinimap;
 
 // local clock flags
 #define LOCALTIME_ON                0x01

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -355,6 +355,7 @@ vmCvar_t cg_shoutcastTeamName1;
 vmCvar_t cg_shoutcastTeamName2;
 vmCvar_t cg_shoutcastDrawHealth;
 vmCvar_t cg_shoutcastGrenadeTrail;
+vmCvar_t cg_shoutcastDrawMinimap;
 
 typedef struct
 {
@@ -603,13 +604,14 @@ static cvarTable_t cvarTable[] =
 
 	{ &cg_visualEffects,          "cg_visualEffects",          "1",           CVAR_ARCHIVE,                 0 },   // Draw visual effects (i.e : airstrike plane, debris ...)
 	{ &cg_bannerTime,             "cg_bannerTime",             "10000",       CVAR_ARCHIVE,                 0 },
-  
-  { &cg_shoutcastDrawPlayers,   "cg_shoutcastDrawPlayers",   "1",           CVAR_ARCHIVE,                 0 },
+
+	{ &cg_shoutcastDrawPlayers,   "cg_shoutcastDrawPlayers",   "1",           CVAR_ARCHIVE,                 0 },
 	{ &cg_shoutcastDrawTeamNames, "cg_shoutcastDrawTeamNames", "1",           CVAR_ARCHIVE,                 0 },
 	{ &cg_shoutcastTeamName1,     "cg_shoutcastTeamName1",     "",            CVAR_ARCHIVE,                 0 },
 	{ &cg_shoutcastTeamName2,     "cg_shoutcastTeamName2",     "",            CVAR_ARCHIVE,                 0 },
 	{ &cg_shoutcastDrawHealth,    "cg_shoutcastDrawHealth",    "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_shoutcastGrenadeTrail,  "cg_shoutcastGrenadeTrail",  "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_shoutcastDrawMinimap,   "cg_shoutcastDrawMinimap",   "1",           CVAR_ARCHIVE,                 0 },
 };
 
 static const unsigned int cvarTableSize = sizeof(cvarTable) / sizeof(cvarTable[0]);

--- a/src/cgame/cg_popupmessages.c
+++ b/src/cgame/cg_popupmessages.c
@@ -615,7 +615,7 @@ void CG_DrawPMItems(rectDef_t rect, int style)
 
 	if (cgs.clientinfo[cg.clientNum].shoutcaster)
 	{
-		y = 140;
+		y = 130;
 	}
 
 	if (cg_drawSmallPopupIcons.integer)

--- a/src/cgame/cg_popupmessages.c
+++ b/src/cgame/cg_popupmessages.c
@@ -615,7 +615,7 @@ void CG_DrawPMItems(rectDef_t rect, int style)
 
 	if (cgs.clientinfo[cg.clientNum].shoutcaster)
 	{
-		y = 130;
+		y = 110;
 	}
 
 	if (cg_drawSmallPopupIcons.integer)

--- a/src/cgame/cg_shoutcastoverlay.c
+++ b/src/cgame/cg_shoutcastoverlay.c
@@ -209,14 +209,23 @@ static void CG_DrawShoutcastPlayerOverlayAxis(clientInfo_t *player, float x, flo
 	curWeap   = CG_GetPlayerCurrentWeapon(player);
 	weapScale = cg_weapons[curWeap].weaponIconScale * 10;
 
+	if (IS_VALID_WEAPON(curWeap) && cg_weapons[curWeap].weaponIconScale == 1)
+	{
+		bottomRowX = x + PLAYER_LIST_OVERLAY_BOX_WIDTH + weapScale - 63;
+	}
+	else
+	{
+		bottomRowX = x + PLAYER_LIST_OVERLAY_BOX_WIDTH - 63;
+	}
+
 	// note: WP_NONE is excluded
 	if (IS_VALID_WEAPON(curWeap) && cg_weapons[curWeap].weaponIcon[0])     // do not try to draw nothing
 	{
-		CG_DrawPic(x + PLAYER_LIST_OVERLAY_BOX_WIDTH - weapScale - (weapScale / 2) - 38, y + (PLAYER_LIST_OVERLAY_BOX_HEIGHT * 0.75f) - 5, -weapScale, 10, cg_weapons[curWeap].weaponIcon[0]);
+		CG_DrawPic(bottomRowX, y + (PLAYER_LIST_OVERLAY_BOX_HEIGHT * 0.75f) - 5, -weapScale, 10, cg_weapons[curWeap].weaponIcon[0]);
 	}
 	else if (IS_VALID_WEAPON(curWeap) && cg_weapons[curWeap].weaponIcon[1])
 	{
-		CG_DrawPic(x + PLAYER_LIST_OVERLAY_BOX_WIDTH - weapScale - (weapScale / 2) - 38, y + (PLAYER_LIST_OVERLAY_BOX_HEIGHT * 0.75f) - 5, -weapScale, 10, cg_weapons[curWeap].weaponIcon[1]);
+		CG_DrawPic(bottomRowX, y + (PLAYER_LIST_OVERLAY_BOX_HEIGHT * 0.75f) - 5, -weapScale, 10, cg_weapons[curWeap].weaponIcon[1]);
 	}
 }
 
@@ -632,14 +641,23 @@ void CG_DrawShoutcastPlayerStatus(void)
 	curWeap   = CG_GetPlayerCurrentWeapon(player);
 	weapScale = cg_weapons[curWeap].weaponIconScale * 10;
 
+	if (IS_VALID_WEAPON(curWeap) && cg_weapons[curWeap].weaponIconScale == 1)
+	{
+		tmpX = statsBoxX + statsBoxWidth + weapScale - 50;
+	}
+	else
+	{
+		tmpX = statsBoxX + statsBoxWidth - 50;
+	}
+
 	// note: WP_NONE is excluded
 	if (IS_VALID_WEAPON(curWeap) && cg_weapons[curWeap].weaponIcon[0])     // do not try to draw nothing
 	{
-		CG_DrawPic(statsBoxX + statsBoxWidth - weapScale - (weapScale / 2) - 22, statsBoxY + (statsBoxHeight / 2) - 5, -weapScale, 10, cg_weapons[curWeap].weaponIcon[0]);
+		CG_DrawPic(tmpX, statsBoxY + (statsBoxHeight / 2) - 5, -weapScale, 10, cg_weapons[curWeap].weaponIcon[0]);
 	}
 	else if (IS_VALID_WEAPON(curWeap) && cg_weapons[curWeap].weaponIcon[1])
 	{
-		CG_DrawPic(statsBoxX + statsBoxWidth - weapScale - (weapScale / 2) - 22, statsBoxY + (statsBoxHeight / 2) - 5, -weapScale, 10, cg_weapons[curWeap].weaponIcon[1]);
+		CG_DrawPic(tmpX, statsBoxY + (statsBoxHeight / 2) - 5, -weapScale, 10, cg_weapons[curWeap].weaponIcon[1]);
 	}
 
 	//Draw hp

--- a/src/cgame/cg_shoutcastoverlay.c
+++ b/src/cgame/cg_shoutcastoverlay.c
@@ -366,12 +366,14 @@ void CG_DrawShoutcastPlayerList(void)
 			players[axis] = ci->clientNum;
 			axis++;
 		}
+
 		if (ci->team == TEAM_ALLIES && allies < MAX_ALLIES)
 		{
 			CG_DrawShoutcastPlayerOverlayAllies(ci, Ccg_WideX(SCREEN_WIDTH) - PLAYER_LIST_OVERLAY_BOX_WIDTH - PLAYER_LIST_OVERLAY_BORDER_DISTANCE_X, PLAYER_LIST_OVERLAY_BORDER_DISTANCE_Y + (PLAYER_LIST_OVERLAY_BOX_HEIGHT * allies) + (1 * allies), allies);
 			players[allies + 6] = ci->clientNum;
 			allies++;
 		}
+
 		if (axis > MAX_AXIS && allies > TEAM_ALLIES)
 		{
 			break;

--- a/src/cgame/cg_shoutcastoverlay.c
+++ b/src/cgame/cg_shoutcastoverlay.c
@@ -578,11 +578,11 @@ void CG_DrawShoutcastPlayerStatus(void)
 	//Draw team flag
 	if (player->team == TEAM_ALLIES)
 	{
-		CG_DrawPic(nameBoxX + 4, nameBoxY + (nameBoxHeight / 2) - 5, 14, 10, cgs.media.alliedFlag);
+		CG_DrawPic(nameBoxX + 4, nameBoxY + (nameBoxHeight / 2) - 4.5f, 14, 9, cgs.media.alliedFlag);
 	}
 	else
 	{
-		CG_DrawPic(nameBoxX + 4, nameBoxY + (nameBoxHeight / 2) - 5, 14, 10, cgs.media.axisFlag);
+		CG_DrawPic(nameBoxX + 4, nameBoxY + (nameBoxHeight / 2) - 4.5f, 14, 9, cgs.media.axisFlag);
 	}
 
 	//Draw name limit 20 chars, width 110

--- a/src/ui/ui_local.h
+++ b/src/ui/ui_local.h
@@ -106,6 +106,14 @@ extern vmCvar_t cl_bypassMouseInput;
 
 extern vmCvar_t ui_serverBrowserSettings;
 
+extern vmCvar_t ui_cg_shoutcastDrawPlayers;
+extern vmCvar_t ui_cg_shoutcastDrawTeamNames;
+extern vmCvar_t ui_cg_shoutcastTeamName1;
+extern vmCvar_t ui_cg_shoutcastTeamName2;
+extern vmCvar_t ui_cg_shoutcastDrawHealth;
+extern vmCvar_t ui_cg_shoutcastGrenadeTrail;
+extern vmCvar_t ui_cg_shoutcastDrawMinimap;
+
 // ui_serverBrowserSettings flags
 #define UI_BROWSER_ALLOW_REDIRECT     BIT(0)
 #define UI_BROWSER_ALLOW_HUMANS_COUNT BIT(1)

--- a/src/ui/ui_main.c
+++ b/src/ui/ui_main.c
@@ -8769,6 +8769,14 @@ vmCvar_t cl_bypassMouseInput;
 
 vmCvar_t ui_serverBrowserSettings;
 
+vmCvar_t ui_cg_shoutcastDrawPlayers;
+vmCvar_t ui_cg_shoutcastDrawTeamNames;
+vmCvar_t ui_cg_shoutcastTeamName1;
+vmCvar_t ui_cg_shoutcastTeamName2;
+vmCvar_t ui_cg_shoutcastDrawHealth;
+vmCvar_t ui_cg_shoutcastGrenadeTrail;
+vmCvar_t ui_cg_shoutcastDrawMinimap;
+
 static cvarTable_t cvarTable[] =
 {
 	{ NULL,                                "ui_textfield_temp",                   "",                           CVAR_TEMP,                      0 },
@@ -8866,6 +8874,14 @@ static cvarTable_t cvarTable[] =
 	{ &ui_cg_crosshairColor,               "cg_crosshairColor",                   "White",                      CVAR_ARCHIVE,                   0 },
 	{ &ui_cg_crosshairColorAlt,            "cg_crosshairColorAlt",                "White",                      CVAR_ARCHIVE,                   0 },
 	{ &ui_cg_crosshairSize,                "cg_crosshairSize",                    "48",                         CVAR_ARCHIVE,                   0 },
+
+	{ &ui_cg_shoutcastDrawPlayers,         "cg_shoutcastDrawPlayers",             "1",                          CVAR_ARCHIVE,                   0 },
+	{ &ui_cg_shoutcastDrawTeamNames,       "cg_shoutcastDrawTeamNames",           "1",                          CVAR_ARCHIVE,                   0 },
+	{ &ui_cg_shoutcastTeamName1,           "cg_shoutcastTeamName1",               "",                           CVAR_ARCHIVE,                   0 },
+	{ &ui_cg_shoutcastTeamName2,           "cg_shoutcastTeamName2",               "",                           CVAR_ARCHIVE,                   0 },
+	{ &ui_cg_shoutcastDrawHealth,          "cg_shoutcastDrawHealth",              "0",                          CVAR_ARCHIVE,                   0 },
+	{ &ui_cg_shoutcastGrenadeTrail,        "cg_shoutcastGrenadeTrail",            "0",                          CVAR_ARCHIVE,                   0 },
+	{ &ui_cg_shoutcastDrawMinimap,         "cg_shoutcastDrawMinimap",             "1",                          CVAR_ARCHIVE,                   0 },
 
 	// game mappings (for create server option)
 	{ NULL,                                "g_altStopwatchMode",                  "0",                          CVAR_ARCHIVE,                   0 },


### PR DESCRIPTION
Changed followed player name to clean name (dark colors are harder to see on some settings).
Changed popups to be a bit higher.
Changed followed player team flag size.

Fixed missing weapon hints, missing defusing and changing clothes bar.
Fixed missing stabilization bar when following covert ops with sniper zoomed in.
Fixed disappearing player list when following covert ops with sniper zoomed in.
Fixed minimap disappearing when followed player died and the follow changed automatically or when followed player died and all players were dead.
Fixed allies spawn time position being incorrect sometimes.
Fixed weapon icon alignment for axis player list and followed player.

Added cvar cg_shoutcastDrawMinimap.
Added new section SHOUTCAST in options->controls->advanced and added cvars related to shoutcasting there.

refs #1433