### PR TITLE
cgame: fix spawn timer disappearing on pause

### DIFF
--- a/src/cgame/cg_servercmds.c
+++ b/src/cgame/cg_servercmds.c
@@ -961,7 +961,6 @@ static void CG_ConfigStringModified(void)
 		break;
 	case CS_LEVEL_START_TIME:
 		cgs.levelStartTime = atoi(CG_ConfigString(num));
-		trap_Cvar_Set("cg_spawnTimer_set", "-1");
 		break;
 	case CS_INTERMISSION_START_TIME:
 		cgs.intermissionStartTime = atoi(CG_ConfigString(num));


### PR DESCRIPTION
This is reverting invalidation of spawn timer stamp when cgs.levelStartTime is changed.
I thought levelStartTime changes only on map restart or map change, but it changes every 500 ms when match is paused too. This is vanilla behavior which was marked as FIXME in G_RunFrame.
So now timer is enabled once its been set, even after map change, which is not a big deal.
I don't have any idea how to detect map restart or change, but one ugly way around this could be to check whether the levelStartTime change is exactly 500.