### PR TITLE
cgame: Shoutcast overlay changes. refs #1433

### DIFF
--- a/src/cgame/cg_commandmap.c
+++ b/src/cgame/cg_commandmap.c
@@ -2302,7 +2302,7 @@ void CG_DrawMapEntityNew(mapEntityData_t *mEnt, float x, float y, float w, float
 
 			mEnt->yaw = (int)snap->ps.viewangles[YAW];
 		}
-		else if (cent->currentValid || cgs.clientinfo[cg.clientNum].shoutcaster)
+		else if (cent->currentValid)
 		{
 			// use more up-to-date info from pvs
 			if (!scissor)
@@ -2320,8 +2320,8 @@ void CG_DrawMapEntityNew(mapEntityData_t *mEnt, float x, float y, float w, float
 		}
 		else
 		{
-			// only see revivables for own team
-			if (mEnt->type == ME_PLAYER_REVIVE)
+			// only see revivables for own team, unless shoutcaster
+			if (mEnt->type == ME_PLAYER_REVIVE && !cgs.clientinfo[cg.clientNum].shoutcaster)
 			{
 				return;
 			}

--- a/src/cgame/cg_commandmap.c
+++ b/src/cgame/cg_commandmap.c
@@ -2288,6 +2288,7 @@ void CG_DrawMapEntityNew(mapEntityData_t *mEnt, float x, float y, float w, float
 		}
 		else if ((cgs.clientinfo[cg.clientNum].team == TEAM_SPECTATOR && snap->ps.clientNum != cg.clientNum && cent - cg_entities == snap->ps.clientNum))
 		{
+
 			// we are following someone, so use their info
 			if (!scissor)
 			{
@@ -2459,9 +2460,16 @@ void CG_DrawMapEntityNew(mapEntityData_t *mEnt, float x, float y, float w, float
 				}
 			}
 
-			// hide ghost icon for following shoutcaster
+			// hide ghost icon for following shoutcaster, highlight followed player.
 			if (cgs.clientinfo[cg.clientNum].shoutcaster && (cg.snap->ps.pm_flags & PMF_FOLLOW) && cg.snap->ps.clientNum == mEnt->data)
 			{
+				//Otherwise highlighting takes some time to disappear
+				if (cg.snap->ps.stats[STAT_HEALTH] > 0)
+				{
+					trap_R_SetColor(colorYellow);
+					CG_DrawPic(icon_pos[0], icon_pos[1], icon_extends[0], icon_extends[1], cgs.media.ccPlayerHighlight);
+					trap_R_SetColor(NULL);
+				}
 				return;
 			}
 

--- a/src/cgame/cg_commandmap.c
+++ b/src/cgame/cg_commandmap.c
@@ -3275,7 +3275,12 @@ int CG_DrawSpawnPointInfoNew(float px, float py, float pw, float ph, qboolean dr
 
 				CG_DrawPic(point[0] - FLAG_LEFTFRAC_NEW * size, point[1] - FLAG_TOPFRAC_NEW * size, size, size, cgs.media.commandCentreSpawnShader[cg.spawnTeams[i] == TEAM_AXIS ? 0 : 1]);
 
-				if (!scissor)
+				if (scissor)
+				{
+					Com_sprintf(buffer, sizeof(buffer), "(%i)", cg.spawnPlayerCounts[i]);
+					CG_Text_Paint_Ext(point[0] + 2.5f + scissor->zoomFactor, point[1], 0.15f, 0.15f, colorWhite, buffer, 0, 0, ITEM_TEXTSTYLE_SHADOWED, &cgs.media.limboFont2);
+				}
+				else
 				{
 					Com_sprintf(buffer, sizeof(buffer), "(%i)", cg.spawnPlayerCounts[i]);
 					CG_Text_Paint_Ext(point[0] + FLAGSIZE_NORMAL_NEW * 0.25f, point[1], 0.2f, 0.2f, colorWhite, buffer, 0, 0, ITEM_TEXTSTYLE_SHADOWED, &cgs.media.limboFont2);

--- a/src/cgame/cg_shoutcastoverlay.c
+++ b/src/cgame/cg_shoutcastoverlay.c
@@ -721,12 +721,12 @@ void CG_DrawShoutcastPlayerStatus(void)
 		//Deaths
 		textWidth  = CG_Text_Width_Ext("D", 0.16f, 0, FONT_TEXT);
 		textHeight = CG_Text_Height_Ext("D", 0.16f, 0, FONT_TEXT);
-		CG_Text_Paint_Ext(statsBoxX + 4, statsBoxY + (statsBoxHeight / 2) - (textHeight / 2), 0.16f, 0.16f, colorMdGrey, "D", 0, 0, ITEM_TEXTSTYLE_NORMAL, FONT_TEXT);
+		CG_Text_Paint_Ext(statsBoxX + 6, statsBoxY + (statsBoxHeight / 2) - (textHeight / 2), 0.16f, 0.16f, colorMdGrey, "D", 0, 0, ITEM_TEXTSTYLE_NORMAL, FONT_TEXT);
 
 		textHeight = CG_Text_Height_Ext(deaths, 0.19f, 0, FONT_TEXT);
 		textWidth2 = CG_Text_Width_Ext(deaths, 0.19f, 0, FONT_TEXT);
-		CG_Text_Paint_Ext(statsBoxX + 4 + (textWidth / 2) - (textWidth2 / 2), statsBoxY + (statsBoxHeight / 2) + (textHeight / 2) + 4, 0.19f, 0.19f, colorWhite, deaths, 0, 0, ITEM_TEXTSTYLE_NORMAL, FONT_TEXT);
-		statsBoxX += 4 + textWidth2;
+		CG_Text_Paint_Ext(statsBoxX + 6 + (textWidth / 2) - (textWidth2 / 2), statsBoxY + (statsBoxHeight / 2) + (textHeight / 2) + 4, 0.19f, 0.19f, colorWhite, deaths, 0, 0, ITEM_TEXTSTYLE_NORMAL, FONT_TEXT);
+		statsBoxX += 6 + textWidth2;
 
 		//Selfkills
 		textWidth  = CG_Text_Width_Ext("SK", 0.16f, 0, FONT_TEXT);


### PR DESCRIPTION
Changes:

- Minimap - Since shoutcaster now receives clientInfo updates about Axis and Allies players we can allow that info to be used when drawing player icons on minimap when players are not in shoutcaster's PVS.
- Minimap - show number of players spawning next to flag
- Minimap - highlight followed player
- Followed player overlay - fix lack of space between kills and deaths stats in some cases

refs #1433