### PR TITLE
game: fix mover health bar not returning after invulnerability toggle

### DIFF
--- a/src/game/g_script_actions.c
+++ b/src/game/g_script_actions.c
@@ -3975,6 +3975,10 @@ qboolean G_ScriptAction_SetDamagable(gentity_t *ent, char *params)
 		{
 			target->s.effect1Time = 0;
 		}
+		else
+		{
+			target->s.effect1Time = 1;
+		}
 	}
 
 	return qtrue;


### PR DESCRIPTION
Fix for mover healthbar not reappearing after it was made non-damageable once and then damageable again.

refs #1563 