### PR TITLE
mod: Allow shoutcasters to follow other shoutcasters, refs #1575

### DIFF
--- a/src/cgame/cg_players.c
+++ b/src/cgame/cg_players.c
@@ -2079,7 +2079,7 @@ static void CG_PlayerSprites(centity_t *cent)
 		height = 8;
 	}
 
-	if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_SPECTATOR || (cg.snap->ps.pm_flags & PMF_FOLLOW && cgs.clientinfo[cg.clientNum].shoutcaster))
+	if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_SPECTATOR || ((cg.snap->ps.pm_flags & PMF_FOLLOW) && cgs.clientinfo[cg.clientNum].shoutcaster))
 	{
 		if (cg_shoutcastDrawHealth.integer > 0 && cgs.clientinfo[cg.clientNum].shoutcaster)
 		{
@@ -2124,7 +2124,8 @@ static void CG_PlayerSprites(centity_t *cent)
 		}
 		if (cent->currentState.eFlags & EF_DEAD &&
 		    ((cg.snap->ps.stats[STAT_PLAYER_CLASS] == PC_MEDIC && cg.snap->ps.stats[STAT_HEALTH] > 0 && sameTeam) ||
-		     (!(cg.snap->ps.pm_flags & PMF_FOLLOW) && cgs.clientinfo[cg.clientNum].shoutcaster)))
+		     (!(cg.snap->ps.pm_flags & PMF_FOLLOW) && cgs.clientinfo[cg.clientNum].shoutcaster) ||
+		     ((cg.snap->ps.pm_flags & PMF_FOLLOW) && cgs.clientinfo[cg.snap->ps.clientNum].shoutcaster)))
 		{
 			CG_PlayerFloatSprite(cent, cgs.media.medicReviveShader, height, numIcons++, NULL);
 			return;

--- a/src/game/g_active.c
+++ b/src/game/g_active.c
@@ -1828,7 +1828,8 @@ void SpectatorClientEndFrame(gentity_t *ent)
 		if (ent->client->sess.spectatorClient >= 0)
 		{
 			cl = &level.clients[ent->client->sess.spectatorClient];
-			if (cl->pers.connected == CON_CONNECTED && cl->sess.sessionTeam != TEAM_SPECTATOR)
+			if ((cl->pers.connected == CON_CONNECTED && cl->sess.sessionTeam != TEAM_SPECTATOR) ||
+			    (cl->pers.connected == CON_CONNECTED && cl->sess.shoutcaster && ent->client->sess.shoutcaster))
 			{
 				int flags = (cl->ps.eFlags & ~(EF_VOTED)) | (ent->client->ps.eFlags & (EF_VOTED));
 				int ping  = ent->client->ps.ping;

--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -2387,8 +2387,8 @@ void Cmd_Follow_f(gentity_t *ent, unsigned int dwCommand, qboolean fValue)
 		return;
 	}
 
-	// can't follow another spectator
-	if (level.clients[i].sess.sessionTeam == TEAM_SPECTATOR)
+	// can't follow another spectator, but shoutcasters can follow other shoutcasters
+	if (level.clients[i].sess.sessionTeam == TEAM_SPECTATOR && (!level.clients[i].sess.shoutcaster || !ent->client->sess.shoutcaster))
 	{
 		return;
 	}


### PR DESCRIPTION
Allow shoutcaster to follow another shoutcaster by using `/follow PLAYER_ID` command, for example: `/follow 1`

refs #1575