### PR TITLE
Add PowerPC64 Little Endian ARCH_STRING

### DIFF
--- a/src/qcommon/q_platform.h
+++ b/src/qcommon/q_platform.h
@@ -203,7 +203,11 @@
 #define idx64 1
 #define ARCH_STRING "x86_64"
 #elif defined __powerpc64__
+#if BYTE_ORDER == BIG_ENDIAN
 #define ARCH_STRING "ppc64"
+#else
+#define ARCH_STRING "ppc64le"
+#endif
 #elif defined __powerpc__
 #define ARCH_STRING "ppc"
 #elif defined __s390__


### PR DESCRIPTION
When I run my game on Linux PPC64LE, the game refuses to start with a warning that failing to find libs with suffix `.ppc64.so`.

The ARCH_STRING of PowerPC64 LE should be `ppc64le` instead of `ppc64`

Good to see that the game now run ok on Linux ppc64le :)

![Screenshot from 2021-03-01 21-36-30](https://user-images.githubusercontent.com/135605/109499017-6fb3fc80-7ae8-11eb-94a3-225a99e300a9.png)
![Screenshot from 2021-03-01 23-44-30](https://user-images.githubusercontent.com/135605/109499021-717dc000-7ae8-11eb-99f3-635bf1d0a2dc.png)
