### PR TITLE
Remove icon referernce from metainfo.xml

### DIFF
--- a/misc/com.etlegacy.ETLegacy.metainfo.xml
+++ b/misc/com.etlegacy.ETLegacy.metainfo.xml
@@ -27,8 +27,6 @@
 
     <launchable type="desktop-id">com.etlegacy.ETLegacy.desktop</launchable>
 
-    <icon type="local">/usr/share/icons/hicolor/scalable/apps/etl.svg</icon>
-
     <categories>
         <category>Game</category>
         <category>ActionGame</category>

--- a/misc/com.etlegacy.ETLegacy.metainfo.xml
+++ b/misc/com.etlegacy.ETLegacy.metainfo.xml
@@ -80,4 +80,8 @@
 
     <update_contact>mail@etlegacy.com</update_contact>
 
+    <releases>
+        <release version="2.77" date="2021-03-01" />
+    </releases>
+
 </component>


### PR DESCRIPTION
The Icon-tag is not part of the metainfo spec, and a strict parser will fail on it.