### PR TITLE
client: fix compatibility with ETJump shared cvar

### DIFF
--- a/src/client/cl_parse.c
+++ b/src/client/cl_parse.c
@@ -283,7 +283,7 @@ void CL_ParsePacketEntities(msg_t *msg, clSnapshot_t *oldframe, clSnapshot_t *ne
 		else
 		{
 			oldstate = &cl.parseEntities[
-			    (oldframe->parseEntitiesNum + oldindex) & (MAX_PARSE_ENTITIES - 1)];
+				(oldframe->parseEntitiesNum + oldindex) & (MAX_PARSE_ENTITIES - 1)];
 			oldnum = oldstate->number;
 		}
 	}
@@ -321,7 +321,7 @@ void CL_ParsePacketEntities(msg_t *msg, clSnapshot_t *oldframe, clSnapshot_t *ne
 			else
 			{
 				oldstate = &cl.parseEntities[
-				    (oldframe->parseEntitiesNum + oldindex) & (MAX_PARSE_ENTITIES - 1)];
+					(oldframe->parseEntitiesNum + oldindex) & (MAX_PARSE_ENTITIES - 1)];
 				oldnum = oldstate->number;
 			}
 		}
@@ -344,7 +344,7 @@ void CL_ParsePacketEntities(msg_t *msg, clSnapshot_t *oldframe, clSnapshot_t *ne
 			else
 			{
 				oldstate = &cl.parseEntities[
-				    (oldframe->parseEntitiesNum + oldindex) & (MAX_PARSE_ENTITIES - 1)];
+					(oldframe->parseEntitiesNum + oldindex) & (MAX_PARSE_ENTITIES - 1)];
 				oldnum = oldstate->number;
 			}
 		}
@@ -593,7 +593,7 @@ void CL_PurgeCache(void);
 static void CL_SetPurePaks(void)
 {
 	const char *s, *t;
-	char *systemInfo = cl.gameState.stringData + cl.gameState.stringOffsets[CS_SYSTEMINFO];
+	char       *systemInfo = cl.gameState.stringData + cl.gameState.stringOffsets[CS_SYSTEMINFO];
 	// check pure server string
 	s = Info_ValueForKey(systemInfo, "sv_paks");
 	t = Info_ValueForKey(systemInfo, "sv_pakNames");
@@ -674,10 +674,12 @@ void CL_SystemInfoChanged(void)
 		else
 		{
 			// If this cvar may not be modified by a server discard the value.
+			// "shared" is for ETJump compatibility, information shared between server & client
+			// TODO: see why CVAR_SERVER_CREATED flag gets dropped here
 			if (!(cvar_flags & (CVAR_SYSTEMINFO | CVAR_SERVER_CREATED | CVAR_USER_CREATED)))
 			{
 				if (Q_stricmp(key, "g_synchronousClients") && Q_stricmp(key, "pmove_fixed") &&
-				    Q_stricmp(key, "pmove_msec"))
+				    Q_stricmp(key, "pmove_msec") && Q_stricmp(key, "shared"))
 				{
 					Com_DPrintf(S_COLOR_YELLOW "WARNING: server is not allowed to set %s=%s\n", key, value);
 					continue;


### PR DESCRIPTION
Temporary fix to allow ETJump `shared` cvar to be modifed on client side by server. `shared` contains information about various settings set on a map level via worldspawn keys, and is sent from server to client upon loading a map to allow client to predict these settings. This can probably be reverted at some point, if adding `CVAR_SYSTEMINFO` to cgame side of this cvar in ETJump is okay and doesn't cause any issues.

Appearently there's also an issue here where `CVAR_SERVER_CREATED` gets dropped along the way, hence the TODO comment.