### PR TITLE
game: Fixed ready status disappearing, refs #1416

### DIFF
--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -2799,6 +2799,11 @@ void ClientSpawn(gentity_t *ent, qboolean revived, qboolean teamChange, qboolean
 	// unlagged
 
 	flags |= (client->ps.eFlags & EF_VOTED);
+
+	if (!teamChange)
+	{
+		flags |= (client->ps.eFlags & EF_READY);
+	}
 	// clear everything but the persistant data
 
 	ent->s.eFlags &= ~EF_MOUNTEDTANK;


### PR DESCRIPTION
`playerState` is cleared on each `ClientSpawn`, changed so `EF_READY` flag is saved(it is still cleared on match start, team change, map change).

refs #1416