### PR TITLE
client: Fixed console scrolling to bottom on map load working only on localhost, refs #437

### DIFF
--- a/src/client/cl_cgame.c
+++ b/src/client/cl_cgame.c
@@ -577,6 +577,8 @@ void CL_CM_LoadMap(const char *mapname)
 		Cvar_Set("com_errorDiagnoseIP", "");
 	}
 
+	Con_ScrollBottom();
+
 	CM_LoadMap(mapname, qtrue, &checksum);
 }
 

--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -481,7 +481,6 @@ void CL_MapLoading(void)
 		return;
 	}
 
-	Con_ScrollBottom();
 	Con_Close();
 	cls.keyCatchers = 0;
 


### PR DESCRIPTION
Previous solution worked only on localhost server, it should work everywhere with this change.

refs #437