### PR TITLE
mod: Shoutcast overlay fixes, refs #1433

### DIFF
--- a/src/cgame/cg_commandmap.c
+++ b/src/cgame/cg_commandmap.c
@@ -3134,7 +3134,7 @@ int CG_DrawSpawnPointInfoNew(float px, float py, float pw, float ph, qboolean dr
 	vec2_t icon_extends;
 	vec2_t point;
 	float  changetime;
-	int    i, e = -1;
+	int    i, width, e = -1;
 
 	if (cgs.ccFilter & CC_FILTER_SPAWNS)
 	{
@@ -3283,14 +3283,31 @@ int CG_DrawSpawnPointInfoNew(float px, float py, float pw, float ph, qboolean dr
 
 				CG_DrawPic(point[0] - FLAG_LEFTFRAC_NEW * size, point[1] - FLAG_TOPFRAC_NEW * size, size, size, cgs.media.commandCentreSpawnShader[cg.spawnTeams[i] == TEAM_AXIS ? 0 : 1]);
 
+				Com_sprintf(buffer, sizeof(buffer), "(%i)", cg.spawnPlayerCounts[i]);
+
 				if (scissor)
 				{
-					Com_sprintf(buffer, sizeof(buffer), "(%i)", cg.spawnPlayerCounts[i]);
-					CG_Text_Paint_Ext(point[0] + 2.5f + scissor->zoomFactor, point[1], 0.15f, 0.15f, colorWhite, buffer, 0, 0, ITEM_TEXTSTYLE_SHADOWED, &cgs.media.limboFont2);
+					// Recalculate for player spawn count clipping
+					point[0] = ((cg.spawnCoordsUntransformed[i][0] - cg.mapcoordsMins[0]) * cg.mapcoordsScale[0]) * pw * scissor->zoomFactor;
+					point[1] = ((cg.spawnCoordsUntransformed[i][1] - cg.mapcoordsMins[1]) * cg.mapcoordsScale[1]) * ph * scissor->zoomFactor;
+
+					width = CG_Text_Width_Ext(buffer, 0.15f, 0, &cgs.media.limboFont2);
+
+					point[0] += 1.5f + scissor->zoomFactor + width;
+					point[1] -= 5;
+
+					if (CG_ScissorPointIsCulled(point, scissor, icon_extends))
+					{
+						continue;
+					}
+
+					point[0] += px - scissor->tl[0] - width;
+					point[1] += py - scissor->tl[1] + 4;
+
+					CG_Text_Paint_Ext(point[0], point[1], 0.15f, 0.15f, colorWhite, buffer, 0, 0, ITEM_TEXTSTYLE_SHADOWED, &cgs.media.limboFont2);
 				}
 				else
 				{
-					Com_sprintf(buffer, sizeof(buffer), "(%i)", cg.spawnPlayerCounts[i]);
 					CG_Text_Paint_Ext(point[0] + FLAGSIZE_NORMAL_NEW * 0.25f, point[1], 0.2f, 0.2f, colorWhite, buffer, 0, 0, ITEM_TEXTSTYLE_SHADOWED, &cgs.media.limboFont2);
 				}
 			}

--- a/src/cgame/cg_commandmap.c
+++ b/src/cgame/cg_commandmap.c
@@ -2942,7 +2942,7 @@ void CG_DrawMapNew(float x, float y, float w, float h, int mEntFilter, mapScisso
 
 			trap_R_SetColor(NULL);
 
-			CG_DrawRect_FixedBorder(x, y, w, h, 1, colorWhite);
+			CG_DrawRect_FixedBorder(x - 0.5f, y - 0.5f, w + 1.0f, h + 1.0f, 1, colorWhite);
 		}
 	}
 	else
@@ -2965,7 +2965,7 @@ void CG_DrawMapNew(float x, float y, float w, float h, int mEntFilter, mapScisso
 		}
 		trap_R_SetColor(NULL);
 
-		CG_DrawRect_FixedBorder(x, y, w, h, 1, colorWhite);
+		CG_DrawRect_FixedBorder(x - 0.5f, y - 0.5f, w + 1.0f, h + 1.0f, 1, colorWhite);
 	}
 
 	exspawn = CG_DrawSpawnPointInfoNew(x, y, w, h, qfalse, scissor, -1);

--- a/src/cgame/cg_shoutcastoverlay.c
+++ b/src/cgame/cg_shoutcastoverlay.c
@@ -568,6 +568,11 @@ void CG_DrawShoutcastPlayerStatus(void)
 	char          *kills, *deaths, *selfkills, *dmgGiven, *dmgRcvd, *text;
 	int           ammo, clip, akimbo, curWeap, weapScale, tmpX;
 
+	if (cgs.topshots.show == SHOW_ON)
+	{
+		return;
+	}
+
 	//Draw name box
 	CG_FillRect(nameBoxX, nameBoxY, nameBoxWidth, nameBoxHeight, bg);
 	CG_DrawRect_FixedBorder(nameBoxX, nameBoxY, nameBoxWidth, nameBoxHeight, 1, colorWhite);

--- a/src/cgame/cg_shoutcastoverlay.c
+++ b/src/cgame/cg_shoutcastoverlay.c
@@ -206,16 +206,13 @@ static void CG_DrawShoutcastPlayerOverlayAxis(clientInfo_t *player, float x, flo
 	}
 
 	//Draw weapon icon
-	curWeap   = CG_GetPlayerCurrentWeapon(player);
-	weapScale = cg_weapons[curWeap].weaponIconScale * 10;
+	curWeap    = CG_GetPlayerCurrentWeapon(player);
+	weapScale  = cg_weapons[curWeap].weaponIconScale * 10;
+	bottomRowX = x + PLAYER_LIST_OVERLAY_BOX_WIDTH - 63;
 
 	if (IS_VALID_WEAPON(curWeap) && cg_weapons[curWeap].weaponIconScale == 1)
 	{
-		bottomRowX = x + PLAYER_LIST_OVERLAY_BOX_WIDTH + weapScale - 63;
-	}
-	else
-	{
-		bottomRowX = x + PLAYER_LIST_OVERLAY_BOX_WIDTH - 63;
+		bottomRowX += weapScale;
 	}
 
 	// note: WP_NONE is excluded
@@ -642,14 +639,11 @@ void CG_DrawShoutcastPlayerStatus(void)
 	//Draw weapon icon
 	curWeap   = CG_GetPlayerCurrentWeapon(player);
 	weapScale = cg_weapons[curWeap].weaponIconScale * 10;
+	tmpX      = statsBoxX + statsBoxWidth - 50;
 
 	if (IS_VALID_WEAPON(curWeap) && cg_weapons[curWeap].weaponIconScale == 1)
 	{
-		tmpX = statsBoxX + statsBoxWidth + weapScale - 50;
-	}
-	else
-	{
-		tmpX = statsBoxX + statsBoxWidth - 50;
+		tmpX += weapScale;
 	}
 
 	// note: WP_NONE is excluded


### PR DESCRIPTION
Shoutcast minimap - additional culling for player spawn counts. (When zoomed the text was sometimes drawn outside of minimap)
Shoutcast minimap - fixing icons being drawn over minimap border.
Shoutcast overlay - Don't draw followed player overlay when topshots window is on.
Shoutcast overlay - refactoring weapon icon drawing.

refs #1433