### PR TITLE
game: Fixing pmove_fixed integration with antiwarp

### DIFF
--- a/src/game/et-antiwarp.c
+++ b/src/game/et-antiwarp.c
@@ -187,9 +187,10 @@ void DoClientThinks(gentity_t *ent)
 		serverTime = cmd->serverTime;
 		totalDelta = latestTime - cmd->serverTime;
 
-		if (ent->client->pers.pmoveFixed)
+		if (ent->client->pers.pmoveFixed || pmove_fixed.integer)
 		{
 			serverTime = ((serverTime + pmove_msec.integer - 1) / pmove_msec.integer) * pmove_msec.integer;
+			deltahax   = qtrue;
 		}
 
 		timeDelta = serverTime - lastTime;


### PR DESCRIPTION
In the current master a game with `g_antiwarp` and `pmove_fixed` enabled means that `pmove_fixed` doesn't work at all, this is an attempt to fix it. From my tests the fix works and I haven't encountered any problems with physics.

@isRyven Maybe you can take a look?