### PR TITLE
game: Changing fixed physics added velocity to emulate framerate-dependent behavior

### DIFF
--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -5169,10 +5169,6 @@ void PmoveSingle(pmove_t *pmove)
 
 	if (PM_FIXEDPHYSICS)
 	{
-		// Pmove accurate code
-		// the new way: don't care so much about 6 bytes/frame
-		// or so of network bandwidth, and add some mostly framerate-
-		// independent error to make up for the lack of rounding error
 		// halt if not going fast enough (0.5 units/sec)
 		if (VectorLengthSquared(pm->ps->velocity) < 0.25f)
 		{
@@ -5180,43 +5176,31 @@ void PmoveSingle(pmove_t *pmove)
 		}
 		else
 		{
-			int   i;
-			float fac;
-			float fps = PM_FIXEDPHYSICSFPS;
+			float fixedFrameTime, scale, decimalTest;
+			float result = 0;
+			int fps = PM_FIXEDPHYSICSFPS;
 
 			if (fps > 333)
 			{
 				fps = 333;
 			}
-			else if (fps < 60)
+			else if (fps < 30)
 			{
-				fps = 60;
+				fps = 30;
 			}
 
-			fac = pml.msec / (1000.0f / fps);
+			fixedFrameTime = (int)(1000.0f / fps) * 0.001f;
 
-			// add some error...
-			for (i = 0; i < 3; ++i)
+			scale = fixedFrameTime / pml.frametime;
+			decimalTest = pm->ps->gravity * fixedFrameTime;
+
+			if (rint(decimalTest) - decimalTest < 0)
 			{
-				// ...if the velocity in this direction changed enough
-				if (Q_fabs(pm->ps->velocity[i] - pml.previous_velocity[i]) > 0.5f / fac)
-				{
-					if (pm->ps->velocity[i] < 0)
-					{
-						pm->ps->velocity[i] -= 0.5f * fac;
-					}
-					else
-					{
-						pm->ps->velocity[i] += 0.5f * fac;
-					}
-				}
+				result = (rint(decimalTest) - decimalTest) * -1;
+				result = result / scale;
 			}
-			// we can stand a little bit of rounding error for the sake
-			// of lower bandwidth
-			VectorScale(pm->ps->velocity, 64.0f, pm->ps->velocity);
-			// snap some parts of playerstate to save network bandwidth
-			trap_SnapVector(pm->ps->velocity);
-			VectorScale(pm->ps->velocity, 1.0f / 64.0f, pm->ps->velocity);
+
+			pm->ps->velocity[2] += result;
 		}
 	}
 	else

--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -5178,7 +5178,7 @@ void PmoveSingle(pmove_t *pmove)
 		{
 			float fixedFrameTime, scale, decimalTest;
 			float result = 0;
-			int fps = PM_FIXEDPHYSICSFPS;
+			int   fps    = PM_FIXEDPHYSICSFPS;
 
 			if (fps > 333)
 			{
@@ -5190,12 +5190,11 @@ void PmoveSingle(pmove_t *pmove)
 			}
 
 			fixedFrameTime = (int)(1000.0f / fps) * 0.001f;
-
-			scale = fixedFrameTime / pml.frametime;
-			decimalTest = pm->ps->gravity * fixedFrameTime;
+			decimalTest    = pm->ps->gravity * fixedFrameTime;
 
 			if (rint(decimalTest) - decimalTest < 0)
 			{
+				scale  = fixedFrameTime / pml.frametime;
 				result = (rint(decimalTest) - decimalTest) * -1;
 				result = result / scale;
 			}


### PR DESCRIPTION
The idea behind it:

Framerate-dependent physics come from rounding velocity because of `pm->ps->gravity * pml.frametime`. 
Gravity is 800 so at certain frametimes if the decimal places will be less than 0.5 the rounding will always be up. 

For example at 125fps frametime = 0.008, 0.008 * 800 = 6.4
1st frame: 270 - 6.4 = 263.6 = 264 (rounding)
2nd frame: 264 - 6.4 = 257,6 = 258 (rounding)
3rd frame: 258 - 6.4 = 251,6 = 252 (rounding)
...

Some explanations of physics here too: https://www.youtube.com/watch?v=P13KmJBNn1c

The solution:

Check when the rounding up would happen and add the rounded up value, but scaled so clients various FPS is taken into account since it will be done on every frame.

I tested it against ETPro `b_fixedPhysics`, `pmove_fixed` and Legacy `pmove_fixed` and everything behaves the same as here(jump height, min height of box is 64u):

```
ETPRO and Legacy com_maxfps 125

fixedfps 30 - 64u
fixedfps 33 - none
fixedfps 40 - none
fixedfps 60 - none
fixedfps 71 - 64u
fixedfps 100 - none
fixedfps 120 - 66u
fixedfps 125 - 66u
fixedfps 200 - none
fixedfps 250 - 66u
fixedfps 333 - 72u

ETPRO and Legacy com_maxfps 200

fixedfps 30 - 64u
fixedfps 33 - none
fixedfps 40 - none
fixedfps 60 - none
fixedfps 71 - 64u
fixedfps 100 - none
fixedfps 120 - 66u
fixedfps 125 - 66u
fixedfps 200 - none
fixedfps 250 - 66u
fixedfps 333 - 72u
```

Map used for testing, big thanks to Aciz for making it! 
[pmove_debug.zip](https://github.com/etlegacy/etlegacy/files/6280955/pmove_debug.zip)

refs #1379