### PR TITLE
game: fix target_remove_powerups not updating flag counters

### DIFF
--- a/src/game/g_target.c
+++ b/src/game/g_target.c
@@ -99,8 +99,16 @@ void Use_target_remove_powerups(gentity_t *ent, gentity_t *other, gentity_t *act
 		return;
 	}
 
-	if (activator->client->ps.powerups[PW_REDFLAG] || activator->client->ps.powerups[PW_BLUEFLAG])
+	if (activator->client->ps.powerups[PW_REDFLAG])
 	{
+		// update objective indicator
+		level.redFlagCounter -= 1;
+		Team_ReturnFlag(&g_entities[activator->client->flagParent]);
+	}
+	if (activator->client->ps.powerups[PW_BLUEFLAG])
+	{
+		// update objective indicator
+		level.blueFlagCounter -= 1;
 		Team_ReturnFlag(&g_entities[activator->client->flagParent]);
 	}
 


### PR DESCRIPTION
`target_remove_powerups` was not updating `level.red/blueFlagCounter`, causing objective indicator to get desynced when objective is returned via this entity.