### PR TITLE
game: Ready state flag fixes

### DIFF
--- a/src/game/g_active.c
+++ b/src/game/g_active.c
@@ -1831,7 +1831,7 @@ void SpectatorClientEndFrame(gentity_t *ent)
 			if ((cl->pers.connected == CON_CONNECTED && cl->sess.sessionTeam != TEAM_SPECTATOR) ||
 			    (cl->pers.connected == CON_CONNECTED && cl->sess.shoutcaster && ent->client->sess.shoutcaster))
 			{
-				int flags = (cl->ps.eFlags & ~(EF_VOTED)) | (ent->client->ps.eFlags & (EF_VOTED));
+				int flags = (cl->ps.eFlags & ~(EF_VOTED | EF_READY)) | (ent->client->ps.eFlags & (EF_VOTED | EF_READY));
 				int ping  = ent->client->ps.ping;
 
 				if (ent->client->sess.sessionTeam != TEAM_SPECTATOR && (ent->client->ps.pm_flags & PMF_LIMBO))

--- a/src/game/g_cmds_ext.c
+++ b/src/game/g_cmds_ext.c
@@ -1182,7 +1182,7 @@ void G_teamready_cmd(gentity_t *ent, unsigned int dwCommand, qboolean fDump)
 		{
 			cl->pers.ready = qtrue;
 
-			G_MakeReady(ent);
+			G_MakeReady(&g_entities[level.sortedClients[i]]);
 		}
 	}
 


### PR DESCRIPTION
1. When spectating a player (while in limbo on warmup) the ready state flag would carry over causing visual bugs.
2. `readyteam` command would update additional flag fields with ready state only for the player that issued the command.