### PR TITLE
game: Fixing a rare case where headshot would register as bodyshot, refs #1408

### DIFF
--- a/src/game/g_combat.c
+++ b/src/game/g_combat.c
@@ -1349,75 +1349,6 @@ void G_Damage(gentity_t *targ, gentity_t *inflictor, gentity_t *attacker, vec3_t
 		VectorNormalize(dir);
 	}
 
-	if ((targ->flags & FL_NO_KNOCKBACK) || (dflags & DAMAGE_NO_KNOCKBACK) ||
-	    (targ->client && g_friendlyFire.integer && (onSameTeam || (attacker->client && targ->client->sess.sessionTeam == G_GetTeamFromEntity(inflictor)))))
-	{
-		knockback = 0;
-	}
-	else
-	{
-		knockback = (damage > 200) ? 200 : damage;
-
-		if (dflags & DAMAGE_HALF_KNOCKBACK)
-		{
-			knockback *= 0.5;
-		}
-
-		// set weapons means less knockback
-		if (targ->client && (GetWeaponTableData(targ->client->ps.weapon)->type & WEAPON_TYPE_SET))
-		{
-			knockback *= 0.5;
-		}
-	}
-
-	// figure momentum add, even if the damage won't be taken
-	if (knockback && targ->client)
-	{
-		vec3_t kvel;
-		float  mass = 200;
-
-		VectorScale(dir, g_knockback.value * (float)knockback / mass, kvel);
-		VectorAdd(targ->client->ps.velocity, kvel, targ->client->ps.velocity);
-
-		// are we pushed? Do not count when already flying ...
-		if (attacker && attacker->client && (targ->client->ps.groundEntityNum != ENTITYNUM_NONE || GetMODTableData(mod)->isExplosive))
-		{
-			targ->client->pmext.shoved = qtrue;
-			targ->client->pmext.pusher = attacker - g_entities;
-		}
-
-		// MOD_ROCKET removed (now MOD_EXPLOSIVE) which is never targ == attacker
-		if (targ == attacker && !(mod != MOD_GRENADE &&
-		                          mod != MOD_GRENADE_LAUNCHER &&
-		                          mod != MOD_GRENADE_PINEAPPLE &&
-		                          mod != MOD_DYNAMITE
-		                          && mod != MOD_GPG40 // ?!
-		                          && mod != MOD_M7 // ?!
-		                          && mod != MOD_LANDMINE
-		                          ))
-		{
-			targ->client->ps.velocity[2] *= 0.25f;
-		}
-
-		// set the timer so that the other client can't cancel
-		// out the movement immediately
-		if (!targ->client->ps.pm_time)
-		{
-			int t = knockback * 2;
-
-			if (t < 50)
-			{
-				t = 50;
-			}
-			if (t > 200)
-			{
-				t = 200;
-			}
-			targ->client->ps.pm_time   = t;
-			targ->client->ps.pm_flags |= PMF_TIME_KNOCKBACK;
-		}
-	}
-
 	// check for completely getting out of the damage
 	if (!(dflags & DAMAGE_NO_PROTECTION))
 	{
@@ -1594,6 +1525,75 @@ void G_Damage(gentity_t *targ, gentity_t *inflictor, gentity_t *attacker, vec3_t
 		}
 
 		//BG_AnimScriptEvent(&targ->client->ps, targ->client->pers.character->animModelInfo, ANIM_ET_PAIN, qfalse, qtrue);
+	}
+
+	if ((targ->flags & FL_NO_KNOCKBACK) || (dflags & DAMAGE_NO_KNOCKBACK) ||
+	    (targ->client && g_friendlyFire.integer && (onSameTeam || (attacker->client && targ->client->sess.sessionTeam == G_GetTeamFromEntity(inflictor)))))
+	{
+		knockback = 0;
+	}
+	else
+	{
+		knockback = (damage > 200) ? 200 : damage;
+
+		if (dflags & DAMAGE_HALF_KNOCKBACK)
+		{
+			knockback *= 0.5;
+		}
+
+		// set weapons means less knockback
+		if (targ->client && (GetWeaponTableData(targ->client->ps.weapon)->type & WEAPON_TYPE_SET))
+		{
+			knockback *= 0.5;
+		}
+	}
+
+	// figure momentum add, even if the damage won't be taken
+	if (knockback && targ->client)
+	{
+		vec3_t kvel;
+		float  mass = 200;
+
+		VectorScale(dir, g_knockback.value * (float)knockback / mass, kvel);
+		VectorAdd(targ->client->ps.velocity, kvel, targ->client->ps.velocity);
+
+		// are we pushed? Do not count when already flying ...
+		if (attacker && attacker->client && (targ->client->ps.groundEntityNum != ENTITYNUM_NONE || GetMODTableData(mod)->isExplosive))
+		{
+			targ->client->pmext.shoved = qtrue;
+			targ->client->pmext.pusher = attacker - g_entities;
+		}
+
+		// MOD_ROCKET removed (now MOD_EXPLOSIVE) which is never targ == attacker
+		if (targ == attacker && !(mod != MOD_GRENADE &&
+		                          mod != MOD_GRENADE_LAUNCHER &&
+		                          mod != MOD_GRENADE_PINEAPPLE &&
+		                          mod != MOD_DYNAMITE
+		                          && mod != MOD_GPG40 // ?!
+		                          && mod != MOD_M7 // ?!
+		                          && mod != MOD_LANDMINE
+		                          ))
+		{
+			targ->client->ps.velocity[2] *= 0.25f;
+		}
+
+		// set the timer so that the other client can't cancel
+		// out the movement immediately
+		if (!targ->client->ps.pm_time)
+		{
+			int t = knockback * 2;
+
+			if (t < 50)
+			{
+				t = 50;
+			}
+			if (t > 200)
+			{
+				t = 200;
+			}
+			targ->client->ps.pm_time   = t;
+			targ->client->ps.pm_flags |= PMF_TIME_KNOCKBACK;
+		}
 	}
 
 #ifndef DEBUG_STATS

--- a/src/game/g_weapon.c
+++ b/src/game/g_weapon.c
@@ -3251,7 +3251,7 @@ void EmitterCheck(gentity_t *ent, gentity_t *attacker, trace_t *tr)
 	vec3_t origin;
 
 	VectorCopy(tr->endpos, origin);
-	SnapVectorTowards(tr->endpos, attacker->s.origin);
+	SnapVectorTowards(origin, attacker->s.origin);
 
 	if (Q_stricmp(ent->classname, "func_leaky") == 0)
 	{
@@ -3389,6 +3389,7 @@ qboolean Bullet_Fire_Extended(gentity_t *source, gentity_t *attacker, vec3_t sta
 	gentity_t *traceEnt;
 	qboolean  hitClient = qfalse;
 	qboolean  waslinked = qfalse;
+	vec3_t    impactPos;
 
 	// prevent shooting ourselves in the head when prone, firing through a breakable
 	if (g_entities[attacker->s.number].client && g_entities[attacker->s.number].r.linked == qtrue)
@@ -3424,7 +3425,8 @@ qboolean Bullet_Fire_Extended(gentity_t *source, gentity_t *attacker, vec3_t sta
 	EmitterCheck(traceEnt, attacker, &tr);
 
 	// snap the endpos to integers, but nudged towards the line
-	SnapVectorTowards(tr.endpos, start);
+	VectorCopy(tr.endpos, impactPos);
+	SnapVectorTowards(impactPos, start);
 
 	if (distance_falloff)
 	{
@@ -3463,7 +3465,7 @@ qboolean Bullet_Fire_Extended(gentity_t *source, gentity_t *attacker, vec3_t sta
 	// send bullet impact
 	if (traceEnt->takedamage && traceEnt->client)
 	{
-		tent              = G_TempEntity(tr.endpos, EV_BULLET_HIT_FLESH);
+		tent              = G_TempEntity(impactPos, EV_BULLET_HIT_FLESH);
 		tent->s.eventParm = traceEnt->s.number;
 		tent->s.weapon    = source->s.weapon;
 
@@ -3522,7 +3524,7 @@ qboolean Bullet_Fire_Extended(gentity_t *source, gentity_t *attacker, vec3_t sta
 			}
 		}
 
-		tent = G_TempEntity(tr.endpos, EV_BULLET_HIT_WALL);
+		tent = G_TempEntity(impactPos, EV_BULLET_HIT_WALL);
 
 		G_Trace(source, &tr2, start, NULL, NULL, end, source->s.number, MASK_WATER | MASK_SHOT);
 


### PR DESCRIPTION
In a rare occasion headshot would register as bodyshot because the `tr.endpos` gets modified before it is used as a starting point for another trace that checks again for headshot hit. Also the knockback code was affecting this second trace causing it to fail too so I moved it after the trace.

https://streamable.com/x10ni3

refs #1408