### PR TITLE
game: Fixing bug which caused wrong spreadscale when pitching or yawing across 0 degrees, refs #1408

### DIFF
--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -3017,6 +3017,11 @@ void PM_AdjustAimSpreadScale(void)
 			for (i = 0; i < 2; i++)
 			{
 				viewchange += Q_fabs(SHORT2ANGLE(pm->cmd.angles[i]) - SHORT2ANGLE(pm->oldcmd.angles[i]));
+
+				if (viewchange > 180)
+				{
+					viewchange = 360 - viewchange;
+				}
 			}
 		}
 


### PR DESCRIPTION
When pitching or yawing across 0 degrees the `viewchange` was incorrectly set as a 350+ degree move, which lead to an increase in spreadscale (in a slow move by 3) when it shouldn't. I think this bug is probably insignificant, and unnoticeable in game, but a bug anyway. 

Doing a more than 180 degree move in 2 frames is practically impossible so the fix shouldn't be abusable I believe.

https://streamable.com/sl9raq

refs #1408