### PR TITLE
server: Fixing Server demos, refs #278

### DIFF
--- a/src/server/server.h
+++ b/src/server/server.h
@@ -503,7 +503,7 @@ void SV_GentityUpdateParentField(sharedEntity_t *gent);
 
 // sv_main.c
 void SV_FinalCommand(const char *cmd, qboolean disconnect);   ///< added disconnect flag so map changes can use this function as well
-void QDECL SV_SendServerCommand(client_t *cl, const char *fmt, ...) _attribute ((format(printf, 2, 3)));
+void QDECL SV_SendServerCommand(client_t *cl, const char *fmt, ...) _attribute((format(printf, 2, 3)));
 void SV_AddOperatorCommands(void);
 void SV_RemoveOperatorCommands(void);
 void SV_MasterHeartbeat(const char *msg);

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -498,6 +498,7 @@ void SV_DemoShutdown(void);
 //int SV_GentityGetHealthField(sharedEntity_t *gent);   // Test purpose
 //void SV_GentitySetHealthField(sharedEntity_t *gent, int value);   // Test purpose
 void SV_GentityUpdateHealthField(sharedEntity_t *gent, playerState_t *player);
+void SV_GentityUpdateItemField(sharedEntity_t *gent);
 
 // sv_main.c
 void SV_FinalCommand(const char *cmd, qboolean disconnect);   ///< added disconnect flag so map changes can use this function as well

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -499,6 +499,7 @@ void SV_DemoShutdown(void);
 //void SV_GentitySetHealthField(sharedEntity_t *gent, int value);   // Test purpose
 void SV_GentityUpdateHealthField(sharedEntity_t *gent, playerState_t *player);
 void SV_GentityUpdateItemField(sharedEntity_t *gent);
+void SV_GentityUpdateParentField(sharedEntity_t *gent);
 
 // sv_main.c
 void SV_FinalCommand(const char *cmd, qboolean disconnect);   ///< added disconnect flag so map changes can use this function as well

--- a/src/server/sv_ccmds.c
+++ b/src/server/sv_ccmds.c
@@ -341,7 +341,7 @@ static void SV_MapRestart_f(void)
 			continue;
 		}
 
-		if (client->netchan.remoteAddress.type == NA_BOT)
+		if (client->netchan.remoteAddress.type == NA_BOT || client->demoClient)
 		{
 			isBot = qtrue;
 		}

--- a/src/server/sv_client.c
+++ b/src/server/sv_client.c
@@ -902,8 +902,8 @@ void SV_ClientEnterWorld(client_t *client, usercmd_t *cmd)
 	}
 
 	// set up the entity for the client
-	ent             = SV_GentityNum(clientNum);
-	ent->s.number   = clientNum;
+	ent           = SV_GentityNum(clientNum);
+	ent->s.number = clientNum;
 
 	// Differentiate between players and bots to properly replay gamestates
 	if (client->demoClient && strlen(client->userinfo) && strlen(Info_ValueForKey(client->userinfo, "cg_etVersion")))

--- a/src/server/sv_client.c
+++ b/src/server/sv_client.c
@@ -608,6 +608,13 @@ gotnewcl:
 	// save the userinfo
 	Q_strncpyz(newcl->userinfo, userinfo, sizeof(newcl->userinfo));
 
+	// Save userinfo changes to demo
+	// Note: client configstring is derived from userinfo so we need to save it before it gets generated and saved in GAME_CLIENT_CONNECT
+	if (sv.demoState == DS_RECORDING)
+	{
+		SV_DemoWriteClientUserinfo(newcl, (const char *)newcl->userinfo);
+	}
+
 	// get the game a chance to reject this connection or modify the userinfo
 	denied = (char *)(VM_Call(gvm, GAME_CLIENT_CONNECT, clientNum, qtrue, qfalse)); // firstTime = qtrue
 	if (denied)
@@ -897,6 +904,13 @@ void SV_ClientEnterWorld(client_t *client, usercmd_t *cmd)
 	// set up the entity for the client
 	ent             = SV_GentityNum(clientNum);
 	ent->s.number   = clientNum;
+
+	// Differentiate between players and bots to properly replay gamestates
+	if (client->demoClient && strlen(client->userinfo) && strlen(Info_ValueForKey(client->userinfo, "cg_etVersion")))
+	{
+		ent->r.svFlags &= ~SVF_BOT;
+	}
+
 	client->gentity = ent;
 
 	client->deltaMessage     = -1;

--- a/src/server/sv_demo.c
+++ b/src/server/sv_demo.c
@@ -1737,6 +1737,11 @@ static void SV_DemoReadAllEntityState(msg_t *msg)
 			}
 		}
 
+		if (entity->s.eType == ET_ITEM && entity->s.groundEntityNum == ENTITYNUM_WORLD)
+		{
+			SV_GentityUpdateItemField(entity);
+		}
+
 		// Save new entity state (in sv.demoEntities, which in other words display the new state)
 		sv.demoEntities[num].s = entity->s;
 	}
@@ -1809,6 +1814,7 @@ static void SV_DemoReadRefreshEntities(void)
 
 		entity = SV_GentityNum(i);
 
+		// FIXME: Redundant?
 		if (entity->s.eType == ET_ITEM && entity->s.groundEntityNum == ENTITYNUM_WORLD)
 		{
 			SV_GentityUpdateItemField(entity);

--- a/src/server/sv_demo.c
+++ b/src/server/sv_demo.c
@@ -860,7 +860,7 @@ void SV_DemoAutoDemoRecord(void)
 static void SV_DemoStopPlayback(void)
 {
 	client_t *client;
-	int olddemostate = sv.demoState;
+	int      olddemostate = sv.demoState;
 
 	// Clear client configstrings
 	if (olddemostate == DS_PLAYBACK)
@@ -1472,7 +1472,7 @@ static void SV_DemoReadServerCommand(msg_t *msg)
 */
 static qboolean SV_GameCommandFilter(const char *cmd)
 {
-	int i;
+	int  i;
 	char *filter[] = { "sc", "ws" };
 
 	for (i = 0; i < 2; i++)
@@ -1499,12 +1499,12 @@ static qboolean SV_GameCommandFilter(const char *cmd)
 static void SV_DemoReadGameCommand(msg_t *msg)
 {
 	playerState_t *player;
-	client_t *client;
-	char *cmd;
-	int clientNum, i;
+	client_t      *client;
+	char          *cmd;
+	int           clientNum, i;
 
 	clientNum = MSG_ReadByte(msg);
-	cmd = MSG_ReadString(msg);
+	cmd       = MSG_ReadString(msg);
 
 	if (SV_CheckLastCmd(cmd, qfalse) && clientNum < sv_maxclients->integer)
 	{
@@ -1601,8 +1601,8 @@ static void SV_DemoReadClientConfigString(msg_t *msg)
 		// DEMOCLIENT INITIAL TEAM MANAGEMENT
 		// Note: needed only to set the initial team of the democlients, subsequent team changes are directly handled by their clientCommands
 		if (configstring && strlen(configstring) &&
-			(svdoldteam == -1 || (svdoldteam != svdnewteam && svdnewteam != -1))   // if there was no team for this player before or if the new team is different
-			)
+		    (svdoldteam == -1 || (svdoldteam != svdnewteam && svdnewteam != -1))   // if there was no team for this player before or if the new team is different
+		    )
 		{
 			// If the client changed team, we manually issue a team change (workaround by using a clientCommand team)
 
@@ -1654,9 +1654,9 @@ static void SV_DemoReadClientConfigString(msg_t *msg)
 static void SV_DemoReadClientUserinfo(msg_t *msg)
 {
 	sharedEntity_t *entity;
-	client_t *client;
-	char     *userinfo;
-	int      num;
+	client_t       *client;
+	char           *userinfo;
+	int            num;
 
 	// Get client
 	num    = MSG_ReadByte(msg);
@@ -1780,7 +1780,7 @@ static void SV_DemoReadAllEntityState(msg_t *msg)
 			// moverState is not changed properly in game code, at least for movers `func_door_rotating`
 			if (entity->s.apos.trType == TR_LINEAR_STOP)
 			{
-				entity->s.apos.trType = TR_LINEAR; 						  
+				entity->s.apos.trType = TR_LINEAR;
 			}
 		}
 
@@ -1846,7 +1846,7 @@ static void SV_DemoReadAllEntityShared(msg_t *msg)
  */
 static void SV_DemoReadRefreshEntities(void)
 {
-	int i;
+	int            i;
 	sharedEntity_t *entity;
 
 	// Overwrite anything the game may have changed
@@ -2045,7 +2045,7 @@ read_next_demo_event: // used to read next demo event
 				}
 				else
 				{
-					svs.time = time;    // refresh server in-game time (overwriting any change the game may have done)
+					svs.time  = time;   // refresh server in-game time (overwriting any change the game may have done)
 					memsvtime = svs.time;     // keep memory of the last server time, in case we want to freeze the demo
 				}
 

--- a/src/server/sv_demo.c
+++ b/src/server/sv_demo.c
@@ -1683,7 +1683,14 @@ static void SV_DemoReadAllEntityState(msg_t *msg)
 			if (entity->s.pos.trType == TR_LINEAR_STOP)  // mover reached end of movement? change it...
 			{
 				entity->s.pos.trType = TR_LINEAR;  // ... to always set movers in a moving linear state.
-				//entity->s.apos.trType = TR_LINEAR; // should apos be also set?
+			}
+
+			// 'Do_Activate_f' from 'g_cmds.c' is not executed when replaying demo thus causing crashes with doors because 'Use_BinaryMover' is not used, but 'Reached_BinaryMover' is.
+			// 'MOVER_POS1ROTATE' -> 'Use_BinaryMover' -> 'MOVER_1TO2ROTATE' -> 'Reached_BinaryMover' -> 'MOVER_POS2ROTATE' -> 'ReturnToPos1Rotate' -> 'MOVER_2TO1ROTATE' -> 'Reached_BinaryMover' -> 'MOVER_POS1ROTATE'
+			// moverState is not changed properly in game code, at least for movers `func_door_rotating`
+			if (entity->s.apos.trType == TR_LINEAR_STOP)
+			{
+				entity->s.apos.trType = TR_LINEAR; 						  
 			}
 		}
 

--- a/src/server/sv_demo.c
+++ b/src/server/sv_demo.c
@@ -1749,6 +1749,7 @@ static void SV_DemoReadAllEntityShared(msg_t *msg)
 static void SV_DemoReadRefreshEntities(void)
 {
 	int i;
+	sharedEntity_t *entity;
 
 	// Overwrite anything the game may have changed
 	for (i = 0; i < sv.num_entities; i++)
@@ -1759,6 +1760,13 @@ static void SV_DemoReadRefreshEntities(void)
 		}
 
 		*SV_GentityNum(i) = sv.demoEntities[i]; // Overwrite entities
+
+		entity = SV_GentityNum(i);
+
+		if (entity->s.eType == ET_ITEM && entity->s.groundEntityNum == ENTITYNUM_WORLD)
+		{
+			SV_GentityUpdateItemField(entity);
+		}
 	}
 
 	for (i = 0; i < sv_democlients->integer; i++)

--- a/src/server/sv_demo.c
+++ b/src/server/sv_demo.c
@@ -859,6 +859,7 @@ void SV_DemoAutoDemoRecord(void)
  */
 static void SV_DemoStopPlayback(void)
 {
+	client_t *client;
 	int olddemostate = sv.demoState;
 
 	// Clear client configstrings
@@ -869,7 +870,12 @@ static void SV_DemoStopPlayback(void)
 		// unload democlients only if we were replaying a demo (if not it will produce an error!)
 		for (i = 0; i < sv_democlients->integer; i++)
 		{
-			SV_SetConfigstring(CS_PLAYERS + i, NULL);
+			client = &svs.clients[i];
+			if (client->demoClient)
+			{
+				SV_DropClient(client, "disconnected");   // same as SV_Disconnect_f(client);
+				client->demoClient = qfalse;
+			}
 		}
 	}
 

--- a/src/server/sv_demo.c
+++ b/src/server/sv_demo.c
@@ -1407,14 +1407,15 @@ static void SV_DemoReadServerCommand(msg_t *msg)
 static void SV_DemoReadGameCommand(msg_t *msg)
 {
 	char *cmd;
+	int clientNum;
 
-	MSG_ReadByte(msg); // clientNum, useless here so we don't save it, but we need to read it in order to move the msg cursor
+	clientNum = MSG_ReadByte(msg); // clientNum, useless here so we don't save it, but we need to read it in order to move the msg cursor
 	cmd = MSG_ReadString(msg);
 
 	if (SV_CheckLastCmd(cmd, qfalse))
 	{
 		// check for duplicates: check that the engine did not already send this very same message resulting from an event (this means that engine gamecommands are never filtered, only demo gamecommands)
-		SV_GameSendServerCommand(-1, cmd);   // send this game command to all clients (-1)
+		SV_GameSendServerCommand(clientNum, cmd);   // send this game command to all clients (-1)
 	}
 }
 

--- a/src/server/sv_demo.c
+++ b/src/server/sv_demo.c
@@ -1767,6 +1767,11 @@ static void SV_DemoReadRefreshEntities(void)
 		{
 			SV_GentityUpdateItemField(entity);
 		}
+
+		if (entity->s.eType == ET_FLAMETHROWER_CHUNK)
+		{
+			SV_GentityUpdateParentField(entity);
+		}
 	}
 
 	for (i = 0; i < sv_democlients->integer; i++)

--- a/src/server/sv_demo_ext.c
+++ b/src/server/sv_demo_ext.c
@@ -106,3 +106,38 @@ void SV_GentityUpdateHealthField(sharedEntity_t *gent, playerState_t *player)
 
 	return;
 }
+
+/**
+* @brief Movers running over items causing crashes because the item field is null.
+* @param[in] gent
+*
+* @note It would be better to set the item to correct item 'ent->item = ent->s.modelindex' and not a dummy, but can't access 'bg_itemlist' at the time.
+*/
+void SV_GentityUpdateItemField(sharedEntity_t *gent)
+{
+	gentity_t *ent = (gentity_t *)gent;
+	//ent->item = BG_GetItem(ent->s.modelindex);
+	//gitem_t *item = &bg_itemlist[ent->s.modelindex];
+
+	gitem_t item = {
+		ITEM_NONE,
+		NULL,                   // classname
+		NULL,                   // pickup_sound
+		{
+			0,                  // world_model[0]
+			0,                  // world_model[1]
+			0                   // world_model[2]
+		},
+		NULL,                   // icon
+		NULL,                   // ammoicon
+		NULL,                   // pickup_name
+		0,                      // quantity
+		IT_BAD,                 // giType
+		WP_NONE,                // giWeapon
+		PW_NONE,                // giPowerUp
+	};
+
+	ent->item = &item;
+
+	return;
+}

--- a/src/server/sv_demo_ext.c
+++ b/src/server/sv_demo_ext.c
@@ -141,3 +141,19 @@ void SV_GentityUpdateItemField(sharedEntity_t *gent)
 
 	return;
 }
+
+/**
+* @brief Flamethrower causing crashes because the parent field is null.
+* @param[in] gent
+*/
+void SV_GentityUpdateParentField(sharedEntity_t *gent)
+{
+	gentity_t *ent = (gentity_t *)gent;
+
+	if (!ent->parent)
+	{
+		ent->parent = SV_GentityNum(ent->r.ownerNum);
+	}
+
+	return;
+}

--- a/src/server/sv_demo_ext.c
+++ b/src/server/sv_demo_ext.c
@@ -119,7 +119,8 @@ void SV_GentityUpdateItemField(sharedEntity_t *gent)
 	//ent->item = BG_GetItem(ent->s.modelindex);
 	//gitem_t *item = &bg_itemlist[ent->s.modelindex];
 
-	gitem_t item = {
+	gitem_t item =
+	{
 		ITEM_NONE,
 		NULL,                   // classname
 		NULL,                   // pickup_sound

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -314,9 +314,9 @@ void SV_MasterHeartbeat(const char *msg)
 	// "dedicated 1" is for lan play, "dedicated 2" is for inet public play
 	if (!com_dedicated || com_dedicated->integer != 2 || !(netenabled & (
 #ifdef FEATURE_IPV6
-	                                                           NET_ENABLEV6 |
+															   NET_ENABLEV6 |
 #endif
-	                                                           NET_ENABLEV4)))
+															   NET_ENABLEV4)))
 	{
 		return;     // only dedicated servers send heartbeats
 
@@ -439,9 +439,9 @@ void SV_MasterGameCompleteStatus()
 	// "dedicated 1" is for lan play, "dedicated 2" is for inet public play
 	if (!com_dedicated || com_dedicated->integer != 2 || !(netenabled & (
 #ifdef FEATURE_IPV6
-	                                                           NET_ENABLEV6 |
+															   NET_ENABLEV6 |
 #endif
-	                                                           NET_ENABLEV4)))
+															   NET_ENABLEV4)))
 	{
 		return;     // only dedicated servers send heartbeats
 
@@ -1206,10 +1206,10 @@ static void SV_ConnectionlessPacket(netadr_t from, msg_t *msg)
 
 	if (!Q_stricmp(c, "getstatus"))
 	{
-	    if(sv_hidden->integer)
-        {
-	        return;
-        }
+		if (sv_hidden->integer)
+		{
+			return;
+		}
 
 		if ((sv_protect->integer & SVP_OWOLF) && SV_CheckDRDoS(from))
 		{
@@ -1220,10 +1220,10 @@ static void SV_ConnectionlessPacket(netadr_t from, msg_t *msg)
 	}
 	else if (!Q_stricmp(c, "getinfo"))
 	{
-        if(sv_hidden->integer)
-        {
-            return;
-        }
+		if (sv_hidden->integer)
+		{
+			return;
+		}
 
 		if ((sv_protect->integer & SVP_OWOLF) && SV_CheckDRDoS(from))
 		{

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -1417,6 +1417,12 @@ static void SV_CheckTimeouts(void)
 
 	for (i = 0, cl = svs.clients ; i < sv_maxclients->integer ; i++, cl++)
 	{
+		// don't timeout democlients
+		if (cl->demoClient)
+		{
+			continue;
+		}
+
 		// message times may be wrong across a changelevel
 		if (cl->lastPacketTime > svs.time)
 		{

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -235,6 +235,10 @@ void QDECL SV_SendServerCommand(client_t *cl, const char *fmt, ...)
 		//{
 		//	SV_DemoWriteServerCommand((char *)message);
 		//}
+		if (cl->demoClient)
+		{
+			return;
+		}
 		SV_AddServerCommand(cl, (char *)message);
 		return;
 	}
@@ -263,8 +267,8 @@ void QDECL SV_SendServerCommand(client_t *cl, const char *fmt, ...)
 		{
 			continue;
 		}
-		// don't need to send messages to AI
-		if (client->gentity && (client->gentity->r.svFlags & SVF_BOT))
+		// don't need to send messages to AI and democlients
+		if (client->gentity && ((client->gentity->r.svFlags & SVF_BOT) || client->demoClient))
 		{
 			continue;
 		}


### PR DESCRIPTION
This patch I hope brings server demos to usable level, there might be still some critical bugs, but I haven't encountered any as of now. I didn't test everything as I've grown a bit tired of figuring this demos out and trying to fix it and need to rest :p

- Fixed crashes related to missing item field
- Fixed crashes related to missing parent field
- Fixed crashes related to invalid moverstate
- Fixed democlients getting dropped for a bad userinfo error
- Fixed democlients getting dropped by a game timeout error
- Fixed democlients getting dropped by a server command overflow error
- Fixed crash on playback stop caused by not properly clearing democlients
- Changed how democlients are initialized and managed to reflect more closely how real clients are handled
- Fixed map_restart breaking demo playback (end of warmup, end of intermission)
- Added new metadata to demos to make sure gamestate is replayed correctly
- Fixed gamestate not being replayed correctly (there is still unsolved issue with GS_WARMUP_COUNTDOWN) but I put a workaround in place and it shouldn't break demo playback
- Changing how game commands are handled so the messages better reflect real game (not finished)

refs #278 