### PR TITLE
server: Fixing OSX build error, refs #278

### DIFF
--- a/src/server/server.h
+++ b/src/server/server.h
@@ -499,7 +499,7 @@ void SV_DemoShutdown(void);
 //void SV_GentitySetHealthField(sharedEntity_t *gent, int value);   // Test purpose
 void SV_GentityUpdateHealthField(sharedEntity_t *gent, playerState_t *player);
 void SV_GentityUpdateItemField(sharedEntity_t *gent);
-void SV_GentityUpdateParentField(sharedEntity_t *gent);
+void SV_GentityUpdateParentField(sharedEntity_t *gent, sharedEntity_t *parent);
 
 // sv_main.c
 void SV_FinalCommand(const char *cmd, qboolean disconnect);   ///< added disconnect flag so map changes can use this function as well

--- a/src/server/sv_demo.c
+++ b/src/server/sv_demo.c
@@ -1869,7 +1869,7 @@ static void SV_DemoReadRefreshEntities(void)
 
 		if (entity->s.eType == ET_FLAMETHROWER_CHUNK)
 		{
-			SV_GentityUpdateParentField(entity);
+			SV_GentityUpdateParentField(entity, SV_GentityNum(entity->r.ownerNum));
 		}
 	}
 

--- a/src/server/sv_demo_ext.c
+++ b/src/server/sv_demo_ext.c
@@ -147,13 +147,13 @@ void SV_GentityUpdateItemField(sharedEntity_t *gent)
 * @brief Flamethrower causing crashes because the parent field is null.
 * @param[in] gent
 */
-void SV_GentityUpdateParentField(sharedEntity_t *gent)
+void SV_GentityUpdateParentField(sharedEntity_t *gent, sharedEntity_t *parent)
 {
 	gentity_t *ent = (gentity_t *)gent;
 
 	if (!ent->parent)
 	{
-		ent->parent = SV_GentityNum(ent->r.ownerNum);
+		ent->parent = (gentity_t *)parent;
 	}
 
 	return;


### PR DESCRIPTION
Fixing:
```
/Users/runner/work/etlegacy/etlegacy/src/server/sv_demo_ext.c:156:17: error: implicit declaration of function 'SV_GentityNum' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
                ent->parent = SV_GentityNum(ent->r.ownerNum);
                              ^
/Users/runner/work/etlegacy/etlegacy/src/server/sv_demo_ext.c:156:15: warning: incompatible integer to pointer conversion assigning to 'gentity_t *' (aka 'struct gentity_s *') from 'int' [-Wint-conversion]
                ent->parent = SV_GentityNum(ent->r.ownerNum);
                            ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

refs #278