### PR TITLE
Changed default IRC network to Libera.chat

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ If you only have a question and don't want to read this whole document:
 Do **NOT** file an issue to ask a question. You will get faster results by using the resources below:
 
 * [etlegacy/#general](https://discordapp.com/channels/260750790203932672/260750790203932672) on Discord
-* [#etlegacy](http://webchat.freenode.net/?channels=#etlegacy) on irc.freenode.net
+* [#etlegacy](https://web.libera.chat/?channels=#etlegacy) on irc.libera.chat
 
 See also our [FAQ](https://github.com/etlegacy/etlegacy/wiki/FAQ).
 
@@ -45,4 +45,4 @@ If you are interested to participate, ensure to read first our contribution guid
 Communication happens online at:
 
 * [etlegacy/#etlegacy](https://discordapp.com/channels/260750790203932672/346956915814957067) on Discord
-* [#etlegacy](http://webchat.freenode.net/?channels=#etlegacy) on irc.freenode.net
+* [#etlegacy](https://web.libera.chat/?channels=#etlegacy) on irc.libera.chat

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ ET: Legacy [![Travis Status](https://travis-ci.org/etlegacy/etlegacy.svg?branch=
 * Documentation: [https://etlegacy.readthedocs.io/](https://etlegacy.readthedocs.io/)
 * Lua API: [https://etlegacy-lua-docs.readthedocs.io](https://etlegacy-lua-docs.readthedocs.io)
 * Translation: [https://www.transifex.com/etlegacy/etlegacy](https://www.transifex.com/etlegacy/etlegacy)
-* Contact: [\#etlegacy](https://webchat.freenode.net/?channels=#etlegacy) on irc.freenode.net and [etlegacy/#etlegacy](https://discordapp.com/channels/260750790203932672/346956915814957067) on Discord.
+* Contact: [#etlegacy](https://web.libera.chat/?channels=#etlegacy) on irc.libera.chat and [etlegacy/#etlegacy](https://discordapp.com/channels/260750790203932672/346956915814957067) on Discord.
 
 ## INTRODUCTION
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@ Users are encouraged to upgrade their server or client version to the latest rel
 If you have discovered an issue that you believe is a vulnerability, please reach us by using one of the resources below:
 
 * [etlegacy/#etlegacy](https://discordapp.com/channels/260750790203932672/346956915814957067) on Discord
-* [#etlegacy](http://webchat.freenode.net/?channels=#etlegacy) on irc.freenode.net
+* [#etlegacy](https://web.libera.chat/?channels=#etlegacy) on irc.libera.chat
 * email at mail@etlegacy.com
 
 Please include a detailed description of the vulnerability. Lack of detailed vulnerability explanation may result in delays and subsequent potential actions on the finding.

--- a/src/irc/irc_client.c
+++ b/src/irc/irc_client.c
@@ -2512,7 +2512,7 @@ void IRC_Connect(void)
 void IRC_Init(void)
 {
 	irc_mode            = Cvar_Get("irc_mode", "0", CVAR_ARCHIVE);
-	irc_server          = Cvar_Get("irc_server", "irc.freenode.net", CVAR_ARCHIVE);
+	irc_server          = Cvar_Get("irc_server", "irc.libera.chat", CVAR_ARCHIVE);
 	irc_channel         = Cvar_Get("irc_channel", "etlegacy", CVAR_ARCHIVE);
 	irc_port            = Cvar_Get("irc_port", "6667", CVAR_ARCHIVE);
 	irc_nickname        = Cvar_Get("irc_nickname", "ETLClient", CVAR_ARCHIVE);


### PR DESCRIPTION
Change IRC network to Libera.chat, as major open source communities are migrating their IRC channels following recent events.
A new channel has been created on Libera.chat a few days ago by @morsik 

The main website also needs to be adjusted once this is reviewed.