### PR TITLE
game: Fixing 'players sticking to each other' prediction errors

### DIFF
--- a/src/game/g_active.c
+++ b/src/game/g_active.c
@@ -1457,13 +1457,13 @@ void ClientThink_real(gentity_t *ent)
 		ent->r.eventTime = level.time;
 	}
 
-	BG_PlayerStateToEntityState(&ent->client->ps, &ent->s, level.time, qtrue);
+	BG_PlayerStateToEntityState(&ent->client->ps, &ent->s, level.time, qfalse);
 
 	// use the precise origin for linking
-	//VectorCopy( ent->client->ps.origin, ent->r.currentOrigin );
+	VectorCopy( ent->client->ps.origin, ent->r.currentOrigin );
 
 	// use the snapped origin for linking so it matches client predicted versions
-	VectorCopy(ent->s.pos.trBase, ent->r.currentOrigin);
+	//VectorCopy(ent->s.pos.trBase, ent->r.currentOrigin);
 
 	VectorCopy(pm.mins, ent->r.mins);
 	VectorCopy(pm.maxs, ent->r.maxs);
@@ -1492,7 +1492,7 @@ void ClientThink_real(gentity_t *ent)
 	}
 
 	// NOTE: now copy the exact origin over otherwise clients can be snapped into solid
-	VectorCopy(ent->client->ps.origin, ent->r.currentOrigin);
+	//VectorCopy(ent->client->ps.origin, ent->r.currentOrigin);
 
 	// touch other objects
 	ClientImpacts(ent, &pm);
@@ -2247,7 +2247,7 @@ void ClientEndFrame(gentity_t *ent)
 
 	// set the latest infor
 
-	BG_PlayerStateToEntityState(&ent->client->ps, &ent->s, level.time, qtrue);
+	BG_PlayerStateToEntityState(&ent->client->ps, &ent->s, level.time, qfalse);
 
 	if (ent->health > 0 && StuckInClient(ent))
 	{

--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -3122,7 +3122,7 @@ void ClientSpawn(gentity_t *ent, qboolean revived, qboolean teamChange, qboolean
 	// positively link the client, even if the command times are weird
 	if (ent->client->sess.sessionTeam != TEAM_SPECTATOR)
 	{
-		BG_PlayerStateToEntityState(&client->ps, &ent->s, level.time, qtrue);
+		BG_PlayerStateToEntityState(&client->ps, &ent->s, level.time, qfalse);
 		VectorCopy(ent->client->ps.origin, ent->r.currentOrigin);
 		trap_LinkEntity(ent);
 	}
@@ -3134,7 +3134,7 @@ void ClientSpawn(gentity_t *ent, qboolean revived, qboolean teamChange, qboolean
 	ent->client->ps.weapAnim = ((ent->client->ps.weapAnim & ANIM_TOGGLEBIT) ^ ANIM_TOGGLEBIT) | WEAP_IDLE1;
 
 	// clear entity state values
-	BG_PlayerStateToEntityState(&client->ps, &ent->s, level.time, qtrue);
+	BG_PlayerStateToEntityState(&client->ps, &ent->s, level.time, qfalse);
 
 	// G_ResetMarkers(ent);
 

--- a/src/game/g_lua.c
+++ b/src/game/g_lua.c
@@ -773,7 +773,7 @@ static int _et_G_XP_Set(lua_State *L)
 	ent->client->ps.stats[STAT_XP] = (int)ent->client->sess.startxptotal;
 
 	G_CalcRank(ent->client);
-	BG_PlayerStateToEntityState(&ent->client->ps, &ent->s, level.time, qtrue);
+	BG_PlayerStateToEntityState(&ent->client->ps, &ent->s, level.time, qfalse);
 
 	return 1;
 }

--- a/src/game/g_misc.c
+++ b/src/game/g_misc.c
@@ -150,7 +150,7 @@ void TeleportPlayer(gentity_t *player, vec3_t origin, vec3_t angles)
 	SetClientViewAngle(player, angles);
 
 	// save results of pmove
-	BG_PlayerStateToEntityState(&player->client->ps, &player->s, level.time, qtrue);
+	BG_PlayerStateToEntityState(&player->client->ps, &player->s, level.time, qfalse);
 
 	// use the precise origin for linking
 	VectorCopy(player->client->ps.origin, player->r.currentOrigin);


### PR DESCRIPTION
Snapping of origin in `entityState_t` was causing players to 'stick' to each other. `playerState_t` origin was not getting snapped and traces in `bg_pmove` were getting different results on player collision than on the server. On server player was linked with snapped values, the antilag was also saving snapped values. To keep everything consistent all snapping was removed even though it seemingly didn't matter for player collision besides snapping in `ClientEndFrame`.

https://streamable.com/81yukx