### PR TITLE
game: Don't snap muzzleTrace since it's not sent over network

### DIFF
--- a/src/game/g_weapon.c
+++ b/src/game/g_weapon.c
@@ -4028,7 +4028,8 @@ void CalcMuzzlePointForActivate(gentity_t *ent, vec3_t forward, vec3_t right, ve
 	AddLean(ent, muzzlePoint);
 
 	// snap to integer coordinates for more efficient network bandwidth usage
-	SnapVector(muzzlePoint);
+	// muzzleTrace is not sent over network
+	//SnapVector(muzzlePoint);
 }
 
 /**


### PR DESCRIPTION
Snapping muzzleTrace (the point where the trace/bullet travel starts) is not needed because it is not sent over network and it causes the hit registration trace check to be slighlty incorrect to where the player actually aimed.

Left not snapped, right snapped:

![muzzlePoint1](https://user-images.githubusercontent.com/4499367/120531028-72233c80-c3de-11eb-9fef-4330ea142bef.png)
![muzzlePoint2](https://user-images.githubusercontent.com/4499367/120531039-75b6c380-c3de-11eb-8575-ac693ca93552.png)


https://streamable.com/xxqlf2

refs #1408