### PR TITLE
game: Make body hitbox height follow head animation, refs #1408

### DIFF
--- a/src/game/g_active.c
+++ b/src/game/g_active.c
@@ -2314,11 +2314,6 @@ void ClientEndFrame(gentity_t *ent)
 		vec3_t       maxs;
 		grefEntity_t refent;
 
-		VectorCopy(ent->r.maxs, maxs);
-		maxs[2] = ClientHitboxMaxZ(ent);
-		// green
-		G_RailBox(ent->r.currentOrigin, ent->r.mins, maxs, tv(0.f, 1.f, 0.f), ent->s.number);
-
 		// wounded player don't have head and legs hitbox, (see G_BuildHead and G_BuildLeg)
 		if (!(ent->client->ps.eFlags & EF_DEAD))
 		{
@@ -2337,6 +2332,11 @@ void ClientEndFrame(gentity_t *ent)
 				G_FreeEntity(legs);
 			}
 		}
+
+		VectorCopy(ent->r.maxs, maxs);
+		maxs[2] = ClientHitboxMaxZ(ent);
+		// green
+		G_RailBox(ent->r.currentOrigin, ent->r.mins, maxs, tv(0.f, 1.f, 0.f), ent->s.number);
 	}
 
 	// debug head and legs box for collision (see PM_TraceHead and PM_TraceLegs)

--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -3400,12 +3400,12 @@ float ClientHitboxMaxZ(gentity_t *hitEnt)
 	else if (hitEnt->client->ps.eFlags & EF_PRONE)
 	{
 		// Prone hitbox height is calculated in G_BuildHead to stay right under head (just for hitbox transition into prone so it's not instantaneous)
-		return hitEnt->r.maxs[2] < PRONE_BODYHEIGHT ? PRONE_BODYHEIGHT : hitEnt->r.maxs[2];
+		return hitEnt->r.maxs[2];
 	}
 	else if (hitEnt->client->ps.eFlags & EF_CROUCHING)
 	{
 		// Crouched hitbox height is calculated in G_BuildHead to stay right under head
-		return hitEnt->r.maxs[2] < CROUCH_IDLE_BODYHEIGHT ? CROUCH_IDLE_BODYHEIGHT : hitEnt->r.maxs[2];
+		return hitEnt->r.maxs[2];
 	}
 	else
 	{

--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -3399,13 +3399,26 @@ float ClientHitboxMaxZ(gentity_t *hitEnt)
 	}
 	else if (hitEnt->client->ps.eFlags & EF_PRONE)
 	{
-		// Prone hitbox height is calculated in G_BuildHead to stay right under head (just for hitbox transition into prone so it's not instantaneous)
-		return hitEnt->r.maxs[2];
+		// Prone hitbox height is calculated with head computed from G_BuildHead to stay right under head
+		// (just for hitbox transition into prone so it's not instantaneous)
+		if (hitEnt->client->tempHead)
+		{
+			float maxs = hitEnt->client->tempHead->r.currentOrigin[2] - hitEnt->r.currentOrigin[2] + hitEnt->client->tempHead->r.mins[2];
+			return (maxs < PRONE_BODYHEIGHT) ? PRONE_BODYHEIGHT : maxs;
+		}
+
+		return PRONE_BODYHEIGHT;
 	}
 	else if (hitEnt->client->ps.eFlags & EF_CROUCHING)
 	{
-		// Crouched hitbox height is calculated in G_BuildHead to stay right under head
-		return hitEnt->r.maxs[2];
+		// Crouched hitbox height is calculated with head computed from G_BuildHead to stay right under head
+		if (hitEnt->client->ps.eFlags & EF_CROUCHING)
+		{
+			float maxs = hitEnt->client->tempHead->r.currentOrigin[2] - hitEnt->r.currentOrigin[2] + hitEnt->client->tempHead->r.mins[2];
+			return (maxs < CROUCH_IDLE_BODYHEIGHT) ? CROUCH_IDLE_BODYHEIGHT : maxs;
+		}
+
+		return CROUCH_BODYHEIGHT;
 	}
 	else
 	{

--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -3399,18 +3399,13 @@ float ClientHitboxMaxZ(gentity_t *hitEnt)
 	}
 	else if (hitEnt->client->ps.eFlags & EF_PRONE)
 	{
-		return PRONE_BODYHEIGHT;
-	}
-	else if (hitEnt->client->ps.eFlags & EF_CROUCHING &&
-	         hitEnt->client->ps.velocity[0] == 0.f && hitEnt->client->ps.velocity[1] == 0.f)
-	{
-		// crouched idle animation is lower than the moving one
-		return CROUCH_IDLE_BODYHEIGHT;
+		// Prone hitbox height is calculated in G_BuildHead to stay right under head (just for hitbox transition into prone so it's not instantaneous)
+		return hitEnt->r.maxs[2] < PRONE_BODYHEIGHT ? PRONE_BODYHEIGHT : hitEnt->r.maxs[2];
 	}
 	else if (hitEnt->client->ps.eFlags & EF_CROUCHING)
 	{
-		// crouched moving animation is higher than the idle one
-		return CROUCH_BODYHEIGHT;
+		// Crouched hitbox height is calculated in G_BuildHead to stay right under head
+		return hitEnt->r.maxs[2] < CROUCH_IDLE_BODYHEIGHT ? CROUCH_IDLE_BODYHEIGHT : hitEnt->r.maxs[2];
 	}
 	else
 	{

--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -3412,12 +3412,18 @@ float ClientHitboxMaxZ(gentity_t *hitEnt)
 	else if (hitEnt->client->ps.eFlags & EF_CROUCHING)
 	{
 		// Crouched hitbox height is calculated with head computed from G_BuildHead to stay right under head
-		if (hitEnt->client->ps.eFlags & EF_CROUCHING)
+		if (hitEnt->client->tempHead)
 		{
 			float maxs = hitEnt->client->tempHead->r.currentOrigin[2] - hitEnt->r.currentOrigin[2] + hitEnt->client->tempHead->r.mins[2];
 			return (maxs < CROUCH_IDLE_BODYHEIGHT) ? CROUCH_IDLE_BODYHEIGHT : maxs;
 		}
+		else if (hitEnt->client->ps.velocity[0] == 0.f && hitEnt->client->ps.velocity[1] == 0.f)
+		{
+			// crouched idle animation is lower than the moving one
+			return CROUCH_IDLE_BODYHEIGHT;
+		}
 
+		// crouched moving animation is higher than the idle one
 		return CROUCH_BODYHEIGHT;
 	}
 	else

--- a/src/game/g_combat.c
+++ b/src/game/g_combat.c
@@ -842,6 +842,9 @@ gentity_t *G_BuildHead(gentity_t *ent, grefEntity_t *refent, qboolean newRefent)
 	head->parent     = ent;
 	head->s.eType    = ET_TEMPHEAD;
 
+	// Set the height for body hitbox to be right under head
+	ent->r.maxs[2] = head->r.currentOrigin[2] - ent->r.currentOrigin[2] + head->r.mins[2];
+
 	trap_LinkEntity(head);
 
 	return head;

--- a/src/game/g_combat.c
+++ b/src/game/g_combat.c
@@ -737,6 +737,7 @@ gentity_t *G_BuildHead(gentity_t *ent, grefEntity_t *refent, qboolean newRefent)
 {
 	gentity_t     *head;
 	orientation_t orientation;
+	float         maxs;
 
 	head            = G_Spawn();
 	head->classname = "head"; // see also ET_TEMPHEAD
@@ -843,7 +844,16 @@ gentity_t *G_BuildHead(gentity_t *ent, grefEntity_t *refent, qboolean newRefent)
 	head->s.eType    = ET_TEMPHEAD;
 
 	// Set the height for body hitbox to be right under head
-	ent->r.maxs[2] = head->r.currentOrigin[2] - ent->r.currentOrigin[2] + head->r.mins[2];
+	if (ent->client->ps.eFlags & EF_PRONE)
+	{
+		maxs           = head->r.currentOrigin[2] - ent->r.currentOrigin[2] + head->r.mins[2];
+		ent->r.maxs[2] = maxs < PRONE_BODYHEIGHT ? PRONE_BODYHEIGHT : maxs;
+	}
+	else if (ent->client->ps.eFlags & EF_CROUCHING)
+	{
+		maxs           = head->r.currentOrigin[2] - ent->r.currentOrigin[2] + head->r.mins[2];
+		ent->r.maxs[2] = maxs < CROUCH_IDLE_BODYHEIGHT ? CROUCH_IDLE_BODYHEIGHT : maxs;
+	}
 
 	trap_LinkEntity(head);
 

--- a/src/game/g_combat.c
+++ b/src/game/g_combat.c
@@ -843,18 +843,6 @@ gentity_t *G_BuildHead(gentity_t *ent, grefEntity_t *refent, qboolean newRefent)
 	head->parent     = ent;
 	head->s.eType    = ET_TEMPHEAD;
 
-	// Set the height for body hitbox to be right under head
-	if (ent->client->ps.eFlags & EF_PRONE)
-	{
-		maxs           = head->r.currentOrigin[2] - ent->r.currentOrigin[2] + head->r.mins[2];
-		ent->r.maxs[2] = maxs < PRONE_BODYHEIGHT ? PRONE_BODYHEIGHT : maxs;
-	}
-	else if (ent->client->ps.eFlags & EF_CROUCHING)
-	{
-		maxs           = head->r.currentOrigin[2] - ent->r.currentOrigin[2] + head->r.mins[2];
-		ent->r.maxs[2] = maxs < CROUCH_IDLE_BODYHEIGHT ? CROUCH_IDLE_BODYHEIGHT : maxs;
-	}
-
 	trap_LinkEntity(head);
 
 	return head;


### PR DESCRIPTION
To keep body hitbox more in sync with animations the `g_realHead` code can be used to set body height to be under head. This should help in situations where the body hitbox is too short compared to the body model, for example: https://streamable.com/yd77am

Legacy old hitbox:
![legacy old hitbox](https://user-images.githubusercontent.com/4499367/121801629-8403ab80-cc38-11eb-88df-07742546a29f.png)

Legacy new hitbox: 
![legacy new hitbox](https://user-images.githubusercontent.com/4499367/121801640-91209a80-cc38-11eb-989f-b66c14f5241d.png)

Legacy old prone mid air hitbox: 
![old prone mid air](https://user-images.githubusercontent.com/4499367/121801645-9da4f300-cc38-11eb-9fb4-e70920dbc7ef.png)

Legacy new prone mid air hitbox: 
![new prone mid air](https://user-images.githubusercontent.com/4499367/121801653-a4cc0100-cc38-11eb-923e-2485fca62553.png)

Legacy old hitbox: https://streamable.com/yswc51
Legacy new hitbox: https://streamable.com/ybjcy2







refs #1408