### PR TITLE
game: Revert snapping for better performance with high number of players

### DIFF
--- a/src/game/g_active.c
+++ b/src/game/g_active.c
@@ -1457,7 +1457,7 @@ void ClientThink_real(gentity_t *ent)
 		ent->r.eventTime = level.time;
 	}
 
-	BG_PlayerStateToEntityState(&ent->client->ps, &ent->s, level.time, qfalse);
+	BG_PlayerStateToEntityState(&ent->client->ps, &ent->s, level.time, qtrue);
 
 	// use the precise origin for linking
 	VectorCopy(ent->client->ps.origin, ent->r.currentOrigin);

--- a/src/game/g_weapon.c
+++ b/src/game/g_weapon.c
@@ -4027,7 +4027,7 @@ void CalcMuzzlePoint(gentity_t *ent, int weapon, vec3_t forward, vec3_t right, v
  */
 void CalcMuzzlePointForActivate(gentity_t *ent, vec3_t forward, vec3_t right, vec3_t up, vec3_t muzzlePoint)
 {
-	VectorCopy(ent->s.pos.trBase, muzzlePoint);
+	VectorCopy(ent->client->ps.origin, muzzlePoint);
 	muzzlePoint[2] += ent->client->ps.viewheight;
 
 	AddLean(ent, muzzlePoint);


### PR DESCRIPTION
After a recent change here https://github.com/etlegacy/etlegacy/pull/1660 there was a decrease of perfomance with high numbers of players (40+). After investigating it for quite some time the issue seems to be players getting rate limited because of the increase of bandwidth usage. 

The question was why other mods don't seem to experience it, when from what I could check in their source code or the fact that the players sticking to each other bug doesn't happen there so they have to not snap values in `ClientEndFrame` too. The answer seems to be that when there is a high number of players, the values in `entityState_t` that are sent to players start getting sent snapped if you snap them in `ClientThink_real` (when in theory they should be sent with values from `ClientEndFrame`). Instead of linking player back to snapped values I left it as not snapped as that's what is intended to be sent to players at all times.

The issue goes away if higher `rate` is set fe. `45000`, but I don't know if this is a solution. It's a increase of precision at the cost of higher bandwith usage. 

 From my tests reverting can cause the bug with collision to occur again, but not always and mostly likely only with high amount of players. Can't tell how much it can affect antilag but since players can receive snapshots with different values that are stored for antilag, it probably will impact it.
 
 https://streamable.com/5re7m0