### PR TITLE
game: add sudden death

### DIFF
--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1323,6 +1323,8 @@ typedef struct level_locals_s
 #endif
 
 	int frameStartTime;
+
+	qboolean suddenDeath;
 } level_locals_t;
 
 /**
@@ -2130,6 +2132,8 @@ extern vmCvar_t g_debugForSingleClient;
 
 #define G_InactivityValue (g_inactivity.integer ? g_inactivity.integer : 60)
 #define G_SpectatorInactivityValue (g_spectatorInactivity.integer ? g_spectatorInactivity.integer : 60)
+
+extern vmCvar_t g_suddenDeath;
 
 /**
  * @struct GeoIPTag

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -4204,7 +4204,7 @@ qboolean DynamiteOnObjective(void)
 	for (e = 0; e < MAX_GENTITIES; e++)
 	{
 		ent = &g_entities[e];
-		if (ent->s.weapon == WP_DYNAMITE && ent->onobjective != NULL)
+		if (ent->s.weapon == WP_DYNAMITE && ent->onobjective)
 		{
 			return qtrue;
 		}

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -370,6 +370,8 @@ vmCvar_t g_playerHitBoxHeight;
 
 vmCvar_t g_debugForSingleClient;
 
+vmCvar_t g_suddenDeath;
+
 cvarTable_t gameCvarTable[] =
 {
 	// don't override the cheat state set by the system
@@ -660,6 +662,7 @@ cvarTable_t gameCvarTable[] =
 	{ &g_xpSaver,                         "g_xpSaver",                         "0",                          CVAR_ARCHIVE,                                    0, qfalse, qfalse },
 	{ &g_dynamiteChaining,                "g_dynamiteChaining",                "0",                          CVAR_ARCHIVE,                                    0, qfalse, qfalse },
 	{ &g_playerHitBoxHeight,              "g_playerHitBoxHeight",              "36",                         CVAR_ARCHIVE | CVAR_SERVERINFO,                  0, qfalse, qfalse },
+	{ &g_suddenDeath,                     "g_suddenDeath",                     "0",                          CVAR_ARCHIVE,                                    0, qtrue,  qfalse },
 };
 
 /**
@@ -4190,6 +4193,27 @@ qboolean ScoreIsTied(void)
 }
 
 /**
+ * @brief DynamiteOnObjective
+ * @return
+ */
+qboolean DynamiteOnObjective(void)
+{
+	int       e;
+	gentity_t *ent;
+
+	for (e = 0; e < MAX_GENTITIES; e++)
+	{
+		ent = &g_entities[e];
+		if (ent->s.weapon == WP_DYNAMITE && ent->onobjective != NULL)
+		{
+			return qtrue;
+		}
+	}
+
+	return qfalse;
+}
+
+/**
  * @brief There will be a delay between the time the exit is qualified for
  * and the time everyone is moved to the intermission spot, so you
  * can see the last frag.
@@ -4297,6 +4321,23 @@ void CheckExitRules(void)
 				{
 					// score is tied, so don't end the game
 					return;
+				}
+
+				if (level.suddenDeath)
+				{
+					if (DynamiteOnObjective())
+					{
+						return;
+					}
+					level.suddenDeath = 0;
+				}
+				else
+				{
+					if (g_suddenDeath.integer && DynamiteOnObjective())
+					{
+						level.suddenDeath = 1;
+						return;
+					}
 				}
 			}
 

--- a/src/game/g_script_actions.c
+++ b/src/game/g_script_actions.c
@@ -1653,6 +1653,12 @@ qboolean G_ScriptAction_Wait(gentity_t *ent, char *params)
 	char *pString = params, *token;
 	int  duration;
 
+	if (level.suddenDeath)
+	{
+		// prevent waiting, as this could cause the round to end
+		return qtrue;
+	}
+
 	// get the duration
 	token = COM_ParseExt(&pString, qfalse);
 	if (!token[0])

--- a/src/game/g_weapon.c
+++ b/src/game/g_weapon.c
@@ -1904,6 +1904,12 @@ weapengineergoto3:
 					return NULL;
 				}
 
+				if (level.suddenDeath)
+				{
+					G_PrintClientSpammyCenterPrint(ent - g_entities, "Too late to arm a dynamite.");
+					return NULL;
+				}
+
 				// dyno chaining
 				traceEnt->onobjective = NULL;
 


### PR DESCRIPTION
Fixes #1498 

Could be changed/improved:
* remove the cvar
* free the entity when trying to arm a dynamite durring sudden death (like planting near a friendly objective)
* codestyle?
* stopwatch-specific behavior?