### PR TITLE
pak0.pk3 download script

### DIFF
--- a/misc/dl-pak0.sh
+++ b/misc/dl-pak0.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 cd "$(dirname "$0")"
 curl https://mirror.etlegacy.com/etmain/pak0.pk3 -o etmain/pak0.pk3
-curl https://mirror.etlegacy.com/etmain/pak0.pk3 -o etmain/pak1.pk3
-curl https://mirror.etlegacy.com/etmain/pak0.pk3 -o etmain/pak2.pk3
+curl https://mirror.etlegacy.com/etmain/pak1.pk3 -o etmain/pak1.pk3
+curl https://mirror.etlegacy.com/etmain/pak2.pk3 -o etmain/pak2.pk3

--- a/misc/dl-pak0.sh
+++ b/misc/dl-pak0.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cd "$(dirname "$0")"
+curl https://mirror.etlegacy.com/etmain/pak0.pk3 -o etmain/pak0.pk3

--- a/misc/dl-pak0.sh
+++ b/misc/dl-pak0.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 cd "$(dirname "$0")"
 curl https://mirror.etlegacy.com/etmain/pak0.pk3 -o etmain/pak0.pk3
+curl https://mirror.etlegacy.com/etmain/pak0.pk3 -o etmain/pak1.pk3
+curl https://mirror.etlegacy.com/etmain/pak0.pk3 -o etmain/pak2.pk3


### PR DESCRIPTION
This script (place in etlegacy) will download pak0.pk3 to etmain. Could ask user to run when trying to start the game without pak0 in etmain. This could also allow me to add etlegacy to homebrew-cask for a one command and complete install on macOS.