### PR TITLE
game: fix prevent picking up weapon when overheating

### DIFF
--- a/src/game/g_items.c
+++ b/src/game/g_items.c
@@ -419,7 +419,8 @@ qboolean G_CanPickupWeapon(weapon_t weapon, gentity_t *ent)
 	}
 
 	// prevent picking up when overheating
-	if (ent->client->ps.weaponTime > 0)
+	// FIXME: heat of dropped weapon isn't reduced overtime
+	if (ent->client->ps.curWeapHeat > 0 && ent->client->ps.weaponTime > 0)
 	{
 		return qfalse;
 	}


### PR DESCRIPTION
This should fix players being unable to pick up weapons while doing other actions like throwing medpacks. 

The weapons that have heat mechanic are unchanged by this, but there is a bug with them anyway. When you switch a weapon the one on the ground doesn't get its heat reduced. Imo if this bug was to be fixed this whole check could be removed as I don't really see a reason why a player should be prevented from picking up a weapon, it's simply throwing a weapon on the ground.

EDIT: Unless the restriction on heat weapons it's done for balance reasons.
