### PR TITLE
mod: allow surrender vote by default on competition configs

### DIFF
--- a/etmain/configs/legacy3.config
+++ b/etmain/configs/legacy3.config
@@ -84,7 +84,7 @@ init
 	setl vote_allow_referee "1"
 	setl vote_allow_shuffleteams "0"
 	setl vote_allow_shuffleteams_norestart "0"
-	setl vote_allow_surrender "0"
+	setl vote_allow_surrender "1"
 	setl vote_allow_swapteams "1"
 	setl vote_allow_timelimit "1"
 	setl vote_allow_warmupdamage "0"

--- a/etmain/configs/legacy5.config
+++ b/etmain/configs/legacy5.config
@@ -83,7 +83,7 @@ init
 	setl vote_allow_referee "1"
 	setl vote_allow_shuffleteams "0"
 	setl vote_allow_shuffleteams_norestart "0"
-	setl vote_allow_surrender "0"
+	setl vote_allow_surrender "1"
 	setl vote_allow_swapteams "1"
 	setl vote_allow_timelimit "1"
 	setl vote_allow_warmupdamage "0"

--- a/etmain/configs/legacy6.config
+++ b/etmain/configs/legacy6.config
@@ -83,7 +83,7 @@ init
 	setl vote_allow_referee "1"
 	setl vote_allow_shuffleteams "0"
 	setl vote_allow_shuffleteams_norestart "0"
-	setl vote_allow_surrender "0"
+	setl vote_allow_surrender "1"
 	setl vote_allow_swapteams "1"
 	setl vote_allow_timelimit "1"
 	setl vote_allow_warmupdamage "0"


### PR DESCRIPTION
Allow teams to surrender by default when `legacy3/5/6` configs are loaded.

refs #1688 