### PR TITLE
game: fix constructing not working when trace hits ET_MOVER element

### DIFF
--- a/src/game/g_weapon.c
+++ b/src/game/g_weapon.c
@@ -1550,7 +1550,7 @@ gentity_t *Weapon_Engineer(gentity_t *ent)
 	traceEnt = &g_entities[tr.entityNum];
 
 	if ((tr.surfaceFlags & SURF_NOIMPACT) || tr.fraction == 1.0f || tr.entityNum == ENTITYNUM_NONE || tr.entityNum == ENTITYNUM_WORLD
-	    || tr.contents & CONTENTS_TRIGGER || traceEnt->r.contents & CONTENTS_TRIGGER)
+	    || tr.contents & CONTENTS_TRIGGER || traceEnt->r.contents & CONTENTS_TRIGGER || traceEnt->s.eType == ET_MOVER)
 	{
 		// might be constructible
 		if (!ent->client->touchingTOI)


### PR DESCRIPTION
Constructions like tank/truck/CP have elements which some of them are of type `ET_MOVER` and due to changes to fix vanilla issues it is possible for a trace to hit such element making it impossible to be build. I think this is the last issue and constructing should always work just like before.