### PR TITLE
cgame: add `cg_simpleItemsScale` to control size of simple items

### DIFF
--- a/etmain/ui/options_customise_game.menu
+++ b/etmain/ui/options_customise_game.menu
@@ -52,11 +52,13 @@ menuDef {
 
 // Items //
 #define ITEMS_Y 194
-	SUBWINDOW( 6, ITEMS_Y, (SUBWINDOW_WIDTH_L), 28, _("ITEMS") )
+	SUBWINDOW( 6, ITEMS_Y, (SUBWINDOW_WIDTH_L), 42, _("ITEMS") )
 	MULTI( 8, ITEMS_Y+16, (SUBWINDOW_WIDTH_R)-4, 10, _("Simple Items:"), .2, 8, "cg_simpleItems", cvarFloatList { "No" 0 "Yes" 1 "Yes except objectives" 2 }, _("Draw simple items") )
+	CVARFLOATLABEL( 8, ITEMS_Y+28, (SUBWINDOW_WIDTH_L)-4, 10, "cg_simpleItemsScale", .2, ITEM_ALIGN_RIGHT, $evalfloat((SUBWINDOW_WIDTH_L)-6), 8 )
+	SLIDER( 8, ITEMS_Y+28, (SUBWINDOW_WIDTH_L)-4, 10, _("Simple Items Scale:"), .2, 8, "cg_simpleItemsScale" 1.0 0.25 1.5, _("Set scale of simple items") )
 
 // Scope //
-#define SCOPE_Y 228
+#define SCOPE_Y 240
 	SUBWINDOW( 6, SCOPE_Y, (SUBWINDOW_WIDTH_R), 52,_( "SCOPE") )
 	MULTI( 8, SCOPE_Y+16, (SUBWINDOW_WIDTH_R)-4, 10, _("Weapon Cycle for Zoom:"), .2, 8, "cg_useWeapsForZoom", cvarFloatList { "Off" 0 "On (normal)" 1 "On (reverse)" 2 }, _("Weapon switch will zoom in and out while scoped, rather than switch weapons") )
 	MULTI( 8, SCOPE_Y+28, (SUBWINDOW_WIDTH_R)-4, 10, _("Default Zoom Level:"), .2, 8, "cg_zoomdefaultsniper", cvarFloatList { "All the way Out" 20 "Near" 16 "Far" 8 "All the Way In" 4 }, _("Set the default zoom level for scopes") )

--- a/src/cgame/cg_ents.c
+++ b/src/cgame/cg_ents.c
@@ -756,8 +756,8 @@ static void CG_Item(centity_t *cent)
 
 		if (simpleItemShader)
 		{
-			simpleItemScaleX *= Com_Clamp(0.1f, 2.f, cg_simpleItemsScale.value);
-			simpleItemScaleY *= Com_Clamp(0.1f, 2.f, cg_simpleItemsScale.value);
+			simpleItemScaleX *= Com_Clamp(0.25f, 1.5f, cg_simpleItemsScale.value);
+			simpleItemScaleY *= Com_Clamp(0.25f, 1.5f, cg_simpleItemsScale.value);
 			origin[2]        += SIMPLEITEM_ICON_SIZE * simpleItemScaleY / 2.f;
 			// build quad out of verts (inversed)
 			VectorSet(temp[0].xyz, 0, 1 * simpleItemScaleX, 1 * simpleItemScaleY);

--- a/src/cgame/cg_ents.c
+++ b/src/cgame/cg_ents.c
@@ -756,7 +756,9 @@ static void CG_Item(centity_t *cent)
 
 		if (simpleItemShader)
 		{
-			origin[2] += SIMPLEITEM_ICON_SIZE * simpleItemScaleY / 2.f;
+			simpleItemScaleX *= Com_Clamp(0.1f, 2.f, cg_simpleItemsScale.value);
+			simpleItemScaleY *= Com_Clamp(0.1f, 2.f, cg_simpleItemsScale.value);
+			origin[2]        += SIMPLEITEM_ICON_SIZE * simpleItemScaleY / 2.f;
 			// build quad out of verts (inversed)
 			VectorSet(temp[0].xyz, 0, 1 * simpleItemScaleX, 1 * simpleItemScaleY);
 			VectorSet(temp[1].xyz, 0, -1 * simpleItemScaleX, 1 * simpleItemScaleY);

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2784,6 +2784,7 @@ extern vmCvar_t cg_altHudFlags;
 extern vmCvar_t cg_tracers;
 extern vmCvar_t cg_fireteamLatchedClass;
 extern vmCvar_t cg_simpleItems;
+extern vmCvar_t cg_simpleItemsScale;
 
 extern vmCvar_t cg_weapaltReloads;
 

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -320,6 +320,7 @@ vmCvar_t cg_fireteamLatchedClass;
 vmCvar_t cg_weapaltReloads;
 
 vmCvar_t cg_simpleItems;
+vmCvar_t cg_simpleItemsScale;
 
 vmCvar_t cg_automapZoom;
 
@@ -582,6 +583,7 @@ static cvarTable_t cvarTable[] =
 	{ &cg_tracers,                "cg_tracers",                "1",           CVAR_ARCHIVE,                 0 },   // Draw tracers
 	{ &cg_fireteamLatchedClass,   "cg_fireteamLatchedClass",   "1",           CVAR_ARCHIVE,                 0 },   // Draw fireteam members latched class
 	{ &cg_simpleItems,            "cg_simpleItems",            "0",           CVAR_ARCHIVE,                 0 },   // Bugged atm
+	{ &cg_simpleItemsScale,       "cg_simpleItemsScale",       "1.0",         CVAR_ARCHIVE,                 0 },
 	{ &cg_automapZoom,            "cg_automapZoom",            "5.159",       CVAR_ARCHIVE,                 0 },
 	{ &cg_drawTime,               "cg_drawTime",               "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_popupFadeTime,          "cg_popupFadeTime",          "2500",        CVAR_ARCHIVE,                 0 },


### PR DESCRIPTION
Cvar to control size of items when `cg_simpleItems` is enabled. Scaling factor is limited to __0.1__ - __2.0__.