### PR TITLE
game: don't count overkill damage towards players stats

### DIFF
--- a/src/game/g_combat.c
+++ b/src/game/g_combat.c
@@ -1659,6 +1659,7 @@ void G_Damage(gentity_t *targ, gentity_t *inflictor, gentity_t *attacker, vec3_t
 	// do the damage
 	if (take)
 	{
+		damage        = targ->health;
 		targ->health -= take;
 
 		// can't gib with bullet weapons
@@ -1732,7 +1733,7 @@ void G_Damage(gentity_t *targ, gentity_t *inflictor, gentity_t *attacker, vec3_t
 				{
 					// Kill the entity.  Note that this funtion can set ->die to another
 					// function pointer, so that next time die is applied to the dead body.
-					targ->die(targ, inflictor, attacker, take, mod);
+					targ->die(targ, inflictor, attacker, damage, mod);
 					// kill stats in player_die function
 				}
 


### PR DESCRIPTION
Full damage was counted towards the stats which was inflating numbers on grenades/PF/arty/airstrike.

Player A with PF (400dmg direct hit) hits a Player B with 1hp. Player A gets awarded with 400 damage done and Player B gets awarded with 400 damage received, both stats should be increased by 1.