### PR TITLE
game: fix dead bodies blocking missiles because of high BBox, refs #503

### DIFF
--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -83,7 +83,7 @@
 #define PRONE_BODYHEIGHT_DELTA           0  ///< prone   body height -8
 
 #define PRONE_BODYHEIGHT_BBOX 12    ///< it appears that 12 is the magic number for the minimum maxs[2] that prevents player from getting stuck into the world.
-#define DEAD_BODYHEIGHT_BBOX 24     ///< was the result of DEFAULT_VIEWHEIGHT - CROUCH_VIEWHEIGHT (40 - 16) stored in crouchMaxZ
+#define DEAD_BODYHEIGHT_BBOX 0      ///< was the result of DEFAULT_VIEWHEIGHT - CROUCH_VIEWHEIGHT (40 - 16) stored in crouchMaxZ
 
 extern vec3_t playerlegsProneMins;
 extern vec3_t playerlegsProneMaxs;


### PR DESCRIPTION
Dead and wounded player bodies have way too big BBox causing all kinds of missiles to be blocked by them. Previously the lower bbox was causing issues but now it seems to be fine.

Old: 
![bbox_old](https://user-images.githubusercontent.com/4499367/131173548-c9847b75-bf44-4217-a863-8d97e242cbd1.png)

New:
![bbox_new](https://user-images.githubusercontent.com/4499367/131173573-7ccef601-96f8-4698-a37b-c8c19c8ee953.png)


refs #503