### PR TITLE
game: fix unable to change follow when followed team went into limbo

### DIFF
--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -2456,7 +2456,7 @@ void Cmd_FollowCycle_f(gentity_t *ent, int dir, qboolean skipBots)
 		}
 
 		// couple extra checks for limbo mode
-		if (ent->client->ps.pm_flags & PMF_LIMBO)
+		if (ent->client->ps.pm_flags & PMF_LIMBO && ent->client->sess.sessionTeam != TEAM_SPECTATOR)
 		{
 			if (level.clients[clientnum].ps.pm_flags & PMF_LIMBO)
 			{


### PR DESCRIPTION
As spectator when following a player that went into limbo and his whole team was in limbo too it was impossible to change following without first exiting follow mode (default by hitting `space`) despite enemy team having player(s) that can be followed.