### PR TITLE
game: fix cursor hints

### DIFF
--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -2677,6 +2677,7 @@ void G_TempTraceIgnorePlayersAndBodies(void);
 void G_TempTraceIgnorePlayersFromTeam(team_t team);
 void G_TempTraceRealHitBox(gentity_t *ent);
 void G_ResetTempTraceRealHitBox(void);
+void G_TempTraceIgnoreEntities(gentity_t *ent);
 
 qboolean G_CanPickupWeapon(weapon_t weapon, gentity_t *ent);
 

--- a/src/game/g_misc.c
+++ b/src/game/g_misc.c
@@ -2637,6 +2637,46 @@ void G_ResetTempTraceRealHitBox()
 	}
 }
 
+/**
+* @brief G_TempTraceIgnoreEntities
+* @param[in] ent
+*/
+void G_TempTraceIgnoreEntities(gentity_t *ent)
+{
+	int           i;
+	int           listLength;
+	int           list[MAX_GENTITIES];
+	gentity_t     *hit;
+	vec3_t        BBmins, BBmaxs;
+	static vec3_t range = { CH_BREAKABLE_DIST, CH_BREAKABLE_DIST, CH_BREAKABLE_DIST };
+
+	if (!ent->client)
+	{
+		return;
+	}
+
+	VectorSubtract(ent->client->ps.origin, range, BBmins);
+	VectorAdd(ent->client->ps.origin, range, BBmaxs);
+
+	listLength = trap_EntitiesInBox(BBmins, BBmaxs, list, MAX_GENTITIES);
+
+	for (i = 0; i < listLength; i++)
+	{
+		hit = &g_entities[list[i]];
+
+		if (hit->s.eType == ET_OID_TRIGGER || hit->s.eType == ET_TRIGGER_MULTIPLE
+		    || hit->s.eType == ET_TRIGGER_FLAGONLY || hit->s.eType == ET_TRIGGER_FLAGONLY_MULTIPLE)
+		{
+			G_TempTraceIgnoreEntity(hit);
+		}
+
+		if (hit->s.eType == ET_CORPSE && !(ent->client->ps.stats[STAT_PLAYER_CLASS] == PC_COVERTOPS))
+		{
+			G_TempTraceIgnoreEntity(hit);
+		}
+	}
+}
+
 
 /**
  * @brief G_ConstructionBegun


### PR DESCRIPTION
This should fix issues with cursor hints, namely engineer hints disappearing because of triggers while arming/defusing near them. It keeps the number of `trap_EntitiesInBox` calls to 2 like before and reduces number of traces to max 1. Something like this could probably be also used for `Cmd_Activate_f` instead of a loop it has now, but not sure if it would be any faster/better.