### PR TITLE
cgame: add fireteam name and location customization cvars

### DIFF
--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -101,6 +101,50 @@ int CG_Text_Width_Ext(const char *text, float scale, int limit, fontHelper_t *fo
 }
 
 /**
+ * @brief CG_Text_Width_Ext_Float
+ * @param[in] text
+ * @param[in] scale
+ * @param[in] limit
+ * @param[in] font
+ * @return
+ */
+float CG_Text_Width_Ext_Float(const char *text, float scale, int limit, fontHelper_t *font)
+{
+	float out = 0;
+
+	if (text)
+	{
+		const char  *s = text;
+		glyphInfo_t *glyph;
+		int         count = 0;
+		int         len   = Q_UTF8_Strlen(text);
+
+		if (limit > 0 && len > limit)
+		{
+			len = limit;
+		}
+
+		while (s && *s && count < len)
+		{
+			if (Q_IsColorString(s))
+			{
+				s += 2;
+				continue;
+			}
+			else
+			{
+				glyph = Q_UTF8_GetGlyph(font, s);
+				out  += glyph->xSkip;
+				s    += Q_UTF8_Width(s);
+				count++;
+			}
+		}
+	}
+
+	return out * scale * Q_UTF8_GlyphScale(font);
+}
+
+/**
  * @brief CG_Text_Width
  * @param[in] text
  * @param[in] scale

--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -66,38 +66,7 @@ void CG_Text_SetActiveFont(int font)
  */
 int CG_Text_Width_Ext(const char *text, float scale, int limit, fontHelper_t *font)
 {
-	float out = 0;
-
-	if (text)
-	{
-		const char  *s = text;
-		glyphInfo_t *glyph;
-		int         count = 0;
-		int         len   = Q_UTF8_Strlen(text);
-
-		if (limit > 0 && len > limit)
-		{
-			len = limit;
-		}
-
-		while (s && *s && count < len)
-		{
-			if (Q_IsColorString(s))
-			{
-				s += 2;
-				continue;
-			}
-			else
-			{
-				glyph = Q_UTF8_GetGlyph(font, s);
-				out  += glyph->xSkip;
-				s    += Q_UTF8_Width(s);
-				count++;
-			}
-		}
-	}
-
-	return out * scale * Q_UTF8_GlyphScale(font);
+	return CG_Text_Width_Ext_Float(text, scale, limit, font);
 }
 
 /**

--- a/src/cgame/cg_fireteamoverlay.c
+++ b/src/cgame/cg_fireteamoverlay.c
@@ -397,7 +397,7 @@ void CG_DrawFireTeamOverlay(rectDef_t *rect)
 	fireteamData_t *f  = NULL;
 	char           *locStr[MAX_FIRETEAM_MEMBERS];
 	int            curWeap;
-	char           name[MAX_NAME_LENGTH];
+	char           name[MAX_FIRETEAM_MEMBERS][MAX_NAME_LENGTH];
 	int            nameMaxLen;
 
 	// assign fireteam data, and early out if not on one
@@ -407,7 +407,7 @@ void CG_DrawFireTeamOverlay(rectDef_t *rect)
 	}
 
 	Com_Memset(locStr, 0, sizeof(char *) * MAX_FIRETEAM_MEMBERS);
-	Com_Memset(name, 0, sizeof(char) * MAX_NAME_LENGTH);
+	Com_Memset(name, 0, sizeof(char) * (MAX_FIRETEAM_MEMBERS + MAX_NAME_LENGTH));
 
 	// First get name and location width, also store location names
 	for (i = 0; i < MAX_FIRETEAM_MEMBERS; i++)
@@ -453,12 +453,12 @@ void CG_DrawFireTeamOverlay(rectDef_t *rect)
 			locwidth = 0;
 		}
 
-		Q_strncpyz(name, ci->name, sizeof(name));
+		Q_strncpyz(name[i], ci->name, sizeof(name[i]));
 		// truncate name if max chars is set
 		if (cg_fireteamNameMaxChars.integer)
 		{
 			nameMaxLen = Com_Clamp(0, MAX_NAME_LENGTH - 1, cg_fireteamNameMaxChars.integer);
-			Q_strncpyz(name, Q_TruncateStr(name, nameMaxLen), sizeof(name));
+			Q_strncpyz(name[i], Q_TruncateStr(name[i], nameMaxLen), sizeof(name[i]));
 
 			// if alignment is requested, keep a static width
 			if (cg_fireteamNameAlign.integer)
@@ -468,12 +468,12 @@ void CG_DrawFireTeamOverlay(rectDef_t *rect)
 			}
 			else
 			{
-				namewidth = CG_Text_Width_Ext(name, 0.2f, 0, FONT_TEXT);
+				namewidth = CG_Text_Width_Ext(name[i], 0.2f, 0, FONT_TEXT);
 			}
 		}
 		else
 		{
-			namewidth = CG_Text_Width_Ext(name, 0.2f, 0, FONT_TEXT);
+			namewidth = CG_Text_Width_Ext(name[i], 0.2f, 0, FONT_TEXT);
 		}
 
 		if (ci->powerups & ((1 << PW_REDFLAG) | (1 << PW_BLUEFLAG) | (1 << PW_OPS_DISGUISED)))
@@ -601,11 +601,11 @@ void CG_DrawFireTeamOverlay(rectDef_t *rect)
 		// right align?
 		if (cg_fireteamNameAlign.integer > 0)
 		{
-			CG_Text_Paint_RightAligned_Ext(x + bestNameWidth - puwidth, y + FT_BAR_HEIGHT, .2f, .2f, colorWhite, name, 0, 0, ITEM_TEXTSTYLE_SHADOWED, FONT_TEXT);
+			CG_Text_Paint_RightAligned_Ext(x + bestNameWidth - puwidth, y + FT_BAR_HEIGHT, .2f, .2f, colorWhite, name[i], 0, 0, ITEM_TEXTSTYLE_SHADOWED, FONT_TEXT);
 		}
 		else
 		{
-			CG_Text_Paint_Ext(x, y + FT_BAR_HEIGHT, .2f, .2f, colorWhite, name, 0, 0, ITEM_TEXTSTYLE_SHADOWED, FONT_TEXT);
+			CG_Text_Paint_Ext(x, y + FT_BAR_HEIGHT, .2f, .2f, colorWhite, name[i], 0, 0, ITEM_TEXTSTYLE_SHADOWED, FONT_TEXT);
 		}
 
 		// add space

--- a/src/cgame/cg_fireteamoverlay.c
+++ b/src/cgame/cg_fireteamoverlay.c
@@ -407,7 +407,10 @@ void CG_DrawFireTeamOverlay(rectDef_t *rect)
 	}
 
 	Com_Memset(locStr, 0, sizeof(char *) * MAX_FIRETEAM_MEMBERS);
-	Com_Memset(name, 0, sizeof(char) * (MAX_FIRETEAM_MEMBERS + MAX_NAME_LENGTH));
+	for (i = 0; i < MAX_FIRETEAM_MEMBERS; i++)
+	{
+		Com_Memset(name[i], 0, sizeof(char) * (MAX_NAME_LENGTH));
+	}
 
 	// First get name and location width, also store location names
 	for (i = 0; i < MAX_FIRETEAM_MEMBERS; i++)

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2776,6 +2776,7 @@ extern vmCvar_t cg_recording_statusline;
 extern vmCvar_t cg_announcer;
 extern vmCvar_t cg_hitSounds;
 extern vmCvar_t cg_locations;
+extern vmCvar_t cg_locationMaxChars;
 
 extern vmCvar_t cg_spawnTimer_period;
 extern vmCvar_t cg_spawnTimer_set;
@@ -2786,6 +2787,9 @@ extern vmCvar_t cg_altHud;
 extern vmCvar_t cg_altHudFlags;
 extern vmCvar_t cg_tracers;
 extern vmCvar_t cg_fireteamLatchedClass;
+extern vmCvar_t cg_fireteamLocationAlign;
+extern vmCvar_t cg_fireteamNameMaxChars;
+extern vmCvar_t cg_fireteamNameAlign;
 extern vmCvar_t cg_simpleItems;
 extern vmCvar_t cg_simpleItemsScale;
 
@@ -2980,6 +2984,7 @@ void CG_Text_PaintWithCursor_Ext(float x, float y, float scale, vec4_t color, co
 void CG_Text_PaintWithCursor(float x, float y, float scale, vec4_t color, const char *text, int cursorPos, const char *cursor, int limit, int style);
 void CG_Text_SetActiveFont(int font);
 int CG_Text_Width_Ext(const char *text, float scale, int limit, fontHelper_t *font);
+float CG_Text_Width_Ext_Float(const char *text, float scale, int limit, fontHelper_t *font);
 int CG_Text_Width(const char *text, float scale, int limit);
 int CG_Text_Height_Ext(const char *text, float scale, int limit, fontHelper_t *font);
 int CG_Text_Height(const char *text, float scale, int limit);

--- a/src/cgame/cg_localents.c
+++ b/src/cgame/cg_localents.c
@@ -135,6 +135,7 @@ char *CG_GetLocationMsg(int clientNum, vec3_t origin)
 char *CG_BuildLocationString(int clientNum, vec3_t origin, int flag)
 {
 	char *locStr = NULL;
+	int  locMaxLen;
 
 	if (cg_locations.integer & flag)
 	{
@@ -163,6 +164,12 @@ char *CG_BuildLocationString(int clientNum, vec3_t origin, int flag)
 					locStr   = va("^3(%s)", BG_GetLocationString(origin[0], origin[1]));
 					locValid = qfalse; // don't draw it twice..
 				}
+			}
+			// truncate location string if max chars is set
+			if (cg_locationMaxChars.integer)
+			{
+				locMaxLen = Com_Clamp(0, 128, cg_locationMaxChars.integer); // 128 is max location length
+				locStr    = Q_TruncateStr(locStr, locMaxLen);
 			}
 		}
 

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -304,6 +304,7 @@ vmCvar_t cg_recording_statusline;
 vmCvar_t cg_announcer;
 vmCvar_t cg_hitSounds;
 vmCvar_t cg_locations;
+vmCvar_t cg_locationMaxChars;
 
 vmCvar_t cg_spawnTimer_set;         // spawntimer
 vmCvar_t cg_spawnTimer_period;      // spawntimer
@@ -316,6 +317,9 @@ vmCvar_t cg_altHud;
 vmCvar_t cg_altHudFlags;
 vmCvar_t cg_tracers;
 vmCvar_t cg_fireteamLatchedClass;
+vmCvar_t cg_fireteamLocationAlign;
+vmCvar_t cg_fireteamNameMaxChars;
+vmCvar_t cg_fireteamNameAlign;
 
 vmCvar_t cg_weapaltReloads;
 
@@ -570,6 +574,7 @@ static cvarTable_t cvarTable[] =
 	{ &cg_announcer,              "cg_announcer",              "1",           CVAR_ARCHIVE,                 0 },
 	{ &cg_hitSounds,              "cg_hitSounds",              "1",           CVAR_ARCHIVE,                 0 },
 	{ &cg_locations,              "cg_locations",              "3",           CVAR_ARCHIVE,                 0 },
+	{ &cg_locationMaxChars,       "cg_locationMaxChars",       "0",           CVAR_ARCHIVE,                 0 },
 
 	{ &cg_spawnTimer_set,         "cg_spawnTimer_set",         "-1",          CVAR_TEMP,                    0 },
 
@@ -582,6 +587,9 @@ static cvarTable_t cvarTable[] =
 	{ &cg_altHudFlags,            "cg_altHudFlags",            "0",           CVAR_ARCHIVE,                 0 },   // Hudstyles
 	{ &cg_tracers,                "cg_tracers",                "1",           CVAR_ARCHIVE,                 0 },   // Draw tracers
 	{ &cg_fireteamLatchedClass,   "cg_fireteamLatchedClass",   "1",           CVAR_ARCHIVE,                 0 },   // Draw fireteam members latched class
+	{ &cg_fireteamLocationAlign,  "cg_fireteamLocationAlign",  "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_fireteamNameMaxChars,   "cg_fireteamNameMaxChars",   "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_fireteamNameAlign,      "cg_fireteamNameAlign",      "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_simpleItems,            "cg_simpleItems",            "0",           CVAR_ARCHIVE,                 0 },   // Bugged atm
 	{ &cg_simpleItemsScale,       "cg_simpleItemsScale",       "1.0",         CVAR_ARCHIVE,                 0 },
 	{ &cg_automapZoom,            "cg_automapZoom",            "5.159",       CVAR_ARCHIVE,                 0 },

--- a/src/qcommon/q_shared.c
+++ b/src/qcommon/q_shared.c
@@ -1725,6 +1725,50 @@ int Q_PrintStrlen(const char *string)
 }
 
 /**
+ * @brief Q_TruncateStr
+ * @param[in] string
+ * @param[in] limit
+ * @return
+ */
+char *Q_TruncateStr(char *string, int limit)
+{
+	char *p;
+	char *s;
+	int  i, len;
+
+	if (!string)
+	{
+		return 0;
+	}
+
+	len = Q_PrintStrlen(string);
+	if (len <= limit)
+	{
+		return string;
+	}
+
+	p = string;
+	s = string;
+	for (i = 0; i < limit; i++)
+	{
+		if (Q_IsColorString(p))
+		{
+			limit += 2;
+			p     += 2;
+			i++;
+			continue;
+		}
+		p++;
+	}
+
+	limit++; // for null byte
+
+	Q_strncpyz(s, string, limit);
+
+	return s;
+}
+
+/**
  * @brief Remove all leading and trailing whitespace and special characters from string.
  * @param[in,out] string
  * @return

--- a/src/qcommon/q_shared.h
+++ b/src/qcommon/q_shared.h
@@ -663,7 +663,7 @@ char *COM_Parse2(char **data_p);
 char *COM_ParseExt2(char **data_p, qboolean allowLineBreaks);
 
 int COM_Compress(char *data_p);
-void COM_ParseError(const char *format, ...) _attribute ((format(printf, 1, 2)));
+void COM_ParseError(const char *format, ...) _attribute((format(printf, 1, 2)));
 //void COM_ParseWarning(const char *format, ...) _attribute ((format(printf, 1, 2))); // Unused
 
 qboolean COM_BitCheck(const int array[], unsigned int bitNum);
@@ -709,7 +709,7 @@ void Parse1DMatrix(char **buf_p, int x, float *m);
 void Parse2DMatrix(char **buf_p, int y, int x, float *m);
 void Parse3DMatrix(char **buf_p, int z, int y, int x, float *m);
 
-int QDECL Com_sprintf(char *dest, unsigned int size, const char *fmt, ...) _attribute ((format(printf, 3, 4)));
+int QDECL Com_sprintf(char *dest, unsigned int size, const char *fmt, ...) _attribute((format(printf, 3, 4)));
 
 char *Com_SkipTokens(char *s, int numTokens, const char *sep);
 char *Com_SkipCharset(char *s, char *sep);
@@ -818,6 +818,9 @@ void Q_strcat(char *dest, size_t size, const char *src);
 /// strlen that discounts Quake color sequences
 int Q_PrintStrlen(const char *string);
 
+/// truncates a string, taking color codes into account
+char *Q_TruncateStr(char *string, int limit);
+
 /// removes leading and trailing whitespaces from string
 char *Q_TrimStr(char *string);
 
@@ -875,7 +878,7 @@ float *tv(float x, float y, float z);
 #define rc(x) va("%s^7", x) ///< shortcut for color reset after printing variable
 
 //char *QDECL va(char *format, ...) _attribute ((format(printf, 1, 2)));
-char *QDECL va(const char *format, ...) _attribute ((format(printf, 1, 2)));
+char *QDECL va(const char *format, ...) _attribute((format(printf, 1, 2)));
 
 #define TRUNCATE_LENGTH 64
 void Com_TruncateLongString(char *buffer, const char *s);
@@ -892,8 +895,8 @@ qboolean Info_Validate(const char *s);
 qboolean Info_NextPair(const char **head, char *key, char *value);
 
 // this is only here so the functions in q_shared.c and bg_*.c can link
-void QDECL Com_Error(int code, const char *fmt, ...) _attribute ((noreturn, format(printf, 2, 3)));
-void QDECL Com_Printf(const char *fmt, ...) _attribute ((format(printf, 1, 2)));
+void QDECL Com_Error(int code, const char *fmt, ...) _attribute((noreturn, format(printf, 2, 3)));
+void QDECL Com_Printf(const char *fmt, ...) _attribute((format(printf, 1, 2)));
 
 /*
 ==========================================================
@@ -1861,13 +1864,13 @@ void Com_ParseUA(userAgent_t *ua, const char *string);
 #define PP_NARG_(...)  EXPAND(PP_ARG_N(__VA_ARGS__))
 
 #define PP_ARG_N( \
-	    _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, \
-	    _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, \
-	    _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, \
-	    _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, \
-	    _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, \
-	    _51, _52, _53, _54, _55, _56, _57, _58, _59, _60, \
-	    _61, _62, _63, N, ...) N
+		_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, \
+		_11, _12, _13, _14, _15, _16, _17, _18, _19, _20, \
+		_21, _22, _23, _24, _25, _26, _27, _28, _29, _30, \
+		_31, _32, _33, _34, _35, _36, _37, _38, _39, _40, \
+		_41, _42, _43, _44, _45, _46, _47, _48, _49, _50, \
+		_51, _52, _53, _54, _55, _56, _57, _58, _59, _60, \
+		_61, _62, _63, N, ...) N
 
 #define PP_RSEQ_N() \
 	63, 62, 61, 60,          \


### PR DESCRIPTION
Ported over ETPros `b_locationMaxChars` and `b_locationJustify`, and extended the functionality to player name.

* `cg_locationMaxChars` = limits number of chars in location string to `N` (default 0 = no limit)
  * this applies to location strings everywhere, not just fireteam overlay (eg. team chats)
* `cg_fireteamLocationAlign` = aligns location string in fireteam overlay (default 0 = no alignment)
  * < 0 = left align
  * \> 0 = right align
  * when both alignment and max chars are set, width reserved for location display is static
* `cg_fireteamNameMaxChars` = limits number of chars in player names to `N` (default 0 = no limit)
* `cg_fireteamNameAlign` = aligns player names in fireteam overlay (default 0 = no alignment)
  * < 0 = left align
  * \> 0 = right align
  * when both alignment and max chars are set, width reserved for player names is static