### PR TITLE
game: fix ammo not despawning after pickup for fieldop that changed class, refs #980

### DIFF
--- a/src/game/g_items.c
+++ b/src/game/g_items.c
@@ -477,8 +477,8 @@ int Pickup_Weapon(gentity_t *ent, gentity_t *other)
 				// extracted code originally here into AddMagicAmmo
 				// add 1 clip of magic ammo for any two-handed weapon
 			}
-			return RESPAWN_NEVER;
 		}
+		return RESPAWN_NEVER;
 	}
 
 	quantity = ent->count;


### PR DESCRIPTION
When fieldop dropped ammo and changed class the ammo packs where not despawning for him after a pickup, meaning he could get a infinite ammo from one pack.

refs #980