### PR TITLE
mod: update fov and maxfps ranges in comp configs

### DIFF
--- a/etmain/configs/legacy1.config
+++ b/etmain/configs/legacy1.config
@@ -128,14 +128,14 @@ init
 
 	command "sv_cvar cg_simpleitems IN 0 1"
 
-	command "sv_cvar cg_fov IN 90 105"
+	command "sv_cvar cg_fov IN 75 130"
 	command "sv_cvar cg_shadows IN 0 1"
 	command "sv_cvar cg_autoaction IN 2 7"
 
 	command "sv_cvar rate EQ 25000"
 	command "sv_cvar cl_maxpackets EQ 125"
 	command "sv_cvar snaps EQ 20"
-	command "sv_cvar com_maxfps IN 40 125"
+	command "sv_cvar com_maxfps IN 40 250"
 
 	command "sv_cvar m_pitch OUT -0.015 0.015"
 	command "sv_cvar m_yaw IN -0.022 0.022"

--- a/etmain/configs/legacy3.config
+++ b/etmain/configs/legacy3.config
@@ -127,14 +127,14 @@ init
 	command "sv_cvar cl_timenudge EQ 0"
 
 	command "sv_cvar cg_simpleitems IN 0 1"
-	command "sv_cvar cg_fov IN 90 105"
+	command "sv_cvar cg_fov IN 75 130"
 	command "sv_cvar cg_shadows IN 0 1"
 	command "sv_cvar cg_autoaction IN 2 7"
 
 	command "sv_cvar rate EQ 25000"
 	command "sv_cvar cl_maxpackets EQ 125"
 	command "sv_cvar snaps EQ 20"
-	command "sv_cvar com_maxfps IN 40 125"
+	command "sv_cvar com_maxfps IN 40 250"
 
 	command "sv_cvar m_pitch OUT -0.015 0.015"
 	command "sv_cvar m_yaw IN -0.022 0.022"

--- a/etmain/configs/legacy5.config
+++ b/etmain/configs/legacy5.config
@@ -126,14 +126,14 @@ init
 	command "sv_cvar cl_timenudge EQ 0"
 
 	command "sv_cvar cg_simpleitems IN 0 1"
-	command "sv_cvar cg_fov IN 90 105"
+	command "sv_cvar cg_fov IN 75 130"
 	command "sv_cvar cg_shadows IN 0 1"
 	command "sv_cvar cg_autoaction IN 2 7"
 
 	command "sv_cvar rate EQ 25000"
 	command "sv_cvar cl_maxpackets EQ 125"
 	command "sv_cvar snaps EQ 20"
-	command "sv_cvar com_maxfps IN 40 125"
+	command "sv_cvar com_maxfps IN 40 250"
 
 	command "sv_cvar m_pitch OUT -0.015 0.015"
 	command "sv_cvar m_yaw IN -0.022 0.022"

--- a/etmain/configs/legacy6.config
+++ b/etmain/configs/legacy6.config
@@ -126,14 +126,14 @@ init
 	command "sv_cvar cl_timenudge EQ 0"
 
 	command "sv_cvar cg_simpleitems IN 0 1"
-	command "sv_cvar cg_fov IN 90 105"
+	command "sv_cvar cg_fov IN 75 130"
 	command "sv_cvar cg_shadows IN 0 1"
 	command "sv_cvar cg_autoaction IN 2 7"
 
 	command "sv_cvar rate EQ 25000"
 	command "sv_cvar cl_maxpackets EQ 125"
 	command "sv_cvar snaps EQ 20"
-	command "sv_cvar com_maxfps IN 40 125"
+	command "sv_cvar com_maxfps IN 40 250"
 
 	command "sv_cvar m_pitch OUT -0.015 0.015"
 	command "sv_cvar m_yaw IN -0.022 0.022"


### PR DESCRIPTION
Updated allowed `cg_fov` range to __75__ - __130__ (as per recent discussion over at discord) and `com_maxfps` to __40__ - __250__ since maxfps related issues are now fixed.