### PR TITLE
cgame: autocomplete shoutcaster login commands

### DIFF
--- a/src/cgame/cg_consolecmds.c
+++ b/src/cgame/cg_consolecmds.c
@@ -2201,6 +2201,9 @@ void CG_InitConsoleCommands(void)
 	trap_AddCommand("lua_status");
 #endif
 
+	trap_AddCommand("sclogin");
+	trap_AddCommand("sclogout");
+
 	// remove engine commands to avoid abuse
 	trap_RemoveCommand("+lookup");
 	trap_RemoveCommand("-lookup");


### PR DESCRIPTION
Add `sclogin` and `sclogout` to cgame console commands for autocompletion.

refs #1570 