### PR TITLE
qcommon: change `cm_optimizePatchPlanes` to `CVAR_SYSTEMINFO`

### DIFF
--- a/src/qcommon/cm_load.c
+++ b/src/qcommon/cm_load.c
@@ -631,7 +631,7 @@ void CM_LoadMap(const char *name, qboolean clientload, unsigned int *checksum)
 	cm_noCurves            = Cvar_Get("cm_noCurves", "0", CVAR_CHEAT);
 	cm_playerCurveClip     = Cvar_Get("cm_playerCurveClip", "1", CVAR_ARCHIVE | CVAR_CHEAT);
 	cm_optimize            = Cvar_Get("cm_optimize", "1", CVAR_CHEAT);
-	cm_optimizePatchPlanes = Cvar_Get("cm_optimizePatchPlanes", "0", CVAR_CHEAT | CVAR_SERVERINFO);
+	cm_optimizePatchPlanes = Cvar_Get("cm_optimizePatchPlanes", "0", CVAR_CHEAT | CVAR_SYSTEMINFO);
 
 	Com_DPrintf("CM_LoadMap( %s, %i )\n", name, clientload);
 


### PR DESCRIPTION
This allows clients to parse and set the cvar to the value that the server has it set to, eliminating prediction errors when a server is running with the value set to __1__ and client is running on ETLegacy.

refs #1590