### PR TITLE
game: fix dynamite chaining deleting non armed dynamites, refs #1487

### DIFF
--- a/src/game/g_combat.c
+++ b/src/game/g_combat.c
@@ -2108,7 +2108,7 @@ qboolean G_RadiusDamage(vec3_t origin, gentity_t *inflictor, gentity_t *attacker
 		{
 			G_DPrintf("dyno chaining: inflictor: %p, ent: %p\n", inflictor->onobjective, ent->onobjective);
 
-			if (inflictor->onobjective == ent->onobjective)
+			if (inflictor->onobjective == ent->onobjective && ent->s.effect1Time)
 			{
 				if (g_dynamiteChaining.integer & DYNAMITECHAINING_FREE)
 				{

--- a/src/game/g_combat.c
+++ b/src/game/g_combat.c
@@ -2251,7 +2251,7 @@ qboolean etpro_RadiusDamage(vec3_t origin, gentity_t *inflictor, gentity_t *atta
 		{
 			G_DPrintf("dyno chaining: inflictor: %p, ent: %p\n", inflictor->onobjective, ent->onobjective);
 
-			if (inflictor->onobjective == ent->onobjective)
+			if (inflictor->onobjective == ent->onobjective && ent->s.effect1Time)
 			{
 				if (g_dynamiteChaining.integer & DYNAMITECHAINING_FREE)
 				{

--- a/src/game/g_missile.c
+++ b/src/game/g_missile.c
@@ -1262,7 +1262,7 @@ void G_ChainFree(gentity_t *self)
 		{
 			G_DPrintf("dyno chaining: inflictor: %p, ent: %p\n", self->onobjective, ent->onobjective);
 
-			if (self->onobjective == ent->onobjective)
+			if (self->onobjective == ent->onobjective && ent->s.effect1Time)
 			{
 				// free the other dynamite now too since they are peers
 				ent->nextthink = level.time;


### PR DESCRIPTION
Armed dynamites not on objectives were deleting not armed dynamites that were on objective causing games to be impacted by it. Armed dynamites on objectives were not deleting not armed dynamites ever. 

Changed the behaviour so not armed dynamites are not deleted.

refs #1487