### PR TITLE
game: fix wounded players getting stuck in solids

### DIFF
--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -818,85 +818,6 @@ static qboolean PM_CheckWaterJump(void)
 }
 
 /**
- * @brief PM_CheckProneOrDeadColision
- * @param[in] checkProne
- * @return
- */
-qboolean PM_CheckProneOrDeadColision(qboolean checkProne)
-{
-	trace_t trace;
-	vec3_t  end;
-	vec3_t  oldOrigin;
-	int     eFlag = checkProne ? EF_PRONE : EF_DEAD;
-
-	BG_LegsCollisionBoxOffset(pm->ps->viewangles, eFlag, end);
-	VectorAdd(pm->ps->origin, end, end);
-
-	pm->trace(&trace, pm->ps->origin, playerlegsProneMins, playerlegsProneMaxs, end, pm->ps->clientNum, pm->tracemask);
-
-	if (trace.fraction != 1.f)
-	{
-		VectorSubtract(trace.endpos, end, end);
-		VectorCopy(pm->ps->origin, oldOrigin);
-
-		pm->ps->eFlags |= eFlag;
-		PM_StepSlideMove(qfalse);
-		PM_TraceAll(&trace, pm->ps->origin, pm->ps->origin);
-
-		if (trace.startsolid || trace.allsolid || trace.fraction != 1.f)
-		{
-			// push back the origin and retry
-			VectorAdd(oldOrigin, end, pm->ps->origin);
-			PM_StepSlideMove(qfalse);
-			PM_TraceAll(&trace, pm->ps->origin, pm->ps->origin);
-
-			if (trace.startsolid || trace.allsolid || trace.fraction != 1.f)
-			{
-				pm->ps->eFlags &= ~eFlag;
-				VectorCopy(oldOrigin, pm->ps->origin);
-				return qfalse;
-			}
-		}
-		pm->ps->eFlags &= ~eFlag;
-	}
-	else
-	{
-		BG_HeadCollisionBoxOffset(pm->ps->viewangles, eFlag, end);
-		VectorAdd(pm->ps->origin, end, end);
-
-		pm->trace(&trace, pm->ps->origin, playerHeadProneMins, playerHeadProneMaxs, end, pm->ps->clientNum, pm->tracemask);
-
-		if (trace.fraction != 1.f)
-		{
-			VectorSubtract(trace.endpos, end, end);
-			VectorCopy(pm->ps->origin, oldOrigin);
-
-			pm->ps->eFlags |= eFlag;
-			PM_StepSlideMove(qfalse);
-			PM_TraceAll(&trace, pm->ps->origin, pm->ps->origin);
-
-			if (trace.startsolid || trace.allsolid || trace.fraction != 1.f)
-			{
-				// push back the origin and retry
-				VectorAdd(oldOrigin, end, pm->ps->origin);
-				PM_StepSlideMove(qfalse);
-				PM_TraceAll(&trace, pm->ps->origin, pm->ps->origin);
-
-				if (trace.startsolid || trace.allsolid || trace.fraction != 1.f)
-				{
-					pm->ps->eFlags &= ~eFlag;
-					VectorCopy(oldOrigin, pm->ps->origin);
-					return qfalse;
-				}
-			}
-			pm->ps->eFlags &= ~eFlag;
-		}
-	}
-
-	return qtrue;
-}
-
-/**
  * @brief Sets mins, maxs, and pm->ps->viewheight
  * @return
  */
@@ -943,6 +864,10 @@ static qboolean PM_CheckProne(void)
 		if ((((pm->ps->pm_flags & PMF_DUCKED) && pm->cmd.doubleTap == DT_FORWARD) ||
 		     (pm->cmd.wbuttons & WBUTTON_PRONE)) && pm->cmd.serverTime - -pm->pmext->proneTime > pronedelay)
 		{
+			trace_t trace;
+			vec3_t  end;
+			vec3_t  oldOrigin;
+
 			pm->mins[0] = pm->ps->mins[0];
 			pm->mins[1] = pm->ps->mins[1];
 
@@ -952,6 +877,70 @@ static qboolean PM_CheckProne(void)
 			pm->mins[2] = pm->ps->mins[2];
 			pm->maxs[2] = pm->ps->crouchMaxZ;
 
+			BG_LegsCollisionBoxOffset(pm->ps->viewangles, EF_PRONE, end);
+			VectorAdd(pm->ps->origin, end, end);
+
+			pm->trace(&trace, pm->ps->origin, playerlegsProneMins, playerlegsProneMaxs, end, pm->ps->clientNum, pm->tracemask);
+
+			if (trace.fraction != 1.f)
+			{
+				VectorSubtract(trace.endpos, end, end);
+				VectorCopy(pm->ps->origin, oldOrigin);
+
+				pm->ps->eFlags |= EF_PRONE;
+				PM_StepSlideMove(qfalse);
+				PM_TraceAll(&trace, pm->ps->origin, pm->ps->origin);
+
+				if (trace.startsolid || trace.allsolid || trace.fraction != 1.f)
+				{
+					// push back the origin and retry
+					VectorAdd(oldOrigin, end, pm->ps->origin);
+					PM_StepSlideMove(qfalse);
+					PM_TraceAll(&trace, pm->ps->origin, pm->ps->origin);
+
+					if (trace.startsolid || trace.allsolid || trace.fraction != 1.f)
+					{
+						pm->ps->eFlags &= ~EF_PRONE;
+						VectorCopy(oldOrigin, pm->ps->origin);
+						return qfalse;
+					}
+				}
+				pm->ps->eFlags &= ~EF_PRONE;
+			}
+			else
+			{
+				BG_HeadCollisionBoxOffset(pm->ps->viewangles, EF_PRONE, end);
+				VectorAdd(pm->ps->origin, end, end);
+
+				pm->trace(&trace, pm->ps->origin, playerHeadProneMins, playerHeadProneMaxs, end, pm->ps->clientNum, pm->tracemask);
+
+				if (trace.fraction != 1.f)
+				{
+					VectorSubtract(trace.endpos, end, end);
+					VectorCopy(pm->ps->origin, oldOrigin);
+
+					pm->ps->eFlags |= EF_PRONE;
+					PM_StepSlideMove(qfalse);
+					PM_TraceAll(&trace, pm->ps->origin, pm->ps->origin);
+
+					if (trace.startsolid || trace.allsolid || trace.fraction != 1.f)
+					{
+						// push back the origin and retry
+						VectorAdd(oldOrigin, end, pm->ps->origin);
+						PM_StepSlideMove(qfalse);
+						PM_TraceAll(&trace, pm->ps->origin, pm->ps->origin);
+
+						if (trace.startsolid || trace.allsolid || trace.fraction != 1.f)
+						{
+							pm->ps->eFlags &= ~EF_PRONE;
+							VectorCopy(oldOrigin, pm->ps->origin);
+							return qfalse;
+						}
+					}
+					pm->ps->eFlags &= ~EF_PRONE;
+				}
+			}
+
 			if (PM_PRONEDELAY)
 			{
 				pm->ps->aimSpreadScale      = AIMSPREAD_MAXSPREAD;
@@ -959,7 +948,7 @@ static qboolean PM_CheckProne(void)
 			}
 
 			// go prone
-			if (PM_CheckProneOrDeadColision(qtrue))
+			if (trace.fraction == 1.0f)
 			{
 				pm->ps->pm_flags    |= PMF_DUCKED;                           // crouched as well
 				pm->ps->eFlags      |= EF_PRONE;
@@ -1456,7 +1445,6 @@ static void PM_DeadMove(void)
 
 	if (!pml.walking)
 	{
-		PM_CheckProneOrDeadColision(qfalse);
 		return;
 	}
 

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -583,6 +583,8 @@ typedef struct pmoveExt_s
 
 	float bobCycle;                ///< used to fix framerate dependency
 
+	qboolean deadInSolid;          ///< true if legs or head start in solid when we die
+
 } pmoveExt_t;  ///< data used both in client and server - store it here
 ///< instead of playerstate to prevent different engine versions of playerstate between XP and MP
 
@@ -642,7 +644,7 @@ typedef struct
 } pmove_t;
 
 // if a full pmove isn't done on the client, you can just update the angles
-void PM_UpdateViewAngles(playerState_t * ps, pmoveExt_t * pmext, usercmd_t * cmd, void(trace) (trace_t * results, const vec3_t start, const vec3_t mins, const vec3_t maxs, const vec3_t end, int passEntityNum, int contentMask), int tracemask);
+void PM_UpdateViewAngles(playerState_t *ps, pmoveExt_t *pmext, usercmd_t *cmd, void(trace) (trace_t * results, const vec3_t start, const vec3_t mins, const vec3_t maxs, const vec3_t end, int passEntityNum, int contentMask), int tracemask);
 int Pmove(pmove_t *pmove);
 void PmovePredict(pmove_t *pmove, float frametime);
 
@@ -956,10 +958,10 @@ typedef enum
  */
 typedef enum
 {
-    SK_BATTLE_SENSE_BINOCULAR = 1,
-    SK_BATTLE_SENSE_STAMINA_RECHARGE,
-    SK_BATTLE_SENSE_HEALTH,
-    SK_BATTLE_SENSE_TRAP_AWARENESS
+	SK_BATTLE_SENSE_BINOCULAR = 1,
+	SK_BATTLE_SENSE_STAMINA_RECHARGE,
+	SK_BATTLE_SENSE_HEALTH,
+	SK_BATTLE_SENSE_TRAP_AWARENESS
 } skill_battlesense_t;
 
 /**
@@ -969,9 +971,9 @@ typedef enum
 typedef enum
 {
 	SK_SOLDIER_PROJECTILE_STAMINA = 1,
-    SK_SOLDIER_OVERHEATING_COOLDOWN,
-    SK_SOLDIER_DEXTERITY,
-    SK_SOLDIER_SMG
+	SK_SOLDIER_OVERHEATING_COOLDOWN,
+	SK_SOLDIER_DEXTERITY,
+	SK_SOLDIER_SMG
 } skill_soldier_t;
 
 /**
@@ -981,9 +983,9 @@ typedef enum
 typedef enum
 {
 	SK_MEDIC_EXTRA_AMMO = 1,
-    SK_MEDIC_RESOURCES,
-    SK_MEDIC_FULL_REVIVE,
-    SK_MEDIC_ADRENALINE
+	SK_MEDIC_RESOURCES,
+	SK_MEDIC_FULL_REVIVE,
+	SK_MEDIC_ADRENALINE
 } skill_medic_t;
 
 /**
@@ -993,9 +995,9 @@ typedef enum
 typedef enum
 {
 	SK_ENGINEER_EXTRA_GRENADE = 1,
-    SK_ENGINEER_PLIERS_DEXTERITY,
-    SK_ENGINEER_STAMINA,
-    SK_ENGINEER_FLAK_JACKET
+	SK_ENGINEER_PLIERS_DEXTERITY,
+	SK_ENGINEER_STAMINA,
+	SK_ENGINEER_FLAK_JACKET
 } skill_engineer_t;
 
 /**
@@ -1005,9 +1007,9 @@ typedef enum
 typedef enum
 {
 	SK_FIELDOPS_RESOURCES = 1,
-    SK_FIELDOPS_FIRE_SUPPORT_STAMINA,
-    SK_FIELDOPS_EXTRA_FIRE_SUPPORT,
-    SK_FIELDOPS_ENEMY_RECOGNITION
+	SK_FIELDOPS_FIRE_SUPPORT_STAMINA,
+	SK_FIELDOPS_EXTRA_FIRE_SUPPORT,
+	SK_FIELDOPS_ENEMY_RECOGNITION
 } skill_fieldops_t;
 
 /**
@@ -1016,10 +1018,10 @@ typedef enum
  */
 typedef enum
 {
-    SK_COVERTOPS_EXTRA_MAX_AMMO = 1,
-    SK_COVERTOPS_STAMINA,
-    SK_COVERTOPS_BREATH_CONTROL,
-    SK_COVERTOPS_ASSASSIN
+	SK_COVERTOPS_EXTRA_MAX_AMMO = 1,
+	SK_COVERTOPS_STAMINA,
+	SK_COVERTOPS_BREATH_CONTROL,
+	SK_COVERTOPS_ASSASSIN
 } skill_covertops_t;
 
 /**
@@ -1029,9 +1031,9 @@ typedef enum
 typedef enum
 {
 	SK_LIGHT_WEAPONS_EXTRA_AMMO = 1,
-    SK_LIGHT_WEAPONS_FASTER_RELOAD,
-    SK_LIGHT_WEAPONS_HANDLING,
-    SK_LIGHT_WEAPONS_AKIMBO
+	SK_LIGHT_WEAPONS_FASTER_RELOAD,
+	SK_LIGHT_WEAPONS_HANDLING,
+	SK_LIGHT_WEAPONS_AKIMBO
 } skill_lightweapons_t;
 
 /**
@@ -1291,8 +1293,8 @@ typedef struct weapontable_s
 
 	const char *className;          ///< g -
 	const char *weapFile;           ///< cg -
-    
-    int chargeTimeSkill;            ///< bg cg -
+
+	int chargeTimeSkill;            ///< bg cg -
 	float chargeTimeCoeff[2];       ///< bg cg -
 
 	meansOfDeath_t mod;                           ///< g - means of death
@@ -3031,8 +3033,8 @@ typedef enum popupMessageBigType_e
 #define HITBOXBIT_LEGS   2048
 #define HITBOXBIT_CLIENT 4096
 
-void PM_TraceLegs(trace_t * trace, float *legsOffset, vec3_t start, vec3_t end, trace_t * bodytrace, vec3_t viewangles, void(tracefunc)(trace_t * results, const vec3_t start, const vec3_t mins, const vec3_t maxs, const vec3_t end, int passEntityNum, int contentMask), int ignoreent, int tracemask);
-void PM_TraceHead(trace_t * trace, vec3_t start, vec3_t end, trace_t * bodytrace, vec3_t viewangles, void(tracefunc)(trace_t * results, const vec3_t start, const vec3_t mins, const vec3_t maxs, const vec3_t end, int passEntityNum, int contentMask), int ignoreent, int tracemask);
+void PM_TraceLegs(trace_t *trace, float *legsOffset, vec3_t start, vec3_t end, trace_t *bodytrace, vec3_t viewangles, void(tracefunc)(trace_t * results, const vec3_t start, const vec3_t mins, const vec3_t maxs, const vec3_t end, int passEntityNum, int contentMask), int ignoreent, int tracemask);
+void PM_TraceHead(trace_t *trace, vec3_t start, vec3_t end, trace_t *bodytrace, vec3_t viewangles, void(tracefunc)(trace_t * results, const vec3_t start, const vec3_t mins, const vec3_t maxs, const vec3_t end, int passEntityNum, int contentMask), int ignoreent, int tracemask);
 void PM_TraceAllParts(trace_t *trace, float *legsOffset, vec3_t start, vec3_t end);
 void PM_TraceAll(trace_t *trace, vec3_t start, vec3_t end);
 

--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -1206,8 +1206,8 @@ void SetWolfSpawnWeapons(gclient_t *client)
 	// parse available primary weapons and check is valid for current class
 	for (i = 0; i < MAX_WEAPS_PER_CLASS && classInfo->classPrimaryWeapons[i].weapon; i++)
 	{
-        if (BG_IsSkillAvailable(client->sess.skill, classInfo->classPrimaryWeapons[i].skill, classInfo->classPrimaryWeapons[i].minSkillLevel)
-                && client->sess.skill[classInfo->classPrimaryWeapons[i].skill] >= classInfo->classPrimaryWeapons[i].minSkillLevel)
+		if (BG_IsSkillAvailable(client->sess.skill, classInfo->classPrimaryWeapons[i].skill, classInfo->classPrimaryWeapons[i].minSkillLevel)
+		    && client->sess.skill[classInfo->classPrimaryWeapons[i].skill] >= classInfo->classPrimaryWeapons[i].minSkillLevel)
 		{
 			if (classInfo->classPrimaryWeapons[i].weapon == client->sess.playerWeapon)
 			{
@@ -1235,7 +1235,7 @@ void SetWolfSpawnWeapons(gclient_t *client)
 	for (i = 0; i < MAX_WEAPS_PER_CLASS && classInfo->classSecondaryWeapons[i].weapon; i++)
 	{
 		if (BG_IsSkillAvailable(client->sess.skill, classInfo->classSecondaryWeapons[i].skill, classInfo->classSecondaryWeapons[i].minSkillLevel)
-                && client->sess.skill[classInfo->classSecondaryWeapons[i].skill] >= classInfo->classSecondaryWeapons[i].minSkillLevel)
+		    && client->sess.skill[classInfo->classSecondaryWeapons[i].skill] >= classInfo->classSecondaryWeapons[i].minSkillLevel)
 		{
 			if (classInfo->classSecondaryWeapons[i].weapon == client->sess.playerWeapon2)
 			{
@@ -1256,7 +1256,7 @@ void SetWolfSpawnWeapons(gclient_t *client)
 		weaponClassInfo = &classInfo->classMiscWeapons[i];
 
 		if (BG_IsSkillAvailable(client->sess.skill, classInfo->classMiscWeapons[i].skill, classInfo->classMiscWeapons[i].minSkillLevel)
-                && client->sess.skill[classInfo->classMiscWeapons[i].skill] >= classInfo->classMiscWeapons[i].minSkillLevel)
+		    && client->sess.skill[classInfo->classMiscWeapons[i].skill] >= classInfo->classMiscWeapons[i].minSkillLevel)
 		{
 			// special check for riflenade, we need the launcher to use it
 			if (GetWeaponTableData(weaponClassInfo->weapon)->type & WEAPON_TYPE_RIFLENADE)
@@ -2962,6 +2962,9 @@ void ClientSpawn(gentity_t *ent, qboolean revived, qboolean teamChange, qboolean
 	client->pmext.bAutoReload = client->pers.bAutoReloadAux;
 
 	client->ps.clientNum = index;
+
+	// start tracing legs and head again if they were in solid
+	client->pmext.deadInSolid = qfalse;
 
 	trap_GetUsercmd(client - level.clients, &ent->client->pers.cmd);
 


### PR DESCRIPTION
This reverts commit 9576bc0.

This reverts the previous "wounded stuck in solid while mid-air" commit as it caused following issues:
1.  if you were wounded between 2 solids so that your head/legs were inside solid, and got pushed to get unstuck resulting in legs/head being inside solid, your player would stand up
2. engineers that died while defusing/arming dynamites would often get pushed away from the dynamite, being unable to continue defusing/arming immediately

Instead, this PR introduces new methods for fixing two variations of getting stuck in solids while wounded: mid air via legs or head, and via body when facing solid sideways

Mid-air stucking is prevented by ignoring head and legs trace completely if on the very first frame we die, either of them start in solid. Since further collision traces ignore them, we no longer get stuck inside solids and just fall to ground as nothing is clipping inside a wall anymore.

Body getting stuck on solids was initially caused by https://github.com/etlegacy/etlegacy/commit/c82f66fb82865839df006a56c85b8a8ddfea2b7b, reason being that it made the body bbox Z component smaller than X/Y components. When this happens, the engine adjusts collision box by shrinking it from sides (X/Y) to be more in line with Z component. This meant that dying sideways (so we don't hit a solid with head or legs bbox) next to a solid would clip you into a solid due to damage knockback. This is now fixed by keeping the low bbox for wounded players to minimize obstruction to projectiles, but adjusting Z component of bbox for trace to match X/Y components, so we get proper world collision.

Big props to @isRyven @ryzyk-krzysiek @Aranud for ideas and help while investigating this!

refs #503