### PR TITLE
game: fix corpses going underground when selfkilling mid-air

### DIFF
--- a/src/game/g_items.c
+++ b/src/game/g_items.c
@@ -1170,7 +1170,7 @@ void G_BounceItem(gentity_t *ent, trace_t *trace)
 
 				if (ent->s.eType == ET_CORPSE)
 				{
-					trap_TraceCapsule(&tr, start, NULL, NULL, end, ent->s.number, mask);
+					trap_TraceCapsule(&tr, start, ent->r.mins, ent->r.maxs, end, ent->s.number, mask);
 				}
 				else
 				{


### PR DESCRIPTION
Corpses were traced with `NULL` mins/maxs on `G_BounceItem`, which caused their origin being set to ground level, but since corpses have their origin 24 units above theirs `mins[2]`, which is `-24`,  they would go underground. This only happened on non-axial groundplane, since on axial ones, they don't redo trace.