### PR TITLE
game: fix arty/airstrike shells getting stuck on patch meshes

### DIFF
--- a/src/game/g_weapon.c
+++ b/src/game/g_weapon.c
@@ -2694,7 +2694,7 @@ void G_AirStrikeThink(gentity_t *ent)
 			float     ground = tr.endpos[2];
 
 			tmp[2] = MAX_MAP_SIZE;
-			trap_Trace(&tr, tr.endpos, NULL, NULL, tmp, ent->s.number, MASK_MISSILESHOT);
+			trap_Trace(&tr, tr.endpos, NULL, NULL, tmp, ent->s.number, CONTENTS_SOLID);
 
 			bomb = fire_missile((ent->parent && ent->parent->client) ? ent->parent : ent, tr.endpos, tv(0, 0, (ground - tr.endpos[2]) * (1.f / 0.75f)), ent->s.weapon);
 
@@ -2986,7 +2986,7 @@ void artillerySpotterThink(gentity_t *ent)
 		ground = tr.endpos[2];
 
 		tmp[2] = MAX_MAP_SIZE;
-		trap_Trace(&tr, tr.endpos, NULL, NULL, tmp, ent->s.number, MASK_MISSILESHOT);
+		trap_Trace(&tr, tr.endpos, NULL, NULL, tmp, ent->s.number, CONTENTS_SOLID);
 
 		bomb = fire_missile((ent->parent && ent->parent->client) ? ent->parent : ent, tr.endpos, tv(0, 0, (ground - tr.endpos[2]) * (1.f / 0.75f)), ent->s.weapon);
 
@@ -3020,7 +3020,7 @@ void artillerySpotterThink(gentity_t *ent)
 		ground = tr.endpos[2];
 
 		tmp[2] = MAX_MAP_SIZE;
-		trap_Trace(&tr, tr.endpos, NULL, NULL, tmp, ent->s.number, MASK_MISSILESHOT);
+		trap_Trace(&tr, tr.endpos, NULL, NULL, tmp, ent->s.number, CONTENTS_SOLID);
 
 		bomb = fire_missile((ent->parent && ent->parent->client) ? ent->parent : ent, tr.endpos, tv(0, 0, (ground - tr.endpos[2]) * (1.f / 0.75f)), ent->s.weapon);
 	}


### PR DESCRIPTION
Some maps such as Radar and Railgun have weird patch meshes where arty/airstrike shells fail trace back from ground to sky, due to collision on these types of surfaces being extremely buggy, and the meshes having a `common/clipmissile` shader at the bottom of the mesh, which sometimes caused the trace back to the sky to start below the collision mesh of the patch and hitting the missile clip, resulting at the shells spawning at the net instead of the sky. The trace back to the sky no longer checks for `MASK_MISSILESHOT` but `CONTENTS_SOLID` instead.

![image](https://user-images.githubusercontent.com/14221121/133882693-206f0ead-3c70-47b2-b15e-8c78e3796418.png)
