### PR TITLE
game: fix med/ammo packs clipping to solids, refs #1714

### DIFF
--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -1333,14 +1333,14 @@ void G_DropItems(gentity_t *self)
 			VectorSet(mins, -(ITEM_RADIUS + 8), -(ITEM_RADIUS + 8), 0);
 			VectorSet(maxs, (ITEM_RADIUS + 8), (ITEM_RADIUS + 8), 2 * (ITEM_RADIUS + 8));
 
-			trap_EngineerTrace(self, &tr, viewpos, mins, maxs, origin, self->s.number, MASK_MISSILESHOT);
+			trap_ItemTrace(self, &tr, viewpos, mins, maxs, origin, self->s.number, MASK_MISSILESHOT);
 			if (tr.startsolid)
 			{
 				VectorCopy(forward, viewpos);
 				VectorNormalizeFast(viewpos);
 				VectorMA(self->r.currentOrigin, -24.f, viewpos, viewpos);
 
-				trap_EngineerTrace(self, &tr, viewpos, mins, maxs, origin, self->s.number, MASK_MISSILESHOT);
+				trap_ItemTrace(self, &tr, viewpos, mins, maxs, origin, self->s.number, MASK_MISSILESHOT);
 
 				VectorCopy(tr.endpos, origin);
 			}

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -2623,6 +2623,7 @@ int G_MaxAvailableArtillery(gentity_t *ent);
 void G_SetTargetName(gentity_t *ent, char *targetname);
 void G_KillEnts(const char *target, gentity_t *ignore, gentity_t *killer, meansOfDeath_t mod);
 void trap_EngineerTrace(gentity_t *ent, trace_t *results, const vec3_t start, const vec3_t mins, const vec3_t maxs, const vec3_t end, int passEntityNum, int contentmask);
+void trap_ItemTrace(gentity_t *ent, trace_t *results, const vec3_t start, const vec3_t mins, const vec3_t maxs, const vec3_t end, int passEntityNum, int contentmask);
 
 int G_CountTeamMedics(team_t team, qboolean alivecheck);
 int G_CountTeamFieldops(team_t team);

--- a/src/game/g_weapon.c
+++ b/src/game/g_weapon.c
@@ -199,14 +199,14 @@ void Weapon_Medic_Ext(gentity_t *ent, vec3_t viewpos, vec3_t tosspos, vec3_t vel
 	VectorSet(mins, -(ITEM_RADIUS + 8), -(ITEM_RADIUS + 8), 0);
 	VectorSet(maxs, (ITEM_RADIUS + 8), (ITEM_RADIUS + 8), 2 * (ITEM_RADIUS + 8));
 
-	trap_EngineerTrace(ent, &tr, viewpos, mins, maxs, tosspos, ent->s.number, MASK_MISSILESHOT);
+	trap_ItemTrace(ent, &tr, viewpos, mins, maxs, tosspos, ent->s.number, MASK_MISSILESHOT);
 	if (tr.startsolid)
 	{
 		VectorCopy(forward, viewpos);
 		VectorNormalizeFast(viewpos);
 		VectorMA(ent->r.currentOrigin, -24.f, viewpos, viewpos);
 
-		trap_EngineerTrace(ent, &tr, viewpos, mins, maxs, tosspos, ent->s.number, MASK_MISSILESHOT);
+		trap_ItemTrace(ent, &tr, viewpos, mins, maxs, tosspos, ent->s.number, MASK_MISSILESHOT);
 
 		VectorCopy(tr.endpos, tosspos);
 	}
@@ -277,14 +277,14 @@ void Weapon_MagicAmmo_Ext(gentity_t *ent, vec3_t viewpos, vec3_t tosspos, vec3_t
 	VectorSet(mins, -(ITEM_RADIUS + 8), -(ITEM_RADIUS + 8), 0);
 	VectorSet(maxs, (ITEM_RADIUS + 8), (ITEM_RADIUS + 8), 2 * (ITEM_RADIUS + 8));
 
-	trap_EngineerTrace(ent, &tr, viewpos, mins, maxs, tosspos, ent->s.number, MASK_MISSILESHOT);
+	trap_ItemTrace(ent, &tr, viewpos, mins, maxs, tosspos, ent->s.number, MASK_MISSILESHOT);
 	if (tr.startsolid)
 	{
 		VectorCopy(forward, viewpos);
 		VectorNormalizeFast(viewpos);
 		VectorMA(ent->r.currentOrigin, -24.f, viewpos, viewpos);
 
-		trap_EngineerTrace(ent, &tr, viewpos, mins, maxs, tosspos, ent->s.number, MASK_MISSILESHOT);
+		trap_ItemTrace(ent, &tr, viewpos, mins, maxs, tosspos, ent->s.number, MASK_MISSILESHOT);
 
 		VectorCopy(tr.endpos, tosspos);
 	}
@@ -1521,6 +1521,27 @@ void trap_EngineerTrace(gentity_t *ent, trace_t *results, const vec3_t start, co
 		vec3_t boxmaxs = { 10, 10, 10 };
 		trap_Trace(results, start, boxmins, boxmaxs, start, passEntityNum, contentmask);
 	}
+
+	G_ResetTempTraceIgnoreEnts();
+	G_ResetTempTraceRealHitBox();
+}
+
+/**
+ * @brief trap_ItemTrace
+ * @param[out] results
+ * @param[in] start
+ * @param[in] mins
+ * @param[in] maxs
+ * @param[in] end
+ * @param[in] passEntityNum
+ * @param[in] contentmask
+ */
+void trap_ItemTrace(gentity_t *ent, trace_t *results, const vec3_t start, const vec3_t mins, const vec3_t maxs, const vec3_t end, int passEntityNum, int contentmask)
+{
+	G_TempTraceRealHitBox(ent);
+	G_TempTraceIgnorePlayersAndBodies();
+
+	trap_Trace(results, start, mins, maxs, end, passEntityNum, contentmask);
 
 	G_ResetTempTraceIgnoreEnts();
 	G_ResetTempTraceRealHitBox();


### PR DESCRIPTION
After recent change to `trap_EngineerTrace`, medpacks and ammopacks were re-traced with too small bbox if the initial trace started in solid, causing them to sometimes be tossed right into solids.