### PR TITLE
game: don't let client set firing flag while noclipping

### DIFF
--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -5002,7 +5002,7 @@ void PmoveSingle(pmove_t *pmove)
 	}
 
 	if (!(pm->ps->pm_flags & PMF_RESPAWNED) &&
-	    (pm->ps->pm_type != PM_INTERMISSION))
+	    ((pm->ps->pm_type != PM_INTERMISSION) && (pm->ps->pm_type != PM_NOCLIP)))
 	{
 		// check for ammo
 		if (PM_WeaponAmmoAvailable(pm->ps->weapon))


### PR DESCRIPTION
This caused players to be able to "fire" flamethrower (only visually) while noclipping.