### PR TITLE
cgame: fix rifle swapping to riflenade when out of ammo

### DIFF
--- a/src/cgame/cg_weapons.c
+++ b/src/cgame/cg_weapons.c
@@ -5244,6 +5244,11 @@ void CG_OutOfAmmoChange(qboolean allowForceSwitch)
 	{
 		for (j = 0; j < MAX_WEAPS_IN_BANK_MP && weapBanksMultiPlayer[weapBankSwitchOrder[i]][j]; j++)
 		{
+			// do not switch to riflegrenade when a rifle runs out of ammo, swap to pistol instead
+			if (GetWeaponTableData(weapBanksMultiPlayer[weapBankSwitchOrder[i]][j])->type & WEAPON_TYPE_RIFLENADE)
+			{
+				continue;
+			}
 			if (CG_WeaponSelectable(weapBanksMultiPlayer[weapBankSwitchOrder[i]][j]))
 			{
 				CG_FinishWeaponChange(cg.predictedPlayerState.weapon, weapBanksMultiPlayer[weapBankSwitchOrder[i]][j]);


### PR DESCRIPTION
When rifle was running out of ammo, `cg_noAmmoAutoSwitch` would start loading a riflenade in instead of swapping to pistol. This is inconsistent with vanilla, and most of the time not the desired behavior.