### PR TITLE
game: fix antiwarp locking players in place on respawn forever on high pings

### DIFF
--- a/src/game/et-antiwarp.c
+++ b/src/game/et-antiwarp.c
@@ -23,8 +23,8 @@ qboolean G_DoAntiwarp(gentity_t *ent)
 
 	if (ent && ent->client)
 	{
-		// don't antiwarp spectators
-		if (ent->client->sess.sessionTeam == TEAM_SPECTATOR || (ent->client->ps.pm_flags & PMF_LIMBO))
+		// don't antiwarp spectators, also players that just spawned or are in limbo
+		if (ent->client->sess.sessionTeam == TEAM_SPECTATOR || (ent->client->ps.pm_flags & (PMF_LIMBO | PMF_RESPAWNED)))
 		{
 			return qfalse;
 		}


### PR DESCRIPTION
Players with 300+ pings and on `sv_fps 40` (OCE players on EU servers) were unable to move because antiwarp would lock them in place on respawn. Same thing would happen on 500+ ping and `sv_fps 20`. This will stop players getting antiwarped for minimum time when they respawn.