### PR TITLE
game: add cvar to disable selfkill animation

### DIFF
--- a/src/game/g_combat.c
+++ b/src/game/g_combat.c
@@ -659,8 +659,11 @@ void player_die(gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int 
 		// set enemy location
 		BG_UpdateConditionValue(self->s.number, ANIM_COND_ENEMY_POSITION, 0, qfalse);
 
-		// play specific anim on suicide
-		BG_UpdateConditionValue(self->s.number, ANIM_COND_SUICIDE, meansOfDeath == MOD_SUICIDE, qtrue);
+		if (g_selfkillAnim.integer)
+		{
+			// play specific anim on suicide
+			BG_UpdateConditionValue(self->s.number, ANIM_COND_SUICIDE, meansOfDeath == MOD_SUICIDE, qtrue);
+		}
 
 		// FIXME: add POSITION_RIGHT, POSITION_LEFT
 		if (infront(self, inflictor))
@@ -677,7 +680,10 @@ void player_die(gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int 
 		// record the death animation to be used later on by the corpse
 		self->client->torsoDeathAnim = self->client->ps.torsoAnim;
 		self->client->legsDeathAnim  = self->client->ps.legsAnim;
-		self->client->deathAnimTime  = level.time + self->client->ps.pm_time;
+		if (g_selfkillAnim.integer)
+		{
+			self->client->deathAnimTime = level.time + self->client->ps.pm_time;
+		}
 
 		// the body can still be gibbed
 		self->die = body_die;
@@ -702,7 +708,7 @@ void player_die(gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int 
 	else if (meansOfDeath == MOD_SUICIDE)
 	{
 #ifdef FEATURE_SERVERMDX
-		self->client->deathAnim = qtrue;    // add animation time
+		self->client->deathAnim = g_selfkillAnim.integer ? qtrue : qfalse;    // add animation time
 #endif
 		limbo(self, qtrue);
 	}

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -2126,6 +2126,8 @@ extern vmCvar_t g_playerHitBoxHeight;
 
 extern vmCvar_t g_debugForSingleClient;
 
+extern vmCvar_t g_selfkillAnim;
+
 #define G_InactivityValue (g_inactivity.integer ? g_inactivity.integer : 60)
 #define G_SpectatorInactivityValue (g_spectatorInactivity.integer ? g_spectatorInactivity.integer : 60)
 

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -371,6 +371,8 @@ vmCvar_t g_debugForSingleClient;
 
 vmCvar_t g_suddenDeath;
 
+vmCvar_t g_selfkillAnim;
+
 cvarTable_t gameCvarTable[] =
 {
 	// don't override the cheat state set by the system
@@ -661,6 +663,7 @@ cvarTable_t gameCvarTable[] =
 	{ &g_xpSaver,                         "g_xpSaver",                         "0",                          CVAR_ARCHIVE,                                    0, qfalse, qfalse },
 	{ &g_playerHitBoxHeight,              "g_playerHitBoxHeight",              "36",                         CVAR_ARCHIVE | CVAR_SERVERINFO,                  0, qfalse, qfalse },
 	{ &g_suddenDeath,                     "g_suddenDeath",                     "0",                          CVAR_ARCHIVE,                                    0, qtrue,  qfalse },
+	{ &g_selfkillAnim,                    "g_selfkillAnim",                    "1",                          CVAR_ARCHIVE,                                    0, qtrue,  qfalse },
 };
 
 /**


### PR DESCRIPTION
There has been a lot of complaints from the competitive community about these animations. There are two main issues:

1. Player do not notice that their opponent selfkills in a gunfight, as the body doesn't instantly go into ground like in other mods, but instead slowly falls on it's knees, then ground, making players waste bullets on people who are already dead.
2. Proned players are hard to distinguish from players who have selfkilled, as their stance is very similar.

I do think listening to the competitive community in this regard is the way to go, as it's there where selfkills play a big role when it comes to gameplay. Therefore, added `g_selfkillAnims` cvar to allow server to disable these animations completely.