### PR TITLE
game: slightly raise crouch bbox, refs #198 #1120

### DIFF
--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -72,7 +72,7 @@
 
 #define DEFAULT_BODYHEIGHT     36  ///< delta height -4
 #define CROUCH_BODYHEIGHT      24  ///< delta height 8
-#define CROUCH_IDLE_BODYHEIGHT 18  ///< delta height 2
+#define CROUCH_IDLE_BODYHEIGHT 21  ///< delta height 5
 #define DEAD_BODYHEIGHT        4   ///< delta height 20
 #define PRONE_BODYHEIGHT       -8  ///< delta height 0
 


### PR DESCRIPTION
Slightly raised crouch hitbox minimum height to avoid some cases where a significant part of the upper torso was unshootable, especially noticeable on engineers defusing dynamites (or holding pliers in general).

old:

![image](https://user-images.githubusercontent.com/14221121/135087913-a89abc1f-6251-414b-8fd8-25bb3d69a042.png)

new:

![image](https://user-images.githubusercontent.com/14221121/135087927-05a15d96-cf56-412f-b093-36e6245c7a66.png)
