### PR TITLE
mod: remove `g_playerHitBoxHeight` and use vanilla hitbox height, refs #1408

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2584,8 +2584,6 @@ typedef struct cgs_s
 	mlType_t currentMenuLevel;
 #endif
 
-	int playerHitBoxHeight;
-
 	qboolean sv_cheats;         // server allows cheats
 	int sv_fps;                 // FPS server wants to send
 	sampledStat_t sampledStat;  // fps client sample data

--- a/src/cgame/cg_predict.c
+++ b/src/cgame/cg_predict.c
@@ -150,7 +150,7 @@ float CG_ClientHitboxMaxZ(entityState_t *hitEnt, float def)
 	}
 	else
 	{
-		return cgs.playerHitBoxHeight;
+		return DEFAULT_BODYHEIGHT;
 	}
 }
 

--- a/src/cgame/cg_servercmds.c
+++ b/src/cgame/cg_servercmds.c
@@ -230,8 +230,6 @@ void CG_ParseServerinfo(void)
 	cgs.fixedphysicsfps = Q_atoi(Info_ValueForKey(info, "g_fixedphysicsfps"));
 	cgs.pronedelay      = Q_atoi(Info_ValueForKey(info, "g_pronedelay"));
 
-	cgs.playerHitBoxHeight = Q_atoi(Info_ValueForKey(info, "g_playerHitBoxHeight"));
-
 	// make this available for ingame_callvote
 	trap_Cvar_Set("cg_ui_voteFlags", ((authLevel.integer == RL_NONE) ? Info_ValueForKey(info, "voteFlags") : "0"));
 }

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -70,7 +70,7 @@
 #define DEAD_VIEWHEIGHT     -16
 #define PRONE_VIEWHEIGHT    -8
 
-#define DEFAULT_BODYHEIGHT     36  ///< delta height -4
+#define DEFAULT_BODYHEIGHT     48  ///< delta height 8
 #define CROUCH_BODYHEIGHT      24  ///< delta height 8
 #define CROUCH_IDLE_BODYHEIGHT 18  ///< delta height 2
 #define DEAD_BODYHEIGHT        4   ///< delta height 20

--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -3444,6 +3444,6 @@ float ClientHitboxMaxZ(gentity_t *hitEnt)
 	}
 	else
 	{
-		return g_playerHitBoxHeight.value;
+		return DEFAULT_BODYHEIGHT;
 	}
 }

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -2122,8 +2122,6 @@ extern vmCvar_t g_multiview;
 extern vmCvar_t g_stickyCharge;
 extern vmCvar_t g_xpSaver;
 
-extern vmCvar_t g_playerHitBoxHeight;
-
 extern vmCvar_t g_debugForSingleClient;
 
 #define G_InactivityValue (g_inactivity.integer ? g_inactivity.integer : 60)

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -365,8 +365,6 @@ vmCvar_t g_multiview; // 0 - off, other - enabled
 vmCvar_t g_stickyCharge;
 vmCvar_t g_xpSaver;
 
-vmCvar_t g_playerHitBoxHeight;
-
 vmCvar_t g_debugForSingleClient;
 
 vmCvar_t g_suddenDeath;
@@ -659,7 +657,6 @@ cvarTable_t gameCvarTable[] =
 #endif
 	{ &g_stickyCharge,                    "g_stickyCharge",                    "0",                          CVAR_ARCHIVE,                                    0, qfalse, qfalse },
 	{ &g_xpSaver,                         "g_xpSaver",                         "0",                          CVAR_ARCHIVE,                                    0, qfalse, qfalse },
-	{ &g_playerHitBoxHeight,              "g_playerHitBoxHeight",              "36",                         CVAR_ARCHIVE | CVAR_SERVERINFO,                  0, qfalse, qfalse },
 	{ &g_suddenDeath,                     "g_suddenDeath",                     "0",                          CVAR_ARCHIVE,                                    0, qtrue,  qfalse },
 };
 


### PR DESCRIPTION
This was added as a test some 9 months ago, but basically ever since then, `g_playerHitBoxHeight` has just been set to __48__ on servers, so let's just remove the cvar and use the vanilla hitbox height, as it's what's currently being used.