### PR TITLE
cgame: swap `cg_simpleItems` values

### DIFF
--- a/etmain/ui/options_customise_game.menu
+++ b/etmain/ui/options_customise_game.menu
@@ -53,7 +53,7 @@ menuDef {
 // Items //
 #define ITEMS_Y 194
 	SUBWINDOW( 6, ITEMS_Y, (SUBWINDOW_WIDTH_L), 42, _("ITEMS") )
-	MULTI( 8, ITEMS_Y+16, (SUBWINDOW_WIDTH_R)-4, 10, _("Simple Items:"), .2, 8, "cg_simpleItems", cvarFloatList { "No" 0 "Yes" 1 "Yes except objectives" 2 }, _("Draw simple items") )
+	MULTI( 8, ITEMS_Y+16, (SUBWINDOW_WIDTH_R)-4, 10, _("Simple Items:"), .2, 8, "cg_simpleItems", cvarFloatList { "No" 0 "Yes except objectives" 1 "Yes" 2 }, _("Draw simple items") )
 	CVARFLOATLABEL( 8, ITEMS_Y+28, (SUBWINDOW_WIDTH_L)-4, 10, "cg_simpleItemsScale", .2, ITEM_ALIGN_RIGHT, $evalfloat((SUBWINDOW_WIDTH_L)-6), 8 )
 	SLIDER( 8, ITEMS_Y+28, (SUBWINDOW_WIDTH_L)-4, 10, _("Simple Items Scale:"), .2, 8, "cg_simpleItemsScale" 1.0 0.25 1.5, _("Set scale of simple items") )
 

--- a/src/cgame/cg_ents.c
+++ b/src/cgame/cg_ents.c
@@ -664,7 +664,7 @@ static void CG_Item(centity_t *cent)
 
 	item = BG_GetItem(es->modelindex);
 
-	if (cg_simpleItems.integer == 1 || (cg_simpleItems.integer > 1 && item->giType != IT_TEAM))
+	if (cg_simpleItems.integer > 1 || (cg_simpleItems.integer == 1 && item->giType != IT_TEAM))
 	{
 		polyVert_t   temp[4];
 		polyVert_t   quad[4];


### PR DESCRIPTION
Makes more sense to "add" features with a higher cvar value, and makes it less awkward to force simple item objectives off for competitive configs.