### PR TITLE
Add PrefersNonDefaultGPU flag to Desktop Entry

### DIFF
--- a/misc/com.etlegacy.ETLegacy.desktop
+++ b/misc/com.etlegacy.ETLegacy.desktop
@@ -10,3 +10,4 @@ MimeType=x-scheme-handler/et;
 Categories=Game;ActionGame;
 StartupNotify=false
 Keywords=team-based;multiplayer;tactical;WWII;enemy;territory;
+PrefersNonDefaultGPU=true


### PR DESCRIPTION
This means that the application will automatically start with the dedicated GPU of laptops, instead of the iGPU.