### PR TITLE
cgame: add chat customizability options

### DIFF
--- a/etmain/scripts/legacy.shader
+++ b/etmain/scripts/legacy.shader
@@ -1425,6 +1425,18 @@ gfx/hud/ranks/xrank11
 	}
 }
 
+// fixed chat background bar using clampMap instead of map for drawing
+gfx/2d/colorbar
+{
+	nomipmaps
+	nopicmip
+	{
+		clampMap gfx/2d/colorbar.tga
+		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
+		rgbGen vertex
+	}
+}
+
 // disguised shader
 gfx/2d/friendlycross
 {

--- a/etmain/ui/options_customise_game.menu
+++ b/etmain/ui/options_customise_game.menu
@@ -66,22 +66,35 @@ menuDef {
 
 // Chat //
 #define CHAT_Y 32
-	SUBWINDOW( 6+(SUBWINDOW_WIDTH_L)+6, CHAT_Y, (SUBWINDOW_WIDTH_R), 76, _("CHAT") )
+	SUBWINDOW( 6+(SUBWINDOW_WIDTH_L)+6, CHAT_Y, (SUBWINDOW_WIDTH_R), 172, _("CHAT") )
 	MULTI( 6+(SUBWINDOW_WIDTH_L)+6+2, CHAT_Y+16, (SUBWINDOW_WIDTH_L)-4, 10, _("Quick Chat:"), .2, 8, "cg_quickChat", cvarFloatList { "Disabled" 0 "Team" 1 "Fireteam" 2 }, _("Specify receiver of quick radio messages") )
 	MULTI( 6+(SUBWINDOW_WIDTH_L)+6+2, CHAT_Y+28, (SUBWINDOW_WIDTH_L)-4, 10, _("Quick Chat Mode:"), .2, 8, "cg_quickMessageAlt", cvarFloatList { "Alpha" 0 "Numeric" 1 }, _("Use alpha or numeric keys to send radio messages") )
 	MULTI( 6+(SUBWINDOW_WIDTH_L)+6+2, CHAT_Y+40, (SUBWINDOW_WIDTH_L)-4, 10, _("Chat Icon Time:"), .2, 8, "cg_voiceSpriteTime", cvarFloatList { "Short" 3000 "Normal" 6000 "Long" 12000 "Really Long" 24000 }, _("Specify how long the chat icon appears above other players' heads") )
 	YESNO( 6+(SUBWINDOW_WIDTH_L)+6+2, CHAT_Y+52, (SUBWINDOW_WIDTH_L)-4, 10, _("Team chat only:"), .2, 8, "cg_teamChatsOnly", _("Play only team chat in-game") )
 	YESNO( 6+(SUBWINDOW_WIDTH_L)+6+2, CHAT_Y+64, (SUBWINDOW_WIDTH_L)-4, 10, _("Voice text:"), .2, 8, "cg_voiceText", _("Show voice text in-game") )
+	CVARFLOATLABEL( 6+(SUBWINDOW_WIDTH_L)+6+2, CHAT_Y+76, (SUBWINDOW_WIDTH_L)-4, 10, "cg_chatX", .2, ITEM_ALIGN_RIGHT, $evalfloat((SUBWINDOW_WIDTH_L)-6), 8 )
+	SLIDER( 6+(SUBWINDOW_WIDTH_L)+6+2, CHAT_Y+76, (SUBWINDOW_WIDTH_L)-4, 10, _("Chat X:"), .2, 8, "cg_chatX" 160 0 640, _("Set X position of chat") )
+	CVARFLOATLABEL( 6+(SUBWINDOW_WIDTH_L)+6+2, CHAT_Y+88, (SUBWINDOW_WIDTH_L)-4, 10, "cg_chatY", .2, ITEM_ALIGN_RIGHT, $evalfloat((SUBWINDOW_WIDTH_L)-6), 8 )
+	SLIDER( 6+(SUBWINDOW_WIDTH_L)+6+2, CHAT_Y+88, (SUBWINDOW_WIDTH_L)-4, 10, _("Chat Y:"), .2, 8, "cg_chatY" 478 0 480, _("Set Y position of chat") )
+	CVARFLOATLABEL( 6+(SUBWINDOW_WIDTH_L)+6+2, CHAT_Y+100, (SUBWINDOW_WIDTH_L)-4, 10, "cg_chatScale", .2, ITEM_ALIGN_RIGHT, $evalfloat((SUBWINDOW_WIDTH_L)-6), 8 )
+	SLIDER( 6+(SUBWINDOW_WIDTH_L)+6+2, CHAT_Y+100, (SUBWINDOW_WIDTH_L)-4, 10, _("Chat Scale:"), .2, 8, "cg_chatScale" 1.0 0.5 2.0, _("Set scale of chat") )
+	CVARFLOATLABEL( 6+(SUBWINDOW_WIDTH_L)+6+2, CHAT_Y+112, (SUBWINDOW_WIDTH_L)-4, 10, "cg_chatAlpha", .2, ITEM_ALIGN_RIGHT, $evalfloat((SUBWINDOW_WIDTH_L)-6), 8 )
+	SLIDER( 6+(SUBWINDOW_WIDTH_L)+6+2, CHAT_Y+112, (SUBWINDOW_WIDTH_L)-4, 10, _("Chat Alpha:"), .2, 8, "cg_chatAlpha" 1.0 0.0 1.0, _("Set opacity of chat") )
+	CVARFLOATLABEL( 6+(SUBWINDOW_WIDTH_L)+6+2, CHAT_Y+124, (SUBWINDOW_WIDTH_L)-4, 10, "cg_chatBackgroundAlpha", .2, ITEM_ALIGN_RIGHT, $evalfloat((SUBWINDOW_WIDTH_L)-6), 8 )
+	SLIDER( 6+(SUBWINDOW_WIDTH_L)+6+2, CHAT_Y+124, (SUBWINDOW_WIDTH_L)-4, 10, _("Chat Background Alpha:"), .2, 8, "cg_chatBackgroundAlpha" 0.66 0.0 1.0, _("Set opacity of chat background") )
+	YESNO( 6+(SUBWINDOW_WIDTH_L)+6+2, CHAT_Y+136, (SUBWINDOW_WIDTH_L)-4, 10, _("Chat Shadow:"), .2, 8, "cg_chatShadow", _("Draw shadow on chat") )
+	YESNO( 6+(SUBWINDOW_WIDTH_L)+6+2, CHAT_Y+148, (SUBWINDOW_WIDTH_L)-4, 10, _("Chat Flags:"), .2, 8, "cg_chatFlags", _("Draw team flags on chat") )
+	MULTI( 6+(SUBWINDOW_WIDTH_L)+6+2, CHAT_Y+160, (SUBWINDOW_WIDTH_L)-4, 10, _("Chat Line Width:"), .2, 8, "cg_chatLineWidth", cvarFloatList { "10 characters" 10 "25 characters" 25 "40 characters" 40 "55 characters" 55 "70 characters" 70 }, _("Width of chat before a line break (includes player name)") )
 
 // Sounds //
-#define SOUND_Y 114
+#define SOUND_Y 210
 	SUBWINDOW( 6+(SUBWINDOW_WIDTH_L)+6, SOUND_Y, (SUBWINDOW_WIDTH_R), 52, _("SOUND") )
 	YESNO( 6+(SUBWINDOW_WIDTH_L)+6+2, SOUND_Y+16, (SUBWINDOW_WIDTH_R)-4, 10, _("Announcer:"), .2, 8, "cg_announcer", _("Play startup announcer voice") )
 	YESNO( 6+(SUBWINDOW_WIDTH_L)+6+2, SOUND_Y+28, (SUBWINDOW_WIDTH_R)-4, 10, _("Voice chat:"), .2, 8, "cg_voiceChats", _("Play voice chat in-game") )
 	MULTI( 6+(SUBWINDOW_WIDTH_L)+6+2, SOUND_Y+40, (SUBWINDOW_WIDTH_R)-4, 10, _("Hitsounds:"), .2, 8, "cg_hitsounds", cvarFloatList { "None" 0 "All" 1 "No Body Hit Sound" 3 "No Head Hit Sound" 5 "No Team Hit Sound" 9 }, _("Set hit sounds") )
 
 // Miscellaneous //
-#define MISC_Y 172
+#define MISC_Y 268
 	SUBWINDOW( 6+(SUBWINDOW_WIDTH_L)+6, MISC_Y, (SUBWINDOW_WIDTH_R), 76, _("MISCELLANEOUS") )
 	MULTI( 6+(SUBWINDOW_WIDTH_L)+6+2, MISC_Y+16, (SUBWINDOW_WIDTH_R)-4, 10, _("Complaint PopUp:"), .2, 8, "cg_complaintPopUp", cvarFloatList { "Off" 0 "On" 1 }, _("Display the option to file complaints about teammates who kill you") )
 	YESNO( 6+(SUBWINDOW_WIDTH_L)+6+2, MISC_Y+28, (SUBWINDOW_WIDTH_R)-4, 10, _("Log Important Messages:"), .2, 8, "cg_printObjectiveInfo",_("Prints important game messages to the console") )

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2841,6 +2841,15 @@ extern vmCvar_t cg_shoutcastDrawHealth;
 extern vmCvar_t cg_shoutcastGrenadeTrail;
 extern vmCvar_t cg_shoutcastDrawMinimap;
 
+extern vmCvar_t cg_chatX;
+extern vmCvar_t cg_chatY;
+extern vmCvar_t cg_chatScale;
+extern vmCvar_t cg_chatAlpha;
+extern vmCvar_t cg_chatBackgroundAlpha;
+extern vmCvar_t cg_chatShadow;
+extern vmCvar_t cg_chatFlags;
+extern vmCvar_t cg_chatLineWidth;
+
 // local clock flags
 #define LOCALTIME_ON                0x01
 #define LOCALTIME_SECOND            0x02

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -366,6 +366,15 @@ vmCvar_t cg_shoutcastDrawHealth;
 vmCvar_t cg_shoutcastGrenadeTrail;
 vmCvar_t cg_shoutcastDrawMinimap;
 
+vmCvar_t cg_chatX;
+vmCvar_t cg_chatY;
+vmCvar_t cg_chatScale;
+vmCvar_t cg_chatAlpha;
+vmCvar_t cg_chatBackgroundAlpha;
+vmCvar_t cg_chatShadow;
+vmCvar_t cg_chatFlags;
+vmCvar_t cg_chatLineWidth;
+
 typedef struct
 {
 	vmCvar_t *vmCvar;
@@ -629,6 +638,15 @@ static cvarTable_t cvarTable[] =
 	{ &cg_shoutcastDrawHealth,    "cg_shoutcastDrawHealth",    "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_shoutcastGrenadeTrail,  "cg_shoutcastGrenadeTrail",  "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_shoutcastDrawMinimap,   "cg_shoutcastDrawMinimap",   "1",           CVAR_ARCHIVE,                 0 },
+
+	{ &cg_chatX,                  "cg_chatX",                  "160",         CVAR_ARCHIVE,                 0 },
+	{ &cg_chatY,                  "cg_chatY",                  "478",         CVAR_ARCHIVE,                 0 },
+	{ &cg_chatScale,              "cg_chatScale",              "1.0",         CVAR_ARCHIVE,                 0 },
+	{ &cg_chatAlpha,              "cg_chatAlpha",              "1.0",         CVAR_ARCHIVE,                 0 },
+	{ &cg_chatBackgroundAlpha,    "cg_chatBackgroundAlpha",    "0.66",        CVAR_ARCHIVE,                 0 },
+	{ &cg_chatShadow,             "cg_chatShadow",             "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_chatFlags,              "cg_chatFlags",              "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_chatLineWidth,          "cg_chatLineWidth",          "70",          CVAR_ARCHIVE,                 0 },
 };
 
 static const unsigned int cvarTableSize = sizeof(cvarTable) / sizeof(cvarTable[0]);

--- a/src/cgame/cg_servercmds.c
+++ b/src/cgame/cg_servercmds.c
@@ -1138,7 +1138,7 @@ static void CG_AddToTeamChat(const char *str, int clientnum) // FIXME: add disgu
 	}
 
 	len       = 0;
-	chatWidth = (cgs.gamestate == GS_INTERMISSION) ? TEAMCHAT_WIDTH + 30 : TEAMCHAT_WIDTH;
+	chatWidth = (cgs.gamestate == GS_INTERMISSION) ? TEAMCHAT_WIDTH + 30 : Com_Clamp(10, TEAMCHAT_WIDTH, cg_chatLineWidth.integer);
 
 	p  = cgs.teamChatMsgs[cgs.teamChatPos % chatHeight];
 	*p = 0;


### PR DESCRIPTION
Adds multiple customizability options for the in-game chat.

* `cg_chatX/Y` - chat X/Y position
  * note that due to the way chat was previously drawn, addition of these cvars makes it so that by default, chat is slightly more to the right on widescreen aspect ratios
* `cg_chatScale` - chat size scale (__0.5 - 2.0__)
* `cg_chatAlpha` - chat opacity
* `cg_chatBackgroundAlpha` - chat background opacity
* `cg_chatShadow` - toggle shadow on chat
* `cg_chatFlags` - toggle team flags on chat
* `cg_chatLineWidth` - max line width on chat before line break is applied (__10 - 70__)
  * this in includes the chatters name

Also added these options to the in-game menu, under other chat options, and fixed an issue with the background shader drawing incorrectly (there was a solid line on the right side) by drawing it with `clampMap`.