### PR TITLE
server: fixing server demos v2, refs #278

### DIFF
--- a/src/server/server.h
+++ b/src/server/server.h
@@ -601,7 +601,7 @@ void SV_RestartGameProgs(void);
 qboolean SV_inPVS(const vec3_t p1, const vec3_t p2);
 qboolean SV_GetTag(int clientNum, int tagFileNumber, char *tagname, orientation_t *orientation);
 int SV_LoadTag(const char *mod_name);
-void SV_GameSendServerCommand(int clientNum, const char *text);
+void SV_GameSendServerCommand(int clientNum, const char *text, qboolean demoPlayback);
 
 void SV_GameBinaryMessageReceived(int cno, const char *buf, int buflen, int commandTime);
 

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -90,6 +90,17 @@ typedef enum
 } serverState_t;
 
 /**
+* @struct svdemoPlayerStats_t
+* @brief Stores player stats during recording
+*/
+typedef struct svdemoPlayerStats_s
+{
+	char guid[9];
+	char name[MAX_NAME_LENGTH];
+	char stats[MAX_STRING_CHARS];
+} svdemoPlayerStats_t;
+
+/**
  * @struct server_t
  * @brief
  */
@@ -148,6 +159,7 @@ typedef struct
 	// serverside demo recording - previous frame for delta compression
 	sharedEntity_t demoEntities[MAX_GENTITIES];
 	playerState_t demoPlayerStates[MAX_CLIENTS];
+	svdemoPlayerStats_t demoPlayerStats[100];
 
 } server_t;
 

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -482,7 +482,7 @@ extern cvar_t *sv_guidCheck;    ///< enable check for client guid validity
 // sv_demo.c
 void SV_DemoAutoDemoRecord(void);
 void SV_DemoRestartPlayback(void);
-void SV_DemoReadFrame(void);
+qboolean SV_DemoReadFrame(void);
 void SV_DemoWriteFrame(void);
 qboolean SV_DemoClientCommandCapture(client_t *client, const char *msg);
 void SV_DemoWriteServerCommand(const char *cmd);

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -492,7 +492,6 @@ void SV_DemoWriteClientUserinfo(client_t *client, const char *userinfo);
 qboolean SV_CheckLastCmd(const char *cmd, qboolean onlyStore);
 void SV_DemoStopAll(void);
 void SV_DemoInit(void);
-void SV_DemoShutdown(void);
 
 // sv_demo_ext.c
 //int SV_GentityGetHealthField(sharedEntity_t *gent);   // Test purpose

--- a/src/server/sv_ccmds.c
+++ b/src/server/sv_ccmds.c
@@ -341,7 +341,7 @@ static void SV_MapRestart_f(void)
 			continue;
 		}
 
-		if (client->netchan.remoteAddress.type == NA_BOT || client->demoClient)
+		if (client->netchan.remoteAddress.type == NA_BOT)
 		{
 			isBot = qtrue;
 		}

--- a/src/server/sv_client.c
+++ b/src/server/sv_client.c
@@ -495,7 +495,8 @@ void SV_DirectConnect(netadr_t from)
 		}
 		if (NET_CompareBaseAdr(from, cl->netchan.remoteAddress)
 		    && (cl->netchan.qport == qport
-		        || from.port == cl->netchan.remoteAddress.port))
+		        || from.port == cl->netchan.remoteAddress.port)
+			&& !cl->demoClient)
 		{
 			Com_Printf("%s:reconnect\n", NET_AdrToString(from));
 			newcl = cl;

--- a/src/server/sv_demo.c
+++ b/src/server/sv_demo.c
@@ -259,8 +259,6 @@ static qboolean SV_CheckServerCommand(const char *cmd)
 * @details Filter demo game commands that should go to every connected client (not bots and democlients)
 *		 also filter qagame game commands that are blocked during playback (because of missing clientSession_t it is sending garbage data)
 *
-* FIXME: look into entinfo and tinfo.
-*
 * @param[in] cmd
 * @return
 */
@@ -336,7 +334,8 @@ static qboolean SV_CheckGameCommand(const char *cmd)
 	else
 	{
 		// we filter out the chat and tchat commands which are recorded and handled directly by clientCommand (which is easier to manage because it makes a difference between say, say_team and tell, which we don't have here in gamecommands: we either have chat(for say and tell) or tchat (for say_team) and the other difference is that chat/tchat messages directly contain the name of the player, while clientCommand only contains the clientid, so that it itself fetch the name from client->name
-		if (!Q_strncmp(cmd, "chat", 4) || !Q_strncmp(cmd, "tchat", 5))
+		// do not save tinfo and entnfo, qagame during playback will handle it
+		if (!Q_strncmp(cmd, "chat", 4) || !Q_strncmp(cmd, "tchat", 5) || !Q_strncmp(cmd, "tinfo", 5) || !Q_strncmp(cmd, "entnfo", 6))
 		{
 			return qfalse; // we return false if the check wasn't right
 		}

--- a/src/server/sv_demo.c
+++ b/src/server/sv_demo.c
@@ -1048,7 +1048,7 @@ static void SV_DemoStartPlayback(void)
 		{
 			// reading sv_fps (from the demo)
 			fps = MSG_ReadLong(&msg);
-			if (sv_fps->integer != fps)
+			if (sv_fps->integer != fps && fps > 0)
 			{
 				savedFPS = sv_fps->integer;
 				Cvar_SetValue("sv_fps", fps);

--- a/src/server/sv_demo.c
+++ b/src/server/sv_demo.c
@@ -1561,6 +1561,7 @@ static void SV_DemoStartPlayback(void)
 	}
 	// Remove g_allowVote (prevent players to call a vote while a map is replaying)
 	Cvar_SetValue("g_allowVote", 0);
+	Cvar_SetValue("vote_allow_map", 0);
 
 	// Printing infos about the demo
 	if (!sv_demoTolerant->integer)   // print the meta datas only if we're not in faults tolerance mode (because if there are missing meta datas, the printing will throw an exception! So we'd better avoid it)

--- a/src/server/sv_demo.c
+++ b/src/server/sv_demo.c
@@ -1389,12 +1389,12 @@ static void SV_DemoStartRecord(void)
 	Com_Memset(sv.demoPlayerStates, 0, sizeof(sv.demoPlayerStates));
 	// End of frame
 	SV_DemoWriteFrame();
-	// Change recording state
-	sv.demoState = DS_RECORDING;
-	Cvar_SetValue("sv_demoState", DS_RECORDING);
 	// Announce we are writing the demo
 	Com_Printf("DEMO: Recording server-side demo %s.\n", sv.demoName);
 	SV_SendServerCommand(NULL, "chat \"^3DEMO: Recording server-side demo %s.\"", sv.demoName);
+	// Change recording state
+	sv.demoState = DS_RECORDING;
+	Cvar_SetValue("sv_demoState", DS_RECORDING);
 }
 
 /**

--- a/src/server/sv_demo.c
+++ b/src/server/sv_demo.c
@@ -1326,6 +1326,10 @@ static void SV_DemoStartPlayback(void)
 		}
 	}
 
+	// force g_antiwarp to 0 as it can break player viewangles sometimes with empty ClientThinks
+	Cvar_SetValue("g_antiwarp", 0);
+	Cvar_SetValue("g_skipCorrection", 0);
+
 	// Memorize g_allowVote
 	if (!keepSaved)
 	{

--- a/src/server/sv_demo.c
+++ b/src/server/sv_demo.c
@@ -956,7 +956,7 @@ static void SV_DemoConnectDummy()
 	client_t       *client;
 	sharedEntity_t *entity;
 	const char     userinfo[]     = "\\cg_etVersion\\ETLTV\\etVersion\\ETLTV\\name\\^7ETLTV\\rate\\45000\\snaps\\40";
-	const char     configstring[] = "n\\^7ETLTV\\3\\1\\c\\1\\lc\\1\\r\\0\\p\\6\\m\\0000000\\s\\0000000\\dn\\ - 1\\w\\3\\lw\\3\\sw\\2\\lsw\\2\\mu\\0\\ref\\0\sc\\1\\u\\246";
+	const char     configstring[] = "n\\^7ETLTV\\3\\1\\c\\1\\lc\\1\\r\\0\\p\\6\\m\\0000000\\s\\0000000\\dn\\ - 1\\w\\3\\lw\\3\\sw\\2\\lsw\\2\\mu\\0\\ref\\0\\sc\\1\\u\\246";
 	int            num            = sv_maxclients->integer - 1;
 
 	client = &svs.clients[num];
@@ -1071,7 +1071,7 @@ static qboolean SV_DemoAutoDemoRecordCheck(void)
 
 		for (i = 0, cl = svs.clients; i < sv_maxclients->integer; i++, cl++)
 		{
-			if (cl->state == CS_ACTIVE && !(cl->gentity->r.svFlags & SVF_BOT))
+			if (cl->state == CS_ACTIVE && cl->gentity && !(cl->gentity->r.svFlags & SVF_BOT))
 			{
 				activePlayers = qtrue;
 				break;

--- a/src/server/sv_demo.c
+++ b/src/server/sv_demo.c
@@ -2226,13 +2226,3 @@ void SV_DemoInit(void)
 	Cmd_AddCommand("demo_play", SV_Demo_Play_f, "Plays a demo record.", SV_CompleteDemoName);
 	Cmd_AddCommand("demo_stop", SV_Demo_Stop_f, "Stops a demo record.");
 }
-
-/**
- * @brief SV_DemoShutdown
- */
-void SV_DemoShutdown(void) // FIXME: don't remove these on server shutdown/demo end so listen servers can start another demo and server owners too
-{
-	Cmd_RemoveCommand("demo_record");
-	Cmd_RemoveCommand("demo_play");
-	Cmd_RemoveCommand("demo_stop");
-}

--- a/src/server/sv_demo.c
+++ b/src/server/sv_demo.c
@@ -345,6 +345,7 @@ static qboolean SV_CheckConfigString(int cs_index, const char *cs_string)
 void SV_DemoFilterClientUserinfo(char *userinfo)
 {
 	Info_RemoveKey(userinfo, "cl_guid");
+	Info_RemoveKey(userinfo, "n_guid"); // nitmod guid
 	Info_RemoveKey(userinfo, "ip");
 	//Info_SetValueForKey(userinfo, "cl_voip", "0");
 }

--- a/src/server/sv_demo_ext.c
+++ b/src/server/sv_demo_ext.c
@@ -116,29 +116,30 @@ void SV_GentityUpdateHealthField(sharedEntity_t *gent, playerState_t *player)
 void SV_GentityUpdateItemField(sharedEntity_t *gent)
 {
 	gentity_t *ent = (gentity_t *)gent;
-	//ent->item = BG_GetItem(ent->s.modelindex);
-	//gitem_t *item = &bg_itemlist[ent->s.modelindex];
 
-	gitem_t item =
+	if(!ent->item)
 	{
-		ITEM_NONE,
-		NULL,                   // classname
-		NULL,                   // pickup_sound
+		gitem_t item =
 		{
-			0,                  // world_model[0]
-			0,                  // world_model[1]
-			0                   // world_model[2]
-		},
-		NULL,                   // icon
-		NULL,                   // ammoicon
-		NULL,                   // pickup_name
-		0,                      // quantity
-		IT_BAD,                 // giType
-		WP_NONE,                // giWeapon
-		PW_NONE,                // giPowerUp
-	};
+			ITEM_NONE,
+			NULL,                   // classname
+			NULL,                   // pickup_sound
+			{
+				0,                  // world_model[0]
+				0,                  // world_model[1]
+				0                   // world_model[2]
+			},
+			NULL,                   // icon
+			NULL,                   // ammoicon
+			NULL,                   // pickup_name
+			0,                      // quantity
+			IT_BAD,                 // giType
+			WP_NONE,                // giWeapon
+			PW_NONE,                // giPowerUp
+		};
 
-	ent->item = &item;
+		ent->item = &item;
+	}
 
 	return;
 }

--- a/src/server/sv_game.c
+++ b/src/server/sv_game.c
@@ -473,20 +473,8 @@ intptr_t SV_GameSystemCalls(intptr_t *args)
 		Cmd_ArgvBuffer(args[1], VMA(2), args[3]);
 		return 0;
 	case G_SEND_CONSOLE_COMMAND:
-
-		if (sv.demoState == DS_PLAYBACK)
-		{
-			const char *s1 = VMA(2);
-
-			if (s1 && strlen(s1) && !Q_strncmp(s1, "map", 3))
-			{
-				return 0;
-			}
-		}
-
 		Cbuf_ExecuteText(args[1], VMA(2));
 		return 0;
-
 	case G_FS_FOPEN_FILE:
 		return FS_FOpenFileByMode(VMA(1), VMA(2), args[3]);
 	case G_FS_READ:

--- a/src/server/sv_game.c
+++ b/src/server/sv_game.c
@@ -473,6 +473,17 @@ intptr_t SV_GameSystemCalls(intptr_t *args)
 		Cmd_ArgvBuffer(args[1], VMA(2), args[3]);
 		return 0;
 	case G_SEND_CONSOLE_COMMAND:
+
+		if (sv.demoState == DS_PLAYBACK)
+		{
+			const char *s1 = VMA(2);
+
+			if (s1 && strlen(s1) && !Q_strncmp(s1, "map", 3))
+			{
+				return 0;
+			}
+		}
+
 		Cbuf_ExecuteText(args[1], VMA(2));
 		return 0;
 

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -1241,7 +1241,6 @@ void SV_Shutdown(const char *finalmsg)
 	SV_ShutdownGameProgs();
 
 	// SV_ShutdownGameProgs calls SV_DemoStopAll();
-	SV_DemoShutdown();
 
 	// free current level
 	SV_ClearServer();

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -1665,6 +1665,12 @@ void SV_Frame(int msec)
 		return;
 	}
 
+	// start recording a demo
+	if (sv_autoDemo->integer)
+	{
+		SV_DemoAutoDemoRecord();
+	}
+
 	// update infostrings if anything has been changed
 	if (cvar_modifiedFlags & CVAR_SERVERINFO)
 	{


### PR DESCRIPTION
Most important changes:

- fixed server demo playback on non-dedicated server (can start watching server demos in etl client)
- fixes to gamestate replaying and new metadata
- reworked handling of game commands
- added dummy client connecting at the start of recording so various game stats can be saved to demo
- added `sv_autoDemo 2` - demos will be auto recorded only when there are players on server (not bots) and will stop if they leave

There could be a lot to write to explain why I did some things the way I did, so instead trying to write them (there are comments in code explaining in some cases anyway) I can answer questions if there are any.

refs #278