### PR TITLE
cgame: allow selectively disabling weapon animations

### DIFF
--- a/etmain/ui/options_customise_game.menu
+++ b/etmain/ui/options_customise_game.menu
@@ -46,19 +46,20 @@ menuDef {
 
 // Weapons //
 #define WEAPONS_Y 146
-	SUBWINDOW( 6, WEAPONS_Y, (SUBWINDOW_WIDTH_L), 42, _("WEAPONS") )
+	SUBWINDOW( 6, WEAPONS_Y, (SUBWINDOW_WIDTH_L), 54, _("WEAPONS") )
 	YESNO( 8, WEAPONS_Y+16, (SUBWINDOW_WIDTH_L)-4, 10, _("Automatic Reload:"), .2, 8, "cg_autoReload", _("Automatically reload when ammunition clip runs out") )
 	YESNO( 8, WEAPONS_Y+28, (SUBWINDOW_WIDTH_L)-4, 10, _("Autoswitch:"), .2, 8, "cg_noAmmoAutoSwitch", _("Automatically switch to a new weapon when out of ammunition") )
+	MULTI( 8, WEAPONS_Y+40, (SUBWINDOW_WIDTH_L)-4, 10, _("Weapon Animations:"), .2, 8, "cg_weapAnims", cvarFloatList { "None" 0 "Move" 1 "Firing" 2 "Reload" 4 "Switch" 8 "Move + Firing" 3 "Move + Reload" 5 "Move + Switch" 9 "Move + Firing + Reload" 7 "Move + Firing + Switch" 11 "Move + Reload + Switch" 13 "Firing + Reload" 6 "Firing + Switch" 10 "Firing + Reload + Switch" 14 "Reload + Switch" 12 "All" 15 }, _("Set which weapon animations to play") )
 
 // Items //
-#define ITEMS_Y 194
+#define ITEMS_Y 206
 	SUBWINDOW( 6, ITEMS_Y, (SUBWINDOW_WIDTH_L), 42, _("ITEMS") )
 	MULTI( 8, ITEMS_Y+16, (SUBWINDOW_WIDTH_R)-4, 10, _("Simple Items:"), .2, 8, "cg_simpleItems", cvarFloatList { "No" 0 "Yes except objectives" 1 "Yes" 2 }, _("Draw simple items") )
 	CVARFLOATLABEL( 8, ITEMS_Y+28, (SUBWINDOW_WIDTH_L)-4, 10, "cg_simpleItemsScale", .2, ITEM_ALIGN_RIGHT, $evalfloat((SUBWINDOW_WIDTH_L)-6), 8 )
 	SLIDER( 8, ITEMS_Y+28, (SUBWINDOW_WIDTH_L)-4, 10, _("Simple Items Scale:"), .2, 8, "cg_simpleItemsScale" 1.0 0.25 1.5, _("Set scale of simple items") )
 
 // Scope //
-#define SCOPE_Y 240
+#define SCOPE_Y 252
 	SUBWINDOW( 6, SCOPE_Y, (SUBWINDOW_WIDTH_R), 52,_( "SCOPE") )
 	MULTI( 8, SCOPE_Y+16, (SUBWINDOW_WIDTH_R)-4, 10, _("Weapon Cycle for Zoom:"), .2, 8, "cg_useWeapsForZoom", cvarFloatList { "Off" 0 "On (normal)" 1 "On (reverse)" 2 }, _("Weapon switch will zoom in and out while scoped, rather than switch weapons") )
 	MULTI( 8, SCOPE_Y+28, (SUBWINDOW_WIDTH_R)-4, 10, _("Default Zoom Level:"), .2, 8, "cg_zoomdefaultsniper", cvarFloatList { "All the way Out" 20 "Near" 16 "Far" 8 "All the Way In" 4 }, _("Set the default zoom level for scopes") )

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2647,7 +2647,7 @@ extern vmCvar_t cg_gun_x;
 extern vmCvar_t cg_gun_y;
 extern vmCvar_t cg_gun_z;
 extern vmCvar_t cg_drawGun;
-extern vmCvar_t cg_WeapAnims;
+extern vmCvar_t cg_weapAnims;
 extern vmCvar_t cg_cursorHints;
 extern vmCvar_t cg_letterbox;
 extern vmCvar_t cg_tracerChance;

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -152,6 +152,12 @@
 #define UNIT_TO_FEET 0.0833333f
 #define UNIT_TO_METER 0.0254f
 
+// gun animations
+#define WEAPANIM_IDLE    0x01
+#define WEAPANIM_FIRING  0x02
+#define WEAPANIM_RELOAD  0x04
+#define WEAPANIM_SWITCH  0x08
+
 /**
  * @struct specLabel_s
  * @typedef specLabel_t
@@ -2641,6 +2647,7 @@ extern vmCvar_t cg_gun_x;
 extern vmCvar_t cg_gun_y;
 extern vmCvar_t cg_gun_z;
 extern vmCvar_t cg_drawGun;
+extern vmCvar_t cg_WeapAnims;
 extern vmCvar_t cg_cursorHints;
 extern vmCvar_t cg_letterbox;
 extern vmCvar_t cg_tracerChance;

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -161,7 +161,7 @@ vmCvar_t cg_markTime;
 vmCvar_t cg_brassTime;
 vmCvar_t cg_letterbox;
 vmCvar_t cg_drawGun;
-vmCvar_t cg_WeapAnims;
+vmCvar_t cg_weapAnims;
 vmCvar_t cg_cursorHints;
 vmCvar_t cg_gun_frame;
 vmCvar_t cg_gun_x;
@@ -380,7 +380,7 @@ static cvarTable_t cvarTable[] =
 {
 	{ &cg_autoswitch,             "cg_autoswitch",             "2",           CVAR_ARCHIVE,                 0 },
 	{ &cg_drawGun,                "cg_drawGun",                "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_WeapAnims,              "cg_WeapAnims",              "15",          CVAR_ARCHIVE,                 0 },
+	{ &cg_weapAnims,              "cg_weapAnims",              "15",          CVAR_ARCHIVE,                 0 },
 	{ &cg_gun_frame,              "cg_gun_frame",              "0",           CVAR_TEMP,                    0 },
 	{ &cg_cursorHints,            "cg_cursorHints",            "1",           CVAR_ARCHIVE,                 0 },
 	{ &cg_zoomDefaultSniper,      "cg_zoomDefaultSniper",      "20",          CVAR_ARCHIVE,                 0 },   // changed per atvi req

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -161,6 +161,7 @@ vmCvar_t cg_markTime;
 vmCvar_t cg_brassTime;
 vmCvar_t cg_letterbox;
 vmCvar_t cg_drawGun;
+vmCvar_t cg_WeapAnims;
 vmCvar_t cg_cursorHints;
 vmCvar_t cg_gun_frame;
 vmCvar_t cg_gun_x;
@@ -379,6 +380,7 @@ static cvarTable_t cvarTable[] =
 {
 	{ &cg_autoswitch,             "cg_autoswitch",             "2",           CVAR_ARCHIVE,                 0 },
 	{ &cg_drawGun,                "cg_drawGun",                "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_WeapAnims,              "cg_WeapAnims",              "15",          CVAR_ARCHIVE,                 0 },
 	{ &cg_gun_frame,              "cg_gun_frame",              "0",           CVAR_TEMP,                    0 },
 	{ &cg_cursorHints,            "cg_cursorHints",            "1",           CVAR_ARCHIVE,                 0 },
 	{ &cg_zoomDefaultSniper,      "cg_zoomDefaultSniper",      "20",          CVAR_ARCHIVE,                 0 },   // changed per atvi req

--- a/src/cgame/cg_weapons.c
+++ b/src/cgame/cg_weapons.c
@@ -2860,17 +2860,17 @@ static void CG_WeaponAnimation(playerState_t *ps, weaponInfo_t *weapon, int *wea
 	int ws = BG_simpleWeaponState(ps->weaponstate);
 
 	// okay to early out here since we can never reload, fire and switch at the same time
-	if (ws == WSTATE_FIRE && !(cg_WeapAnims.integer & WEAPANIM_FIRING))
+	if (ws == WSTATE_FIRE && !(cg_weapAnims.integer & WEAPANIM_FIRING))
 	{
 		*weapOld = *weap = CG_DefaultAnimFrameForWeapon(ps->weapon);
 		return;
 	}
-	if (ws == WSTATE_RELOAD && !(cg_WeapAnims.integer & WEAPANIM_RELOAD))
+	if (ws == WSTATE_RELOAD && !(cg_weapAnims.integer & WEAPANIM_RELOAD))
 	{
 		*weapOld = *weap = CG_DefaultAnimFrameForWeapon(ps->weapon);
 		return;
 	}
-	if (ws == WSTATE_SWITCH && !(cg_WeapAnims.integer & WEAPANIM_SWITCH))
+	if (ws == WSTATE_SWITCH && !(cg_weapAnims.integer & WEAPANIM_SWITCH))
 	{
 		*weapOld = *weap = CG_DefaultAnimFrameForWeapon(ps->weapon);
 		return;
@@ -2884,7 +2884,7 @@ static void CG_WeaponAnimation(playerState_t *ps, weaponInfo_t *weapon, int *wea
 
 	// this forces a refresh to animation frame when force switching from a weapon to another
 	// eg. firing panzer -> autoswitching to pistol, otherwise we carry the anim frame from the old weapon
-	if (ws == WSTATE_IDLE && !(cg_WeapAnims.integer & WEAPANIM_SWITCH))
+	if (ws == WSTATE_IDLE && !(cg_weapAnims.integer & WEAPANIM_SWITCH))
 	{
 		*weapOld = *weap = CG_DefaultAnimFrameForWeapon(ps->weapon);
 	}
@@ -2976,7 +2976,7 @@ static void CG_CalculateWeaponPosition(vec3_t origin, vec3_t angles)
 	}
 
 	// gun angles from bobbing
-	if (cg_WeapAnims.integer & WEAPANIM_IDLE)
+	if (cg_weapAnims.integer & WEAPANIM_IDLE)
 	{
 		angles[ROLL]  += scale * cg.bobfracsin * 0.005f;
 		angles[YAW]   += scale * cg.bobfracsin * 0.01f;


### PR DESCRIPTION
Allow players to selectively disable certain gun animations with more granular control than `cg_gun_frame` offers via `cg_weapAnims` cvar. This is a bitmask cvar, with following values:

* 1 = movement/idle animations
* 2 = firing animations
* 4 = reload animations
* 8 = switch animations

By default everything is enabled of course ( `cg_weapAnims 15`)