### PR TITLE
app: use same versioning string for Android snapshot

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ else {
 }
 
 def getGitCommits = Integer.parseInt(['sh','-c','git rev-list $(git describe --abbrev=0)..HEAD --count'].execute().text.trim())
-def getGitSha = 'git rev-parse --short=8 HEAD'.execute([], project.rootDir).text.trim()
+def getGitSha = 'git rev-parse --short=7 HEAD'.execute([], project.rootDir).text.trim()
 
 def extractInt( String input ) {
   return input.replaceAll("[^0-9]", "")
@@ -31,7 +31,7 @@ android {
         targetSdkVersion 26
         versionCode 1
         versionName "${VERSION[1]}.${VERSION[2]}.${VERSION[3]}"
-        setProperty("archivesBaseName", "etlegacy-v${VERSION[1]}.${VERSION[2]}.${VERSION[3]}-${getGitCommits}-${getGitSha}")
+        setProperty("archivesBaseName", "etlegacy-v${VERSION[1]}.${VERSION[2]}.${VERSION[3]}-${getGitCommits}-g${getGitSha}")
         externalNativeBuild {
             cmake {
                 arguments "-DCROSS_COMPILE32=OFF", "-DFEATURE_RENDERER_GLES=ON", "-DBUILD_SERVER=OFF", "-DINSTALL_EXTRA=OFF","-DARM=ON" , "-DCMAKE_BUILD_TYPE=Release", "-DBUNDLED_LIBS=OFF", "-DFEATURE_LUA=OFF", "-DFEATURE_OPENAL=OFF", "-DRENDERER_DYNAMIC=OFF", "-DFEATURE_FREETYPE=OFF", "-DFEATURE_THEORA=OFF", "-DFEATURE_SSL=OFF"


### PR DESCRIPTION
This adjusts the version string for Android snapshots, as to make it identical to other platforms.
Adds the 'g' and reduce the hash to 7 chars.

Currently:
* android: etlegacy-v2.78.0-11-f52f83c2
* others: etlegacy-v2.78.0-11-gf52f83c