### PR TITLE
Adjust legacy competitive configs

### DIFF
--- a/etmain/configs/legacy1.config
+++ b/etmain/configs/legacy1.config
@@ -10,6 +10,7 @@ init
 {
 	setl sv_pure "1"
 	setl sv_cheats "0"
+	setl sv_fps "40"
 
 	setl g_gameType "3"
 	setl g_warmup "15"
@@ -36,6 +37,7 @@ init
 	setl g_speed "320"
 	setl g_gravity "800"
 	setl g_knockback "1000"
+	setl g_countryFlags "1"
 
 	setl team_maxSoldiers "0"
 	setl team_maxMedics "0"
@@ -126,15 +128,16 @@ init
 	command "sv_cvar cl_yawspeed EQ 0"
 	command "sv_cvar cl_timenudge EQ 0"
 
-	command "sv_cvar cg_simpleitems IN 0 1"
-
+	command "sv_cvar cg_simpleItems IN 0 1"
+	command "sv_cvar cg_visualEffects EQ 0"
+	command "sv_cvar cg_drawEnvAwareness EQ 0"
 	command "sv_cvar cg_fov IN 75 130"
 	command "sv_cvar cg_shadows IN 0 1"
 	command "sv_cvar cg_autoaction IN 2 7"
 
-	command "sv_cvar rate EQ 25000"
-	command "sv_cvar cl_maxpackets EQ 125"
-	command "sv_cvar snaps EQ 20"
+	command "sv_cvar rate IN 25000 45000"
+	command "sv_cvar cl_maxpackets IN 100 125"
+	command "sv_cvar snaps EQ 40"
 	command "sv_cvar com_maxfps IN 40 250"
 
 	command "sv_cvar m_pitch OUT -0.015 0.015"
@@ -158,7 +161,6 @@ init
 	command "sv_cvar r_nv_fogdist_mode INCLUDE NV GL_EYE_RADIAL_NV" // vanilla clients only
 	command "sv_cvar r_subdivisions IN 1 20"
 	command "sv_cvar r_lodcurveerror GE 60"
-
 	command "sv_cvar r_wolffog EQ 0"
 	command "sv_cvar r_zfar EQ 0"
 }

--- a/etmain/configs/legacy1.config
+++ b/etmain/configs/legacy1.config
@@ -40,7 +40,9 @@ init
 	setl g_knockback "1000"
 	setl g_countryFlags "1"
 	setl g_misc "0"	
-	setl g_skillrating "0"			
+	setl g_skillrating "0"
+	setl g_playerHitBoxHeight "48"
+	setl g_dropObjDelay "3000"
 
 	setl team_maxSoldiers "0"
 	setl team_maxMedics "0"

--- a/etmain/configs/legacy1.config
+++ b/etmain/configs/legacy1.config
@@ -11,6 +11,7 @@ init
 	setl sv_pure "1"
 	setl sv_cheats "0"
 	setl sv_fps "40"
+	setl sv_floodProtect "0"
 
 	setl g_gameType "3"
 	setl g_warmup "15"
@@ -38,6 +39,8 @@ init
 	setl g_gravity "800"
 	setl g_knockback "1000"
 	setl g_countryFlags "1"
+	setl g_misc "0"	
+	setl g_skillrating "0"			
 
 	setl team_maxSoldiers "0"
 	setl team_maxMedics "0"
@@ -70,6 +73,8 @@ init
 	setl sv_maxping "0"
 
 	setl pmove_fixed "0"
+	setl pmove_msec "8"
+
 	set nextmap "map_restart 0"
 
 	setl g_allowVote "1"
@@ -92,6 +97,7 @@ init
 	setl vote_allow_warmupdamage "0"
 	setl vote_allow_maprestart "1"
 	setl vote_allow_cointoss "1"
+	setl vote_allow_antilag "0"
 	setl vote_limit "99"
 	setl vote_percent "51"
 
@@ -110,6 +116,9 @@ init
 	setl g_multiview "0"
 	setl g_shove "0"
 	setl g_antiwarp "1"
+	setl g_maxWarp "4"
+	setl g_antilag "1" 				
+	setl g_realHead "1"	
 	setl g_fixedphysics "1"
 	setl g_fixedphysicsfps "125"
 	setl g_campaignfile ""

--- a/etmain/configs/legacy3.config
+++ b/etmain/configs/legacy3.config
@@ -38,7 +38,6 @@ init
 	setl g_gravity "800"
 	setl g_knockback "1000"
 	setl g_autoFireteams "2"
-	setl g_dynamiteChaining "1"
 	setl g_countryFlags "1"
 
 	setl team_maxSoldiers "0"

--- a/etmain/configs/legacy3.config
+++ b/etmain/configs/legacy3.config
@@ -41,7 +41,9 @@ init
 	setl g_autoFireteams "2"
 	setl g_countryFlags "1"
 	setl g_misc "0"	
-	setl g_skillrating "0"	
+	setl g_skillrating "0"
+	setl g_playerHitBoxHeight "48"
+	setl g_dropObjDelay "3000"
 
 	setl team_maxSoldiers "0"
 	setl team_maxMedics "-1"

--- a/etmain/configs/legacy3.config
+++ b/etmain/configs/legacy3.config
@@ -10,6 +10,7 @@ init
 {
 	setl sv_pure "1"
 	setl sv_cheats "0"
+	setl sv_fps "40"
 
 	setl g_gameType "3"
 	setl g_warmup "15"
@@ -36,6 +37,9 @@ init
 	setl g_speed "320"
 	setl g_gravity "800"
 	setl g_knockback "1000"
+	setl g_autoFireteams "2"
+	setl g_dynamiteChaining "1"
+	setl g_countryFlags "1"
 
 	setl team_maxSoldiers "0"
 	setl team_maxMedics "-1"
@@ -126,14 +130,16 @@ init
 	command "sv_cvar cl_yawspeed EQ 0"
 	command "sv_cvar cl_timenudge EQ 0"
 
-	command "sv_cvar cg_simpleitems IN 0 1"
+	command "sv_cvar cg_simpleItems IN 0 1"
+	command "sv_cvar cg_visualEffects EQ 0"
+	command "sv_cvar cg_drawEnvAwareness EQ 0"
 	command "sv_cvar cg_fov IN 75 130"
 	command "sv_cvar cg_shadows IN 0 1"
 	command "sv_cvar cg_autoaction IN 2 7"
 
-	command "sv_cvar rate EQ 25000"
-	command "sv_cvar cl_maxpackets EQ 125"
-	command "sv_cvar snaps EQ 20"
+	command "sv_cvar rate IN 25000 45000"
+	command "sv_cvar cl_maxpackets IN 100 125"
+	command "sv_cvar snaps EQ 40"
 	command "sv_cvar com_maxfps IN 40 250"
 
 	command "sv_cvar m_pitch OUT -0.015 0.015"
@@ -157,7 +163,6 @@ init
 	command "sv_cvar r_nv_fogdist_mode INCLUDE NV GL_EYE_RADIAL_NV" // vanilla clients only
 	command "sv_cvar r_subdivisions IN 1 20"
 	command "sv_cvar r_lodcurveerror GE 60"
-
 	command "sv_cvar r_wolffog EQ 0"
 	command "sv_cvar r_zfar EQ 0"
 }
@@ -231,6 +236,12 @@ map et_ice
 	setl g_useraxisrespawntime "25"
 	mapscripthash ""
 }
+map etl_ice_v8
+{
+	set g_userTimeLimit "10"
+	setl g_useraxisrespawntime "25"
+	mapscripthash ""
+}
 map tc_base
 {
 	set g_userTimeLimit "10"
@@ -261,7 +272,19 @@ map frostbite
 	setl g_useraxisrespawntime "30"
 	mapscripthash ""
 }
+map etl_frostbite_v15
+{
+	set g_userTimeLimit "10"
+	setl g_useralliedrespawntime "25"
+	setl g_useraxisrespawntime "30"
+	mapscripthash ""
+}
 map adlernest
+{
+	set g_userTimeLimit "10"
+	mapscripthash ""
+}
+map etl_adlernest_v2
 {
 	set g_userTimeLimit "10"
 	mapscripthash ""
@@ -274,6 +297,11 @@ map warbell
 	mapscripthash ""
 }
 map supply
+{
+	set g_userTimeLimit "12"
+	mapscripthash ""
+}
+map etl_supply_v6
 {
 	set g_userTimeLimit "12"
 	mapscripthash ""

--- a/etmain/configs/legacy3.config
+++ b/etmain/configs/legacy3.config
@@ -11,6 +11,7 @@ init
 	setl sv_pure "1"
 	setl sv_cheats "0"
 	setl sv_fps "40"
+	setl sv_floodProtect "0"
 
 	setl g_gameType "3"
 	setl g_warmup "15"
@@ -39,6 +40,8 @@ init
 	setl g_knockback "1000"
 	setl g_autoFireteams "2"
 	setl g_countryFlags "1"
+	setl g_misc "0"	
+	setl g_skillrating "0"	
 
 	setl team_maxSoldiers "0"
 	setl team_maxMedics "-1"
@@ -71,6 +74,8 @@ init
 	setl sv_maxping "0"
 
 	setl pmove_fixed "0"
+	setl pmove_msec "8"
+	
 	set nextmap "map_restart 0"
 
 	setl g_allowVote "1"
@@ -93,6 +98,7 @@ init
 	setl vote_allow_warmupdamage "0"
 	setl vote_allow_maprestart "1"
 	setl vote_allow_cointoss "1"
+	setl vote_allow_antilag "0"
 	setl vote_limit "99"
 	setl vote_percent "51"
 
@@ -111,6 +117,9 @@ init
 	setl g_multiview "0"
 	setl g_shove "60"
 	setl g_antiwarp "1"
+	setl g_maxWarp "4"
+	setl g_antilag "1" 				
+	setl g_realHead "1"
 	setl g_fixedphysics "1"
 	setl g_fixedphysicsfps "125"
 	setl g_campaignfile ""

--- a/etmain/configs/legacy5.config
+++ b/etmain/configs/legacy5.config
@@ -11,6 +11,7 @@ init
 	setl sv_pure "1"
 	setl sv_cheats "0"
 	setl sv_fps "40"
+	setl sv_floodProtect "0"
 
 	setl g_gameType "3"
 	setl g_warmup "15"
@@ -39,6 +40,8 @@ init
 	setl g_knockback "1000"
 	setl g_autoFireteams "2"
 	setl g_countryFlags "1"
+	setl g_misc "0"	
+	setl g_skillrating "0"
 
 	setl team_maxSoldiers "1"
 	setl team_maxMedics "-1"
@@ -70,6 +73,8 @@ init
 	setl sv_maxping "0"
 
 	setl pmove_fixed "0"
+	setl pmove_msec "8"
+	
 	set nextmap "map_restart 0"
 
 	setl g_allowVote "1"
@@ -92,6 +97,7 @@ init
 	setl vote_allow_warmupdamage "0"
 	setl vote_allow_maprestart "1"
 	setl vote_allow_cointoss "1"
+	setl vote_allow_antilag "0"
 	setl vote_limit "99"
 	setl vote_percent "51"
 
@@ -110,6 +116,9 @@ init
 	setl g_multiview "0"
 	setl g_shove "60"
 	setl g_antiwarp "1"
+	setl g_maxWarp "4"
+	setl g_antilag "1" 				
+	setl g_realHead "1"
 	setl g_fixedphysics "1"
 	setl g_fixedphysicsfps "125"
 	setl g_campaignfile ""

--- a/etmain/configs/legacy5.config
+++ b/etmain/configs/legacy5.config
@@ -42,6 +42,8 @@ init
 	setl g_countryFlags "1"
 	setl g_misc "0"	
 	setl g_skillrating "0"
+	setl g_playerHitBoxHeight "48"
+	setl g_dropObjDelay "3000"
 
 	setl team_maxSoldiers "1"
 	setl team_maxMedics "-1"

--- a/etmain/configs/legacy5.config
+++ b/etmain/configs/legacy5.config
@@ -38,7 +38,6 @@ init
 	setl g_gravity "800"
 	setl g_knockback "1000"
 	setl g_autoFireteams "2"
-	setl g_dynamiteChaining "1"
 	setl g_countryFlags "1"
 
 	setl team_maxSoldiers "1"

--- a/etmain/configs/legacy5.config
+++ b/etmain/configs/legacy5.config
@@ -10,6 +10,7 @@ init
 {
 	setl sv_pure "1"
 	setl sv_cheats "0"
+	setl sv_fps "40"
 
 	setl g_gameType "3"
 	setl g_warmup "15"
@@ -36,6 +37,9 @@ init
 	setl g_speed "320"
 	setl g_gravity "800"
 	setl g_knockback "1000"
+	setl g_autoFireteams "2"
+	setl g_dynamiteChaining "1"
+	setl g_countryFlags "1"
 
 	setl team_maxSoldiers "1"
 	setl team_maxMedics "-1"
@@ -125,14 +129,16 @@ init
 	command "sv_cvar cl_yawspeed EQ 0"
 	command "sv_cvar cl_timenudge EQ 0"
 
-	command "sv_cvar cg_simpleitems IN 0 1"
+	command "sv_cvar cg_simpleItems IN 0 1"
+	command "sv_cvar cg_visualEffects EQ 0"
+	command "sv_cvar cg_drawEnvAwareness EQ 0"
 	command "sv_cvar cg_fov IN 75 130"
 	command "sv_cvar cg_shadows IN 0 1"
 	command "sv_cvar cg_autoaction IN 2 7"
 
-	command "sv_cvar rate EQ 25000"
-	command "sv_cvar cl_maxpackets EQ 125"
-	command "sv_cvar snaps EQ 20"
+	command "sv_cvar rate IN 25000 45000"
+	command "sv_cvar cl_maxpackets IN 100 125"
+	command "sv_cvar snaps EQ 40"
 	command "sv_cvar com_maxfps IN 40 250"
 
 	command "sv_cvar m_pitch OUT -0.015 0.015"
@@ -156,7 +162,6 @@ init
 	command "sv_cvar r_nv_fogdist_mode INCLUDE NV GL_EYE_RADIAL_NV" // vanilla clients only
 	command "sv_cvar r_subdivisions IN 1 20"
 	command "sv_cvar r_lodcurveerror GE 60"
-
 	command "sv_cvar r_wolffog EQ 0"
 	command "sv_cvar r_zfar EQ 0"
 }
@@ -221,6 +226,13 @@ map et_ice
 	setl team_maxLandmines "0"
 	mapscripthash ""
 }
+map etl_ice_v8
+{
+	set g_userTimeLimit "12"
+	setl g_useraxisrespawntime "25"
+	setl team_maxLandmines "0"
+	mapscripthash ""
+}
 map tc_base
 {
 	set g_userTimeLimit "12"
@@ -252,7 +264,19 @@ map frostbite
 	setl g_useraxisrespawntime "30"
 	mapscripthash ""
 }
+map etl_frostbite_v15
+{
+	set g_userTimeLimit "10"
+	setl g_useralliedrespawntime "25"
+	setl g_useraxisrespawntime "30"
+	mapscripthash ""
+}
 map adlernest
+{
+	set g_userTimeLimit "10"
+	mapscripthash ""
+}
+map etl_adlernest_v2
 {
 	set g_userTimeLimit "10"
 	mapscripthash ""
@@ -265,6 +289,11 @@ map warbell
 	mapscripthash ""
 }
 map supply
+{
+	set g_userTimeLimit "15"
+	mapscripthash ""
+}
+map etl_supply_v6
 {
 	set g_userTimeLimit "15"
 	mapscripthash ""

--- a/etmain/configs/legacy6.config
+++ b/etmain/configs/legacy6.config
@@ -11,6 +11,7 @@ init
 	setl sv_pure "1"
 	setl sv_cheats "0"
 	setl sv_fps "40"
+	setl sv_floodProtect "0"
 
 	setl g_gameType "3"
 	setl g_warmup "15"
@@ -39,6 +40,8 @@ init
 	setl g_knockback "1000"
 	setl g_autoFireteams "2"
 	setl g_countryFlags "1"
+	setl g_misc "0"	
+	setl g_skillrating "0"
 
 	setl team_maxSoldiers "1"
 	setl team_maxMedics "-1"
@@ -70,6 +73,8 @@ init
 	setl sv_maxping "0"
 
 	setl pmove_fixed "0"
+	setl pmove_msec "8"
+	
 	set nextmap "map_restart 0"
 
 	setl g_allowVote "1"
@@ -92,6 +97,7 @@ init
 	setl vote_allow_warmupdamage "0"
 	setl vote_allow_maprestart "1"
 	setl vote_allow_cointoss "1"
+	setl vote_allow_antilag "0"
 	setl vote_limit "99"
 	setl vote_percent "51"
 
@@ -110,6 +116,9 @@ init
 	setl g_multiview "0"
 	setl g_shove "60"
 	setl g_antiwarp "1"
+	setl g_maxWarp "4"
+	setl g_antilag "1" 				
+	setl g_realHead "1"
 	setl g_fixedphysics "1"
 	setl g_fixedphysicsfps "125"
 	setl g_campaignfile ""

--- a/etmain/configs/legacy6.config
+++ b/etmain/configs/legacy6.config
@@ -42,6 +42,8 @@ init
 	setl g_countryFlags "1"
 	setl g_misc "0"	
 	setl g_skillrating "0"
+	setl g_playerHitBoxHeight "48"
+	setl g_dropObjDelay "3000"
 
 	setl team_maxSoldiers "1"
 	setl team_maxMedics "-1"

--- a/etmain/configs/legacy6.config
+++ b/etmain/configs/legacy6.config
@@ -38,7 +38,6 @@ init
 	setl g_gravity "800"
 	setl g_knockback "1000"
 	setl g_autoFireteams "2"
-	setl g_dynamiteChaining "1"
 	setl g_countryFlags "1"
 
 	setl team_maxSoldiers "1"

--- a/etmain/configs/legacy6.config
+++ b/etmain/configs/legacy6.config
@@ -10,6 +10,7 @@ init
 {
 	setl sv_pure "1"
 	setl sv_cheats "0"
+	setl sv_fps "40"
 
 	setl g_gameType "3"
 	setl g_warmup "15"
@@ -36,6 +37,9 @@ init
 	setl g_speed "320"
 	setl g_gravity "800"
 	setl g_knockback "1000"
+	setl g_autoFireteams "2"
+	setl g_dynamiteChaining "1"
+	setl g_countryFlags "1"
 
 	setl team_maxSoldiers "1"
 	setl team_maxMedics "-1"
@@ -125,14 +129,16 @@ init
 	command "sv_cvar cl_yawspeed EQ 0"
 	command "sv_cvar cl_timenudge EQ 0"
 
-	command "sv_cvar cg_simpleitems IN 0 1"
+	command "sv_cvar cg_simpleItems IN 0 1"
+	command "sv_cvar cg_visualEffects EQ 0"
+	command "sv_cvar cg_drawEnvAwareness EQ 0"
 	command "sv_cvar cg_fov IN 75 130"
 	command "sv_cvar cg_shadows IN 0 1"
 	command "sv_cvar cg_autoaction IN 2 7"
 
-	command "sv_cvar rate EQ 25000"
-	command "sv_cvar cl_maxpackets EQ 125"
-	command "sv_cvar snaps EQ 20"
+	command "sv_cvar rate IN 25000 45000"
+	command "sv_cvar cl_maxpackets IN 100 125"
+	command "sv_cvar snaps EQ 40"
 	command "sv_cvar com_maxfps IN 40 250"
 
 	command "sv_cvar m_pitch OUT -0.015 0.015"
@@ -220,6 +226,13 @@ map et_ice
 	setl team_maxLandmines "0"
 	mapscripthash ""
 }
+map etl_ice_v8
+{
+	set g_userTimeLimit "12"
+	setl g_useraxisrespawntime "25"
+	setl team_maxLandmines "0"
+	mapscripthash ""
+}
 map tc_base
 {
 	set g_userTimeLimit "12"
@@ -251,7 +264,19 @@ map frostbite
 	setl g_useraxisrespawntime "30"
 	mapscripthash ""
 }
+map etl_frostbite_v15
+{
+	set g_userTimeLimit "10"
+	setl g_useralliedrespawntime "25"
+	setl g_useraxisrespawntime "30"
+	mapscripthash ""
+}
 map adlernest
+{
+	set g_userTimeLimit "10"
+	mapscripthash ""
+}
+map etl_adlernest_v2
 {
 	set g_userTimeLimit "10"
 	mapscripthash ""
@@ -264,6 +289,11 @@ map warbell
 	mapscripthash ""
 }
 map supply
+{
+	set g_userTimeLimit "15"
+	mapscripthash ""
+}
+map etl_supply_v6
 {
 	set g_userTimeLimit "15"
 	mapscripthash ""


### PR DESCRIPTION
Adjust legacy1, legacy3, legacy5 and legacy6 configs to match the values currently used in actual competitive Legacy games. Provide a universal .cfg + .config files package for competition server administrators. 

What has been done:

- force `sv_fps` and `snaps` value to "40" (value has been tested for 2-3 months now and it seems is pretty much safe to play on);
- set `g_countryFlags` to "1" to allow the shoutcasters see the players' flags in shoutcaster mode;
- force `cg_visualEffects` to "0" to prevent plane giving away airstrike's place of explosion;
- force `cg_drawEnvAwareness` to "0" as the feature is too over-powered for competitive games;
- set `g_autoFireteams` to "2" to enable automatic fireteams;
- ~~set `g_dynamiteChaining` to "1";~~ - CVAR obsolete
- adjust `rate` and `cl_maxpackets` value;
- add some cvars from `etl_server.cfg` that should be in the `.config` files: `sv_floodProtect`, `g_misc`, `g_skillrating`, `pmove_msec`, `g_maxWarp`, `g_antilag`, `g_realHead`;
- add `vote_allow_antilag` cvar to prevent changing antilag value through voting mid-game;
- add to the configs the newest versions of ETL map overhauls that are currently being used in competitive games instead of standard versions: `etl_ice_v8`, `etl_adlernest_v2`, `etl_supply_v6`, `etl_frostbite_v15`. Those will have to be updated regularly together with the release of new overhauls versions;

TODO:

- provide a `etl_server_comp.cfg` template file for competition servers that will complement the `legacy1-6` configs. This will provide a ready-to-go "package" for competition server administrators (`etl_server_comp.cfg` + `legacy1-6` configs) that would require little to no adjustment on their side and that could be efortlessly deployed on the competition server;
- adjust `defaultpublic` and `defaultcomp` configs so that the cvars values changed by competition configs get reverted to default ones;
