### PR TITLE
misc: add etl_server_comp.cfg template file

### DIFF
--- a/misc/etmain/etl_server_comp.cfg
+++ b/misc/etmain/etl_server_comp.cfg
@@ -1,0 +1,84 @@
+// This is a ET: Legacy competition server template config file.
+// This template should be used together with legacy1, legacy3, legacy5 and legacy6 configs.
+// Fill in empty cvars to finish the server configuration.
+// For ET: Legacy engine servers only.
+
+
+// CLIENTS
+
+set sv_maxclients 			""						// number of players including private slots
+set sv_privateclients   	"0"           			// if set > 0, then this number of client slots will be reserved for connections 
+set sv_privatepassword  	""                		// that have "password" set to the value of "sv_privatePassword" 
+
+// PASSWORDS
+
+set g_password				""      				// set to password the server 
+set rconpassword			""       				// remote console access password 
+set refereePassword 		""    					// referee status password
+set ShoutcastPassword		""						// shoutcaster status password
+
+// NETWORK
+
+set sv_timeout 			"40"					// Seconds without any message from connected clients
+set sv_dl_timeout 			"240"					// Seconds without any message from downloading or preparing clients
+set sv_minping 			"0" 					// minimum ping required on connect (0: no minimum)
+set sv_maxping 			"0" 					// maximum ping allowed on connect (0: no maximum)
+set sv_ipMaxClients		"0"						// limits connections per IP to cvar value (0: no maximum)
+//set net_ip ""                                 	// set to override the default IPv4 ET uses
+//set net_port "27960"                          	// set to override the default port ET uses
+//set net_ip6 ""                                	// set to override the default IPv6 ET uses
+//set net_port6 "27960"                         	// set to override the default port ET uses
+
+// DOWNLOAD
+
+set sv_maxRate             "45000"                 // 10000 standard but poor for ET 
+set sv_dl_maxRate 			"42000"                	// increase/decerease if you have plenty/little spare bandwidth 
+set sv_allowDownload 		"1"                 	// global toggle for both legacy download and web download 
+set sv_wwwDownload 		"1"                 	// toggle to enable web download 
+set sv_wwwBaseURL 			""        				// base URL for redirection 
+set sv_wwwDlDisconnected	"0"             		// tell clients to perform their downloads while disconnected from the server 
+set sv_wwwFallbackURL 		""                 		// URL to send to if an http/ftp fails or is refused client side 
+
+// MOTD
+
+set sv_hostname  			"" 
+set server_motd0 			""   
+set server_motd1 			""
+set server_motd2 			""
+set server_motd3 			""
+set server_motd4 			""
+set server_motd5 			""
+
+// MISC SETTINGS 
+
+set sv_fps 				"40"					// to ensure that the server starts at sv_fps 40
+set g_customConfig 		"legacy6"				// sets the config that the server will load upon starting
+set g_gametype 			"3"						// game type should be set from map rotation script 
+
+// OMNIBOTS
+
+set omnibot_enable 		"0"
+
+// LOGGING & PROTECTION
+
+set g_log 					"game.log"				// enables game logging if set. Name of game logging file - logs weapon changes, kills, connects etc.
+set g_logSync 				"1"						// game logging options (0: buffered 1: sync'ed)
+set g_ip_max_clients 		"0"						// limits connections per IP to cvar value.
+set logfile 				"1"						// enables console logging - 'etconsole.log' (1: enabled 2: enabled and sync'ed)
+set sv_protectLog 			"sv_protect.log"		// when set all sv_protect and server security related messages are written into this log file
+
+// PROTECTION
+
+set sv_pure 				"1"						// enable hash check of client pk3 files
+set sv_protect 			"1"						// getstatus response limit protection
+set sv_guidCheck 			"0"						// invalid guid checking for players connecting to a server - "1" prevents 2.60b clients without PB from connecting
+set g_protect 				"1"						// mod side security options
+
+// WATCHDOG - in case the game dies with an ERR_DROP or any situation leading to server running with no map 
+
+set com_watchdog 			"60"            		// defaults to 60 
+set com_watchdog_cmd "exec objectivecycle.cfg"		// defaults to quit
+
+// MAP
+
+map radar											// map that the server will load upon starting


### PR DESCRIPTION
As explained here https://github.com/etlegacy/etlegacy/pull/1787, this provides a `etl_server_comp.cfg` template file for competition servers that will complement the legacy1-6 configs. 

This template together with `legacy1-6` configs is aimed to provide a ready-to-go "package" for competition server administrators (`etl_server_comp.cfg` + `legacy1-6` configs) that would require little to no adjustment on their side and that could be just deployed on the server. My aim was to keep the `.cfg` file as clean as possible and ideally move as many cvars as possible to `.config` files. 

This is a template, so it needs filling in the empty cvars from server administrators. I tried to keep the empty cvars to a minimum.

I did this for my own purposes, as recently on ET: Legacy Scrims Discord we've been getting more and more competition servers for gathers set up by different contributors, so I thought by providing a simple server.cfg template file together with the adjusted legacy1-6 configs would help to keep consistency across all servers managed by different people (this is also needed for the 3v3 cup starting today - over 20 teams signed up) and also would make the initial process of setting the server up a lot easier, with little to no help needed from our side.

Now this could also be shipped to ETL if you consider it beneficial in some way.