### PR TITLE
cgame: fix grenadecam bind not being drawn because of wrong array used

### DIFF
--- a/src/cgame/cg_info.c
+++ b/src/cgame/cg_info.c
@@ -1989,7 +1989,7 @@ void CG_DemoHelpDraw(void)
 		for (i = 0; i < ARRAY_LEN(edvhelp); i++)
 		{
 			y += tSpacing;
-			if (help[i] != NULL)
+			if (edvhelp[i] != NULL)
 			{
 				CG_Text_Paint_Ext(x, y, tScale, tScale, tColor, edvhelp[i], 0.0f, 0, tStyle, tFont);
 			}


### PR DESCRIPTION
![Bez tytułu](https://user-images.githubusercontent.com/4499367/138850497-b0a431b8-d62a-4a90-b1ca-3fec820bd98f.png)
