### PR TITLE
mod: cap speed on weapon scoped, refs #1796

### DIFF
--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -1315,12 +1315,7 @@ static void CG_DrawCrosshair(void)
 	{
 		if (!BG_PlayerMounted(cg.snap->ps.eFlags))
 		{
-			// don't let players prone moving and run with rifles -- speed 80 == crouch, 128 == walk, 256 == run
-/*			if (VectorLengthSquared(cg.snap->ps.velocity) > Square(160) || cg.predictedPlayerState.eFlags & EF_PRONE_MOVING)
-            {
-                CG_FinishWeaponChange(cg.snap->ps.weapon, GetWeaponTableData(cg.snap->ps.weapon)->weapAlts);
-            }
-            else */if (
+            if (
 #ifdef FEATURE_MULTIVIEW
 				cg.mvTotalClients < 1 ||
 #endif

--- a/src/cgame/cg_playerstate.c
+++ b/src/cgame/cg_playerstate.c
@@ -537,12 +537,6 @@ void CG_TransitionPlayerState(playerState_t *ps, playerState_t *ops)
 		}
 	}
 
-	// don't let players run with rifles -- speed 80 == crouch, 128 == walk, 256 == run until player start to don't run
-	if ((GetWeaponTableData(ps->weapon)->type & WEAPON_TYPE_SCOPED) && VectorLength(ps->velocity) > 127)
-	{
-		CG_FinishWeaponChange(ps->weapon, GetWeaponTableData(ps->weapon)->weapAlts);
-	}
-
 	// run events
 	CG_CheckPlayerstateEvents(ps, ops);
 

--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -63,8 +63,8 @@ extern vmCvar_t g_pronedelay;
 #define AIMSPREAD_MAXSPREAD 255
 #define MAX_AIMSPREAD_TIME 1000
 
-pmove_t * pm;
-pml_t pml;
+pmove_t *pm;
+pml_t   pml;
 
 // movement parameters
 float pm_stopspeed = 100;
@@ -645,7 +645,8 @@ static float PM_CmdScale(usercmd_t *cmd)
 	             + cmd->rightmove * cmd->rightmove + cmd->upmove * cmd->upmove);
 	scale = (float)pm->ps->speed * max / (127.0f * total);
 
-	if ((pm->cmd.buttons & BUTTON_SPRINT) && pm->pmext->sprintTime > 50)
+	if ((pm->cmd.buttons & BUTTON_SPRINT) && pm->pmext->sprintTime > 50
+	    && !(GetWeaponTableData(pm->ps->weapon)->type & (WEAPON_TYPE_SCOPED)))
 	{
 		scale *= pm->ps->sprintSpeedScale;
 	}
@@ -684,6 +685,11 @@ static float PM_CmdScale(usercmd_t *cmd)
 				scale *= 0.5f;
 			}
 		}
+	}
+	else if (GetWeaponTableData(pm->ps->weapon)->type & WEAPON_TYPE_SCOPED)
+	{
+		// half move speed if weapon is scoped
+		scale *= 0.5f;
 	}
 
 	return scale;
@@ -1028,14 +1034,6 @@ static qboolean PM_CheckProne(void)
 				pm->ps->eFlags      &= ~EF_PRONE;
 				pm->ps->eFlags      &= ~EF_PRONE_MOVING;
 				pm->pmext->proneTime = -pm->cmd.serverTime; // timestamp 'stop prone'
-
-				// don't let them keep scope out when
-				// standing from prone or they will
-				// look right through a wall
-				if (GetWeaponTableData(pm->ps->weapon)->type & (WEAPON_TYPE_SCOPED | WEAPON_TYPE_SET))
-				{
-					PM_BeginWeaponChange((weapon_t)pm->ps->weapon, GetWeaponTableData(pm->ps->weapon)->weapAlts, qfalse);
-				}
 
 				// don't jump for a bit
 				pm->pmext->jumpTime = pm->cmd.serverTime - 650;
@@ -4857,7 +4855,9 @@ void PM_Sprint(void)
 {
 	if (pm->waterlevel <= 1) // no sprint & no stamina recharge under water
 	{
-		if ((pm->cmd.buttons & BUTTON_SPRINT) && (pm->cmd.forwardmove || pm->cmd.rightmove) && !(pm->ps->pm_flags & PMF_DUCKED) && !(pm->ps->eFlags & EF_PRONE))
+		if ((pm->cmd.buttons & BUTTON_SPRINT) && (pm->cmd.forwardmove || pm->cmd.rightmove)
+		    && !(pm->ps->pm_flags & PMF_DUCKED) && !(pm->ps->eFlags & EF_PRONE)
+		    && !(GetWeaponTableData(pm->ps->weapon)->type & (WEAPON_TYPE_SCOPED)))
 		{
 			if (pm->ps->powerups[PW_ADRENALINE])
 			{

--- a/src/game/g_weapon.c
+++ b/src/game/g_weapon.c
@@ -3334,7 +3334,8 @@ void EmitterCheck(gentity_t *ent, gentity_t *attacker, trace_t *tr)
  */
 void Bullet_Endpos(gentity_t *ent, float spread, vec3_t *end)
 {
-	if (GetWeaponTableData(ent->s.weapon)->type & WEAPON_TYPE_SCOPED)
+	if (GetWeaponTableData(ent->s.weapon)->type & WEAPON_TYPE_SCOPED
+        && ent->s.groundEntityNum != ENTITYNUM_NONE)
 	{
 		// aim dir already accounted for sway of scoped weapons in CalcMuzzlePoints()
 		VectorMA(muzzleTrace, 2 * MAX_TRACE, forward, *end);


### PR DESCRIPTION
* Cap to half the run speed (128, initial speed limit where the weapon would be automaticly unscoped
* Don't allow sprint while scoped
* Add spread while mid-air / jump and scoped