### PR TITLE
app: fixed version string with tags

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,7 +30,7 @@ android {
         targetSdkVersion 26
         versionCode 1
         versionName "${VERSION[1]}.${VERSION[2]}.${VERSION[3]}"
-        setProperty("archivesBaseName", "etlegacy-${getVersion()}")
+        setProperty("archivesBaseName", "etlegacy-${getVersion}")
         externalNativeBuild {
             cmake {
                 arguments "-DCROSS_COMPILE32=OFF", "-DFEATURE_RENDERER_GLES=ON", "-DBUILD_SERVER=OFF", "-DINSTALL_EXTRA=OFF","-DARM=ON" , "-DCMAKE_BUILD_TYPE=Release", "-DBUNDLED_LIBS=OFF", "-DFEATURE_LUA=OFF", "-DFEATURE_OPENAL=OFF", "-DRENDERER_DYNAMIC=OFF", "-DFEATURE_FREETYPE=OFF", "-DFEATURE_THEORA=OFF", "-DFEATURE_SSL=OFF"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,9 +7,7 @@ else {
     apply plugin: 'com.android.library'
 }
 
-def getGitCommits = Integer.parseInt(['sh','-c','git rev-list $(git describe --abbrev=0)..HEAD --count'].execute().text.trim())
-def getGitSha = 'git rev-parse --short=7 HEAD'.execute([], project.rootDir).text.trim()
-def getLatestTag = 'git describe --abbrev=0 --tags `git rev-list --tags --skip=1  --max-count=1`'.execute([], project.rootDir).text.trim()
+def getVersion = 'git describe --tags --abbrev=7'.execute([], project.rootDir).text.trim()
 
 def extractInt( String input ) {
   return input.replaceAll("[^0-9]", "")
@@ -32,12 +30,7 @@ android {
         targetSdkVersion 26
         versionCode 1
         versionName "${VERSION[1]}.${VERSION[2]}.${VERSION[3]}"
-        if ("${versionName}" == "2.78.1") { //getLatestTag()
-			setProperty("archivesBaseName", "etlegacy-v${VERSION[1]}.${VERSION[2]}.${VERSION[3]}")
-        }
-        else {
-			setProperty("archivesBaseName", "etlegacy-v${VERSION[1]}.${VERSION[2]}.${VERSION[3]}-${getGitCommits}-g${getGitSha}")
-        }
+        setProperty("archivesBaseName", "etlegacy-${getVersion()}")
         externalNativeBuild {
             cmake {
                 arguments "-DCROSS_COMPILE32=OFF", "-DFEATURE_RENDERER_GLES=ON", "-DBUILD_SERVER=OFF", "-DINSTALL_EXTRA=OFF","-DARM=ON" , "-DCMAKE_BUILD_TYPE=Release", "-DBUNDLED_LIBS=OFF", "-DFEATURE_LUA=OFF", "-DFEATURE_OPENAL=OFF", "-DRENDERER_DYNAMIC=OFF", "-DFEATURE_FREETYPE=OFF", "-DFEATURE_THEORA=OFF", "-DFEATURE_SSL=OFF"


### PR DESCRIPTION
This is a simpler way to get either the complete version string for a snapshot (`v2.78.0-96-g96f9484`), or just the tag for release version (`v2.78.1`).

Do note the `v` is included in the version string already.

@rafal1137 This is untested on Android build, so feel free to have a closer look. I only tested how git outputs the string on regular commit or commit with a tag.