### PR TITLE
glimp: made windowed fullscreen always on top, refs #1802

### DIFF
--- a/src/sdl/sdl_glimp.c
+++ b/src/sdl/sdl_glimp.c
@@ -749,7 +749,7 @@ static int GLimp_SetMode(glconfig_t *glConfig, int mode, qboolean fullscreen, qb
 	{
 		if (noborder)
 		{
-			flags |= SDL_WINDOW_BORDERLESS;
+			flags |= SDL_WINDOW_BORDERLESS | SDL_WINDOW_ALWAYS_ON_TOP;
 		}
 
 		glConfig->isFullscreen = qfalse;


### PR DESCRIPTION
Adding the `SDL_WINDOW_ALWAYS_ON_TOP` flag ensures nothing else will appear above the game window.

Refs #1802 