### PR TITLE
cgame: fix losing keyboard and mouse input after intermission

### DIFF
--- a/src/cgame/cg_debriefing.c
+++ b/src/cgame/cg_debriefing.c
@@ -1788,6 +1788,7 @@ void CG_Debriefing_Startup(void)
 void CG_Debriefing_Shutdown(void)
 {
 	cgs.dbShowing = qfalse;
+	trap_Key_SetCatcher(trap_Key_GetCatcher() & ~KEYCATCH_CGAME);
 }
 
 /**


### PR DESCRIPTION
After intermission ends this part sets back the `KEYCATCH_CGAME`, but it only is run if a player moved mouse, if he didn't because for example he was alt-tabbed and someone killed him he would be unable to move/tapout losing input control (he would be `PM_DEAD`). I'm not sure if this part is only used for intermission, I tried founding out and I couldn't find anything that would lead me here, but I might have missed something so I rather leave it even though it might be dead code.

https://github.com/etlegacy/etlegacy/blob/7c193a08d49487e9b71f33c8be2377f33a49ba43/src/cgame/cg_newDraw.c#L708-L715

Also adding check for `PM_DEAD` seems bad because players are stuck in "talk" animation after intermission till they move their mouse because of this:

https://github.com/etlegacy/etlegacy/blob/495e3a63f69e755402d85abed76ac129ec8f7624/src/client/cl_input.c#L1015-L1018

https://github.com/etlegacy/etlegacy/blob/7c193a08d49487e9b71f33c8be2377f33a49ba43/src/game/bg_pmove.c#L5049-L5062