### PR TITLE
mod: fix wounded players collision issues, refs #503 #1363

### DIFF
--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -413,17 +413,15 @@ void PM_TraceHead(trace_t *trace, vec3_t start, vec3_t end, trace_t *bodytrace, 
  */
 void PM_TraceAllParts(trace_t *trace, float *legsOffset, vec3_t start, vec3_t end)
 {
-	// body
-	pm->trace(trace, start, pm->mins, pm->maxs, end, pm->ps->clientNum, pm->tracemask);
-
-	// if dead, redo body trace with a square bbox so wounded players don't clip into solids
-	// only do this while we're NOT on a flat ground (we are in air for a brief moment when
-	// getting killed even while standing on flat ground), otherwise we get stuck in slopes
-	// and slide downhill because of PM_CorrectAllSolid
-	if ((pm->ps->eFlags & EF_DEAD) && trace->plane.normal[2] == 0)
+	// if dead, body trace with a square bbox so wounded players don't clip into solids
+	if (pm->ps->eFlags & EF_DEAD)
 	{
-		const vec3_t squareMaxs = { 18.f, 18.f, 12.f }; // mins is -18 -18 -24
+		const vec3_t squareMaxs = { 18.f, 18.f, 16.f }; // mins is -18 -18 -24
 		pm->trace(trace, start, pm->mins, squareMaxs, end, pm->ps->clientNum, pm->tracemask);
+	}
+	else
+	{
+		pm->trace(trace, start, pm->mins, pm->maxs, end, pm->ps->clientNum, pm->tracemask);
 	}
 
 	// legs and head

--- a/src/game/bg_slidemove.c
+++ b/src/game/bg_slidemove.c
@@ -433,7 +433,17 @@ void PM_StepSlideMove(qboolean gravity)
 		}
 	}
 
-	pm->trace(&trace, pm->ps->origin, pm->mins, pm->maxs, down, pm->ps->clientNum, pm->tracemask);
+	// if dead, body trace with a square bbox so wounded players don't clip into solids
+	if (pm->ps->eFlags & EF_DEAD)
+	{
+		const vec3_t squareMaxs = { 18.f, 18.f, 16.f }; // mins is -18 -18 -24
+		pm->trace(&trace, pm->ps->origin, pm->mins, squareMaxs, down, pm->ps->clientNum, pm->tracemask);
+	}
+	else
+	{
+		pm->trace(&trace, pm->ps->origin, pm->mins, pm->maxs, down, pm->ps->clientNum, pm->tracemask);
+	}
+
 	if (!trace.allsolid)
 	{
 		VectorCopy(trace.endpos, pm->ps->origin);


### PR DESCRIPTION
Corpses in `G_StepSlideCorpse` might need similiar fix so they don't fall through on radar too.

Increased maxs[2] to 16 (prone body BBox height) so wounded don't fly through windows.

refs #503 #1363