### PR TITLE
game: allow shoutcasters to use setviewpos

### DIFF
--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -3647,7 +3647,7 @@ void Cmd_SetViewpos_f(gentity_t *ent)
 	char   buffer[MAX_TOKEN_CHARS];
 	int    i;
 
-	if (!g_cheats.integer)
+	if (!g_cheats.integer && !ent->client->sess.shoutcaster)
 	{
 		trap_SendServerCommand(ent - g_entities, va("print \"Cheats are not enabled on this server.\n\""));
 		return;


### PR DESCRIPTION
Allow shoutcasters to use `setviewpos` command so they can make binds/configs for fixed camera angles.