### PR TITLE
game: add cvar to swap suicide anims to regular death anims

### DIFF
--- a/src/game/g_combat.c
+++ b/src/game/g_combat.c
@@ -660,7 +660,14 @@ void player_die(gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int 
 		BG_UpdateConditionValue(self->s.number, ANIM_COND_ENEMY_POSITION, 0, qfalse);
 
 		// play specific anim on suicide
-		BG_UpdateConditionValue(self->s.number, ANIM_COND_SUICIDE, meansOfDeath == MOD_SUICIDE, qtrue);
+		if (g_altSuicideAnim.integer)
+		{
+			BG_UpdateConditionValue(self->s.number, ANIM_COND_ENEMY_WEAPON, meansOfDeath == MOD_SUICIDE, qtrue);
+		}
+		else
+		{
+			BG_UpdateConditionValue(self->s.number, ANIM_COND_SUICIDE, meansOfDeath == MOD_SUICIDE, qtrue);
+		}
 
 		// FIXME: add POSITION_RIGHT, POSITION_LEFT
 		if (infront(self, inflictor))

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -2133,6 +2133,7 @@ extern vmCvar_t g_debugForSingleClient;
 
 extern vmCvar_t g_suddenDeath;
 extern vmCvar_t g_dropObjDelay;
+extern vmCvar_t g_altSuicideAnim;
 
 /**
  * @struct GeoIPTag

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -374,6 +374,8 @@ vmCvar_t g_suddenDeath;
 
 vmCvar_t g_dropObjDelay;
 
+vmCvar_t g_altSuicideAnim;
+
 cvarTable_t gameCvarTable[] =
 {
 	// don't override the cheat state set by the system
@@ -666,6 +668,7 @@ cvarTable_t gameCvarTable[] =
 	{ &g_playerHitBoxHeight,              "g_playerHitBoxHeight",              "36",                         CVAR_ARCHIVE | CVAR_SERVERINFO,                  0, qfalse, qfalse },
 	{ &g_suddenDeath,                     "g_suddenDeath",                     "0",                          CVAR_ARCHIVE,                                    0, qtrue,  qfalse },
 	{ &g_dropObjDelay,                    "g_dropObjDelay",                    "3000",                       CVAR_ARCHIVE,                                    0, qtrue,  qfalse },
+	{ &g_altSuicideAnim,                  "g_altSuicideAnim",                  "0",                          CVAR_ARCHIVE,                                    0, qtrue,  qfalse },
 };
 
 /**


### PR DESCRIPTION
This is meant as a temporary test to gather feedback, adds `g_altSuicideAnims` to use regular death animations as suicide animations. Many people believe this will lead to less confusion, so I think it's worth trying this out.

Edit: sorry about the commit message, brain froze while doing this apparently.