### PR TITLE
cgame: move popup shadow from althud flags to a seperate cvar

### DIFF
--- a/etmain/ui/options_customise_hud_advanced.menu
+++ b/etmain/ui/options_customise_hud_advanced.menu
@@ -30,16 +30,17 @@ menuDef {
 
 // Popup //
 #define POPUP_Y 32
-	SUBWINDOW( 6, POPUP_Y, (SUBWINDOW_WIDTH_L), 54, _("POPUPS AND BANNER") )
+	SUBWINDOW( 6, POPUP_Y, (SUBWINDOW_WIDTH_L), 66, _("POPUPS AND BANNER") )
 	CVARFLOATLABEL( 8, POPUP_Y+16, (SUBWINDOW_WIDTH_L)-6, 10, "cg_popupStayTime", .2, ITEM_ALIGN_RIGHT, $evalfloat((SUBWINDOW_WIDTH_L)-4), 8 )
 	SLIDER( 8, POPUP_Y+16, (SUBWINDOW_WIDTH_L)-4, 10, _("Popup Stay Time:"), .2, 8, "cg_popupStayTime" 2500 0 6000, _("Set the time a pop-up stays visible") )
 	CVARFLOATLABEL( 8, POPUP_Y+28, (SUBWINDOW_WIDTH_L)-6, 10, "cg_popupFadeTime", .2, ITEM_ALIGN_RIGHT, $evalfloat((SUBWINDOW_WIDTH_L)-4), 8 )
 	SLIDER( 8, POPUP_Y+28, (SUBWINDOW_WIDTH_L)-4, 10, _("Popup Fade Time:"), .2, 8, "cg_popupFadeTime" 2500 0 6000, _("Set the time a pop-up fades away") )
-	CVARFLOATLABEL( 8, POPUP_Y+40, (SUBWINDOW_WIDTH_L)-6, 10, "cg_bannerTime", .2, ITEM_ALIGN_RIGHT, $evalfloat((SUBWINDOW_WIDTH_L)-4), 8 )
-	SLIDER( 8, POPUP_Y+40, (SUBWINDOW_WIDTH_L)-4, 10, _("Banner Time:"), .2, 8, "cg_bannerTime" 2500 0 10000, _("Set the time a banner stays visible") )
+	YESNO( 8, POPUP_Y+40, (SUBWINDOW_WIDTH_L)-4, 10, _("Popup Shadow:"), .2, 8, "cg_popupShadow", _("Draw shadow on popups") )
+	CVARFLOATLABEL( 8, POPUP_Y+52, (SUBWINDOW_WIDTH_L)-6, 10, "cg_bannerTime", .2, ITEM_ALIGN_RIGHT, $evalfloat((SUBWINDOW_WIDTH_L)-4), 8 )
+	SLIDER( 8, POPUP_Y+52, (SUBWINDOW_WIDTH_L)-4, 10, _("Banner Time:"), .2, 8, "cg_bannerTime" 2500 0 10000, _("Set the time a banner stays visible") )
 
 // Shoutcast //
-#define SHOUTCAST_Y 92
+#define SHOUTCAST_Y 104
 	SUBWINDOW( 6, SHOUTCAST_Y, (SUBWINDOW_WIDTH_L), 100, _("SHOUTCAST") )
 	MULTI( 8, SHOUTCAST_Y+16, (SUBWINDOW_WIDTH_L)-4, 10, _("Show minimap:"), .2, 8, "cg_shoutcastDrawMinimap", cvarFloatList { "Off" 0 "On" 1 }, _("Display minimap") )
 	MULTI( 8, SHOUTCAST_Y+28, (SUBWINDOW_WIDTH_L)-4, 10, _("Show player lists:"), .2, 8, "cg_shoutcastDrawPlayers", cvarFloatList { "Off" 0 "On" 1 }, _("Display player lists") )
@@ -50,7 +51,7 @@ menuDef {
 	EDITFIELD( 8, SHOUTCAST_Y+88, (SUBWINDOW_WIDTH_L)-4, 10, _("Allies team name:"), .2, 8, "cg_shoutcastTeamNameBlue", 64, 18, _("Set allies team name (Allies if empty)") )
 
 // Fonts //
-#define FONTS_Y 198
+#define FONTS_Y 210
 	SUBWINDOW( 6, FONTS_Y, (SUBWINDOW_WIDTH_L), 78, _("FONTS") )
 	MULTIACTION( 8, FONTS_Y+16, (SUBWINDOW_WIDTH_L)-4, 10, _("Fonts Size:"), .2, 8, "cg_fontScale", cvarFloatList { "Tiny" 2 "Small" 1 "Normal" 0 }, uiScript SetFontScale, _("Set the size of the in-game fonts") )
 	CVARFLOATLABEL( 8, FONTS_Y+28, (SUBWINDOW_WIDTH_L)-6, 10, "cg_fontScaleTP", .2, ITEM_ALIGN_RIGHT, $evalfloat((SUBWINDOW_WIDTH_L)-4), 8 )
@@ -63,7 +64,7 @@ menuDef {
 	SLIDER( 8, FONTS_Y+64, (SUBWINDOW_WIDTH_L)-4, 10, _("Crosshair Name:"), .2, 8, "cg_fontScaleCN" 0.15 0 0.5, _("Set font size for Crosshair Name label") )
 
 // Chat //
-#define CHAT_Y 282
+#define CHAT_Y 294
 	SUBWINDOW( 6, CHAT_Y, (SUBWINDOW_WIDTH_L), 112, _("CHAT") )
 	CVARFLOATLABEL( 8, CHAT_Y+16, (SUBWINDOW_WIDTH_L)-4, 10, "cg_chatX", .2, ITEM_ALIGN_RIGHT, $evalfloat((SUBWINDOW_WIDTH_L)-6), 8 )
 	SLIDER( 8, CHAT_Y+16, (SUBWINDOW_WIDTH_L)-4, 10, _("Chat X:"), .2, 8, "cg_chatX" 160 0 640, _("Set chat X position") )

--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -38,10 +38,9 @@
 
 typedef enum
 {
-	FLAGS_MOVE_TIMERS   = BIT(0),
-	FLAGS_REMOVE_RANKS  = BIT(1),
-	FLAGS_MOVE_POPUPS   = BIT(2),
-	FLAGS_POPUPS_SHADOW = BIT(3)
+	FLAGS_MOVE_TIMERS  = BIT(0),
+	FLAGS_REMOVE_RANKS = BIT(1),
+	FLAGS_MOVE_POPUPS  = BIT(2)
 } althud_flags;
 
 typedef enum
@@ -3399,16 +3398,18 @@ void CG_DrawActiveHud(void)
  */
 void CG_DrawGlobalHud(void)
 {
+	int style = cg_popupShadow.integer ? ITEM_TEXTSTYLE_SHADOWED : ITEM_TEXTSTYLE_NORMAL;
+
 	if (cg_altHudFlags.integer & FLAGS_MOVE_POPUPS)
 	{
-		CG_DrawPMItems(activehud->popupmessages.location, (cg_altHudFlags.integer & FLAGS_POPUPS_SHADOW) ? ITEM_TEXTSTYLE_SHADOWED : 0);
+		CG_DrawPMItems(activehud->popupmessages.location, style);
 	}
 	else
 	{
-		CG_DrawPMItems(hud0.popupmessages.location, (cg_altHudFlags.integer & FLAGS_POPUPS_SHADOW) ? ITEM_TEXTSTYLE_SHADOWED : 0);
+		CG_DrawPMItems(hud0.popupmessages.location, style);
 	}
 
-	CG_DrawPMItemsBig((cg_altHudFlags.integer & FLAGS_POPUPS_SHADOW) ? ITEM_TEXTSTYLE_SHADOWED : 0);
+	CG_DrawPMItemsBig(style);
 
 #ifdef FEATURE_EDV
 	if (cgs.demoCamera.renderingFreeCam || cgs.demoCamera.renderingWeaponCam)

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2824,6 +2824,7 @@ extern vmCvar_t cg_popupStayTime;
 extern vmCvar_t cg_popupFilter;
 extern vmCvar_t cg_popupBigFilter;
 extern vmCvar_t cg_graphicObituaries;
+extern vmCvar_t cg_popupShadow;
 
 extern vmCvar_t cg_fontScaleTP;
 extern vmCvar_t cg_fontScaleSP;

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -337,6 +337,7 @@ vmCvar_t cg_popupStayTime;
 vmCvar_t cg_popupFilter;
 vmCvar_t cg_popupBigFilter;
 vmCvar_t cg_graphicObituaries;
+vmCvar_t cg_popupShadow;
 
 vmCvar_t cg_fontScaleTP; // top print
 vmCvar_t cg_fontScaleSP; // side print
@@ -612,6 +613,7 @@ static cvarTable_t cvarTable[] =
 	{ &cg_popupFilter,            "cg_popupFilter",            "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_popupBigFilter,         "cg_popupBigFilter",         "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_graphicObituaries,      "cg_graphicObituaries",      "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_popupShadow,            "cg_popupShadow",            "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_weapaltReloads,         "cg_weapaltReloads",         "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_weapaltSwitches,        "cg_weapaltSwitches",        "1",           CVAR_ARCHIVE,                 0 },
 


### PR DESCRIPTION
I don't think many people realize that drawing shadow on popups is even a possibility, I didn't know about this either until like a month ago, especially since it's not even included in the options menu for althud flags. So therefore, removed `cg_althudFlags 8` in favor of `cg_popupShadow`, I don't really understand why it was hidden there in the first place.