### PR TITLE
game: fix vote timeout logic, refs #1386 #1825

### DIFF
--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -3223,9 +3223,9 @@ qboolean Cmd_CallVote_f(gentity_t *ent, unsigned int dwCommand, qboolean fRefCom
 	{
 		level.voteInfo.voteTime = level.warmupTime - VOTE_TIME;
 	}
-	else if (g_gamestate.integer == GS_PLAYING && (level.startTime + (g_timelimit.integer * 60000) - level.time < VOTE_TIME))
+	else if (g_gamestate.integer == GS_PLAYING && (level.startTime + (g_timelimit.value * 60000) - level.time < VOTE_TIME))
 	{
-		level.voteInfo.voteTime = level.startTime + (g_timelimit.integer * 60000) - VOTE_TIME;
+		level.voteInfo.voteTime = level.startTime + (g_timelimit.value * 60000) - VOTE_TIME;
 	}
 	else
 	{

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -4540,7 +4540,7 @@ void CheckVote(void)
 			AP(va("cpm \"^1Vote FAILED! ^7(^2Y:%d^7-^1N:%d^7) ^7(%s)\n\"", level.voteInfo.voteYes, level.voteInfo.voteNo, level.voteInfo.voteString));
 			G_LogPrintf("Vote Failed: (Y:%d-N:%d) %s\n", level.voteInfo.voteYes, level.voteInfo.voteNo, level.voteInfo.voteString);
 		}
-		else if (level.time > level.voteInfo.voteTime + VOTE_TIME) // timeout, no enough vote
+		else if (level.time - level.voteInfo.voteTime >= VOTE_TIME) // timeout, no enough vote
 		{
 			// same behavior as a no response vote
 			AP(va("cpm \"^1Vote TIMEOUT! No enough voters to pass vote ^7(^1%d^7/^2%d^7) ^7(%s)\n\"", level.voteInfo.voteYes, pcnt * total / 100, level.voteInfo.voteString));

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -4540,7 +4540,7 @@ void CheckVote(void)
 			AP(va("cpm \"^1Vote FAILED! ^7(^2Y:%d^7-^1N:%d^7) ^7(%s)\n\"", level.voteInfo.voteYes, level.voteInfo.voteNo, level.voteInfo.voteString));
 			G_LogPrintf("Vote Failed: (Y:%d-N:%d) %s\n", level.voteInfo.voteYes, level.voteInfo.voteNo, level.voteInfo.voteString);
 		}
-		else if (level.time - level.voteInfo.voteTime >= VOTE_TIME) // timeout, no enough vote
+		else if (level.time > level.voteInfo.voteTime + VOTE_TIME) // timeout, no enough vote
 		{
 			// same behavior as a no response vote
 			AP(va("cpm \"^1Vote TIMEOUT! No enough voters to pass vote ^7(^1%d^7/^2%d^7) ^7(%s)\n\"", level.voteInfo.voteYes, pcnt * total / 100, level.voteInfo.voteString));


### PR DESCRIPTION
Vote timeout was using wrong logic, resulting in votes being automatically timed out when there was less than 30s of round remaining.