### PR TITLE
game: disable sudden death on second round of stopwatch, refs #1498

### DIFF
--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -4296,7 +4296,8 @@ void CheckExitRules(void)
 				}
 				else
 				{
-					if (g_suddenDeath.integer && DynamiteOnObjective() && g_gametype.integer != GT_WOLF_STOPWATCH)
+					// sudden death is disabled on second round of stopwatch
+					if (g_suddenDeath.integer && (g_gametype.integer != GT_WOLF_STOPWATCH || g_currentRound.integer == 0) && DynamiteOnObjective())
 					{
 						level.suddenDeath = 1;
 						return;


### PR DESCRIPTION
Do not merge, it needs to be tested.

Check discussion in #1498 

---

It is now enabled on first round only (`g_currentRound == 0`).

If sudden death is used to win the first round, `g_nextTimeLimit` will be greater than the default `g_timelimit`.