### PR TITLE
game: allow selection of minor spawnpoint per major spawnpoint, refs #1641

### DIFF
--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -2844,7 +2844,7 @@ void ClientSpawn(gentity_t *ent, qboolean revived, qboolean teamChange, qboolean
 		}
 		else
 		{
-			spawnPoint = SelectCTFSpawnPoint(client->sess.sessionTeam, client->pers.teamState.state, spawn_origin, spawn_angles, client->sess.userSpawnPointValue);
+			spawnPoint = SelectCTFSpawnPoint(client->sess.sessionTeam, client->pers.teamState.state, spawn_origin, spawn_angles, client->sess.userSpawnPointValue, client->sess.userMinorSpawnPointValue);
 		}
 	}
 

--- a/src/game/g_etbot_interface.cpp
+++ b/src/game/g_etbot_interface.cpp
@@ -5227,7 +5227,7 @@ public:
 			{
 				if (pEnt && pEnt->client)
 				{
-					SetPlayerSpawn(pEnt, pMsg->m_SpawnPoint, qtrue);
+					SetPlayerSpawn(pEnt, pMsg->m_SpawnPoint, -1, qtrue);
 				}
 			}
 			break;

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -543,6 +543,8 @@ struct gentity_s
 	// dyno chaining
 	gentity_t *onobjective;
 
+	int spawnId;                        ///< team_CTF_redspawn/team_CTF_bluespawn minor spawnpoint id
+
 #ifdef FEATURE_OMNIBOT
 	int numPlanted;                     ///< Omni-bot increment dyno count
 #endif
@@ -633,6 +635,7 @@ typedef struct
 	weapon_t playerWeapon;                              ///< primary weapon
 	weapon_t playerWeapon2;                             ///< secondary weapon
 	int userSpawnPointValue;                            ///< index of objective to spawn nearest to (returned from UI)
+	int userMinorSpawnPointValue;                       ///< index of minor spawnpoint to spawn nearest to
 	int resolvedSpawnPointIndex;                        ///< most possible objective to spawn nearest to
 	int latchPlayerType;                                ///< latched class
 	weapon_t latchPlayerWeapon;                         ///< latched primary weapon
@@ -2568,7 +2571,7 @@ const char *TeamName(int team);
 const char *TeamColorString(int team);
 void Team_DroppedFlagThink(gentity_t *ent);
 void Team_ReturnFlag(gentity_t *ent);
-gentity_t *SelectCTFSpawnPoint(team_t team, int teamstate, vec3_t origin, vec3_t angles, int spawnObjective);
+gentity_t *SelectCTFSpawnPoint(team_t team, int teamstate, vec3_t origin, vec3_t angles, int majorSpawn, int minorSpawn);
 void TeamplayInfoMessage(team_t team);
 void CheckTeamStatus(void);
 int Pickup_Team(gentity_t *ent, gentity_t *other);
@@ -2663,7 +2666,7 @@ void G_ChainFree(gentity_t *self);
 void G_MakeReady(gentity_t *ent);
 void G_MakeUnready(gentity_t *ent);
 
-void SetPlayerSpawn(gentity_t *ent, int spawn, qboolean update);
+void SetPlayerSpawn(gentity_t *ent, int majorSpawn, int minorSpawn, qboolean update);
 void G_UpdateSpawnPointState(gentity_t *ent);
 void G_UpdateSpawnPointStatePlayerCounts(void);
 

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -2344,8 +2344,9 @@ void G_InitGame(int levelTime, int randomSeed, int restart, int etLegacyServer, 
 
 	for (i = 0; i < level.numConnectedClients; i++)
 	{
-		level.clients[level.sortedClients[i]].sess.userSpawnPointValue     = 0;
-		level.clients[level.sortedClients[i]].sess.resolvedSpawnPointIndex = 0;
+		level.clients[level.sortedClients[i]].sess.userSpawnPointValue      = 0;
+		level.clients[level.sortedClients[i]].sess.userMinorSpawnPointValue = -1;
+		level.clients[level.sortedClients[i]].sess.resolvedSpawnPointIndex  = 0;
 	}
 
 	// init the anim scripting

--- a/src/game/g_spawn.c
+++ b/src/game/g_spawn.c
@@ -236,13 +236,16 @@ field_t fields[] =
 	{ "baseAngle",    FOFS(s.apos.trBase),  F_VECTOR,    0 },
 	{ "baseOrigin",   FOFS(s.pos.trBase),   F_VECTOR,    0 },
 
+	// team_CTF_redspawn/team_CTF_bluespawn minor spawnpoint id
+	{ "id",           FOFS(spawnId),        F_INT,       0 },
+
 	{ NULL,           0,                    F_IGNORE,    0 }
 };
 
 typedef struct
 {
 	char *name;
-	void (*spawn)(gentity_t * ent);
+	void (*spawn)(gentity_t *ent);
 } spawn_t;
 
 void SP_info_player_start(gentity_t *ent);


### PR DESCRIPTION
Added possibility of selecting minor spawnpoint per major spawnpoint. For the feature to work `team_CTF_redspawn/team_CTF_bluespawn` ent need to have defined `id` field which will be mapped to `spawnId`.

Usage: `setspawnpt <major spawnpoint> <minor spawnpoint>` for example `setspawnpt 0 8`

If no minor spawnpoint is selected or doesn't exist everything will behave as before. If it is chosen, it will be determined which minor spawnpoint of selected `id` is closest to selected major spawnpoint. Then if it is not available, another closest minor spawnpoint will be searched for it.

refs #1641