### PR TITLE
mod: fix wounded players not dropping down when on ladders, refs #406

### DIFF
--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -1462,24 +1462,6 @@ static void PM_DeadMove(void)
 {
 	float forward;
 
-	// push back from ladder
-	if (pm->ps->pm_flags & PMF_LADDER)
-	{
-		float  angle;
-		vec3_t flatforward;
-
-		angle          = DEG2RAD(pm->ps->viewangles[YAW]);
-		flatforward[0] = cos(angle);
-		flatforward[1] = sin(angle);
-		flatforward[2] = 0;
-
-		VectorMA(pm->ps->origin, -32, flatforward, pm->ps->origin);
-
-		PM_StepSlideMove(qtrue);
-
-		pm->ps->pm_flags &= ~PMF_LADDER;
-	}
-
 	if (!pml.walking)
 	{
 		return;


### PR DESCRIPTION
The issue was fixed in https://github.com/etlegacy/etlegacy/commit/764acd479de16b976f113b5b39e04fa3397d95cc with `pm->pmext->deadInSolid` part but the push players received here was getting body bbox stuck, mostly at the top of the ladders in railings or floor.

refs #406