### PR TITLE
cgame: merge shoutcast minimap with compass and allow usage of square minimap, refs #1000 #1282 #1433

### DIFF
--- a/etmain/scripts/legacy.shader
+++ b/etmain/scripts/legacy.shader
@@ -805,6 +805,20 @@ sprites/ready
 	}
 }
 
+sprites/cm_medic_icon
+{
+	nopicmip
+	nocompress
+	nomipmaps
+	{
+		map sprites/voicemedic.tga
+		depthFunc equal
+		blendfunc blend
+		rgbGen vertex
+		alphaGen vertex
+	}
+}
+
 ui/assets/mp_ammo_blue
 {
 	nopicmip

--- a/src/cgame/cg_commandmap.c
+++ b/src/cgame/cg_commandmap.c
@@ -736,7 +736,7 @@ void CG_DrawMapEntity(mapEntityData_t *mEnt, float x, float y, float w, float h,
 			reviveClr[3] = .5f + .5f * (float)((sin(sqrt((double)msec) * 25 * M_TAU_F) + 1) * 0.5);
 
 			trap_R_SetColor(reviveClr);
-			CG_DrawPic(icon_pos[0] + 2, icon_pos[1] + 2, icon_extends[0] - 2, icon_extends[1] - 2, cgs.media.medicIcon);
+			CG_DrawPic(icon_pos[0] + 2, icon_pos[1] + 2, icon_extends[0] - 2, icon_extends[1] - 2, cgs.media.ccMedicIcon);
 		}
 		else
 		{
@@ -1548,7 +1548,7 @@ void CG_DrawMap(float x, float y, float w, float h, int mEntFilter, mapScissor_t
 				}
 
 				trap_R_SetColor(reviveClr);
-				CG_DrawPic(icon_pos[0] - icon_extends[0] * 0.5f + 2, icon_pos[1] - icon_extends[1] * 0.5f + 2, icon_extends[0] - 2, icon_extends[1] - 2, cgs.media.medicIcon);
+				CG_DrawPic(icon_pos[0] - icon_extends[0] * 0.5f + 2, icon_pos[1] - icon_extends[1] * 0.5f + 2, icon_extends[0] - 2, icon_extends[1] - 2, cgs.media.ccMedicIcon);
 				trap_R_SetColor(NULL);
 				return;
 			}

--- a/src/cgame/cg_commandmap.c
+++ b/src/cgame/cg_commandmap.c
@@ -52,6 +52,14 @@ qboolean ccInitial = qtrue;
 #define FLAG_TOPFRAC                0.7421875f // 95/128
 #define SPAWN_SIZEUPTIME            1000.f
 
+// square minimap values
+#define AUTOMAP_PLAYER_ICON_SIZE_NEW    20
+#define CONST_ICON_NORMAL_SIZE_NEW      17
+#define CONST_ICON_EXPANDED_SIZE_NEW    20
+#define CONST_ICON_LANDMINE_SIZE_NEW    8
+#define FLAGSIZE_EXPANDED_NEW           98
+#define FLAGSIZE_NORMAL_NEW             82
+
 /**
  * @brief CG_TransformToCommandMapCoord
  * @param[in] coord_x
@@ -175,6 +183,7 @@ void CG_TransformAutomapEntity(void)
 		h = hud->compass.location.h - (hud->compass.location.h * 0.25f);
 	}
 
+	// FIXME: this is needed or mines position breaks
 	if (cgs.clientinfo[cg.clientNum].shoutcaster)
 	{
 		w = 150;
@@ -632,7 +641,7 @@ void CG_DrawMapEntity(mapEntityData_t *mEnt, float x, float y, float w, float h,
 
 			mEnt->yaw = (int)snap->ps.viewangles[YAW];
 		}
-		else if (cent->currentValid || cgs.clientinfo[cg.clientNum].shoutcaster)
+		else if (cent->currentValid)
 		{
 			// use more up-to-date info from pvs
 			if (!scissor)
@@ -650,8 +659,8 @@ void CG_DrawMapEntity(mapEntityData_t *mEnt, float x, float y, float w, float h,
 		}
 		else
 		{
-			// only see revivables for own team
-			if (mEnt->type == ME_PLAYER_REVIVE)
+			// only see revivables for own team, unless shoutcaster
+			if (mEnt->type == ME_PLAYER_REVIVE && !cgs.clientinfo[cg.clientNum].shoutcaster)
 			{
 				return;
 			}
@@ -789,9 +798,16 @@ void CG_DrawMapEntity(mapEntityData_t *mEnt, float x, float y, float w, float h,
 				}
 			}
 
-			// hide ghost icon for following shoutcaster
+			// hide ghost icon for following shoutcaster, highlight followed player.
 			if (cgs.clientinfo[cg.clientNum].shoutcaster && (cg.snap->ps.pm_flags & PMF_FOLLOW) && cg.snap->ps.clientNum == mEnt->data)
 			{
+				// otherwise highlighting takes some time to disappear
+				if (cg.snap->ps.stats[STAT_HEALTH] > 0)
+				{
+					trap_R_SetColor(colorYellow);
+					CG_DrawPic(icon_pos[0], icon_pos[1], icon_extends[0], icon_extends[1], cgs.media.ccPlayerHighlight);
+					trap_R_SetColor(NULL);
+				}
 				return;
 			}
 
@@ -1015,8 +1031,16 @@ void CG_DrawMapEntity(mapEntityData_t *mEnt, float x, float y, float w, float h,
 		{
 			float width;
 
-			icon_extends[0] = CONST_ICON_EXPANDED_SIZE;
-			icon_extends[1] = CONST_ICON_EXPANDED_SIZE;
+			if (scissor && !scissor->circular)
+			{
+				icon_extends[0] = CONST_ICON_EXPANDED_SIZE_NEW;
+				icon_extends[1] = CONST_ICON_EXPANDED_SIZE_NEW;
+			}
+			else
+			{
+				icon_extends[0] = CONST_ICON_EXPANDED_SIZE;
+				icon_extends[1] = CONST_ICON_EXPANDED_SIZE;
+			}
 
 			if (mEnt->type == ME_TANK_DEAD || mEnt->type == ME_TANK)
 			{
@@ -1069,8 +1093,16 @@ void CG_DrawMapEntity(mapEntityData_t *mEnt, float x, float y, float w, float h,
 				scalesize = 12 * (1 - ((time - 700) / 700.f));
 			}
 
-			icon_extends[0] = CONST_ICON_NORMAL_SIZE + scalesize;
-			icon_extends[1] = CONST_ICON_NORMAL_SIZE + scalesize;
+			if (scissor && !scissor->circular)
+			{
+				icon_extends[0] = CONST_ICON_NORMAL_SIZE_NEW + scalesize;
+				icon_extends[1] = CONST_ICON_NORMAL_SIZE_NEW + scalesize;
+			}
+			else
+			{
+				icon_extends[0] = CONST_ICON_NORMAL_SIZE + scalesize;
+				icon_extends[1] = CONST_ICON_NORMAL_SIZE + scalesize;
+			}
 
 			if (mEnt->type == ME_TANK_DEAD || mEnt->type == ME_TANK)
 			{
@@ -1099,8 +1131,16 @@ void CG_DrawMapEntity(mapEntityData_t *mEnt, float x, float y, float w, float h,
 		}
 		else
 		{
-			icon_extends[0] = CONST_ICON_NORMAL_SIZE;
-			icon_extends[1] = CONST_ICON_NORMAL_SIZE;
+			if (scissor && !scissor->circular)
+			{
+				icon_extends[0] = CONST_ICON_NORMAL_SIZE_NEW;
+				icon_extends[1] = CONST_ICON_NORMAL_SIZE_NEW;
+			}
+			else
+			{
+				icon_extends[0] = CONST_ICON_NORMAL_SIZE;
+				icon_extends[1] = CONST_ICON_NORMAL_SIZE;
+			}
 
 			if (mEnt->type == ME_TANK_DEAD || mEnt->type == ME_TANK)
 			{
@@ -1109,8 +1149,11 @@ void CG_DrawMapEntity(mapEntityData_t *mEnt, float x, float y, float w, float h,
 
 			if (scissor)
 			{
-				icon_extends[0] *= (scissor->zoomFactor / AUTOMAP_ZOOM);
-				icon_extends[1] *= (scissor->zoomFactor / AUTOMAP_ZOOM);
+				if (scissor->circular)
+				{
+					icon_extends[0] *= (scissor->zoomFactor / AUTOMAP_ZOOM);
+					icon_extends[1] *= (scissor->zoomFactor / AUTOMAP_ZOOM);
+				}
 			}
 			else
 			{
@@ -1130,6 +1173,7 @@ void CG_DrawMapEntity(mapEntityData_t *mEnt, float x, float y, float w, float h,
 		trap_R_SetColor(NULL);
 		return;
 	case ME_LANDMINE:
+	{
 		if (mEntFilter & CC_FILTER_LANDMINES)
 		{
 			return;
@@ -1158,13 +1202,24 @@ void CG_DrawMapEntity(mapEntityData_t *mEnt, float x, float y, float w, float h,
 			icon_pos[1] = y + mEnt->transformed[1];
 		}
 
-		icon_extends[0] = CONST_ICON_LANDMINE_SIZE;
-		icon_extends[1] = CONST_ICON_LANDMINE_SIZE;
+		if (scissor && !scissor->circular)
+		{
+			icon_extends[0] = CONST_ICON_LANDMINE_SIZE_NEW;
+			icon_extends[1] = CONST_ICON_LANDMINE_SIZE_NEW;
+		}
+		else
+		{
+			icon_extends[0] = CONST_ICON_LANDMINE_SIZE;
+			icon_extends[1] = CONST_ICON_LANDMINE_SIZE;
+		}
 
 		if (scissor)
 		{
-			icon_extends[0] *= (scissor->zoomFactor / AUTOMAP_ZOOM);
-			icon_extends[1] *= (scissor->zoomFactor / AUTOMAP_ZOOM);
+			if (scissor->circular)
+			{
+				icon_extends[0] *= (scissor->zoomFactor / AUTOMAP_ZOOM);
+				icon_extends[1] *= (scissor->zoomFactor / AUTOMAP_ZOOM);
+			}
 		}
 		else
 		{
@@ -1185,6 +1240,7 @@ void CG_DrawMapEntity(mapEntityData_t *mEnt, float x, float y, float w, float h,
 
 		j++;
 		return;
+	}
 	default:
 		return;
 	}
@@ -1256,37 +1312,76 @@ void CG_DrawMap(float x, float y, float w, float h, int mEntFilter, mapScissor_t
 
 	if (scissor)
 	{
-		icon_size = AUTOMAP_PLAYER_ICON_SIZE;
-
-		if (scissor->br[0] >= scissor->tl[0])
+		if (scissor->circular)
 		{
-			float s0, s1, t0, t1;
-			float sc_x = x, sc_y = y, sc_w = w, sc_h = h;
+			icon_size = AUTOMAP_PLAYER_ICON_SIZE;
 
-			CG_DrawPic(sc_x, sc_y, sc_w, sc_h, cgs.media.commandCentreAutomapMaskShader);
-
-			s0 = (scissor->tl[0]) / (w * scissor->zoomFactor);
-			s1 = (scissor->br[0]) / (w * scissor->zoomFactor);
-			t0 = (scissor->tl[1]) / (h * scissor->zoomFactor);
-			t1 = (scissor->br[1]) / (h * scissor->zoomFactor);
-
-			CG_AdjustFrom640(&sc_x, &sc_y, &sc_w, &sc_h);
-
-			if (cgs.ccLayers)
+			if (scissor->br[0] >= scissor->tl[0])
 			{
-				trap_R_DrawStretchPic(sc_x, sc_y, sc_w, sc_h, s0, t0, s1, t1, cgs.media.commandCentreAutomapShader[cgs.ccSelectedLayer]);
+				float s0, s1, t0, t1;
+				float sc_x = x, sc_y = y, sc_w = w, sc_h = h;
+
+				CG_DrawPic(sc_x, sc_y, sc_w, sc_h, cgs.media.commandCentreAutomapMaskShader);
+
+				s0 = (scissor->tl[0]) / (w * scissor->zoomFactor);
+				s1 = (scissor->br[0]) / (w * scissor->zoomFactor);
+				t0 = (scissor->tl[1]) / (h * scissor->zoomFactor);
+				t1 = (scissor->br[1]) / (h * scissor->zoomFactor);
+
+				CG_AdjustFrom640(&sc_x, &sc_y, &sc_w, &sc_h);
+
+				if (cgs.ccLayers)
+				{
+					trap_R_DrawStretchPic(sc_x, sc_y, sc_w, sc_h, s0, t0, s1, t1, cgs.media.commandCentreAutomapShader[cgs.ccSelectedLayer]);
+				}
+				else
+				{
+					trap_R_DrawStretchPic(sc_x, sc_y, sc_w, sc_h, s0, t0, s1, t1, cgs.media.commandCentreAutomapShader[0]);
+				}
+				// FIXME: the code above seems to do weird things to the next trap_R_DrawStretchPic issued.
+				// This hack works around this.
+				// trap_R_DrawStretchPic(0, 0, 0, 0, 0, 0, 0, 0, cgs.media.whiteShader);
 			}
-			else
-			{
-				trap_R_DrawStretchPic(sc_x, sc_y, sc_w, sc_h, s0, t0, s1, t1, cgs.media.commandCentreAutomapShader[0]);
-			}
-			// FIXME: the code above seems to do weird things to the next trap_R_DrawStretchPic issued.
-			// This hack works around this.
-			// trap_R_DrawStretchPic(0, 0, 0, 0, 0, 0, 0, 0, cgs.media.whiteShader);
+
+			// Draw the grid
+			CG_DrawGrid(x, y, w, h, scissor);
 		}
+		else
+		{
+			icon_size = AUTOMAP_PLAYER_ICON_SIZE_NEW;
 
-		// Draw the grid
-		CG_DrawGrid(x, y, w, h, scissor);
+			if (scissor->br[0] >= scissor->tl[0])
+			{
+				float s0, s1, t0, t1;
+				float sc_x = x, sc_y = y, sc_w = w, sc_h = h;
+
+				vec4_t color;
+
+				Vector4Set(color, 1.f, 1.f, 1.f, alpha);
+				trap_R_SetColor(color);
+				CG_DrawPic(sc_x, sc_y, sc_w, sc_h, cgs.media.blackmask);
+
+				s0 = (scissor->tl[0]) / (w * scissor->zoomFactor);
+				s1 = (scissor->br[0]) / (w * scissor->zoomFactor);
+				t0 = (scissor->tl[1]) / (h * scissor->zoomFactor);
+				t1 = (scissor->br[1]) / (h * scissor->zoomFactor);
+
+				CG_AdjustFrom640(&sc_x, &sc_y, &sc_w, &sc_h);
+
+				if (cgs.ccLayers)
+				{
+					trap_R_DrawStretchPic(sc_x, sc_y, sc_w, sc_h, s0, t0, s1, t1, cgs.media.commandCentreAutomapShader[cgs.ccSelectedLayer]);
+				}
+				else
+				{
+					trap_R_DrawStretchPic(sc_x, sc_y, sc_w, sc_h, s0, t0, s1, t1, cgs.media.commandCentreAutomapShader[0]);
+				}
+
+				trap_R_SetColor(NULL);
+
+				CG_DrawRect_FixedBorder(x - 0.5f, y - 0.5f, w + 1.0f, h + 1.0f, 1, colorWhite);
+			}
+		}
 	}
 	else
 	{
@@ -1604,11 +1699,25 @@ void CG_DrawExpandedAutoMap(void)
  * @param[in] w
  * @param[in] h
  */
-void CG_DrawAutoMap(float x, float y, float w, float h)
+void CG_DrawAutoMap(float basex, float basey, float basew, float baseh)
 {
-	//float        x, y, w, h;
+	int          i;
+	float        x = basex, y = basey, w = basew, h = baseh;
+	float        angle, diff;
+	static float lastangle  = 0;
+	static float anglespeed = 0;
 	mapScissor_t mapScissor;
 	vec2_t       automapTransformed;
+	snapshot_t   *snap;
+
+	if (cg.nextSnap && !cg.nextFrameTeleport && !cg.thisFrameTeleport)
+	{
+		snap = cg.nextSnap;
+	}
+	else
+	{
+		snap = cg.snap;
+	}
 
 	Com_Memset(&mapScissor, 0, sizeof(mapScissor));
 
@@ -1616,13 +1725,6 @@ void CG_DrawAutoMap(float x, float y, float w, float h)
 	{
 		cgs.ccSelectedLayer = CG_CurLayerForZ((int)cg.predictedPlayerEntity.lerpOrigin[2]);
 	}
-
-	/*
-	x = Ccg_WideX(SCREEN_WIDTH) - 100 - 20;
-	y = 20;
-	w = 100;
-	h = 100;
-	*/
 
 	if (cgs.autoMapExpanded)
 	{
@@ -1634,7 +1736,7 @@ void CG_DrawAutoMap(float x, float y, float w, float h)
 		{
 			CG_DrawExpandedAutoMap();
 
-			if (!cg_altHud.integer)
+			if (!cg_altHud.integer || cg_drawCompass.integer == 2)
 			{
 				return;
 			}
@@ -1664,7 +1766,23 @@ void CG_DrawAutoMap(float x, float y, float w, float h)
 	}
 #endif
 
-	mapScissor.circular = qtrue;
+	if (!cgs.clientinfo[cg.clientNum].shoutcaster)
+	{
+		diff = basew * 0.25f;
+		x    = x + (diff / 2);
+		y    = y + (diff / 2);
+		w    = w - diff;
+		h    = h - diff;
+	}
+
+	if (cg_drawCompass.integer == 2 || cgs.clientinfo[cg.clientNum].shoutcaster)
+	{
+		mapScissor.circular = qfalse;
+	}
+	else
+	{
+		mapScissor.circular = qtrue;
+	}
 
 	mapScissor.zoomFactor = cg_automapZoom.value;
 
@@ -1704,6 +1822,50 @@ void CG_DrawAutoMap(float x, float y, float w, float h)
 	}
 
 	CG_DrawMap(x, y, w, h, cgs.ccFilter, &mapScissor, qfalse, 1.f, qfalse);
+
+	if (mapScissor.circular)
+	{
+		CG_DrawPic(basex + 4, basey + 4, basew - 8, baseh - 8, cgs.media.compassShader);
+
+		angle       = (cg.predictedPlayerState.viewangles[YAW] + 180.f) / 360.f - (0.125f);
+		diff        = AngleSubtract(angle * 360, lastangle * 360) / 360.f;
+		anglespeed /= 1.08f;
+		anglespeed += diff * 0.01f;
+		if (Q_fabs(anglespeed) < 0.00001f)
+		{
+			anglespeed = 0;
+		}
+		lastangle += anglespeed;
+		CG_DrawRotatedPic(basex + 4, basey + 4, basew - 8, baseh - 8, cgs.media.compass2Shader, lastangle);
+	}
+
+	if (!cgs.clientinfo[cg.clientNum].shoutcaster)
+	{
+		for (i = 0; i < snap->numEntities; ++i)
+		{
+			centity_t *cent = &cg_entities[snap->entities[i].number];
+			qhandle_t icon;
+
+			// skip self
+			if (cent->currentState.eType == ET_PLAYER && cent->currentState.clientNum == cg.clientNum)
+			{
+				continue;
+			}
+
+			icon = CG_GetCompassIcon(&snap->entities[i], qfalse, qtrue, !(cg_drawCompassIcons.integer & 4), !(cg_drawCompassIcons.integer & 2), qtrue, NULL);
+
+			if (icon)
+			{
+				CG_DrawCompassIcon(basex, basey, basew, baseh, cg.predictedPlayerState.origin, cent->lerpOrigin, icon, 1.f, 14, &mapScissor);
+
+				// draw overlapping shader for disguised covops
+				if (icon == cgs.media.friendShader)
+				{
+					CG_DrawCompassIcon(basex, basey, basew, baseh, cg.predictedPlayerState.origin, cent->lerpOrigin, cgs.media.buddyShader, 1.f, 14, &mapScissor);
+				}
+			}
+		}
+	}
 }
 
 /**
@@ -1724,7 +1886,7 @@ int CG_DrawSpawnPointInfo(float px, float py, float pw, float ph, qboolean draw,
 	vec2_t icon_extends;
 	vec2_t point;
 	float  changetime;
-	int    i, e = -1;
+	int    i, width, e = -1;
 
 	if (cgs.ccFilter & CC_FILTER_SPAWNS)
 	{
@@ -1770,13 +1932,24 @@ int CG_DrawSpawnPointInfo(float px, float py, float pw, float ph, qboolean draw,
 			point[1] = py + (((cg.spawnCoordsUntransformed[i][1] - cg.mapcoordsMins[1]) * cg.mapcoordsScale[1]) * ph);
 		}
 
-		icon_extends[0] = FLAGSIZE_NORMAL;
-		icon_extends[1] = FLAGSIZE_NORMAL;
+		if (scissor && !scissor->circular)
+		{
+			icon_extends[0] = FLAGSIZE_NORMAL_NEW;
+			icon_extends[1] = FLAGSIZE_NORMAL_NEW;
+		}
+		else
+		{
+			icon_extends[0] = FLAGSIZE_NORMAL;
+			icon_extends[1] = FLAGSIZE_NORMAL;
+		}
 
 		if (scissor)
 		{
-			icon_extends[0] *= (scissor->zoomFactor / AUTOMAP_ZOOM);
-			icon_extends[1] *= (scissor->zoomFactor / AUTOMAP_ZOOM);
+			if (scissor->circular)
+			{
+				icon_extends[0] *= (scissor->zoomFactor / AUTOMAP_ZOOM);
+				icon_extends[1] *= (scissor->zoomFactor / AUTOMAP_ZOOM);
+			}
 		}
 		else
 		{
@@ -1795,8 +1968,11 @@ int CG_DrawSpawnPointInfo(float px, float py, float pw, float ph, qboolean draw,
 			point[1] += py - scissor->tl[1];
 		}
 
-		point[0] -= (icon_extends[0] * (39 / 128.f));
-		point[1] += (icon_extends[1] * (31 / 128.f));
+		if (!scissor || (scissor && scissor->circular))
+		{
+			point[0] -= (icon_extends[0] * (39 / 128.f));
+			point[1] += (icon_extends[1] * (31 / 128.f));
+		}
 
 		if (changetime != 0.f)
 		{
@@ -1829,7 +2005,15 @@ int CG_DrawSpawnPointInfo(float px, float py, float pw, float ph, qboolean draw,
 		{
 			if (draw)
 			{
-				float size = FLAGSIZE_EXPANDED;
+				float size;
+				if (scissor && !scissor->circular)
+				{
+					size = FLAGSIZE_EXPANDED_NEW;
+				}
+				else
+				{
+					size = FLAGSIZE_EXPANDED;
+				}
 
 				if (scissor)
 				{
@@ -1861,6 +2045,14 @@ int CG_DrawSpawnPointInfo(float px, float py, float pw, float ph, qboolean draw,
 			if (draw)
 			{
 				float size = FLAGSIZE_NORMAL;
+				if (scissor && !scissor->circular)
+				{
+					size = FLAGSIZE_NORMAL_NEW;
+				}
+				else
+				{
+					size = FLAGSIZE_NORMAL;
+				}
 
 				if (scissor)
 				{
@@ -1873,9 +2065,31 @@ int CG_DrawSpawnPointInfo(float px, float py, float pw, float ph, qboolean draw,
 
 				CG_DrawPic(point[0] - FLAG_LEFTFRAC * size, point[1] - FLAG_TOPFRAC * size, size, size, cgs.media.commandCentreSpawnShader[cg.spawnTeams[i] == TEAM_AXIS ? 0 : 1]);
 
-				if (!scissor)
+				Com_sprintf(buffer, sizeof(buffer), "(%i)", cg.spawnPlayerCounts[i]);
+
+				if (scissor && !scissor->circular)
 				{
-					Com_sprintf(buffer, sizeof(buffer), "(%i)", cg.spawnPlayerCounts[i]);
+					// recalculate for player spawn count clipping
+					point[0] = ((cg.spawnCoordsUntransformed[i][0] - cg.mapcoordsMins[0]) * cg.mapcoordsScale[0]) * pw * scissor->zoomFactor;
+					point[1] = ((cg.spawnCoordsUntransformed[i][1] - cg.mapcoordsMins[1]) * cg.mapcoordsScale[1]) * ph * scissor->zoomFactor;
+
+					width = CG_Text_Width_Ext(buffer, 0.15f, 0, &cgs.media.limboFont2);
+
+					point[0] += 1.5f + scissor->zoomFactor + width;
+					point[1] -= 5;
+
+					if (CG_ScissorPointIsCulled(point, scissor, icon_extends))
+					{
+						continue;
+					}
+
+					point[0] += px - scissor->tl[0] - width;
+					point[1] += py - scissor->tl[1] + 4;
+
+					CG_Text_Paint_Ext(point[0], point[1], 0.15f, 0.15f, colorWhite, buffer, 0, 0, ITEM_TEXTSTYLE_SHADOWED, &cgs.media.limboFont2);
+				}
+				else if (!scissor)
+				{
 					CG_Text_Paint_Ext(point[0] + FLAGSIZE_NORMAL * 0.25f, point[1], 0.2f, 0.2f, colorWhite, buffer, 0, 0, ITEM_TEXTSTYLE_SHADOWED, &cgs.media.limboFont2);
 				}
 			}
@@ -2083,1359 +2297,105 @@ void CG_CommandMap_DrawHighlightText(void)
 	*cg_highlightText = '\0';
 }
 
-//////////////////////////////////////////////////
-//
-//
-//			New square minimap
-//
-//
-//////////////////////////////////////////////////
-
-#define AUTOMAP_ZOOM_NEW                5.159f
-#define COMMANDMAP_PLAYER_ICON_SIZE_NEW 6
-#define AUTOMAP_PLAYER_ICON_SIZE_NEW    20
-#define CONST_ICON_NORMAL_SIZE_NEW      17
-#define CONST_ICON_EXPANDED_SIZE_NEW    20
-#define CONST_ICON_LANDMINE_SIZE_NEW    8
-#define FLAGSIZE_EXPANDED_NEW           98
-#define FLAGSIZE_NORMAL_NEW             82
-#define FLAG_LEFTFRAC_NEW               0.1953125f
-#define FLAG_TOPFRAC_NEW                0.7421875f
-#define SPAWN_SIZEUPTIME_NEW            1000.f
-
 /**
-* @brief CG_DrawNewAutoMap
+* @brief CG_DrawCompassIcon
 * @param[in] x
 * @param[in] y
 * @param[in] w
 * @param[in] h
+* @param[in] origin
+* @param[in] dest
+* @param[in] shader
 */
-void CG_DrawAutoMapNew(float x, float y, float w, float h)
+void CG_DrawCompassIcon(float x, float y, float w, float h, vec3_t origin, vec3_t dest, qhandle_t shader, float dstScale, float baseSize, mapScissor_t *scissor)
 {
-	//float        x, y, w, h;
-	mapScissor_t mapScissor;
-	vec2_t       automapTransformed;
+	float  iconx, icony, iconWidth, iconHeight;
+	float  angle, len, diff;
+	vec3_t v1, angles;
 
-	Com_Memset(&mapScissor, 0, sizeof(mapScissor));
+	VectorCopy(dest, v1);
+	VectorSubtract(origin, v1, v1);
+	len = VectorLength(v1);
+	VectorNormalize(v1);
+	vectoangles(v1, angles);
 
-	if (cgs.ccLayers)
+	if (scissor->circular)
 	{
-		cgs.ccSelectedLayer = CG_CurLayerForZ((int)cg.predictedPlayerEntity.lerpOrigin[2]);
-	}
-
-	if (cgs.autoMapExpanded)
-	{
-		if (cg.time - cgs.autoMapExpandTime < 100.f)
+		if (v1[0] == 0.f && v1[1] == 0.f && v1[2] == 0.f)
 		{
-			CG_DrawExpandedAutoMap();
-		}
-		else
-		{
-			CG_DrawExpandedAutoMap();
 			return;
 		}
+
+		angles[YAW] = AngleSubtract(cg.predictedPlayerState.viewangles[YAW], angles[YAW]);
+
+		angle = ((angles[YAW] + 180.f) / 360.f - (0.50f / 2.f)) * M_TAU_F;
+
+		w /= 2;
+		h /= 2;
+
+		x += w;
+		y += h;
+
+		{
+			w = (float)sqrt((w * w) + (h * h)) / 3.f * 2.f * 0.9f;
+		}
+
+		x = x + ((float)cos(angle) * w);
+		y = y + ((float)sin(angle) * w);
+
+		len = 1 - MIN(1.f, len / 2000.f * dstScale);
+
+		CG_DrawPic(x - (baseSize * len + 4) / 2, y - (baseSize * len + 4) / 2, baseSize * len + 8, baseSize * len + 8, shader);
 	}
 	else
 	{
-		if (cg.time - cgs.autoMapExpandTime <= 150.f)
-		{
-			CG_DrawExpandedAutoMap();
-			return;
-		}
-		else if ((cg.time - cgs.autoMapExpandTime > 150.f) && (cg.time - cgs.autoMapExpandTime < 250.f))
-		{
-			CG_DrawExpandedAutoMap();
-		}
-	}
+		diff = w * 0.25f;
+		x    = x + (diff / 2);
+		y    = y + (diff / 2);
+		w    = w - diff;
+		h    = h - diff;
 
-	if (!cg_shoutcastDrawMinimap.integer)
-	{
-		return;
-	}
+		len = 1 - MIN(1.f, len / 2000.f * dstScale);
 
-#ifdef FEATURE_EDV
-	if (cgs.demoCamera.renderingFreeCam == qtrue || cgs.demoCamera.renderingWeaponCam == qtrue || !cg_drawCompass.integer)
-	{
-		return;
-	}
-#endif
+		iconWidth  = baseSize * len + 8;
+		iconHeight = baseSize * len + 8;
 
-	mapScissor.circular = qfalse;
+		// calculate the screen coordinate of this entity for the compass, consider the zoom value
+		iconx = (dest[0] - cg.mapcoordsMins[0]) * cg.mapcoordsScale[0] * w * scissor->zoomFactor;
+		icony = (dest[1] - cg.mapcoordsMins[1]) * cg.mapcoordsScale[1] * h * scissor->zoomFactor;
 
-	mapScissor.zoomFactor = cg_automapZoom.value;
+		iconx = iconx - scissor->tl[0] + x - (iconWidth * (scissor->zoomFactor / AUTOMAP_ZOOM));
+		icony = icony - scissor->tl[1] + y - (iconHeight * (scissor->zoomFactor / AUTOMAP_ZOOM));
 
-	mapScissor.tl[0] = mapScissor.tl[1] = 0;
-	mapScissor.br[0] = mapScissor.br[1] = -1;
-
-	automapTransformed[0] = ((cg.predictedPlayerEntity.lerpOrigin[0] - cg.mapcoordsMins[0]) * cg.mapcoordsScale[0]) * w * mapScissor.zoomFactor;
-	automapTransformed[1] = ((cg.predictedPlayerEntity.lerpOrigin[1] - cg.mapcoordsMins[1]) * cg.mapcoordsScale[1]) * h * mapScissor.zoomFactor;
-
-	// update clip region (for next drawing). clip region has a size kAutomap_width x kAutomap_height
-	// and it is after zooming is accounted for.
-
-	// first try to center the clip region around the player. then make sure the region
-	// stays within the world map.
-	mapScissor.tl[0] = automapTransformed[0] - w / 2;
-	if (mapScissor.tl[0] < 0)
-	{
-		mapScissor.tl[0] = 0;
-	}
-	mapScissor.br[0] = mapScissor.tl[0] + w;
-	if (mapScissor.br[0] > (w * mapScissor.zoomFactor))
-	{
-		mapScissor.br[0] = w * mapScissor.zoomFactor;
-		mapScissor.tl[0] = mapScissor.br[0] - w;
-	}
-
-	mapScissor.tl[1] = automapTransformed[1] - h / 2;
-	if (mapScissor.tl[1] < 0)
-	{
-		mapScissor.tl[1] = 0;
-	}
-	mapScissor.br[1] = mapScissor.tl[1] + h;
-	if (mapScissor.br[1] > (h * mapScissor.zoomFactor))
-	{
-		mapScissor.br[1] = h * mapScissor.zoomFactor;
-		mapScissor.tl[1] = mapScissor.br[1] - h;
-	}
-
-	CG_DrawMapNew(x, y, w, h, cgs.ccFilter, &mapScissor, qfalse, 1.f, qfalse);
-}
-
-/**
-* @brief CG_DrawMapEntityNew
-* @param[in] mEnt
-* @param[in] x
-* @param[in] y
-* @param[in] w
-* @param[in] h
-* @param[in] mEntFilter
-* @param[in] scissor
-* @param[in] interactive
-* @param[in] snap
-* @param[in] icon_size
-*/
-void CG_DrawMapEntityNew(mapEntityData_t *mEnt, float x, float y, float w, float h, int mEntFilter, mapScissor_t *scissor, qboolean interactive, snapshot_t *snap, int icon_size)
-{
-	int              j = 1;
-	qhandle_t        pic;
-	clientInfo_t     *ci;
-	bg_playerclass_t *classInfo;
-	centity_t        *cent;
-	const char       *name;
-	vec4_t           c_clr = { 1.f, 1.f, 1.f, 1.f };
-	vec2_t           icon_extends, icon_pos, string_pos = { 0 };
-	int              customimage = 0;
-	oidInfo_t        *oidInfo    = NULL;
-	int              entNum;
-
-	switch (mEnt->type)
-	{
-	case ME_PLAYER_OBJECTIVE:
-	case ME_PLAYER_DISGUISED:
-	case ME_PLAYER_REVIVE:
-	case ME_PLAYER:
-		ci = &cgs.clientinfo[mEnt->data];
-		if (!ci->infoValid)
+		// don't draw if inside the map
+		if (iconx > x - iconWidth &&
+		    iconx < x + w - iconWidth &&
+		    icony > y - iconHeight &&
+		    icony < y + h - iconHeight)
 		{
 			return;
 		}
 
-		if (ci->team == TEAM_AXIS)
+		if (iconx < x)
 		{
-			if (mEntFilter & CC_FILTER_AXIS)
-			{
-				return;
-			}
-		}
-		else if (ci->team == TEAM_ALLIES)
-		{
-			if (mEntFilter & CC_FILTER_ALLIES)
-			{
-				return;
-			}
-		}
-		else
-		{
-			return;
+			iconx = x;
 		}
 
-		cent = &cg_entities[mEnt->data];
-
-		if (mEnt->type == ME_PLAYER_DISGUISED && !(cent->currentState.powerups & (1 << PW_OPS_DISGUISED)))
+		if (iconx > x + w - iconWidth)
 		{
-			return;
+			iconx = x + w - iconWidth;
 		}
 
-		classInfo = CG_PlayerClassForClientinfo(ci, cent);
-
-		// For these, if available, ignore the coordinate data and grab the most up to date pvs data
-		if (cent - cg_entities == cg.clientNum)
+		if (icony < y)
 		{
-			// use our own lerp'ed origin
-			if (!scissor)
-			{
-				mEnt->transformed[0] = ((cg.predictedPlayerEntity.lerpOrigin[0] - cg.mapcoordsMins[0]) * cg.mapcoordsScale[0]) * w;
-				mEnt->transformed[1] = ((cg.predictedPlayerEntity.lerpOrigin[1] - cg.mapcoordsMins[1]) * cg.mapcoordsScale[1]) * h;
-			}
-			else
-			{
-				mEnt->automapTransformed[0] = ((cg.predictedPlayerEntity.lerpOrigin[0] - cg.mapcoordsMins[0]) * cg.mapcoordsScale[0]) * w * scissor->zoomFactor;
-				mEnt->automapTransformed[1] = ((cg.predictedPlayerEntity.lerpOrigin[1] - cg.mapcoordsMins[1]) * cg.mapcoordsScale[1]) * h * scissor->zoomFactor;
-			}
-
-			mEnt->yaw = (int)cg.predictedPlayerState.viewangles[YAW];
-		}
-		else if ((cgs.clientinfo[cg.clientNum].team == TEAM_SPECTATOR && snap->ps.clientNum != cg.clientNum && cent - cg_entities == snap->ps.clientNum))
-		{
-
-			// we are following someone, so use their info
-			if (!scissor)
-			{
-				mEnt->transformed[0] = ((snap->ps.origin[0] - cg.mapcoordsMins[0]) * cg.mapcoordsScale[0]) * w;
-				mEnt->transformed[1] = ((snap->ps.origin[1] - cg.mapcoordsMins[1]) * cg.mapcoordsScale[1]) * h;
-			}
-			else
-			{
-				mEnt->automapTransformed[0] = ((snap->ps.origin[0] - cg.mapcoordsMins[0]) * cg.mapcoordsScale[0]) * w * scissor->zoomFactor;
-				mEnt->automapTransformed[1] = ((snap->ps.origin[1] - cg.mapcoordsMins[1]) * cg.mapcoordsScale[1]) * h * scissor->zoomFactor;
-			}
-
-			mEnt->yaw = (int)snap->ps.viewangles[YAW];
-		}
-		else if (cent->currentValid)
-		{
-			// use more up-to-date info from pvs
-			if (!scissor)
-			{
-				mEnt->transformed[0] = ((cent->lerpOrigin[0] - cg.mapcoordsMins[0]) * cg.mapcoordsScale[0]) * w;
-				mEnt->transformed[1] = ((cent->lerpOrigin[1] - cg.mapcoordsMins[1]) * cg.mapcoordsScale[1]) * h;
-			}
-			else
-			{
-				mEnt->automapTransformed[0] = ((cent->lerpOrigin[0] - cg.mapcoordsMins[0]) * cg.mapcoordsScale[0]) * w * scissor->zoomFactor;
-				mEnt->automapTransformed[1] = ((cent->lerpOrigin[1] - cg.mapcoordsMins[1]) * cg.mapcoordsScale[1]) * h * scissor->zoomFactor;
-			}
-
-			mEnt->yaw = (int)cent->lerpAngles[YAW];
-		}
-		else
-		{
-			// only see revivables for own team, unless shoutcaster
-			if (mEnt->type == ME_PLAYER_REVIVE && !cgs.clientinfo[cg.clientNum].shoutcaster)
-			{
-				return;
-			}
-
-			// use the coordinates from clientinfo
-			if (!scissor)
-			{
-				mEnt->transformed[0] = ((ci->location[0] - cg.mapcoordsMins[0]) * cg.mapcoordsScale[0]) * w;
-				mEnt->transformed[1] = ((ci->location[1] - cg.mapcoordsMins[1]) * cg.mapcoordsScale[1]) * h;
-			}
-			else
-			{
-				mEnt->automapTransformed[0] = ((ci->location[0] - cg.mapcoordsMins[0]) * cg.mapcoordsScale[0]) * w * scissor->zoomFactor;
-				mEnt->automapTransformed[1] = ((ci->location[1] - cg.mapcoordsMins[1]) * cg.mapcoordsScale[1]) * h * scissor->zoomFactor;
-			}
+			icony = y;
 		}
 
-		if (cgs.ccLayers)
+		if (icony > y + h - iconHeight)
 		{
-			if (CG_CurLayerForZ(mEnt->z) != cgs.ccSelectedLayer)
-			{
-				return;
-			}
+			icony = y + h - iconHeight;
 		}
 
-		if (scissor)
-		{
-			icon_pos[0] = mEnt->automapTransformed[0] - scissor->tl[0] + x - (icon_size * (scissor->zoomFactor / AUTOMAP_ZOOM_NEW));
-			icon_pos[1] = mEnt->automapTransformed[1] - scissor->tl[1] + y - (icon_size * (scissor->zoomFactor / AUTOMAP_ZOOM_NEW));
-		}
-		else
-		{
-			icon_pos[0]   = x + mEnt->transformed[0] - icon_size;
-			icon_pos[1]   = y + mEnt->transformed[1] - icon_size;
-			string_pos[0] = x + mEnt->transformed[0] + icon_size;
-			string_pos[1] = y + mEnt->transformed[1] + icon_size;
-		}
-
-		icon_extends[0] = 2 * icon_size;
-		icon_extends[1] = 2 * icon_size;
-
-		if (scissor)
-		{
-			icon_extends[0] *= (scissor->zoomFactor / AUTOMAP_ZOOM_NEW);
-			icon_extends[1] *= (scissor->zoomFactor / AUTOMAP_ZOOM_NEW);
-		}
-
-		// now check to see if the entity is within our clip region
-		if (scissor && CG_ScissorEntIsCulled(mEnt, scissor, icon_extends))
-		{
-			trap_R_SetColor(NULL);
-			return;
-		}
-
-		if (mEnt->type == ME_PLAYER_REVIVE && !(cent->currentState.powerups & (1 << PW_INVULNERABLE)))
-		{
-			float  msec;
-			vec4_t reviveClr = { 1.f, 1.f, 1.f, 1.f };
-
-			if (cgs.clientinfo[cg.snap->ps.clientNum].team == TEAM_AXIS || (cgs.clientinfo[cg.clientNum].shoutcaster && mEnt->team == TEAM_AXIS))
-			{
-				msec = (cg_redlimbotime.integer - (cg.time % cg_redlimbotime.integer)) / (float)cg_redlimbotime.integer;
-			}
-			else if (cgs.clientinfo[cg.snap->ps.clientNum].team == TEAM_ALLIES || (cgs.clientinfo[cg.clientNum].shoutcaster && mEnt->team == TEAM_ALLIES))
-			{
-				msec = (cg_bluelimbotime.integer - (cg.time % cg_bluelimbotime.integer)) / (float)cg_bluelimbotime.integer;
-			}
-			else
-			{
-				msec = 0;
-			}
-
-			reviveClr[3] = .5f + .5f * (float)((sin(sqrt((double)msec) * 25 * M_TAU_F) + 1) * 0.5);
-
-			trap_R_SetColor(reviveClr);
-			CG_DrawPic(icon_pos[0] + 2, icon_pos[1] + 2, icon_extends[0] - 2, icon_extends[1] - 2, cgs.media.medicIcon);
-		}
-		else
-		{
-			if (cg.clientNum == mEnt->data)
-			{
-				if (ci->selected)
-				{
-					trap_R_SetColor(colorRed);
-				}
-				else
-				{
-					trap_R_SetColor(colorYellow);
-				}
-
-				CG_DrawPic(icon_pos[0], icon_pos[1], icon_extends[0], icon_extends[1], cgs.media.ccPlayerHighlight);
-				trap_R_SetColor(NULL);
-
-				if (cg.predictedPlayerEntity.voiceChatSpriteTime > cg.time)
-				{
-					CG_DrawPic(icon_pos[0] + 12, icon_pos[1], icon_extends[0] * 0.5f, icon_extends[1] * 0.5f, cg.predictedPlayerEntity.voiceChatSprite);
-				}
-			}
-			else if (/*!(cgs.ccFilter & CC_FILTER_BUDDIES) &&*/ CG_IsOnSameFireteam(cg.clientNum, mEnt->data))
-			{
-				if (ci->selected)
-				{
-					trap_R_SetColor(colorRed);
-				}
-				else
-				{
-					trap_R_SetColor(colorGreen);
-				}
-
-				CG_DrawPic(icon_pos[0], icon_pos[1], icon_extends[0], icon_extends[1], cgs.media.ccPlayerHighlight);
-				trap_R_SetColor(NULL);
-
-				if (!scissor)
-				{
-					CG_Text_Paint_Ext(string_pos[0], string_pos[1], 0.2f, 0.2f, colorWhite, ci->name, 0, 0, ITEM_TEXTSTYLE_SHADOWED, &cgs.media.limboFont2);
-				}
-
-				if (cent->voiceChatSpriteTime > cg.time)
-				{
-					CG_DrawPic(icon_pos[0] + 12, icon_pos[1], icon_extends[0] * 0.5f, icon_extends[1] * 0.5f, cent->voiceChatSprite);
-				}
-			}
-			else if (ci->team == snap->ps.persistant[PERS_TEAM])
-			{
-				if (ci->selected)
-				{
-					trap_R_SetColor(colorRed);
-					CG_DrawPic(icon_pos[0], icon_pos[1], icon_extends[0], icon_extends[1], cgs.media.ccPlayerHighlight);
-					trap_R_SetColor(NULL);
-				}
-
-				if (cent->voiceChatSpriteTime > cg.time)
-				{
-					CG_DrawPic(icon_pos[0] + 12, icon_pos[1], icon_extends[0] * 0.5f, icon_extends[1] * 0.5f, cent->voiceChatSprite);
-				}
-			}
-
-			// hide ghost icon for following shoutcaster, highlight followed player.
-			if (cgs.clientinfo[cg.clientNum].shoutcaster && (cg.snap->ps.pm_flags & PMF_FOLLOW) && cg.snap->ps.clientNum == mEnt->data)
-			{
-				//Otherwise highlighting takes some time to disappear
-				if (cg.snap->ps.stats[STAT_HEALTH] > 0)
-				{
-					trap_R_SetColor(colorYellow);
-					CG_DrawPic(icon_pos[0], icon_pos[1], icon_extends[0], icon_extends[1], cgs.media.ccPlayerHighlight);
-					trap_R_SetColor(NULL);
-				}
-				return;
-			}
-
-			c_clr[3] = 1.0f;
-
-			trap_R_SetColor(c_clr);
-
-			// FIXME: the map entity ME_PLAYER_DISGUISED is never defined here, so this is a bit hackish
-			if (cent->currentState.powerups & (1 << PW_OPS_DISGUISED))
-			{
-				CG_DrawPic(icon_pos[0], icon_pos[1], icon_extends[0], icon_extends[1], classInfo->icon);
-				if (ci->team == snap->ps.persistant[PERS_TEAM] || cgs.clientinfo[cg.clientNum].shoutcaster)
-				{
-					CG_DrawPic(icon_pos[0], icon_pos[1], icon_extends[0], icon_extends[1], cgs.media.friendShader);
-				}
-			}
-			else if (mEnt->type == ME_PLAYER_OBJECTIVE)
-			{
-				CG_DrawPic(icon_pos[0], icon_pos[1], icon_extends[0], icon_extends[1], cgs.media.objectiveShader);
-			}
-			else
-			{
-				CG_DrawPic(icon_pos[0], icon_pos[1], icon_extends[0], icon_extends[1], classInfo->icon);
-			}
-			CG_DrawRotatedPic(icon_pos[0] - 1, icon_pos[1] - 1, icon_extends[0] + 2, icon_extends[1] + 2, classInfo->arrow, (0.5f - (mEnt->yaw - 180.f) / 360.f));
-		}
-		trap_R_SetColor(NULL);
-		return;
-	case ME_CONSTRUCT:
-	case ME_DESTRUCT:
-	case ME_DESTRUCT_2:
-	case ME_TANK:
-	case ME_TANK_DEAD:
-	case ME_COMMANDMAP_MARKER:
-		cent = NULL;
-		if (mEnt->type == ME_TANK || mEnt->type == ME_TANK_DEAD)
-		{
-			oidInfo = &cgs.oidInfo[mEnt->data];
-
-			for (j = 0; j < cg.snap->numEntities; j++)
-			{
-				if (cg.snap->entities[j].eType == ET_OID_TRIGGER && cg.snap->entities[j].teamNum == mEnt->data)
-				{
-					cent = &cg_entities[cg.snap->entities[j].number];
-					if (!scissor)
-					{
-						mEnt->transformed[0] = ((cent->lerpOrigin[0] - cg.mapcoordsMins[0]) * cg.mapcoordsScale[0]) * w;
-						mEnt->transformed[1] = ((cent->lerpOrigin[1] - cg.mapcoordsMins[1]) * cg.mapcoordsScale[1]) * h;
-					}
-					else
-					{
-						mEnt->automapTransformed[0] = ((cent->lerpOrigin[0] - cg.mapcoordsMins[0]) * cg.mapcoordsScale[0]) * w * scissor->zoomFactor;
-						mEnt->automapTransformed[1] = ((cent->lerpOrigin[1] - cg.mapcoordsMins[1]) * cg.mapcoordsScale[1]) * h * scissor->zoomFactor;
-					}
-					break;
-				}
-			}
-		}
-		else if (mEnt->type == ME_CONSTRUCT || mEnt->type == ME_DESTRUCT || mEnt->type == ME_DESTRUCT_2)
-		{
-			cent = &cg_entities[mEnt->data];
-			if (!cent->currentValid)
-			{
-				return;
-			}
-
-			oidInfo = &cgs.oidInfo[cent->currentState.modelindex2];
-
-			if (!scissor)
-			{
-				mEnt->transformed[0] = ((cent->lerpOrigin[0] - cg.mapcoordsMins[0]) * cg.mapcoordsScale[0]) * w;
-				mEnt->transformed[1] = ((cent->lerpOrigin[1] - cg.mapcoordsMins[1]) * cg.mapcoordsScale[1]) * h;
-			}
-			else
-			{
-				mEnt->automapTransformed[0] = ((cent->lerpOrigin[0] - cg.mapcoordsMins[0]) * cg.mapcoordsScale[0]) * w * scissor->zoomFactor;
-				mEnt->automapTransformed[1] = ((cent->lerpOrigin[1] - cg.mapcoordsMins[1]) * cg.mapcoordsScale[1]) * h * scissor->zoomFactor;
-			}
-		}
-		else if (mEnt->type == ME_COMMANDMAP_MARKER)
-		{
-			oidInfo = &cgs.oidInfo[mEnt->data];
-
-			if (!scissor)
-			{
-				mEnt->transformed[0] = ((oidInfo->origin[0] - cg.mapcoordsMins[0]) * cg.mapcoordsScale[0]) * w;
-				mEnt->transformed[1] = ((oidInfo->origin[1] - cg.mapcoordsMins[1]) * cg.mapcoordsScale[1]) * h;
-			}
-			else
-			{
-				mEnt->automapTransformed[0] = ((oidInfo->origin[0] - cg.mapcoordsMins[0]) * cg.mapcoordsScale[0]) * w * scissor->zoomFactor;
-				mEnt->automapTransformed[1] = ((oidInfo->origin[1] - cg.mapcoordsMins[1]) * cg.mapcoordsScale[1]) * h * scissor->zoomFactor;
-			}
-		}
-
-		if (cgs.ccLayers)
-		{
-			if (CG_CurLayerForZ(mEnt->z) != cgs.ccSelectedLayer)
-			{
-				return;
-			}
-		}
-
-		if (oidInfo)
-		{
-			customimage = mEnt->team == TEAM_AXIS ? oidInfo->customimageaxis : oidInfo->customimageallies;
-
-			// we have an oidInfo - check for main objective and do special color in case of
-			// note: to make this work map scripts have to be adjusted
-			if (snap->ps.persistant[PERS_TEAM] != TEAM_SPECTATOR)
-			{
-				entNum = Q_atoi(CG_ConfigString(mEnt->team == TEAM_AXIS ? CS_MAIN_AXIS_OBJECTIVE : CS_MAIN_ALLIES_OBJECTIVE));
-
-				if (entNum == oidInfo->entityNum)
-				{
-					trap_R_SetColor(colorYellow);
-				}
-			}
-		}
-
-		switch (mEnt->type)
-		{
-		case ME_CONSTRUCT:
-			if (mEntFilter & CC_FILTER_CONSTRUCTIONS)
-			{
-				trap_R_SetColor(NULL);
-				return;
-			}
-			pic = mEnt->team == TEAM_AXIS ? cgs.media.ccConstructIcon[0] : cgs.media.ccConstructIcon[1];
-			break;
-		case ME_TANK:
-			if (mEntFilter & CC_FILTER_OBJECTIVES)
-			{
-				trap_R_SetColor(NULL);
-				return;
-			}
-			pic = cgs.media.ccTankIcon; // FIXME: this is churchill - add jagdpanther?
-			break;
-		case ME_TANK_DEAD:
-			if (mEntFilter & CC_FILTER_OBJECTIVES)
-			{
-				trap_R_SetColor(NULL);
-				return;
-			}
-			pic = cgs.media.ccTankIcon; // FIXME: this is churchill - add jagdpanther?
-			trap_R_SetColor(colorRed);
-			break;
-		case ME_COMMANDMAP_MARKER:
-			pic = 0;
-			break;
-		case ME_DESTRUCT_2:
-			pic = 0;
-			break;
-		case ME_DESTRUCT:
-			if (mEntFilter & CC_FILTER_DESTRUCTIONS)
-			{
-				trap_R_SetColor(NULL);
-				return;
-			}
-			pic = mEnt->team == TEAM_AXIS ? cgs.media.ccDestructIcon[cent->currentState.effect1Time][0] : cgs.media.ccDestructIcon[cent->currentState.effect1Time][1];
-			break;
-		default:
-			break;
-		}
-
-		{
-			int info = 0;
-
-			if (oidInfo)
-			{
-				info = oidInfo->spawnflags;
-			}
-
-			if (info & (1 << 4))
-			{
-				if (mEntFilter & CC_FILTER_OBJECTIVES)
-				{
-					trap_R_SetColor(NULL);
-					return;
-				}
-			}
-			if (info & (1 << 5))
-			{
-				if (mEntFilter & CC_FILTER_HACABINETS)
-				{
-					trap_R_SetColor(NULL);
-					return;
-				}
-			}
-			if (info & (1 << 6))
-			{
-				if (mEnt->type == ME_DESTRUCT_2)
-				{
-					pic = mEnt->team == TEAM_AXIS ? cgs.media.ccCmdPost[0] : cgs.media.ccCmdPost[1];
-				}
-				if (mEntFilter & CC_FILTER_CMDPOST)
-				{
-					trap_R_SetColor(NULL);
-					return;
-				}
-			}
-		}
-
-		if (customimage)
-		{
-			pic = customimage;
-		}
-
-		if (scissor)
-		{
-			icon_pos[0] = mEnt->automapTransformed[0] - scissor->tl[0] + x;
-			icon_pos[1] = mEnt->automapTransformed[1] - scissor->tl[1] + y;
-		}
-		else
-		{
-			icon_pos[0] = x + mEnt->transformed[0];
-			icon_pos[1] = y + mEnt->transformed[1];
-		}
-
-		if (interactive && !expanded && BG_RectContainsPoint(x + mEnt->transformed[0] - CONST_ICON_NORMAL_SIZE_NEW * 0.5f, y + mEnt->transformed[1] - CONST_ICON_NORMAL_SIZE_NEW * 0.5f, CONST_ICON_NORMAL_SIZE_NEW, CONST_ICON_NORMAL_SIZE_NEW, cgDC.cursorx, cgDC.cursory))
-		{
-			float width;
-
-			icon_extends[0] = CONST_ICON_EXPANDED_SIZE_NEW;
-			icon_extends[1] = CONST_ICON_EXPANDED_SIZE_NEW;
-
-			if (mEnt->type == ME_TANK_DEAD || mEnt->type == ME_TANK)
-			{
-				icon_extends[1] *= 0.5f;
-			}
-
-			if (scissor)
-			{
-				icon_extends[0] *= (scissor->zoomFactor / AUTOMAP_ZOOM_NEW);
-				icon_extends[1] *= (scissor->zoomFactor / AUTOMAP_ZOOM_NEW);
-			}
-			else
-			{
-				icon_extends[0] *= cgs.ccZoomFactor;
-				icon_extends[1] *= cgs.ccZoomFactor;
-			}
-
-			// now check to see if the entity is within our clip region
-			if (scissor && CG_ScissorEntIsCulled(mEnt, scissor, icon_extends))
-			{
-				trap_R_SetColor(NULL);
-				return;
-			}
-
-			CG_DrawPic(icon_pos[0] - icon_extends[0] * 0.5f, icon_pos[1] - icon_extends[1] * 0.5f, icon_extends[0], icon_extends[1], pic);
-
-			if (oidInfo)
-			{
-				name = oidInfo->name;
-			}
-			else
-			{
-				name = va("%i", j);
-			}
-
-			width = CG_Text_Width_Ext(name, 0.2f, 0, &cgs.media.limboFont2);
-			CG_CommandMap_SetHighlightText(name, icon_pos[0] - (width * 0.5f), icon_pos[1] - 8);
-		}
-		else if (interactive && ((mEnt->yaw & 0xFF) & (1 << cgs.ccSelectedObjective)))
-		{
-			float scalesize;
-			int   time = cg.time % 1400;
-
-			if (time <= 700)
-			{
-				scalesize = 12 * (time) / 700.f;
-			}
-			else
-			{
-				scalesize = 12 * (1 - ((time - 700) / 700.f));
-			}
-
-			icon_extends[0] = CONST_ICON_NORMAL_SIZE_NEW + scalesize;
-			icon_extends[1] = CONST_ICON_NORMAL_SIZE_NEW + scalesize;
-
-			if (mEnt->type == ME_TANK_DEAD || mEnt->type == ME_TANK)
-			{
-				icon_extends[1] *= 0.5f;
-			}
-
-			if (scissor)
-			{
-				icon_extends[0] *= (scissor->zoomFactor / AUTOMAP_ZOOM_NEW);
-				icon_extends[1] *= (scissor->zoomFactor / AUTOMAP_ZOOM_NEW);
-			}
-			else
-			{
-				icon_extends[0] *= cgs.ccZoomFactor;
-				icon_extends[1] *= cgs.ccZoomFactor;
-			}
-
-			// now check to see if the entity is within our clip region
-			if (scissor && CG_ScissorEntIsCulled(mEnt, scissor, icon_extends))
-			{
-				trap_R_SetColor(NULL);
-				return;
-			}
-
-			CG_DrawPic(icon_pos[0] - icon_extends[0] * 0.5f, icon_pos[1] - icon_extends[1] * 0.5f, icon_extends[0], icon_extends[1], pic);
-		}
-		else
-		{
-			icon_extends[0] = CONST_ICON_NORMAL_SIZE_NEW;
-			icon_extends[1] = CONST_ICON_NORMAL_SIZE_NEW;
-
-			if (mEnt->type == ME_TANK_DEAD || mEnt->type == ME_TANK)
-			{
-				icon_extends[1] *= 0.5f;
-			}
-
-			if (scissor)
-			{
-				//icon_extends[0] *= (AUTOMAP_ZOOM_NEW / scissor->zoomFactor);
-				//icon_extends[1] *= (AUTOMAP_ZOOM_NEW / scissor->zoomFactor);
-			}
-			else
-			{
-				icon_extends[0] *= cgs.ccZoomFactor;
-				icon_extends[1] *= cgs.ccZoomFactor;
-			}
-
-			// now check to see if the entity is within our clip region
-			if (scissor && CG_ScissorEntIsCulled(mEnt, scissor, icon_extends))
-			{
-				trap_R_SetColor(NULL);
-				return;
-			}
-
-			CG_DrawPic(icon_pos[0] - icon_extends[0] * 0.5f, icon_pos[1] - icon_extends[1] * 0.5f, icon_extends[0], icon_extends[1], pic);
-		}
-		trap_R_SetColor(NULL);
-		return;
-	case ME_LANDMINE:
-	{
-		float x1 = x;
-		float y1 = y;
-		float w1 = w;
-		float h1 = h;
-
-		if (mEntFilter & CC_FILTER_LANDMINES)
-		{
-			return;
-		}
-
-		if (cgs.ccLayers)
-		{
-			if (CG_CurLayerForZ(mEnt->z) != cgs.ccSelectedLayer)
-			{
-				return;
-			}
-		}
-
-		CG_AdjustFrom640(&x1, &y1, &w1, &h1);
-
-		pic = mEnt->data == TEAM_AXIS ? cgs.media.commandCentreAxisMineShader : cgs.media.commandCentreAlliedMineShader;
-
-		c_clr[3] = 1.0f;
-
-		if (scissor)
-		{
-			icon_pos[0] = mEnt->automapTransformed[0] - scissor->tl[0] + x;
-			icon_pos[1] = mEnt->automapTransformed[1] - scissor->tl[1] + y;
-		}
-		else
-		{
-			icon_pos[0] = x + mEnt->transformed[0];
-			icon_pos[1] = y + mEnt->transformed[1];
-		}
-
-		icon_extends[0] = CONST_ICON_LANDMINE_SIZE_NEW;
-		icon_extends[1] = CONST_ICON_LANDMINE_SIZE_NEW;
-
-		if (scissor)
-		{
-			//icon_extends[0] *= (scissor->zoomFactor / AUTOMAP_ZOOM_NEW);
-			//icon_extends[1] *= (scissor->zoomFactor / AUTOMAP_ZOOM_NEW);
-		}
-		else
-		{
-			icon_extends[0] *= cgs.ccZoomFactor;
-			icon_extends[1] *= cgs.ccZoomFactor;
-		}
-
-		// now check to see if the entity is within our clip region
-		if (scissor && CG_ScissorEntIsCulled(mEnt, scissor, icon_extends))
-		{
-			trap_R_SetColor(NULL);
-			return;
-		}
-
-		trap_R_SetColor(c_clr);
-		CG_DrawPic(icon_pos[0] - icon_extends[0] * 0.5f, icon_pos[1] - icon_extends[1] * 0.5f, icon_extends[0], icon_extends[1], pic);
-		trap_R_SetColor(NULL);
-
-		j++;
-		return;
-	}
-	default:
-		return;
-	}
-}
-
-/**
-* @brief CG_DrawMapNew
-* @param[in] x
-* @param[in] y
-* @param[in] w
-* @param[in] h
-* @param[in] mEntFilter
-* @param[in] scissor
-* @param[in] interactive
-* @param[in] alpha
-* @param[in] borderblend
-*/
-void CG_DrawMapNew(float x, float y, float w, float h, int mEntFilter, mapScissor_t *scissor, qboolean interactive, float alpha, qboolean borderblend)
-{
-	int             i;
-	snapshot_t      *snap;
-	mapEntityData_t *mEnt;
-	int             icon_size;
-	int             exspawn;
-	team_t          RealTeam = CG_LimboPanel_GetRealTeam();
-
-	//expanded = qfalse;
-
-	if (cg.nextSnap && !cg.nextFrameTeleport && !cg.thisFrameTeleport)
-	{
-		snap = cg.nextSnap;
-	}
-	else
-	{
-		snap = cg.snap;
-	}
-
-	if (scissor)
-	{
-		icon_size = AUTOMAP_PLAYER_ICON_SIZE_NEW;
-
-		if (scissor->br[0] >= scissor->tl[0])
-		{
-			float s0, s1, t0, t1;
-			float sc_x = x, sc_y = y, sc_w = w, sc_h = h;
-
-			vec4_t color;
-
-			Vector4Set(color, 1.f, 1.f, 1.f, alpha);
-			trap_R_SetColor(color);
-			CG_DrawPic(sc_x, sc_y, sc_w, sc_h, cgs.media.blackmask);
-
-			s0 = (scissor->tl[0]) / (w * scissor->zoomFactor);
-			s1 = (scissor->br[0]) / (w * scissor->zoomFactor);
-			t0 = (scissor->tl[1]) / (h * scissor->zoomFactor);
-			t1 = (scissor->br[1]) / (h * scissor->zoomFactor);
-
-			CG_AdjustFrom640(&sc_x, &sc_y, &sc_w, &sc_h);
-
-			if (cgs.ccLayers)
-			{
-				trap_R_DrawStretchPic(sc_x, sc_y, sc_w, sc_h, s0, t0, s1, t1, cgs.media.commandCentreAutomapShader[cgs.ccSelectedLayer]);
-			}
-			else
-			{
-				trap_R_DrawStretchPic(sc_x, sc_y, sc_w, sc_h, s0, t0, s1, t1, cgs.media.commandCentreAutomapShader[0]);
-			}
-
-			trap_R_SetColor(NULL);
-
-			CG_DrawRect_FixedBorder(x - 0.5f, y - 0.5f, w + 1.0f, h + 1.0f, 1, colorWhite);
-		}
-	}
-	else
-	{
-		vec4_t color;
-
-		icon_size = COMMANDMAP_PLAYER_ICON_SIZE_NEW;
-
-		Vector4Set(color, 1.f, 1.f, 1.f, alpha);
-		trap_R_SetColor(color);
-		CG_DrawPic(x, y, w, h, cgs.media.blackmask);
-
-		if (cgs.ccLayers)
-		{
-			CG_DrawPic(x, y, w, h, cgs.media.commandCentreMapShaderTrans[cgs.ccSelectedLayer]);
-		}
-		else
-		{
-			CG_DrawPic(x, y, w, h, cgs.media.commandCentreMapShaderTrans[0]);
-		}
-		trap_R_SetColor(NULL);
-
-		CG_DrawRect_FixedBorder(x - 0.5f, y - 0.5f, w + 1.0f, h + 1.0f, 1, colorWhite);
-	}
-
-	exspawn = CG_DrawSpawnPointInfoNew(x, y, w, h, qfalse, scissor, -1);
-
-	// entnfo data
-	for (i = 0, mEnt = &mapEntities[0]; i < mapEntityCount; ++i, ++mEnt)
-	{
-		// spectators can see icons of both teams
-		if ((interactive && mEnt->team != RealTeam) ||
-		    (mEnt->team != snap->ps.persistant[PERS_TEAM] && snap->ps.persistant[PERS_TEAM] != TEAM_SPECTATOR))
-		{
-			if (mEnt->team != RealTeam && !CG_DisguiseMapCheck(mEnt))
-			{
-				continue;
-			}
-
-			if (mEnt->type != ME_PLAYER &&
-			    mEnt->type != ME_PLAYER_DISGUISED &&
-			    mEnt->type != ME_PLAYER_OBJECTIVE &&
-			    mEnt->type != ME_PLAYER_REVIVE)
-			{
-				continue;
-			}
-
-			CG_DrawMapEntityNew(mEnt, x, y, w, h, mEntFilter, scissor, interactive, snap, icon_size);
-			continue;
-		}
-
-		CG_DrawMapEntityNew(mEnt, x, y, w, h, mEntFilter, scissor, interactive, snap, icon_size);
-	}
-
-	// spawn point info
-	CG_DrawSpawnPointInfoNew(x, y, w, h, qtrue, scissor, exspawn);
-
-	// mortar impact markers
-	CG_DrawMortarMarkerNew(x, y, w, h, qtrue, scissor, exspawn);
-
-	// entnfo players data
-	for (i = 0, mEnt = &mapEntities[0]; i < mapEntityCount; ++i, ++mEnt)
-	{
-		if (mEnt->team != RealTeam && !CG_DisguiseMapCheck(mEnt) && !cgs.clientinfo[cg.clientNum].shoutcaster)
-		{
-			continue;
-		}
-
-		if (mEnt->type != ME_PLAYER &&
-		    mEnt->type != ME_PLAYER_DISGUISED &&
-		    mEnt->type != ME_PLAYER_OBJECTIVE &&
-		    mEnt->type != ME_PLAYER_REVIVE)
-		{
-			continue;
-		}
-
-		CG_DrawMapEntityNew(mEnt, x, y, w, h, mEntFilter, scissor, interactive, snap, icon_size);
-	}
-
-	// draw spectator position and direction
-	if (cgs.clientinfo[cg.clientNum].team == TEAM_SPECTATOR)
-	{
-		vec2_t           icon_pos, icon_extends;
-		bg_playerclass_t *classInfo;
-
-		icon_extends[0] = 2 * icon_size;
-		icon_extends[1] = 2 * icon_size;
-
-		if (scissor)
-		{
-			icon_extends[0] *= (scissor->zoomFactor / AUTOMAP_ZOOM_NEW);
-			icon_extends[1] *= (scissor->zoomFactor / AUTOMAP_ZOOM_NEW);
-		}
-		else
-		{
-			icon_extends[0] *= cgs.ccZoomFactor;
-			icon_extends[1] *= cgs.ccZoomFactor;
-		}
-
-		if (scissor)
-		{
-			icon_pos[0] = ((cg.predictedPlayerEntity.lerpOrigin[0] - cg.mapcoordsMins[0]) * cg.mapcoordsScale[0]) * w * scissor->zoomFactor - scissor->tl[0] + x;
-			icon_pos[1] = ((cg.predictedPlayerEntity.lerpOrigin[1] - cg.mapcoordsMins[1]) * cg.mapcoordsScale[1]) * h * scissor->zoomFactor - scissor->tl[1] + y;
-		}
-		else
-		{
-			icon_pos[0] = x + ((cg.predictedPlayerEntity.lerpOrigin[0] - cg.mapcoordsMins[0]) * cg.mapcoordsScale[0]) * w;
-			icon_pos[1] = y + ((cg.predictedPlayerEntity.lerpOrigin[1] - cg.mapcoordsMins[1]) * cg.mapcoordsScale[1]) * h;
-		}
-
-		if (snap->ps.persistant[PERS_TEAM] == TEAM_SPECTATOR)
-		{
-			// draw a arrow when free-spectating
-			CG_DrawPic(icon_pos[0] - icon_extends[0] * 0.5f, icon_pos[1] - icon_extends[1] * 0.5f, icon_extends[0], icon_extends[1], cgs.media.cm_spec_icon);
-			CG_DrawRotatedPic(icon_pos[0] - icon_extends[0] * 0.5f - 1, icon_pos[1] - icon_extends[1] * 0.5f - 1, icon_extends[0] + 2, icon_extends[1] + 2, cgs.media.cm_arrow_spec, (0.5f - (cg.predictedPlayerState.viewangles[YAW] - 180.f) / 360.f));
-		}
-		else
-		{
-			// show only current player position to spectators
-			classInfo = CG_PlayerClassForClientinfo(&cgs.clientinfo[snap->ps.clientNum], &cg_entities[snap->ps.clientNum]);
-
-			if (snap->ps.powerups[PW_OPS_DISGUISED])
-			{
-				CG_DrawPic(icon_pos[0] - icon_extends[0] * 0.5f, icon_pos[1] - icon_extends[1] * 0.5f, icon_extends[0], icon_extends[1], classInfo->icon);
-				CG_DrawPic(icon_pos[0] - icon_extends[0] * 0.5f, icon_pos[1] - icon_extends[1] * 0.5f, icon_extends[0], icon_extends[1], cgs.media.friendShader);
-			}
-			else if (snap->ps.powerups[PW_REDFLAG] || snap->ps.powerups[PW_BLUEFLAG])
-			{
-				CG_DrawPic(icon_pos[0] - icon_extends[0] * 0.5f, icon_pos[1] - icon_extends[1] * 0.5f, icon_extends[0], icon_extends[1], cgs.media.objectiveShader);
-			}
-			else if (snap->ps.eFlags & EF_DEAD && !(snap->ps.powerups[PW_INVULNERABLE]))
-			{
-				float  msec;
-				vec4_t reviveClr = { 1.f, 1.f, 1.f, 1.f };
-
-				if (snap->ps.persistant[PERS_TEAM] == TEAM_SPECTATOR || cgs.clientinfo[cg.clientNum].shoutcaster)
-				{
-					if (cgs.clientinfo[cg.snap->ps.clientNum].team == TEAM_AXIS || (cgs.clientinfo[cg.clientNum].shoutcaster && mEnt->team == TEAM_AXIS))
-					{
-						msec = (cg_redlimbotime.integer - (cg.time % cg_redlimbotime.integer)) / (float)cg_redlimbotime.integer;
-					}
-					else if (cgs.clientinfo[cg.snap->ps.clientNum].team == TEAM_ALLIES || (cgs.clientinfo[cg.clientNum].shoutcaster && mEnt->team == TEAM_ALLIES))
-					{
-						msec = (cg_bluelimbotime.integer - (cg.time % cg_bluelimbotime.integer)) / (float)cg_bluelimbotime.integer;
-					}
-					else
-					{
-						msec = 0;
-					}
-
-					reviveClr[3] = .5f + .5f * (float)((sin(sqrt((double)msec) * 25 * M_TAU_F) + 1) * 0.5);
-				}
-				else
-				{
-					// following spectator can't guess reinforcement timer
-					reviveClr[3] = .5f + fabs(sin(cg.time * 0.002)) * 0.5;
-				}
-
-				trap_R_SetColor(reviveClr);
-				CG_DrawPic(icon_pos[0] - icon_extends[0] * 0.5f + 2, icon_pos[1] - icon_extends[1] * 0.5f + 2, icon_extends[0] - 2, icon_extends[1] - 2, cgs.media.medicIcon);
-				trap_R_SetColor(NULL);
-				return;
-			}
-			else
-			{
-				CG_DrawPic(icon_pos[0] - icon_extends[0] * 0.5f, icon_pos[1] - icon_extends[1] * 0.5f, icon_extends[0], icon_extends[1], classInfo->icon);
-			}
-
-			CG_DrawRotatedPic(icon_pos[0] - icon_extends[0] * 0.5f - 1, icon_pos[1] - icon_extends[1] * 0.5f - 1, icon_extends[0] + 2, icon_extends[1] + 2, classInfo->arrow, (0.5f - (cg.predictedPlayerState.viewangles[YAW] - 180.f) / 360.f));
-		}
-	}
-}
-
-/**
-* @brief CG_DrawSpawnPointInfoNew
-* @param[in] px
-* @param[in] py
-* @param[in] pw
-* @param[in] ph
-* @param[in] draw
-* @param[in] scissor
-* @param[in] expand
-* @return
-*/
-int CG_DrawSpawnPointInfoNew(float px, float py, float pw, float ph, qboolean draw, mapScissor_t *scissor, int expand)
-{
-	team_t team = CG_LimboPanel_GetRealTeam();
-	char   buffer[64];
-	vec2_t icon_extends;
-	vec2_t point;
-	float  changetime;
-	int    i, width, e = -1;
-
-	if (cgs.ccFilter & CC_FILTER_SPAWNS)
-	{
-		return -1;
-	}
-
-	for (i = 1; i < cg.spawnCount; i++)
-	{
-		changetime = 0;
-
-		if (cg.spawnTeams_changeTime[i])
-		{
-			changetime = (cg.time - cg.spawnTeams_changeTime[i]);
-			if (changetime > SPAWN_SIZEUPTIME_NEW || changetime < 0)
-			{
-				changetime = cg.spawnTeams_changeTime[i] = 0;
-			}
-		}
-
-		if (!(cg.spawnTeams[i] & 0xF) ||
-		    (cgs.clientinfo[cg.clientNum].team != TEAM_SPECTATOR && cg.spawnTeams[i] != team) ||
-		    ((cg.spawnTeams[i] & 256) && changetime == 0.f))
-		{
-			continue;
-		}
-
-		if (cgs.ccLayers)
-		{
-			if (CG_CurLayerForZ((int)cg.spawnCoords[i][2]) != cgs.ccSelectedLayer)
-			{
-				break;
-			}
-		}
-
-		if (scissor)
-		{
-			point[0] = ((cg.spawnCoordsUntransformed[i][0] - cg.mapcoordsMins[0]) * cg.mapcoordsScale[0]) * pw * scissor->zoomFactor;
-			point[1] = ((cg.spawnCoordsUntransformed[i][1] - cg.mapcoordsMins[1]) * cg.mapcoordsScale[1]) * ph * scissor->zoomFactor;
-		}
-		else
-		{
-			point[0] = px + (((cg.spawnCoordsUntransformed[i][0] - cg.mapcoordsMins[0]) * cg.mapcoordsScale[0]) * pw);
-			point[1] = py + (((cg.spawnCoordsUntransformed[i][1] - cg.mapcoordsMins[1]) * cg.mapcoordsScale[1]) * ph);
-		}
-
-		icon_extends[0] = FLAGSIZE_NORMAL_NEW;
-		icon_extends[1] = FLAGSIZE_NORMAL_NEW;
-
-		if (scissor)
-		{
-			//icon_extends[0] *= (scissor->zoomFactor / AUTOMAP_ZOOM_NEW);
-			//icon_extends[1] *= (scissor->zoomFactor / AUTOMAP_ZOOM_NEW);
-		}
-		else
-		{
-			icon_extends[0] *= cgs.ccZoomFactor;
-			icon_extends[1] *= cgs.ccZoomFactor;
-		}
-
-		if (scissor && CG_ScissorPointIsCulled(point, scissor, icon_extends))
-		{
-			continue;
-		}
-
-		if (scissor)
-		{
-			point[0] += px - scissor->tl[0];
-			point[1] += py - scissor->tl[1];
-		}
-
-		//point[0] -= (icon_extends[0] * (39 / 128.f));
-		//point[1] += (icon_extends[1] * (31 / 128.f));
-
-		if (changetime != 0.f)
-		{
-			if (draw)
-			{
-				float size;
-
-				if (cg.spawnTeams[i] == team)
-				{
-					size = 20 * (changetime / SPAWN_SIZEUPTIME_NEW);
-				}
-				else
-				{
-					size = 20 * (1 - (changetime / SPAWN_SIZEUPTIME_NEW));
-				}
-
-				if (scissor)
-				{
-					size *= (scissor->zoomFactor / AUTOMAP_ZOOM_NEW);
-				}
-				else
-				{
-					size *= cgs.ccZoomFactor;
-				}
-
-				CG_DrawPic(point[0] - FLAG_LEFTFRAC_NEW * size, point[1] - FLAG_TOPFRAC_NEW * size, size, size, cgs.media.commandCentreSpawnShader[cg.spawnTeams[i] == TEAM_AXIS ? 0 : 1]);
-			}
-		}
-		else if ((draw && i == expand) || (!expanded && BG_RectContainsPoint(point[0] - FLAGSIZE_NORMAL_NEW * 0.5f, point[1] - FLAGSIZE_NORMAL_NEW * 0.5f, FLAGSIZE_NORMAL_NEW, FLAGSIZE_NORMAL_NEW, cgDC.cursorx, cgDC.cursory)))
-		{
-			if (draw)
-			{
-				float size = FLAGSIZE_EXPANDED_NEW;
-
-				if (scissor)
-				{
-					size *= (scissor->zoomFactor / AUTOMAP_ZOOM_NEW);
-				}
-				else
-				{
-					size *= cgs.ccZoomFactor;
-				}
-
-				CG_DrawPic(point[0] - FLAG_LEFTFRAC_NEW * size, point[1] - FLAG_TOPFRAC_NEW * size, size, size, cgs.media.commandCentreSpawnShader[cg.spawnTeams[i] == TEAM_AXIS ? 0 : 1]);
-			}
-			else
-			{
-				if (!scissor)
-				{
-					float w;
-
-					Com_sprintf(buffer, sizeof(buffer), "%s (%i)", cg.spawnPoints[i], cg.spawnPlayerCounts[i]);
-					w = CG_Text_Width_Ext(buffer, 0.2f, 0, &cgs.media.limboFont2);
-					CG_CommandMap_SetHighlightText(buffer, point[0] - (w * 0.5f), point[1] - 8);
-				}
-
-				e = i;
-			}
-		}
-		else
-		{
-			if (draw)
-			{
-				float size = FLAGSIZE_NORMAL_NEW;
-
-				if (scissor)
-				{
-					size *= (scissor->zoomFactor / AUTOMAP_ZOOM_NEW);
-				}
-				else
-				{
-					size *= cgs.ccZoomFactor;
-				}
-
-				CG_DrawPic(point[0] - FLAG_LEFTFRAC_NEW * size, point[1] - FLAG_TOPFRAC_NEW * size, size, size, cgs.media.commandCentreSpawnShader[cg.spawnTeams[i] == TEAM_AXIS ? 0 : 1]);
-
-				Com_sprintf(buffer, sizeof(buffer), "(%i)", cg.spawnPlayerCounts[i]);
-
-				if (scissor)
-				{
-					// Recalculate for player spawn count clipping
-					point[0] = ((cg.spawnCoordsUntransformed[i][0] - cg.mapcoordsMins[0]) * cg.mapcoordsScale[0]) * pw * scissor->zoomFactor;
-					point[1] = ((cg.spawnCoordsUntransformed[i][1] - cg.mapcoordsMins[1]) * cg.mapcoordsScale[1]) * ph * scissor->zoomFactor;
-
-					width = CG_Text_Width_Ext(buffer, 0.15f, 0, &cgs.media.limboFont2);
-
-					point[0] += 1.5f + scissor->zoomFactor + width;
-					point[1] -= 5;
-
-					if (CG_ScissorPointIsCulled(point, scissor, icon_extends))
-					{
-						continue;
-					}
-
-					point[0] += px - scissor->tl[0] - width;
-					point[1] += py - scissor->tl[1] + 4;
-
-					CG_Text_Paint_Ext(point[0], point[1], 0.15f, 0.15f, colorWhite, buffer, 0, 0, ITEM_TEXTSTYLE_SHADOWED, &cgs.media.limboFont2);
-				}
-				else
-				{
-					CG_Text_Paint_Ext(point[0] + FLAGSIZE_NORMAL_NEW * 0.25f, point[1], 0.2f, 0.2f, colorWhite, buffer, 0, 0, ITEM_TEXTSTYLE_SHADOWED, &cgs.media.limboFont2);
-				}
-			}
-		}
-	}
-
-	return e;
-}
-
-/**
-* @brief CG_DrawMortarMarkerNew
-* @param[in] px
-* @param[in] py
-* @param[in] pw
-* @param[in] ph
-* @param[in] draw - unused
-* @param[in] scissor - unused
-* @param[in] expand
-*/
-void CG_DrawMortarMarkerNew(float px, float py, float pw, float ph, qboolean draw, mapScissor_t *scissor, int expand)
-{
-	vec3_t point;
-	vec2_t icon_extends;
-	int    i, fadeTime;
-
-	if (CHECKBITWISE(GetWeaponTableData(cg.lastFiredWeapon)->type, WEAPON_TYPE_MORTAR | WEAPON_TYPE_SET) && cg.mortarImpactTime >= 0)
-	{
-		vec4_t color = { 1.f, 1.f, 1.f, 1.f };
-
-		if (!(CHECKBITWISE(GetWeaponTableData(cg.snap->ps.weapon)->type, WEAPON_TYPE_MORTAR | WEAPON_TYPE_SET)))
-		{
-			cg.mortarImpactTime = 0;
-		}
-		else
-		{
-			if (scissor)
-			{
-				point[0] = ((cg.mortarImpactPos[0] - cg.mapcoordsMins[0]) * cg.mapcoordsScale[0]) * pw * scissor->zoomFactor;
-				point[1] = ((cg.mortarImpactPos[1] - cg.mapcoordsMins[1]) * cg.mapcoordsScale[1]) * ph * scissor->zoomFactor;
-			}
-			else
-			{
-				point[0] = px + (((cg.mortarImpactPos[0] - cg.mapcoordsMins[0]) * cg.mapcoordsScale[0]) * pw);
-				point[1] = py + (((cg.mortarImpactPos[1] - cg.mapcoordsMins[1]) * cg.mapcoordsScale[1]) * ph);
-			}
-
-			// don't return if the marker is culled, just don't draw it
-			if (!(scissor && CG_ScissorPointIsCulled(point, scissor, icon_extends)))
-			{
-				if (scissor)
-				{
-					point[0] += px - scissor->tl[0];
-					point[1] += py - scissor->tl[1];
-				}
-
-				if (cg.mortarImpactOutOfMap)
-				{
-					if (!scissor)
-					{
-						// near the edge of the map, fit into it
-						if (point[0] + 8.f > (px + pw))
-						{
-							point[0] -= 8.f;
-						}
-						else if (point[0] - 8.f < px)
-						{
-							point[0] += 8.f;
-						}
-
-						if (point[1] + 8.f > (py + ph))
-						{
-							point[1] -= 8.f;
-						}
-						else if (point[1] - 8.f < py)
-						{
-							point[1] += 8.f;
-						}
-					}
-					color[3] = .5f;
-				}
-
-				trap_R_SetColor(color);
-				CG_DrawRotatedPic(point[0] - 8.f, point[1] - 8.f, 16, 16, cgs.media.ccMortarHit, .5f - (cg.mortarFireAngles[YAW] /*- 180.f */ + 45.f) / 360.f);
-				trap_R_SetColor(NULL);
-			}
-		}
-	}
-
-	// display arty target to all teammates
-	for (i = 0; i < cgs.maxclients; i++)
-	{
-		vec4_t color = { 1.f, 1.f, 1.f, 1.f };
-
-		fadeTime = cg.time - (cg.artilleryRequestTime[i] + 25000);
-
-		if (fadeTime < 5000 && cg.artilleryRequestTime[i] > 0)
-		{
-			if (fadeTime > 0)
-			{
-				color[3] = 1.f - (fadeTime / 5000.f);
-			}
-
-			if (scissor)
-			{
-				point[0] = ((cg.artilleryRequestPos[i][0] - cg.mapcoordsMins[0]) * cg.mapcoordsScale[0]) * pw * scissor->zoomFactor;
-				point[1] = ((cg.artilleryRequestPos[i][1] - cg.mapcoordsMins[1]) * cg.mapcoordsScale[1]) * ph * scissor->zoomFactor;
-			}
-			else
-			{
-				point[0] = px + (((cg.artilleryRequestPos[i][0] - cg.mapcoordsMins[0]) * cg.mapcoordsScale[0]) * pw);
-				point[1] = py + (((cg.artilleryRequestPos[i][1] - cg.mapcoordsMins[1]) * cg.mapcoordsScale[1]) * ph);
-			}
-
-			// don't return if the marker is culled, just skip it (so we draw the rest, if any)
-			if (scissor && CG_ScissorPointIsCulled(point, scissor, icon_extends))
-			{
-				continue;
-			}
-
-			if (scissor)
-			{
-				point[0] += px - scissor->tl[0];
-				point[1] += py - scissor->tl[1];
-			}
-
-			trap_R_SetColor(color);
-			CG_DrawPic(point[0] - 8.f, point[1] - 8.f, 16, 16, cgs.media.ccMortarTarget);
-			trap_R_SetColor(NULL);
-		}
+		CG_DrawPic(iconx, icony, iconWidth, iconHeight, shader);
 	}
 }

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -3001,8 +3001,6 @@ const char *CG_TranslateString(const char *string);
 
 void CG_InitStatsDebug(void);
 void CG_StatsDebugAddText(const char *text);
-qhandle_t CG_GetCompassIcon(entityState_t *ent, qboolean drawAllVoicesChat, qboolean drawFireTeam, qboolean drawPrimaryObj, qboolean drawSecondaryObj, qboolean drawDynamic, char *name);
-void CG_DrawCompassIcon(float x, float y, float w, float h, vec3_t origin, vec3_t dest, qhandle_t shader, float dstScale, float baseSize);
 
 void CG_AddLagometerFrameInfo(void);
 void CG_AddLagometerSnapshotInfo(snapshot_t *snap);
@@ -3318,11 +3316,6 @@ qboolean CG_ViewingDraw(void);
 // cg_scoreboard.c
 qboolean CG_DrawScoreboard(void);
 int SkillNumForClass(int classNum);
-
-void CG_TransformToCommandMapCoord(float *coord_x, float *coord_y);
-
-void CG_DrawExpandedAutoMap(void);
-void CG_DrawAutoMap(float x, float y, float w, float h);
 
 qboolean CG_DrawFlag(float x, float y, float fade, int clientNum);
 
@@ -3874,10 +3867,14 @@ void CG_CommandMap_SetHighlightText(const char *text, float x, float y);
 void CG_CommandMap_DrawHighlightText(void);
 qboolean CG_CommandCentreSpawnPointClick(void);
 
-void CG_DrawAutoMapNew(float x, float y, float w, float h);
-void CG_DrawMapNew(float x, float y, float w, float h, int mEntFilter, mapScissor_t *scissor, qboolean interactive, float alpha, qboolean borderblend);
-int CG_DrawSpawnPointInfoNew(float px, float py, float pw, float ph, qboolean draw, mapScissor_t *scissor, int expand);
-void CG_DrawMortarMarkerNew(float px, float py, float pw, float ph, qboolean draw, mapScissor_t *scissor, int expand);
+void CG_DrawNewCompass(rectDef_t location);
+qhandle_t CG_GetCompassIcon(entityState_t *ent, qboolean drawAllVoicesChat, qboolean drawFireTeam, qboolean drawPrimaryObj, qboolean drawSecondaryObj, qboolean drawDynamic, char *name);
+void CG_DrawCompassIcon(float x, float y, float w, float h, vec3_t origin, vec3_t dest, qhandle_t shader, float dstScale, float baseSize, mapScissor_t *scissor);
+
+void CG_TransformToCommandMapCoord(float *coord_x, float *coord_y);
+
+void CG_DrawExpandedAutoMap(void);
+void CG_DrawAutoMap(float basex, float basey, float basew, float baseh);
 
 #define LIMBO_3D_X  287 //% 280
 #define LIMBO_3D_Y  382

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1854,6 +1854,7 @@ typedef struct
 	qhandle_t ccDestructIcon[3][2];
 	qhandle_t ccTankIcon;
 	qhandle_t skillPics[SK_NUM_SKILLS];
+	qhandle_t ccMedicIcon;
 #ifdef FEATURE_PRESTIGE
 	qhandle_t prestigePics[3];
 #endif

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -1878,6 +1878,8 @@ static void CG_RegisterGraphics(void)
 	cgs.media.skillPics[SK_HEAVY_WEAPONS]                            = trap_R_RegisterShaderNoMip("gfx/limbo/ic_soldier");
 	cgs.media.skillPics[SK_MILITARY_INTELLIGENCE_AND_SCOPED_WEAPONS] = trap_R_RegisterShaderNoMip("gfx/limbo/ic_covertops");
 
+	cgs.media.ccMedicIcon = trap_R_RegisterShaderNoMip("sprites/cm_medic_icon");
+
 #ifdef FEATURE_PRESTIGE
 	cgs.media.prestigePics[0] = trap_R_RegisterShaderNoMip("gfx/hud/prestige/prestige");
 	cgs.media.prestigePics[1] = trap_R_RegisterShaderNoMip("gfx/hud/prestige/prestige_stamp");
@@ -2086,7 +2088,6 @@ static void CG_RegisterGraphics(void)
 	cgs.media.hMountedFPMG42     = trap_R_RegisterModel("models/multiplayer/mg42/v_mg42.md3");
 	cgs.media.hMountedFPBrowning = trap_R_RegisterModel("models/multiplayer/browning/tankmounted.md3");
 
-	// icons for commandmap
 	cgs.media.medicIcon = trap_R_RegisterShaderNoMip("sprites/voiceMedic");
 	cgs.media.ammoIcon  = trap_R_RegisterShaderNoMip("sprites/voiceAmmo");
 

--- a/src/cgame/cg_shoutcastoverlay.c
+++ b/src/cgame/cg_shoutcastoverlay.c
@@ -58,7 +58,7 @@
 #define MINIMAP_WIDTH 150
 #define MINIMAP_HEIGHT 150
 #define MINIMAP_X (Ccg_WideX(SCREEN_WIDTH) - MINIMAP_WIDTH - PLAYER_LIST_OVERLAY_BORDER_DISTANCE_X)
-#define MINIMAP_Y 15
+#define MINIMAP_Y 31
 
 #define GAMETIME_WIDTH 60
 #define GAMETIME_HEIGHT 30
@@ -86,7 +86,18 @@ int players[12];
 */
 void CG_DrawMinimap(void)
 {
-	CG_DrawAutoMapNew(MINIMAP_X, MINIMAP_Y, MINIMAP_WIDTH, MINIMAP_HEIGHT);
+	// FIXME: this cvar seems redundant as of now, can use cg_drawCompass instead
+	if (!cg_shoutcastDrawMinimap.integer)
+	{
+		return;
+	}
+
+	rectDef_t location;
+	location.x = MINIMAP_X;
+	location.y = MINIMAP_Y;
+	location.w = MINIMAP_WIDTH;
+	location.h = MINIMAP_HEIGHT;
+	CG_DrawNewCompass(location);
 }
 
 /**


### PR DESCRIPTION
Initialy I separated shoutcast minimap and compass because I didn't want to break compass as I barely knew the project. I did it however in mind of eventually adding it back and allowing using it for normal gameplay and this PR should be it.

- standard compass should be working as before
- shoutcast minimap should be working as before - it is still forced in both the size and placement
- enabled with `cg_drawCompass 2`

I would consider it a work in progress, standard `cg_altHud` settings will correctly draw the square minimap, but it is hardly usable. It's too small and icons are too big for such small size. As of now it is best used with custom hud, where players can set the size and location as they wish.

What I feel could and probably should be worked on in the future:

- improve the icons scaling - square minimap uses big icons so they are easily visible when max zoomed out but with small minimap dimensions it barely presents any information because of it. Compass on the other hand has **very** small icons when max zoomed out making it only usable with big zoom which reduces the overall needed "visibility".
- fix voice chat sprites - on square minimap they can be drawn out side of minimap (same as compass but it has bigger border). Position of sprites is also pretty bad - full zoom it is under the player icon, full zoom out it is way too far from player icon.
- to make square minimap work with current `cg_altHud`s it is also reduced in size just like compass which shouldn't be necessary imo. https://github.com/etlegacy/etlegacy/compare/master...ryzyk-krzysiek:square-minimap?expand=1#diff-09bf4aee5c64caee30f85eb55b903a2b2004f3461eb16040b223a25ff18523b8R1771-R1775

Custom hud example:
![square minimap](https://user-images.githubusercontent.com/4499367/144152140-921b0558-5e49-4b9f-a102-2dfa679744ac.png)

refs #1000 #1282 #1433