### PR TITLE
cgame: fix voice chat sprite position and drawing outside of command map

### DIFF
--- a/etmain/scripts/legacy.shader
+++ b/etmain/scripts/legacy.shader
@@ -819,6 +819,34 @@ sprites/cm_medic_icon
 	}
 }
 
+sprites/cm_ammo_icon
+{
+	nopicmip
+	nocompress
+	nomipmaps
+	{
+		map sprites/voiceammo.tga
+		depthFunc equal
+		blendfunc blend
+		rgbGen vertex
+		alphaGen vertex
+	}
+}
+
+sprites/cm_voicechat_icon
+{
+	nopicmip
+	nocompress
+	nomipmaps
+	{
+		map sprites/voicechat.tga
+		depthFunc equal
+		blendfunc blend
+		rgbGen vertex
+		alphaGen vertex
+	}
+}
+
 ui/assets/mp_ammo_blue
 {
 	nopicmip

--- a/src/cgame/cg_commandmap.c
+++ b/src/cgame/cg_commandmap.c
@@ -167,6 +167,33 @@ static qboolean CG_ScissorPointIsCulled(vec2_t vec, mapScissor_t *scissor, vec2_
 }
 
 /**
+* @brief CG_GetVoiceChatForCommandMap
+* @details Maps default voice chat shader to command map shader.
+*          Command map requires different shaders to not draw icons outside of the map.
+*
+* @param[in,out] voiceChat
+*/
+static int CG_GetVoiceChatForCommandMap(int voiceChat)
+{
+	if (voiceChat == cgs.media.voiceChatShader)
+	{
+		return cgs.media.ccVoiceChatShader;
+	}
+
+	if (voiceChat == cgs.media.medicIcon)
+	{
+		return cgs.media.ccMedicIcon;
+	}
+
+	if (voiceChat == cgs.media.ammoIcon)
+	{
+		return cgs.media.ccAmmoIcon;
+	}
+
+	return voiceChat;
+}
+
+/**
  * @brief Calculate the scaled (zoomed) yet unshifted coordinate for
  * each map entity within the automap
  */
@@ -756,7 +783,7 @@ void CG_DrawMapEntity(mapEntityData_t *mEnt, float x, float y, float w, float h,
 
 				if (cg.predictedPlayerEntity.voiceChatSpriteTime > cg.time)
 				{
-					CG_DrawPic(icon_pos[0] + 12, icon_pos[1], icon_extends[0] * 0.5f, icon_extends[1] * 0.5f, cg.predictedPlayerEntity.voiceChatSprite);
+					CG_DrawPic(icon_pos[0] + icon_extends[0], icon_pos[1], icon_extends[0] * 0.5f, icon_extends[1] * 0.5f, CG_GetVoiceChatForCommandMap(cg.predictedPlayerEntity.voiceChatSprite));
 				}
 			}
 			else if (/*!(cgs.ccFilter & CC_FILTER_BUDDIES) &&*/ CG_IsOnSameFireteam(cg.clientNum, mEnt->data))
@@ -780,7 +807,7 @@ void CG_DrawMapEntity(mapEntityData_t *mEnt, float x, float y, float w, float h,
 
 				if (cent->voiceChatSpriteTime > cg.time)
 				{
-					CG_DrawPic(icon_pos[0] + 12, icon_pos[1], icon_extends[0] * 0.5f, icon_extends[1] * 0.5f, cent->voiceChatSprite);
+					CG_DrawPic(icon_pos[0] + icon_extends[0], icon_pos[1], icon_extends[0] * 0.5f, icon_extends[1] * 0.5f, CG_GetVoiceChatForCommandMap(cent->voiceChatSprite));
 				}
 			}
 			else if (ci->team == snap->ps.persistant[PERS_TEAM])
@@ -794,7 +821,7 @@ void CG_DrawMapEntity(mapEntityData_t *mEnt, float x, float y, float w, float h,
 
 				if (cent->voiceChatSpriteTime > cg.time)
 				{
-					CG_DrawPic(icon_pos[0] + 12, icon_pos[1], icon_extends[0] * 0.5f, icon_extends[1] * 0.5f, cent->voiceChatSprite);
+					CG_DrawPic(icon_pos[0] + icon_extends[0], icon_pos[1], icon_extends[0] * 0.5f, icon_extends[1] * 0.5f, CG_GetVoiceChatForCommandMap(cent->voiceChatSprite));
 				}
 			}
 

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1855,6 +1855,8 @@ typedef struct
 	qhandle_t ccTankIcon;
 	qhandle_t skillPics[SK_NUM_SKILLS];
 	qhandle_t ccMedicIcon;
+	qhandle_t ccAmmoIcon;
+	qhandle_t ccVoiceChatShader;
 #ifdef FEATURE_PRESTIGE
 	qhandle_t prestigePics[3];
 #endif

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -1878,7 +1878,9 @@ static void CG_RegisterGraphics(void)
 	cgs.media.skillPics[SK_HEAVY_WEAPONS]                            = trap_R_RegisterShaderNoMip("gfx/limbo/ic_soldier");
 	cgs.media.skillPics[SK_MILITARY_INTELLIGENCE_AND_SCOPED_WEAPONS] = trap_R_RegisterShaderNoMip("gfx/limbo/ic_covertops");
 
-	cgs.media.ccMedicIcon = trap_R_RegisterShaderNoMip("sprites/cm_medic_icon");
+	cgs.media.ccMedicIcon       = trap_R_RegisterShaderNoMip("sprites/cm_medic_icon");
+	cgs.media.ccAmmoIcon        = trap_R_RegisterShaderNoMip("sprites/cm_ammo_icon");
+	cgs.media.ccVoiceChatShader = trap_R_RegisterShaderNoMip("sprites/cm_voicechat_icon");
 
 #ifdef FEATURE_PRESTIGE
 	cgs.media.prestigePics[0] = trap_R_RegisterShaderNoMip("gfx/hud/prestige/prestige");


### PR DESCRIPTION
- fixed voice chat sprite  position - it should be now correctly taking zoom into account
- fixed voice chat sprite being drawn outside of the map

Initially I wanted to add another field `ccVoiceChatSprite` to `centity_t` and map the shader directly in `CG_PlayVoiceChat`, but in the end I don't know which solution would be better and so I opted to mapping it every frame (instead of once in `CG_PlayVoiceChat`) in command map.
