### PR TITLE
cmake: add DOCDIR variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ The following variables can be adjusted in CMake:
   * (optional) **`INSTALL_DEFAULT_MODDIR`**: Location for libraries and paks. Appended to `CMAKE_INSTALL_PREFIX`.
     Defaults to `lib/etlegacy` and then `legacy` is appended to it.
 
+  * (optional) **`DOCDIR`**: Location for documentation. Defaults to `INSTALL_DEFAULT_SHAREDIR/doc/etlegacy`.
 
 ### Linux
 

--- a/cmake/ETLInstall.cmake
+++ b/cmake/ETLInstall.cmake
@@ -2,6 +2,10 @@
 # Install
 #-----------------------------------------------------------------
 
+if(NOT DOCDIR)
+	set(DOCDIR "${INSTALL_DEFAULT_SHAREDIR}/doc/etlegacy")
+endif()
+
 # description file - see FS_GetModList
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/misc/description.txt"
 	DESTINATION "${INSTALL_DEFAULT_MODDIR}/${MODNAME}"
@@ -45,7 +49,7 @@ if(UNIX AND NOT APPLE)
 		DESTINATION "${INSTALL_DEFAULT_SHAREDIR}/man/man6"
 	)
 	install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/docs/INSTALL.txt"
-		DESTINATION "${INSTALL_DEFAULT_SHAREDIR}/doc/etlegacy"
+		DESTINATION "${DOCDIR}"
 	)
 	install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/COPYING.txt"
 		DESTINATION "${INSTALL_DEFAULT_SHAREDIR}/licenses/etlegacy"


### PR DESCRIPTION
Some distributions, e.g. Gentoo, require a particular naming scheme
for /usr/share/doc. In case of Gentoo, the package version is also
included, so it would be for example /usr/share/doc/etlegacy-2.78.1.