### PR TITLE
game: change movers to not kill players or destroy items, refs #1754

### DIFF
--- a/src/game/g_mover.c
+++ b/src/game/g_mover.c
@@ -639,44 +639,13 @@ qboolean G_MoverPush(gentity_t *pusher, vec3_t move, vec3_t amove, gentity_t **o
 	{
 		check = &g_entities[moveList[e]];
 
-		// some situations in front of mover should gib players (by damage)
 		switch (check->s.eType)
 		{
-		case ET_PLAYER:
-			if (!check->client)
-			{
-				break;
-			}
-
-			if (check->s.groundEntityNum != pusher->s.number)
-			{
-				if (check->client->ps.eFlags & (EF_DEAD | EF_PRONE | EF_PRONE_MOVING))
-				{
-					trap_LinkEntity(check);
-					G_Damage(check, pusher, pusher, NULL, NULL, GIB_DAMAGE(check->health), 0, MOD_CRUSH);
-					moveList[e] = ENTITYNUM_NONE;   // prevent re-linking later on
-					continue;
-				}
-			}
-			break;
 		case ET_CORPSE: // always gib corpses ...
 			trap_LinkEntity(check);
 			GibEntity(check, ENTITYNUM_WORLD);
 			moveList[e] = ENTITYNUM_NONE; // prevent re-linking later on
 			continue;
-		case ET_ITEM:
-			// items should be removed (except CTF objectives)
-			if (check->s.groundEntityNum == ENTITYNUM_WORLD)
-			{
-				if (check->item->giType != IT_TEAM)
-				{
-					trap_LinkEntity(check);
-					G_FreeEntity(check);
-					moveList[e] = ENTITYNUM_NONE;
-					continue;
-				}
-			}
-			break;
 		default:
 			break;
 		}


### PR DESCRIPTION
This changes behaviour to vanilla like - players and items will be pushed instead.

refs #1754