### PR TITLE
game: match time of wait command to sv_fps 20 on higher sv_fps, refs #1637

### DIFF
--- a/src/game/g_script_actions.c
+++ b/src/game/g_script_actions.c
@@ -1652,6 +1652,7 @@ qboolean G_ScriptAction_Wait(gentity_t *ent, char *params)
 {
 	char *pString = params, *token;
 	int  duration;
+	int  frametime = 1000 / sv_fps.integer;
 
 	if (level.suddenDeath)
 	{
@@ -1685,6 +1686,13 @@ qboolean G_ScriptAction_Wait(gentity_t *ent, char *params)
 		}
 		max = Q_atoi(token);
 
+		// match wait time to sv_fps 20
+		if (sv_fps.integer > 20)
+		{
+			min = min + 50 - (min % 50) - frametime;
+			max = max + 50 - (max % 50) - frametime;
+		}
+
 		if (ent->scriptStatus.scriptStackChangeTime + min > level.time)
 		{
 			return qfalse;
@@ -1699,6 +1707,13 @@ qboolean G_ScriptAction_Wait(gentity_t *ent, char *params)
 	}
 
 	duration = Q_atoi(token);
+
+	// match wait time to sv_fps 20
+	if (sv_fps.integer > 20)
+	{
+		duration = duration + 50 - (duration % 50) - frametime;
+	}
+
 	return (ent->scriptStatus.scriptStackChangeTime + duration < level.time);
 }
 


### PR DESCRIPTION
This should make `wait` command behaviour the same as `sv_fps 20` (or very close to if 50 modulo frametime is not 0) on higher `sv_fps`.

For example `wait 100` on `sv_fps 20` is `wait 150` and `wait 125` on `sv_fps 40` partly because of the comparison operator being `'<'` not `'<='`, making the times of execution different. My proposal is to match the time so it stays the same.

Example:
`sv_fps 20 wait 123` will execute at `150`.
`sv_fps 40 wait 123` will be changed to `wait 125` and so it will execute at `150` too (without adjusting it will execute at `125`).
`sv_fps 100 wait 123` will be changed to `wait 140` and so it will execute at `150` too (without adjusting it will execute at `130`).

refs #1637