### PR TITLE
game: fix missing hitsound when player has exactly FORCE_LIMBO_HEALTH health

### DIFF
--- a/src/game/g_combat.c
+++ b/src/game/g_combat.c
@@ -1375,7 +1375,7 @@ void G_Damage(gentity_t *targ, gentity_t *inflictor, gentity_t *attacker, vec3_t
 	}
 
 	// add to the attacker's hit counter (but only if target is a client)
-	if (attacker && attacker->client && targ->client  && targ != attacker && targ->health > FORCE_LIMBO_HEALTH &&
+	if (attacker && attacker->client && targ->client  && targ != attacker && targ->health >= FORCE_LIMBO_HEALTH &&
 	    mod != MOD_SWITCHTEAM && mod != MOD_SWAP_PLACES && mod != MOD_SUICIDE)
 	{
 		if (onSameTeam || (targ->client->ps.powerups[PW_OPS_DISGUISED] && (g_friendlyFire.integer & 1)))


### PR DESCRIPTION
When player had `FORCE_LIMBO_HEALTH` (-113) health and got hit the hitsound would not register. I guess the other solution would be to force to limbo at -113hp but decided to fix the hitsound instead and limbo will be forced like it is now at -114 still.