### PR TITLE
game: unready players on swap team (vote), refs #1416

### DIFF
--- a/src/game/g_team.c
+++ b/src/game/g_team.c
@@ -1655,6 +1655,7 @@ void G_swapTeams(void)
 			cl->sess.playerWeapon2 = cl->sess.latchPlayerWeapon2 = GetWeaponTableData(cl->sess.playerWeapon2)->weapEquiv;
 		}
 
+		G_MakeUnready(&g_entities[level.sortedClients[i]]);
 		G_UpdateCharacter(cl);
 		ClientUserinfoChanged(level.sortedClients[i]);
 		ClientBegin(level.sortedClients[i]);


### PR DESCRIPTION
This was causing a visual issue where `eFlags` where reset in `ClientBegin` but persistant data does not (`pers.ready`).

refs #1416