### PR TITLE
game: revert not antiwarping players on respawn and show icon when player is lagging

### DIFF
--- a/src/game/et-antiwarp.c
+++ b/src/game/et-antiwarp.c
@@ -23,8 +23,8 @@ qboolean G_DoAntiwarp(gentity_t *ent)
 
 	if (ent && ent->client)
 	{
-		// don't antiwarp spectators, also players that just spawned or are in limbo
-		if (ent->client->sess.sessionTeam == TEAM_SPECTATOR || (ent->client->ps.pm_flags & (PMF_LIMBO | PMF_RESPAWNED)))
+		// don't antiwarp spectators and players that are in limbo
+		if (ent->client->sess.sessionTeam == TEAM_SPECTATOR || (ent->client->ps.pm_flags & PMF_LIMBO))
 		{
 			return qfalse;
 		}

--- a/src/game/g_active.c
+++ b/src/game/g_active.c
@@ -2285,10 +2285,11 @@ void ClientEndFrame(gentity_t *ent)
 	frames = level.framenum - ent->client->lastUpdateFrame - 1;
 
 	// etpro antiwarp
-	// frames = level.framenum - ent->client->lastUpdateFrame - 1)
 	if (g_maxWarp.integer && frames > g_maxWarp.integer && G_DoAntiwarp(ent))
 	{
-		ent->client->warping = qtrue;
+		ent->client->warping    = qtrue;
+		ent->client->ps.eFlags |= EF_CONNECTION;
+		ent->s.eFlags          |= EF_CONNECTION;
 	}
 
 	if (g_skipCorrection.integer && !ent->client->warped && frames > 0 && !G_DoAntiwarp(ent))
@@ -2297,8 +2298,6 @@ void ClientEndFrame(gentity_t *ent)
 		{
 			// we need frames to be = 2 here
 			frames = 3;
-			ent->client->ps.eFlags |= EF_CONNECTION;
-			ent->s.eFlags          |= EF_CONNECTION;
 		}
 		G_PredictPmove(ent, (float)frames / (float)sv_fps.integer);
 	}


### PR DESCRIPTION
Revert not antiwarping players on respawn - not antiwarping on respawn was causing player to not spawn correctly and because of that his hitbox was missing (except head). This was only happening either for players that were already disconnected or were lagging to the point that they couldn't move anyway.

This was helping high pingers to play on `sv_fps 40` though, because they would get stuck on respawn. Now instead `g_maxWarp` should be increased according to `sv_fps` to fix that.
The current default is `200ms` (amount of time player user commands are not reaching server and miss server frames before `commandTime`s will be adjusted) that means on:
- `sv_fps 20` `g_maxWarp` should be set to `4`
- `sv_fps 40` `g_maxWarp` should be set to `8`
- `sv_fps 100` `g_maxWarp` should be set to `20`

Changed when disconnect icon shows up - before it would only show when player respawned and was lagged out from the game. Right now it will show up whenever player is missing more than `g_maxWarp` server frames in a row causing him to start to lag. This could be an overkill but could help identify what kind of connection issue players have.