### PR TITLE
Add keywords for advanced users

### DIFF
--- a/misc/com.etlegacy.ETLegacy.desktop
+++ b/misc/com.etlegacy.ETLegacy.desktop
@@ -9,5 +9,5 @@ Terminal=false
 MimeType=x-scheme-handler/et;
 Categories=Game;ActionGame;
 StartupNotify=false
-Keywords=team-based;multiplayer;tactical;WWII;enemy;territory;
+Keywords=team-based;multiplayer;tactical;WWII;enemy;territory;etl;etlegacy;
 PrefersNonDefaultGPU=true


### PR DESCRIPTION
This helps advanced users who instinctively search for the application name 'etl' when they want to start the application