### PR TITLE
game: fix throwable missiles infinite bouncing

### DIFF
--- a/src/game/g_missile.c
+++ b/src/game/g_missile.c
@@ -122,7 +122,7 @@ void G_BounceMissile(gentity_t *ent, trace_t *trace)
 
 		// check for stop
 		//if ( trace->plane.normal[2] > 0.2 && VectorLengthSquared( ent->s.pos.trDelta ) < Square(40) )
-		if (trace->plane.normal[2] > 0.2f && VectorLengthSquared(relativeDelta) < 1600) // Square(40)
+		if ((trace->plane.normal[2] > 0.2f && VectorLengthSquared(relativeDelta) < 1600) || !trace->fraction) // Square(40)
 		{
 			// make the world the owner of the ent, so the player can shoot it after it stops moving
 			if (ent->r.contents == CONTENTS_CORPSE)
@@ -447,10 +447,10 @@ void G_ExplodeMissile(gentity_t *ent)
 }
 
 /**
- * @brief Landmine_Check_Ground
+ * @brief MissileGroundCheck
  * @param[in,out] self
  */
-void Landmine_Check_Ground(gentity_t *self)
+void MissileGroundCheck(gentity_t *self)
 {
 	vec3_t  mins, maxs;
 	vec3_t  start, end;
@@ -481,10 +481,12 @@ void G_RunMissile(gentity_t *ent)
 	vec3_t  origin, angle;
 	trace_t tr;
 
-	// shootable ent (i.e landmine, dynamite, satchel)
-	if (ent->r.contents == CONTENTS_CORPSE)
+	// throwable ent (landmine, dynamite, satchel, grenade)
+	// if ent already landed but the ground "disappeared" later on (i.e player got gibbed)
+	// check for such change so the ent can still fall down and not be floating in the air
+	if (GetWeaponTableData(ent->s.weapon)->firingMode & WEAPON_FIRING_MODE_THROWABLE)
 	{
-		Landmine_Check_Ground(ent);
+		MissileGroundCheck(ent);
 
 		if (ent->s.groundEntityNum == -1)
 		{


### PR DESCRIPTION
- Grenades will now behave like other missiles and will drop if the ground they were on is gone (etpro like)
- Adjusted the code where in some occasions missiles would bounce forever and were making a lot of noise and players were unable to interact with them. This can still happen to my knowledge (but less than before) at least with doors when they are entirely stuck in them, but players will be able to interact with them unlike before.