### PR TITLE
cgame: fix fireteam highlight overlay spacing

### DIFF
--- a/src/cgame/cg_fireteamoverlay.c
+++ b/src/cgame/cg_fireteamoverlay.c
@@ -547,10 +547,20 @@ void CG_DrawFireTeamOverlay(rectDef_t *rect)
 			break;
 		}
 
-		// hilight selected players
+		// highlight selected players
 		if (ci->selected)
 		{
-			CG_FillRect(x, y, boxWidth - 2, FT_BAR_HEIGHT + FT_BAR_YSPACING, FT_select);
+			// first member requires thicker highlight bar
+			if (i == 0)
+			{
+				CG_FillRect(x, y, boxWidth - 2, FT_BAR_HEIGHT + (2 * FT_BAR_YSPACING), FT_select);
+			}
+			// adjust y to account for the thicker highlight bar of first member
+			else
+			{
+				CG_FillRect(x, y + FT_BAR_YSPACING, boxWidth - 2, FT_BAR_HEIGHT + FT_BAR_YSPACING, FT_select);
+			}
+
 		}
 
 		x += 4;


### PR DESCRIPTION
Fireteam overlay has a bigger spacing for the first member of the fireteam, but this was not taken into account in the drawing of the highlighting overlay.

Old:
![image](https://user-images.githubusercontent.com/14221121/149674660-a1ee40ac-79af-4ae6-9eee-4871a9e324cc.png)

New:
![image](https://user-images.githubusercontent.com/14221121/149674615-f52fbc30-5a48-44b6-b2a5-f549def4e3e7.png)
