### PR TITLE
game: fix accuracy calculation for splashdamage weapons

### DIFF
--- a/src/game/g_match.c
+++ b/src/game/g_match.c
@@ -291,13 +291,19 @@ void G_addStats(gentity_t *targ, gentity_t *attacker, int damage, meansOfDeath_t
 	{
 		if (attacker && attacker->client)
 		{
-			int x;
+			weapon_t weap = GetMODTableData(mod)->weaponIcon;
 
-			x = attacker->client->sess.aWeaponStats[GetMODTableData(mod)->indexWeaponStat].atts--;
-
-			if (x < 1)
+			// don't count hits/shots for hitscan weapons
+			if (!GetWeaponTableData(weap)->splashDamage)
 			{
-				attacker->client->sess.aWeaponStats[GetMODTableData(mod)->indexWeaponStat].atts = 1;
+				int x;
+
+				x = attacker->client->sess.aWeaponStats[GetMODTableData(mod)->indexWeaponStat].atts--;
+
+				if (x < 1)
+				{
+					attacker->client->sess.aWeaponStats[GetMODTableData(mod)->indexWeaponStat].atts = 1;
+				}
 			}
 
 			if (targ->health <= FORCE_LIMBO_HEALTH)


### PR DESCRIPTION
The hack in accuracy calculation that's intended to not count shots/hits for a weapon when you use it to gib someone was causing splash damage weapons to calculate accuracy wrong, as the reduction in shots would be called for every hit, meaning if you hit 2 wounded enemies with a grenade, your total "shot" grenades would go down by 2. This PR removes this hack completely for non-hitscan weapons, since you could argue that you don't really purposefully aim them anyway (except maybe flamethrower). Fixing this "for real" to work properly on splash damage weapons would be close to impossible I think (yes, ETPro has this exact same bug).