### PR TITLE
game: fix riflenades exploding too early, refs #1887

### DIFF
--- a/src/game/g_missile.c
+++ b/src/game/g_missile.c
@@ -122,7 +122,8 @@ void G_BounceMissile(gentity_t *ent, trace_t *trace)
 
 		// check for stop
 		//if ( trace->plane.normal[2] > 0.2 && VectorLengthSquared( ent->s.pos.trDelta ) < Square(40) )
-		if ((trace->plane.normal[2] > 0.2f && VectorLengthSquared(relativeDelta) < 1600) || !trace->fraction) // Square(40)
+		if ((trace->plane.normal[2] > 0.2f && VectorLengthSquared(relativeDelta) < 1600)
+		    || (!trace->fraction && !(GetWeaponTableData(ent->s.weapon)->type & WEAPON_TYPE_RIFLENADE))) // Square(40)
 		{
 			// make the world the owner of the ent, so the player can shoot it after it stops moving
 			if (ent->r.contents == CONTENTS_CORPSE)


### PR DESCRIPTION
The change in `G_BounceMissile` introduced in #1887 made rifle grenades explode prematurely as they would trigger the new `!trace.fraction` part of the if statement checking for stop. This is fine for everything else except rifle grenades because they will then get their `ent->nextthink` adjusted and basically explode instantly, as they don't bounce off player like you'd think they do, but instead get kind of stuck inside them and instantly trigger another call to `G_BounceMissile`, causing the `G_ExplodeMissile` to run at the very start of the function.

refs #1887 