### PR TITLE
cgame: introduce sharetimer command

### DIFF
--- a/etmain/ui/options_controls_advanced.menu
+++ b/etmain/ui/options_controls_advanced.menu
@@ -59,8 +59,10 @@ menuDef {
 	EDITFIELD( 8, JOYSTICK_Y+52, (SUBWINDOW_WIDTH)-4, 10, _("Joystick Threshold:"), .2, 8, "in_joystickThreshold", 64, 18, _("Set joystick threshold sensitivity") )
 
 #define MISC_Y 32
-	SUBWINDOW( 6+(SUBWINDOW_WIDTH)+6, MISC_Y, (SUBWINDOW_WIDTH), 32, _("MISC") )
+	SUBWINDOW( 6+(SUBWINDOW_WIDTH)+6, MISC_Y, (SUBWINDOW_WIDTH), 56, _("MISC") )
 	MULTI( 8+(SUBWINDOW_WIDTH)+6, MISC_Y+16, (SUBWINDOW_WIDTH)-4, 10, _("Activate lean:"), .2, 8, "cl_activatelean", cvarFloatList { "No" 0 "Yes" 1 }, _("Lean while using the activate button") )
+    BIND( 8+(SUBWINDOW_WIDTH)+6, MISC_Y+28, (SUBWINDOW_WIDTH)-4, 10, _("Sharetimer:"), .2, 8, "sharetimer", "Share the next time the enemy spawns with your team according to your spawntimer" )
+    BIND( 8+(SUBWINDOW_WIDTH)+6, MISC_Y+40, (SUBWINDOW_WIDTH)-4, 10, _("Sharetimer fireteam:"), .2, 8, "sharetimer_buddy", "Share the next time the enemy spawns with your fireteam according to your spawntimer" )
 
 // Buttons //
 	BUTTON( 6, WINDOW_HEIGHT-24, WINDOW_WIDTH-12, 18, _("BACK"), .3, 14, close options_controls_advanced ; open options_controls )

--- a/etmain/ui/options_customise_game.menu
+++ b/etmain/ui/options_customise_game.menu
@@ -77,12 +77,13 @@ menuDef {
 
 // Miscellaneous //
 #define MISC_Y 172
-	SUBWINDOW( 6+(SUBWINDOW_WIDTH_L)+6, MISC_Y, (SUBWINDOW_WIDTH_R), 76, _("MISCELLANEOUS") )
+	SUBWINDOW( 6+(SUBWINDOW_WIDTH_L)+6, MISC_Y, (SUBWINDOW_WIDTH_R), 88, _("MISCELLANEOUS") )
 	MULTI( 6+(SUBWINDOW_WIDTH_L)+6+2, MISC_Y+16, (SUBWINDOW_WIDTH_R)-4, 10, _("Complaint PopUp:"), .2, 8, "cg_complaintPopUp", cvarFloatList { "Off" 0 "On" 1 }, _("Display the option to file complaints about teammates who kill you") )
 	YESNO( 6+(SUBWINDOW_WIDTH_L)+6+2, MISC_Y+28, (SUBWINDOW_WIDTH_R)-4, 10, _("Log Important Messages:"), .2, 8, "cg_printObjectiveInfo",_("Print important game messages to the console") )
 	MULTI( 6+(SUBWINDOW_WIDTH_L)+6+2, MISC_Y+40, (SUBWINDOW_WIDTH_R)-4, 10, _("Auto-Action:"), .2, 8, "cg_autoAction", cvarFloatList { "None" 0 "Demo" 1 "Screenshot" 2 "Stats Dump" 4 "Demo + SS" 3 "Demo + Stats" 5 "SS + Stats" 6 "Demo + SS + Stats" 7 }, _("Perform automatic actions at the start or end of a round") )
 	YESNO( 6+(SUBWINDOW_WIDTH_L)+6+2, MISC_Y+52, (SUBWINDOW_WIDTH_R)-4, 10, _("Show Tool Tips:"), .2, 8, "ui_showtooltips", _("Display Tool Tips in the UI") )
 	EDITFIELD( 6+(SUBWINDOW_WIDTH_L)+6+2, MISC_Y+64, (SUBWINDOW_WIDTH_R)-4, 10, _("Log File:"), .2, 8, "cg_logFile", 15, 13, _("Set the name of the log file (if empty logging is disabled)") )
+    EDITFIELD( 6+(SUBWINDOW_WIDTH_L)+6+2, MISC_Y+76, (SUBWINDOW_WIDTH_R)-4, 10, _("Sharetimer Custom Text:"), .2, 8, "cg_sharetimerText", 64, 18, _("Specify a custom text to announce the next enemy spawn. Use ${nextspawn} and ${enemylimbotime} as variables.") )
 
 // Buttons //
 	BUTTON( 6, WINDOW_HEIGHT-24, WINDOW_WIDTH-12, 18, _("BACK"), .3, 14, close options_customise_game ; open options )

--- a/src/cgame/cg_consolecmds.c
+++ b/src/cgame/cg_consolecmds.c
@@ -1647,7 +1647,11 @@ static void CG_ShareTimer_f(void)
 	int num = MOD(seconds - st, 60);
 
 	char text[MAX_SAY_TEXT];
-	trap_Args(text, sizeof(text));
+	trap_Cvar_VariableStringBuffer("cg_sharetimerText", text, MAX_SAY_TEXT);
+	if (!strlen(text))
+	{
+		trap_Args(text, sizeof(text));
+	}
 	if (strlen(text))
 	{
 		char buffer[MAX_SAY_TEXT];

--- a/src/cgame/cg_consolecmds.c
+++ b/src/cgame/cg_consolecmds.c
@@ -1629,9 +1629,8 @@ static void CG_ReadHuds_f(void)
 static void CG_ShareTimer_f(void)
 {
 	qtime_t ct;
-	char    *cmd, *stChar;
+	char    *cmd, *stChar, text[MAX_SAY_TEXT];
 	int     st, limboTime, nextSpawn;
-	char    text[MAX_SAY_TEXT];
 	stChar = CG_SpawnTimerText();
 
 	if (stChar == NULL)
@@ -1653,17 +1652,19 @@ static void CG_ShareTimer_f(void)
 	if (strlen(text))
 	{
 		char buffer[MAX_SAY_TEXT];
-		char *spawntime, *enemylimbo;
+		char *spawntime, *enemylimbo, *nextSpawnText, *enemyLimbotimeText;
+		nextSpawnText      = "${nextspawn}";
+		enemyLimbotimeText = "${enemylimbotime}";
 
-		Q_strncpyz(buffer, text, strlen(text) + 1);
-		spawntime = Q_TruncateStr(Q_stristr(buffer, "${nextspawn}"), 12);
+		Q_strncpyz(buffer, text, sizeof(text));
+		spawntime = Q_TruncateStr(Q_stristr(buffer, nextSpawnText), strlen(nextSpawnText));
 		if (spawntime)
 		{
 			Q_strncpyz(text, Q_StrReplace(text, spawntime, va("%i", nextSpawn)), sizeof(text));
 		}
 
-		Q_strncpyz(buffer, text, strlen(text) + 1);
-		enemylimbo = Q_TruncateStr(Q_stristr(buffer, "${enemylimbotime}"), 13);
+		Q_strncpyz(buffer, text, sizeof(text));
+		enemylimbo = Q_TruncateStr(Q_stristr(buffer, enemyLimbotimeText), strlen(enemyLimbotimeText));
 		if (enemylimbo)
 		{
 			Q_strncpyz(text, Q_StrReplace(text, enemylimbo, va("%i", limboTime)), sizeof(text));

--- a/src/cgame/cg_consolecmds.c
+++ b/src/cgame/cg_consolecmds.c
@@ -1656,14 +1656,14 @@ static void CG_ShareTimer_f(void)
 		nextSpawnText      = "${nextspawn}";
 		enemyLimbotimeText = "${enemylimbotime}";
 
-		Q_strncpyz(buffer, text, sizeof(text));
+		Q_strncpyz(buffer, text, sizeof(buffer));
 		spawntime = Q_TruncateStr(Q_stristr(buffer, nextSpawnText), strlen(nextSpawnText));
 		if (spawntime)
 		{
 			Q_strncpyz(text, Q_StrReplace(text, spawntime, va("%i", nextSpawn)), sizeof(text));
 		}
 
-		Q_strncpyz(buffer, text, sizeof(text));
+		Q_strncpyz(buffer, text, sizeof(buffer));
 		enemylimbo = Q_TruncateStr(Q_stristr(buffer, enemyLimbotimeText), strlen(enemyLimbotimeText));
 		if (enemylimbo)
 		{

--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -2442,7 +2442,7 @@ static float CG_DrawFPS(float y)
  * @brief CG_SpawnTimerText red colored spawn time text in reinforcement time HUD element.
  * @return red colored text or NULL when its not supposed to be rendered
 */
-static char *CG_SpawnTimerText()
+char *CG_SpawnTimerText()
 {
 	int msec = (cgs.timelimit * 60000.f) - (cg.time - cgs.levelStartTime);
 	int seconds;

--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -2507,30 +2507,17 @@ static qboolean CG_SpawnTimersText(char **s, char **rt)
 
 static char *CG_RoundTimerText()
 {
-	int tens;
-	int msec = (cgs.timelimit * 60000.f) - (cg.time - cgs.levelStartTime);        // 60.f * 1000.f
+	qtime_t qt;
+	int     msec = CG_RoundTime(&qt);
 	if (msec < 0 && cgs.timelimit > 0.0f)
 	{
 		return "0:00"; // round ended
 	}
 
-	int seconds = msec / 1000;
-	int mins    = seconds / 60;
-	seconds -= mins * 60;
-	tens     = seconds / 10;
-	seconds -= tens * 10;
+	char *seconds = qt.tm_sec > 9 ? va("%i", qt.tm_sec) : va("0%i", qt.tm_sec);
+	char *minutes = qt.tm_min > 9 ? va("%i", qt.tm_min) : va("0%i", qt.tm_min);
 
-	if (cgs.gamestate != GS_PLAYING)
-	{
-		msec     = (cgs.timelimit * 60000.f); // 60.f * 1000.f
-		seconds  = msec / 1000;
-		mins     = seconds / 60;
-		seconds -= mins * 60;
-		tens     = seconds / 10;
-		seconds -= tens * 10;
-	}
-
-	return va("%i:%i%i", mins, tens, seconds);
+	return va("%s:%s", minutes, seconds);
 }
 
 static char *CG_LocalTimeText()

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2826,6 +2826,8 @@ extern vmCvar_t cg_simpleItemsScale;
 extern vmCvar_t cg_weapaltReloads;
 extern vmCvar_t cg_weapaltSwitches;
 
+extern vmCvar_t cg_sharetimerText;
+
 extern vmCvar_t cg_automapZoom;
 
 extern vmCvar_t cg_drawTime;

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -3344,6 +3344,7 @@ void CG_LoadRankIcons(void);
 
 void CG_ParseFireteams(void);
 void CG_ParseOIDInfos(void);
+char *CG_SpawnTimerText(void);
 //oidInfo_t *CG_OIDInfoForEntityNum(int num);
 
 // cg_consolecmds.c
@@ -4085,8 +4086,8 @@ typedef struct hudComponent_s
 	rectDef_t location;
 	int visible;
 	int style;
-    float scale;
-    vec4_t color;
+	float scale;
+	vec4_t color;
 	int offset;
 } hudComponent_t;
 

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2936,6 +2936,7 @@ int CG_LastAttacker(void);
 void CG_KeyEvent(int key, qboolean down);
 void CG_MouseEvent(int x, int y);
 void CG_EventHandling(int type, qboolean fForced);
+int CG_RoundTime(qtime_t *qtime);
 
 qboolean CG_GetTag(int clientNum, const char *tagname, orientation_t *orientation);
 qboolean CG_GetWeaponTag(int clientNum, const char *tagname, orientation_t *orientation);

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -326,6 +326,8 @@ vmCvar_t cg_fireteamSprites;
 vmCvar_t cg_weapaltReloads;
 vmCvar_t cg_weapaltSwitches;
 
+vmCvar_t cg_sharetimerText;
+
 vmCvar_t cg_simpleItems;
 vmCvar_t cg_simpleItemsScale;
 
@@ -618,6 +620,7 @@ static cvarTable_t cvarTable[] =
 	{ &cg_popupShadow,            "cg_popupShadow",            "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_weapaltReloads,         "cg_weapaltReloads",         "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_weapaltSwitches,        "cg_weapaltSwitches",        "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_sharetimerText,         "cg_sharetimerText",         "",            CVAR_ARCHIVE,                 0 },
 
 	// Fonts
 	{ &cg_fontScaleTP,            "cg_fontScaleTP",            "0.35",        CVAR_ARCHIVE,                 0 },   // TopPrint

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -3040,3 +3040,25 @@ void QDECL CG_WriteToLog(const char *fmt, ...)
 		trap_FS_Write(string, (int)strlen(string), cg.logFile);
 	}
 }
+
+int CG_RoundTime(qtime_t *qtime)
+{
+	int msec = cgs.timelimit * 60000.f;
+	if (cgs.gamestate == GS_PLAYING)
+	{
+		msec -= cg.time - cgs.levelStartTime;
+	}
+
+	int seconds = msec / 1000;
+	int mins    = seconds / 60;
+	int hours   = mins / 60;
+	seconds -= mins * 60;
+	int tens = seconds / 10;
+	seconds       -= tens * 10;
+	seconds        = Q_atoi(va("%i%i", tens, seconds));
+	qtime->tm_sec  = seconds;
+	qtime->tm_min  = mins;
+	qtime->tm_hour = hours;
+
+	return msec;
+}

--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -2320,7 +2320,7 @@ static void CL_FrameHandleVideo(int *msec)
 		//clc.aviVideoFrameRemainder = frameDuration + msec;
 	}
 	else if ((!cl_avidemo->integer && CL_VideoRecording())
-			 || (cl_avidemo->integer && (cls.state != CA_ACTIVE || !cl_forceavidemo->integer)))
+	         || (cl_avidemo->integer && (cls.state != CA_ACTIVE || !cl_forceavidemo->integer)))
 	{
 		CL_StopVideo_f();
 	}
@@ -3013,6 +3013,7 @@ void CL_Init(void)
 	Cvar_Get("cg_autoReload", "1", CVAR_ARCHIVE);
 	Cvar_Get("cg_weapaltReloads", "0", CVAR_ARCHIVE);
 	Cvar_Get("cg_weapaltSwitches", "1", CVAR_ARCHIVE);
+	Cvar_Get("cg_sharetimerText", "", CVAR_ARCHIVE);
 
 	cl_missionStats = Cvar_Get("g_missionStats", "0", CVAR_ROM);
 

--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -3013,7 +3013,6 @@ void CL_Init(void)
 	Cvar_Get("cg_autoReload", "1", CVAR_ARCHIVE);
 	Cvar_Get("cg_weapaltReloads", "0", CVAR_ARCHIVE);
 	Cvar_Get("cg_weapaltSwitches", "1", CVAR_ARCHIVE);
-	Cvar_Get("cg_sharetimerText", "", CVAR_ARCHIVE);
 
 	cl_missionStats = Cvar_Get("g_missionStats", "0", CVAR_ROM);
 

--- a/src/qcommon/q_shared.h
+++ b/src/qcommon/q_shared.h
@@ -615,6 +615,7 @@ void *Hunk_Alloc(size_t size, ha_pref preference);
 #define Com_Dealloc free
 
 #define CTRL(a) ((a) - 'a' + 1)
+#define MOD(a, b) ((((a) % (b)) + (b)) % (b))
 
 /**
  * @enum CIN_Flags

--- a/src/ui/ui_main.c
+++ b/src/ui/ui_main.c
@@ -9130,6 +9130,7 @@ static cvarTable_t cvarTable[] =
 	{ NULL,                                "cg_autoReload",                       "1",                          CVAR_ARCHIVE,                   0 },
 	{ NULL,                                "cg_weapaltReloads",                   "0",                          CVAR_ARCHIVE,                   0 },
 	{ NULL,                                "cg_weapaltSwitches",                  "1",                          CVAR_ARCHIVE,                   0 },
+	{ NULL,                                "cg_sharetimerText",                   "",                           CVAR_ARCHIVE,                   0 },
 	{ NULL,                                "cg_noAmmoAutoSwitch",                 "1",                          CVAR_ARCHIVE,                   0 },
 	{ NULL,                                "cg_useWeapsForZoom",                  "1",                          CVAR_ARCHIVE,                   0 },
 	{ NULL,                                "cg_zoomDefaultSniper",                "20",                         CVAR_ARCHIVE,                   0 },

--- a/src/ui/ui_shared.c
+++ b/src/ui/ui_shared.c
@@ -822,6 +822,8 @@ static bind_t g_bindings[] =
 	{ "selectbuddy 6",    K_KP_HOME,       -1,  K_KP_HOME,       -1,  -1, -1, -1 },
 	{ "selectbuddy 7",    K_KP_UPARROW,    -1,  K_KP_UPARROW,    -1,  -1, -1, -1 },
 	{ "selectbuddy -2",   K_KP_MINUS,      -1,  K_KP_MINUS,      -1,  -1, -1, -1 },
+	{ "sharetimer",       -1,              -1,  -1,              -1,  -1, -1, -1 },
+	{ "sharetimer_buddy", -1,              -1,  -1,              -1,  -1, -1, -1 },
 };
 
 static const int g_bindCount = sizeof(g_bindings) / sizeof(bind_t);


### PR DESCRIPTION
With this command you can share the spawntimer you have set for when you think the enemy spawns. So `roundtimer - current spawntimer` e.g. `14:30 - 23 = enemy spawns at 7`. This is also configurable with `${nextspawn}` and `${enemylimbotime}`.

Please take a look at how buffer and text are handled. I would like it to be cleaner.