### PR TITLE
cgame: fix viewmodel fov calculation, refs #1175

### DIFF
--- a/src/cgame/cg_weapons.c
+++ b/src/cgame/cg_weapons.c
@@ -3830,9 +3830,9 @@ void CG_AddViewWeapon(playerState_t *ps)
 	}
 
 	// drop gun lower at higher fov
-	if (cg_fov.value > 90)
+	if (cg_fov.value > 75)
 	{
-		fovOffset = -0.2f * (cg_fov.value - 90);
+		fovOffset = -0.2f * (cg_fov.value - 75);
 	}
 	else
 	{


### PR DESCRIPTION
Ever since we dropped minimum FOV from 90 to 75, our viewmodel FOV has been wrong. Viewmodel is supposed to drop lower when you raise your FOV from minimum, but this check was never updated to match the new 75 minimum. This meant that while the new minimum low value 75 would roughly match VET minimum 90, the viewmodel FOV was only correct when you had 75 FOV, every other value was drawing viewmodel incorrectly because the calculation got out of sync as soon as we raised FOV over 75, since we only started adjusting after FOV was > 90.

Old Legacy 90 FOV
![2022-02-04-100955-goldrush](https://user-images.githubusercontent.com/14221121/152495522-73e7bf1c-e8bb-4120-b2ee-51be6989dbab.png)

New Legacy 90 FOV
![2022-02-04-101148-goldrush](https://user-images.githubusercontent.com/14221121/152495550-f7e13151-5bf9-42c3-a209-cf60f7702338.png)

ETPro 107 FOV @ 16:9 (roughly matches Legacy 90 FOV)
![2022-02-04-101311-goldrush](https://user-images.githubusercontent.com/14221121/152495637-10fc38e6-ba22-4812-8d27-1ba974d735a7.jpg)

