### PR TITLE
cgame: add cvars to control fireteam alpha values

### DIFF
--- a/etmain/scripts/legacy.shader
+++ b/etmain/scripts/legacy.shader
@@ -847,6 +847,28 @@ sprites/cm_voicechat_icon
 	}
 }
 
+sprites/uniform_allied_hud
+{
+	nocompress
+	nopicmip
+	{
+		map sprites/active_uniform_allied.tga
+		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
+		rgbGen vertex
+	}
+}
+
+sprites/uniform_axis_hud
+{
+	nocompress
+	nopicmip
+	{
+		map sprites/active_uniform_axis.tga
+		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
+		rgbGen vertex
+	}
+}
+
 ui/assets/mp_ammo_blue
 {
 	nopicmip

--- a/src/cgame/cg_fireteamoverlay.c
+++ b/src/cgame/cg_fireteamoverlay.c
@@ -513,6 +513,8 @@ void CG_DrawFireTeamOverlay(rectDef_t *rect)
 		x = MIN_BORDER_DISTANCE;
 	}
 
+	FT_bg2[3] = Com_Clamp(0.0f, 1.0f, cg_fireteamBgAlpha.value);
+
 	CG_FillRect(x, y, boxWidth, h, FT_bg2);
 	CG_DrawRect(x, y, boxWidth, h, 1, FT_border);
 

--- a/src/cgame/cg_fireteamoverlay.c
+++ b/src/cgame/cg_fireteamoverlay.c
@@ -36,13 +36,6 @@
 
 static int sortedFireTeamClients[MAX_CLIENTS];
 
-// colors and fonts for overlays
-static vec4_t FT_bg     = { 0.16f, 0.2f, 0.17f, 0.8f };           // header
-static vec4_t FT_bg2    = { 0.0f, 0.0f, 0.0f, 0.3f };             // box itself
-static vec4_t FT_border = { 0.5f, 0.5f, 0.5f, 0.5f };
-static vec4_t FT_select = { 0.5f, 0.5f, 0.2f, 0.3f };             // selected member
-static vec4_t FT_text   = { 0.6f, 0.6f, 0.6f, 1.0f };
-
 #define FONT_HEADER         &cgs.media.limboFont1
 #define FONT_TEXT           &cgs.media.limboFont2
 
@@ -400,6 +393,17 @@ void CG_DrawFireTeamOverlay(rectDef_t *rect)
 	char           name[MAX_FIRETEAM_MEMBERS][MAX_NAME_LENGTH];
 	int            nameMaxLen;
 
+	// colors and fonts for overlays
+	vec4_t FT_bg      = { 0.16f, 0.2f, 0.17f, 0.8f };           // header
+	vec4_t FT_bg2     = { 0.0f, 0.0f, 0.0f, 0.3f };             // box itself
+	vec4_t FT_border  = { 0.5f, 0.5f, 0.5f, 0.5f };             // the border
+	vec4_t FT_select  = { 0.5f, 0.5f, 0.2f, 0.3f };             // selected member
+	vec4_t FT_text    = { 0.6f, 0.6f, 0.6f, 1.0f };             // "uncolored" text
+	vec4_t iconColor  = { 1.0f, 1.0f, 1.0f, 1.0f };             // icon "color", used for alpha adjustments
+	vec4_t textWhite  = { 1.0f, 1.0f, 1.0f, 1.0f };             // regular text
+	vec4_t textYellow = { 1.0f, 1.0f, 0.0f, 1.0f };             // yellow text for health drawing
+	vec4_t textRed    = { 1.0f, 0.0f, 0.0f, 1.0f };             // red text for health drawing
+
 	// assign fireteam data, and early out if not on one
 	if (!(f = CG_IsOnFireteam(cg.clientNum)))
 	{
@@ -513,7 +517,20 @@ void CG_DrawFireTeamOverlay(rectDef_t *rect)
 		x = MIN_BORDER_DISTANCE;
 	}
 
+	// fireteam alpha adjustments
+
+	// set background alpha first
 	FT_bg2[3] = Com_Clamp(0.0f, 1.0f, cg_fireteamBgAlpha.value);
+
+	FT_bg[3]      *= Com_Clamp(0.0f, 1.0f, cg_fireteamAlpha.value);
+	FT_bg2[3]     *= Com_Clamp(0.0f, 1.0f, cg_fireteamAlpha.value);
+	FT_border[3]  *= Com_Clamp(0.0f, 1.0f, cg_fireteamAlpha.value);
+	FT_select[3]  *= Com_Clamp(0.0f, 1.0f, cg_fireteamAlpha.value);
+	FT_text[3]    *= Com_Clamp(0.0f, 1.0f, cg_fireteamAlpha.value);
+	iconColor[3]  *= Com_Clamp(0.0f, 1.0f, cg_fireteamAlpha.value);
+	textWhite[3]  *= Com_Clamp(0.0f, 1.0f, cg_fireteamAlpha.value);
+	textYellow[3] *= Com_Clamp(0.0f, 1.0f, cg_fireteamAlpha.value);
+	textRed[3]    *= Com_Clamp(0.0f, 1.0f, cg_fireteamAlpha.value);
 
 	CG_FillRect(x, y, boxWidth, h, FT_bg2);
 	CG_DrawRect(x, y, boxWidth, h, 1, FT_border);
@@ -568,6 +585,7 @@ void CG_DrawFireTeamOverlay(rectDef_t *rect)
 		x += 4;
 
 		// draw class icon in fireteam overlay
+		trap_R_SetColor(iconColor);
 		CG_DrawPic(x, y + 2, 12, 12, cgs.media.skillPics[SkillNumForClass(ci->cls)]);
 		x += 14;
 
@@ -577,6 +595,7 @@ void CG_DrawFireTeamOverlay(rectDef_t *rect)
 			CG_Text_Paint_Ext(x, y + FT_BAR_HEIGHT, .2f, .2f, FT_text, "^3->", 0, 0, ITEM_TEXTSTYLE_SHADOWED, FONT_TEXT);
 			x += 14;
 			// draw latched class icon in fireteam overlay
+			trap_R_SetColor(iconColor);
 			CG_DrawPic(x, y + 2, 12, 12, cgs.media.skillPics[SkillNumForClass(ci->latchedcls)]);
 			x += 14;
 		}
@@ -593,6 +612,7 @@ void CG_DrawFireTeamOverlay(rectDef_t *rect)
 		// draw objective icon (if they are carrying one) in fireteam overlay
 		if (ci->powerups & ((1 << PW_REDFLAG) | (1 << PW_BLUEFLAG)))
 		{
+			trap_R_SetColor(iconColor);
 			CG_DrawPic(x, y + 2, 12, 12, cgs.media.objectiveShader);
 			x      += 14;
 			puwidth = 14;
@@ -600,6 +620,7 @@ void CG_DrawFireTeamOverlay(rectDef_t *rect)
 		// or else draw the disguised icon in fireteam overlay
 		else if (ci->powerups & (1 << PW_OPS_DISGUISED))
 		{
+			trap_R_SetColor(iconColor);
 			CG_DrawPic(x, y + 2, 12, 12, ci->team == TEAM_AXIS ? cgs.media.alliedUniformShader : cgs.media.axisUniformShader);
 			x      += 14;
 			puwidth = 14;
@@ -616,11 +637,11 @@ void CG_DrawFireTeamOverlay(rectDef_t *rect)
 		// right align?
 		if (cg_fireteamNameAlign.integer > 0)
 		{
-			CG_Text_Paint_RightAligned_Ext(x + bestNameWidth - puwidth, y + FT_BAR_HEIGHT, .2f, .2f, colorWhite, name[i], 0, 0, ITEM_TEXTSTYLE_SHADOWED, FONT_TEXT);
+			CG_Text_Paint_RightAligned_Ext(x + bestNameWidth - puwidth, y + FT_BAR_HEIGHT, .2f, .2f, textWhite, name[i], 0, 0, ITEM_TEXTSTYLE_SHADOWED, FONT_TEXT);
 		}
 		else
 		{
-			CG_Text_Paint_Ext(x, y + FT_BAR_HEIGHT, .2f, .2f, colorWhite, name[i], 0, 0, ITEM_TEXTSTYLE_SHADOWED, FONT_TEXT);
+			CG_Text_Paint_Ext(x, y + FT_BAR_HEIGHT, .2f, .2f, textWhite, name[i], 0, 0, ITEM_TEXTSTYLE_SHADOWED, FONT_TEXT);
 		}
 
 		// add space
@@ -650,10 +671,12 @@ void CG_DrawFireTeamOverlay(rectDef_t *rect)
 		// note: WP_NONE is excluded
 		if (IS_VALID_WEAPON(curWeap) && cg_weapons[curWeap].weaponIcon[0])     // do not try to draw nothing
 		{
+			trap_R_SetColor(iconColor);
 			CG_DrawPic(x, y + 2, cg_weapons[curWeap].weaponIconScale * 10, 10, cg_weapons[curWeap].weaponIcon[0]);
 		}
 		else if (IS_VALID_WEAPON(curWeap) && cg_weapons[curWeap].weaponIcon[1])
 		{
+			trap_R_SetColor(iconColor);
 			CG_DrawPic(x, y + 2, cg_weapons[curWeap].weaponIconScale * 10, 10, cg_weapons[curWeap].weaponIcon[1]);
 		}
 
@@ -668,25 +691,25 @@ void CG_DrawFireTeamOverlay(rectDef_t *rect)
 		else if (ci->health >= 10)
 		{
 			x += 6;
-			CG_Text_Paint_Ext(x, y + FT_BAR_HEIGHT, .2f, .2f, ci->health > 80 ? FT_text : colorYellow, va("%i", ci->health), 0, 0, ITEM_TEXTSTYLE_SHADOWED, FONT_TEXT);
+			CG_Text_Paint_Ext(x, y + FT_BAR_HEIGHT, .2f, .2f, ci->health > 80 ? FT_text : textYellow, va("%i", ci->health), 0, 0, ITEM_TEXTSTYLE_SHADOWED, FONT_TEXT);
 			x += 6;
 		}
 		else if (ci->health > 0)
 		{
 			x += 12;
-			CG_Text_Paint_Ext(x, y + FT_BAR_HEIGHT, .2f, .2f, colorYellow, va("%i", ci->health), 0, 0, ITEM_TEXTSTYLE_SHADOWED, FONT_TEXT);
+			CG_Text_Paint_Ext(x, y + FT_BAR_HEIGHT, .2f, .2f, textYellow, va("%i", ci->health), 0, 0, ITEM_TEXTSTYLE_SHADOWED, FONT_TEXT);
 		}
 		else if (ci->health == 0)
 		{
 			x += 6;
-			CG_Text_Paint_Ext(x, y + FT_BAR_HEIGHT, .2f, .2f, ((cg.time % 500) > 250)  ? colorWhite : colorRed, "*", 0, 0, ITEM_TEXTSTYLE_SHADOWED, FONT_TEXT);
+			CG_Text_Paint_Ext(x, y + FT_BAR_HEIGHT, .2f, .2f, ((cg.time % 500) > 250)  ? textWhite : textRed, "*", 0, 0, ITEM_TEXTSTYLE_SHADOWED, FONT_TEXT);
 			x += 6;
-			CG_Text_Paint_Ext(x, y + FT_BAR_HEIGHT, .2f, .2f, ((cg.time % 500) > 250)  ? colorRed : colorWhite, "0", 0, 0, ITEM_TEXTSTYLE_SHADOWED, FONT_TEXT);
+			CG_Text_Paint_Ext(x, y + FT_BAR_HEIGHT, .2f, .2f, ((cg.time % 500) > 250)  ? textRed : textWhite, "0", 0, 0, ITEM_TEXTSTYLE_SHADOWED, FONT_TEXT);
 		}
 		else
 		{
 			x += 12;
-			CG_Text_Paint_Ext(x, y + FT_BAR_HEIGHT, .2f, .2f, colorRed, "0", 0, 0, ITEM_TEXTSTYLE_SHADOWED, FONT_TEXT);
+			CG_Text_Paint_Ext(x, y + FT_BAR_HEIGHT, .2f, .2f, textRed, "0", 0, 0, ITEM_TEXTSTYLE_SHADOWED, FONT_TEXT);
 		}
 
 		// set hard limit on width
@@ -703,6 +726,8 @@ void CG_DrawFireTeamOverlay(rectDef_t *rect)
 			}
 		}
 	}
+
+	trap_R_SetColor(NULL);
 }
 
 /*

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2820,6 +2820,8 @@ extern vmCvar_t cg_fireteamLocationAlign;
 extern vmCvar_t cg_fireteamNameMaxChars;
 extern vmCvar_t cg_fireteamNameAlign;
 extern vmCvar_t cg_fireteamSprites;
+extern vmCvar_t cg_fireteamBgAlpha;
+
 extern vmCvar_t cg_simpleItems;
 extern vmCvar_t cg_simpleItemsScale;
 
@@ -4087,8 +4089,8 @@ typedef struct hudComponent_s
 	rectDef_t location;
 	int visible;
 	int style;
-    float scale;
-    vec4_t color;
+	float scale;
+	vec4_t color;
 	int offset;
 } hudComponent_t;
 

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2820,6 +2820,7 @@ extern vmCvar_t cg_fireteamLocationAlign;
 extern vmCvar_t cg_fireteamNameMaxChars;
 extern vmCvar_t cg_fireteamNameAlign;
 extern vmCvar_t cg_fireteamSprites;
+extern vmCvar_t cg_fireteamAlpha;
 extern vmCvar_t cg_fireteamBgAlpha;
 
 extern vmCvar_t cg_simpleItems;

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -322,6 +322,7 @@ vmCvar_t cg_fireteamLocationAlign;
 vmCvar_t cg_fireteamNameMaxChars;
 vmCvar_t cg_fireteamNameAlign;
 vmCvar_t cg_fireteamSprites;
+vmCvar_t cg_fireteamAlpha;
 vmCvar_t cg_fireteamBgAlpha;
 
 vmCvar_t cg_weapaltReloads;
@@ -609,6 +610,7 @@ static cvarTable_t cvarTable[] =
 	{ &cg_fireteamNameMaxChars,   "cg_fireteamNameMaxChars",   "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_fireteamNameAlign,      "cg_fireteamNameAlign",      "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_fireteamSprites,        "cg_fireteamSprites",        "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_fireteamAlpha,          "cg_fireteamAlpha",          "1.0",         CVAR_ARCHIVE,                 0 },
 	{ &cg_fireteamBgAlpha,        "cg_fireteamBgAlpha",        "0.3",         CVAR_ARCHIVE,                 0 },
 
 	{ &cg_simpleItems,            "cg_simpleItems",            "0",           CVAR_ARCHIVE,                 0 },   // Bugged atm
@@ -1835,8 +1837,8 @@ static void CG_RegisterGraphics(void)
 	cgs.media.genericConstructionShader = trap_R_RegisterShader("textures/sfx/construction");
 	cgs.media.shoutcastLandmineShader   = trap_R_RegisterShader("textures/sfx/shoutcast_landmine");
 
-	cgs.media.alliedUniformShader = trap_R_RegisterShader("sprites/uniform_allied");
-	cgs.media.axisUniformShader   = trap_R_RegisterShader("sprites/uniform_axis");
+	cgs.media.alliedUniformShader = trap_R_RegisterShader("sprites/uniform_allied_hud");
+	cgs.media.axisUniformShader   = trap_R_RegisterShader("sprites/uniform_axis_hud");
 
 	// used in: command map
 	cgs.media.ccFilterPics[0] = trap_R_RegisterShaderNoMip("gfx/limbo/filter_axis");

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -322,6 +322,7 @@ vmCvar_t cg_fireteamLocationAlign;
 vmCvar_t cg_fireteamNameMaxChars;
 vmCvar_t cg_fireteamNameAlign;
 vmCvar_t cg_fireteamSprites;
+vmCvar_t cg_fireteamBgAlpha;
 
 vmCvar_t cg_weapaltReloads;
 vmCvar_t cg_weapaltSwitches;
@@ -608,6 +609,8 @@ static cvarTable_t cvarTable[] =
 	{ &cg_fireteamNameMaxChars,   "cg_fireteamNameMaxChars",   "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_fireteamNameAlign,      "cg_fireteamNameAlign",      "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_fireteamSprites,        "cg_fireteamSprites",        "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_fireteamBgAlpha,        "cg_fireteamBgAlpha",        "0.3",         CVAR_ARCHIVE,                 0 },
+
 	{ &cg_simpleItems,            "cg_simpleItems",            "0",           CVAR_ARCHIVE,                 0 },   // Bugged atm
 	{ &cg_simpleItemsScale,       "cg_simpleItemsScale",       "1.0",         CVAR_ARCHIVE,                 0 },
 	{ &cg_automapZoom,            "cg_automapZoom",            "5.159",       CVAR_ARCHIVE,                 0 },


### PR DESCRIPTION
Cvar to allow adjusting the background alpha of fireteam overlay. Full fireteam alpha is unfortunately not possible (at least in a simple way) since we use images in the overlay, so they get their alpha values from shaders.