### PR TITLE
game: remove g_altSuicideAnim and default to the normal death anim

### DIFF
--- a/src/game/g_combat.c
+++ b/src/game/g_combat.c
@@ -659,16 +659,6 @@ void player_die(gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int 
 		// set enemy location
 		BG_UpdateConditionValue(self->s.number, ANIM_COND_ENEMY_POSITION, 0, qfalse);
 
-		// play specific anim on suicide
-		if (g_altSuicideAnim.integer)
-		{
-			BG_UpdateConditionValue(self->s.number, ANIM_COND_ENEMY_WEAPON, meansOfDeath == MOD_SUICIDE, qtrue);
-		}
-		else
-		{
-			BG_UpdateConditionValue(self->s.number, ANIM_COND_SUICIDE, meansOfDeath == MOD_SUICIDE, qtrue);
-		}
-
 		// FIXME: add POSITION_RIGHT, POSITION_LEFT
 		if (infront(self, inflictor))
 		{
@@ -1179,8 +1169,8 @@ void G_DamageExt(gentity_t *targ, gentity_t *inflictor, gentity_t *attacker, vec
 	int         take;
 	int         knockback;
 	qboolean    wasAlive, onSameTeam;
-	hitRegion_t hr = HR_NUM_HITREGIONS;
-	int hitEventType = HIT_NONE;
+	hitRegion_t hr           = HR_NUM_HITREGIONS;
+	int         hitEventType = HIT_NONE;
 
 	if (hitEventOut)
 	{

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -2175,7 +2175,6 @@ extern vmCvar_t g_debugForSingleClient;
 
 extern vmCvar_t g_suddenDeath;
 extern vmCvar_t g_dropObjDelay;
-extern vmCvar_t g_altSuicideAnim;
 
 // flood protection
 extern vmCvar_t g_floodProtection;
@@ -2888,7 +2887,7 @@ void G_RailBox(vec_t *origin, vec_t *mins, vec_t *maxs, vec_t *color, int index)
 typedef struct weapFireTable_t
 {
 	weapon_t weapon;
-	gentity_t *(*fire)(gentity_t * ent);  ///< -
+	gentity_t *(*fire)(gentity_t *ent);   ///< -
 	void (*think)(gentity_t *ent);        ///< -
 	void (*free)(gentity_t *ent);         ///< -
 	int eType;                            ///< -

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -372,8 +372,6 @@ vmCvar_t g_suddenDeath;
 
 vmCvar_t g_dropObjDelay;
 
-vmCvar_t g_altSuicideAnim;
-
 // flood protection
 vmCvar_t g_floodProtection;
 vmCvar_t g_floodLimit;
@@ -670,7 +668,6 @@ cvarTable_t gameCvarTable[] =
 	{ &g_xpSaver,                         "g_xpSaver",                         "0",                          CVAR_ARCHIVE,                                    0, qfalse, qfalse },
 	{ &g_suddenDeath,                     "g_suddenDeath",                     "0",                          CVAR_ARCHIVE,                                    0, qtrue,  qfalse },
 	{ &g_dropObjDelay,                    "g_dropObjDelay",                    "3000",                       CVAR_ARCHIVE,                                    0, qtrue,  qfalse },
-	{ &g_altSuicideAnim,                  "g_altSuicideAnim",                  "0",                          CVAR_ARCHIVE,                                    0, qtrue,  qfalse },
 
 	{ &g_floodProtection,                 "g_floodProtection",                 "1",                          CVAR_ARCHIVE | CVAR_SERVERINFO,                  0, qtrue,  qfalse },
 	{ &g_floodLimit,                      "g_floodLimit",                      "5",                          CVAR_ARCHIVE,                                    0, qtrue,  qfalse },


### PR DESCRIPTION
Since the addition of this cvar, the complaints about the suicide animation being confusing have mostly vanished and people seem to like the default death animation, so I don't think we need this anymore. Regular death animation is now played on suicide.