### PR TITLE
game: allow disabling Z shove completely

### DIFF
--- a/etmain/configs/legacy1.config
+++ b/etmain/configs/legacy1.config
@@ -116,6 +116,7 @@ init
 	setl g_intermissiontime "20"
 	setl g_multiview "0"
 	setl g_shove "0"
+	setl g_shoveNoZ "1"
 	setl g_antiwarp "1"
 	setl g_maxWarp "4"
 	setl g_antilag "1"

--- a/etmain/configs/legacy3.config
+++ b/etmain/configs/legacy3.config
@@ -117,6 +117,7 @@ init
 	setl g_intermissiontime "20"
 	setl g_multiview "0"
 	setl g_shove "60"
+	setl g_shoveNoZ "1"
 	setl g_antiwarp "1"
 	setl g_maxWarp "4"
 	setl g_antilag "1"

--- a/etmain/configs/legacy5.config
+++ b/etmain/configs/legacy5.config
@@ -116,6 +116,7 @@ init
 	setl g_intermissiontime "20"
 	setl g_multiview "0"
 	setl g_shove "60"
+	setl g_shoveNoZ "1"
 	setl g_antiwarp "1"
 	setl g_maxWarp "4"
 	setl g_antilag "1"

--- a/etmain/configs/legacy6.config
+++ b/etmain/configs/legacy6.config
@@ -116,6 +116,7 @@ init
 	setl g_intermissiontime "20"
 	setl g_multiview "0"
 	setl g_shove "60"
+	setl g_shoveNoZ "1"
 	setl g_antiwarp "1"
 	setl g_maxWarp "4"
 	setl g_antilag "1"

--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -4324,13 +4324,12 @@ qboolean G_PushPlayer(gentity_t *ent, gentity_t *victim)
 		}
 		else
 		{
-			push[2] = 64;
+			push[2] = g_shoveNoZ.integer ? 0 : 64;
 		}
 	}
 	else
 	{
-		// give them a little hop
-		push[2] = 64;
+		push[2] = g_shoveNoZ.integer ? 0 : 64;
 	}
 
 	VectorAdd(victim->s.pos.trDelta, push, victim->s.pos.trDelta);

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -2084,6 +2084,7 @@ extern vmCvar_t g_dropHealth;
 extern vmCvar_t g_dropAmmo;
 
 extern vmCvar_t g_shove;
+extern vmCvar_t g_shoveNoZ;
 
 // MAPVOTE
 extern vmCvar_t g_mapVoteFlags;
@@ -2888,7 +2889,7 @@ void G_RailBox(vec_t *origin, vec_t *mins, vec_t *maxs, vec_t *color, int index)
 typedef struct weapFireTable_t
 {
 	weapon_t weapon;
-	gentity_t *(*fire)(gentity_t * ent);  ///< -
+	gentity_t *(*fire)(gentity_t *ent);   ///< -
 	void (*think)(gentity_t *ent);        ///< -
 	void (*free)(gentity_t *ent);         ///< -
 	int eType;                            ///< -

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -271,6 +271,7 @@ vmCvar_t g_dropHealth;
 vmCvar_t g_dropAmmo;
 
 vmCvar_t g_shove;
+vmCvar_t g_shoveNoZ;
 
 // MAPVOTE
 vmCvar_t g_mapVoteFlags;
@@ -599,6 +600,7 @@ cvarTable_t gameCvarTable[] =
 	{ &g_dropHealth,                      "g_dropHealth",                      "0",                          0,                                               0, qfalse, qfalse },
 	{ &g_dropAmmo,                        "g_dropAmmo",                        "0",                          0,                                               0, qfalse, qfalse },
 	{ &g_shove,                           "g_shove",                           "60",                         0,                                               0, qfalse, qfalse },
+	{ &g_shoveNoZ,                        "g_shoveNoZ",                        "0",                          0,                                               0, qfalse, qfalse },
 
 	// MAPVOTE
 	{ &g_mapVoteFlags,                    "g_mapVoteFlags",                    "0",                          0,                                               0, qfalse, qfalse },


### PR DESCRIPTION
Allow disabling Z shove completely with `g_shoveNoZ` similar to ETPro `b_shovenoZ`. Defaulted off as I don't think it's really important for public gameplay, but enabled it for comp configs.