### PR TITLE
cgame: change cg_errorDecay to CVAR_CHEAT

### DIFF
--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -459,7 +459,7 @@ static cvarTable_t cvarTable[] =
 	{ &cg_debugPosition,           "cg_debugposition",           "0",           CVAR_CHEAT,                   0 },
 	{ &cg_debugEvents,             "cg_debugevents",             "0",           CVAR_CHEAT,                   0 },
 	{ &cg_debugPlayerHitboxes,     "cg_debugPlayerHitboxes",     "0",           CVAR_CHEAT,                   0 },
-	{ &cg_errorDecay,              "cg_errordecay",              "100",         0,                            0 },
+	{ &cg_errorDecay,              "cg_errordecay",              "100",         CVAR_CHEAT,                   0 },
 	{ &cg_nopredict,               "cg_nopredict",               "0",           CVAR_CHEAT,                   0 },
 	{ &cg_noPlayerAnims,           "cg_noplayeranims",           "0",           CVAR_CHEAT,                   0 },
 	{ &cg_showmiss,                "cg_showmiss",                "0",           0,                            0 },


### PR DESCRIPTION
While I was fixing screen shake to not clip into walls and causing players to see through them I learned that screen shake is basically forced prediction error and it turns out you can turn it off by changing `cg_errordecay` which is neither a cheat cvar nor forced in configs in both legacy and etpro.

Adding shake by modifying player origin that causes prediction error because it is only done client side:
https://github.com/etlegacy/etlegacy/blob/0c76b868f587d5ff22030eb0995409a14b59b3fe/src/cgame/cg_predict.c#L1473-L1491

https://streamable.com/k9jud0   legacy
https://streamable.com/3qwbqs  etpro (not forced in comp configs either as far as I can tell, hirntot servers also)