### PR TITLE
client: restore vanilla activatelean behavior, refs #1781

### DIFF
--- a/src/client/cl_input.c
+++ b/src/client/cl_input.c
@@ -748,6 +748,20 @@ void CL_KeyMove(usercmd_t *cmd)
 	side += movespeed * CL_KeyState(&kb[KB_MOVERIGHT]);
 	side -= movespeed * CL_KeyState(&kb[KB_MOVELEFT]);
 
+	if (cmd->buttons & BUTTON_ACTIVATE)
+	{
+		if (side > 0)
+		{
+			cmd->wbuttons |= WBUTTON_LEANRIGHT;
+		}
+		else if (side < 0)
+		{
+			cmd->wbuttons |= WBUTTON_LEANLEFT;
+		}
+
+		side = 0;   // disallow the strafe when holding 'activate'
+	}
+
 	up += movespeed * CL_KeyState(&kb[KB_UP]);
 	up -= movespeed * CL_KeyState(&kb[KB_DOWN]);
 

--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -64,8 +64,8 @@ extern vmCvar_t g_pronedelay;
 #define MAX_AIMSPREAD_TIME 1000
 #define EXTENDEDPRONE_TIME 400
 
-pmove_t *pm;
-pml_t   pml;
+pmove_t * pm;
+pml_t pml;
 
 // movement parameters
 float pm_stopspeed = 100;
@@ -4953,17 +4953,18 @@ void PmoveSingle(pmove_t *pmove)
 		pm->ps->eFlags &= ~EF_ZOOMING;
 	}
 
-	if (pm->activateLean && pm->cmd.buttons & BUTTON_ACTIVATE)
+	if (!pm->activateLean)
 	{
-		if (pm->cmd.rightmove < 0)
+		if (pm->cmd.wbuttons & WBUTTON_LEANLEFT && pm->cmd.buttons & BUTTON_ACTIVATE)
 		{
-			pm->cmd.wbuttons |= WBUTTON_LEANLEFT;
+			pm->cmd.rightmove = -127;
+			pm->cmd.wbuttons ^= WBUTTON_LEANLEFT;
 		}
-		else if (pm->cmd.rightmove > 0)
+		else if (pm->cmd.wbuttons & WBUTTON_LEANRIGHT && pm->cmd.buttons & BUTTON_ACTIVATE)
 		{
-			pm->cmd.wbuttons |= WBUTTON_LEANRIGHT;
+			pm->cmd.rightmove = 127;
+			pm->cmd.wbuttons ^= WBUTTON_LEANRIGHT;
 		}
-		pm->cmd.rightmove = 0;
 	}
 
 	// make sure walking button is clear if they are running, to avoid


### PR DESCRIPTION
Vanilla 2.60b has +activate leaning enabled by default. After moving the toggle cvar to mod code in fbfd630853eeb7c81ad1983e8c68c1b06aff3c1b, this was no longer the case. Restored the code to `cl_input` to enable it by default. This does not change anything in legacy mod, the mod-sided cvar is still ultimately in control of this feature, this merely enables and restores consistency with 2.60b for +activate lean behavior for mods which do not implement a toggle for this, such as silent mod.