### PR TITLE
mod: fix new voicechat sprites drawing through walls, refs #1274

### DIFF
--- a/etmain/scripts/legacy.shader
+++ b/etmain/scripts/legacy.shader
@@ -1695,3 +1695,82 @@ gfx/2d/crosshairp_alt
 		rgbGen vertex
 	}
 }
+
+// voice chat sprites
+
+sprites/greentick
+{
+	nocompress
+	nopicmip
+	{
+		map sprites/greentick.tga
+		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
+		rgbGen vertex
+	}
+}
+
+sprites/redcross
+{
+	nocompress
+	nopicmip
+	{
+		map sprites/redcross.tga
+		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
+		rgbGen vertex
+	}
+}
+
+gfx/limbo/ic_soldier
+{
+	nocompress
+	nopicmip
+	{
+		map gfx/limbo/ic_soldier.tga
+		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
+		rgbGen vertex
+	}
+}
+
+gfx/limbo/ic_medic
+{
+	nocompress
+	nopicmip
+	{
+		map gfx/limbo/ic_medic.tga
+		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
+		rgbGen vertex
+	}
+}
+
+gfx/limbo/ic_engineer
+{
+	nocompress
+	nopicmip
+	{
+		map gfx/limbo/ic_engineer.tga
+		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
+		rgbGen vertex
+	}
+}
+
+gfx/limbo/ic_fieldops
+{
+	nocompress
+	nopicmip
+	{
+		map gfx/limbo/ic_fieldops.tga
+		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
+		rgbGen vertex
+	}
+}
+
+gfx/limbo/ic_covertops
+{
+	nocompress
+	nopicmip
+	{
+		map gfx/limbo/ic_covertops.tga
+		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
+		rgbGen vertex
+	}
+}


### PR DESCRIPTION
Added shaders to the new voice chat sprites to prevent them from drawing through walls, likely caused by the renderer doing runtime implicit shaders which are known to have depth sorting problems.