### PR TITLE
sdl: add sample count preset levels

### DIFF
--- a/etmain/ui/options_system.menu
+++ b/etmain/ui/options_system.menu
@@ -113,7 +113,7 @@ menuDef {
 	YESNO( 6+(SUBWINDOW_WIDTH_L)+6+2, AUDIO_Y+64, (SUBWINDOW_WIDTH_L)-4, 10, _("Mute When Minimized:"), .2, 8, "s_muteWhenMinimized", _("Toggle audio mute when window is minimized") )
 	YESNO( 6+(SUBWINDOW_WIDTH_L)+6+2, AUDIO_Y+76, (SUBWINDOW_WIDTH_L)-4, 10, _("Mute When Unfocused:"), .2, 8, "s_muteWhenUnfocused", _("Toggle audio mute when window is unfocused") )
 	MULTIACTION( 6+(SUBWINDOW_WIDTH_L)+6+2, AUDIO_Y+88, (SUBWINDOW_WIDTH_L)-4, 10, _("Sound System:"), .2, 8, "ui_s_initsound", cvarFloatList { "SDL2" 1 "OpenAL" 2 }, uiScript update "ui_s_initsound", _("Set the sound system backend") )
-	MULTIACTION( 6+(SUBWINDOW_WIDTH_L)+6+2, AUDIO_Y+100, (SUBWINDOW_WIDTH_L)-4, 10, _("SDL Sample Count:"), .2, 8, "s_sdlLevelSamps", cvarFloatList { "Default" 0 "Low" 1 "Very Low" 2 }, uiScript update "ui_s_sdlLevelSamps", _("Set SDL sample count. Lower values improve latency but might break audio.\nSet as low as possible, effects are highly dependant on hardware and SDL audio driver.\ns_sdlDevSamps must be set to 0 for this to work.") )
+	MULTIACTION( 6+(SUBWINDOW_WIDTH_L)+6+2, AUDIO_Y+100, (SUBWINDOW_WIDTH_L)-4, 10, _("SDL Sample Count:"), .2, 8, "ui_s_sdlLevelSamps", cvarFloatList { "Default" 0 "Low" 1 "Very Low" 2 }, uiScript update "ui_s_sdlLevelSamps", _("Set SDL sample count. Lower values improve latency but might break audio.\nSet as low as possible, effects are highly dependant on hardware and SDL audio driver.\ns_sdlDevSamps must be set to 0 for this to work.") )
 
 // Networking //
 #define NETWORK_Y 228

--- a/etmain/ui/options_system.menu
+++ b/etmain/ui/options_system.menu
@@ -103,7 +103,7 @@ menuDef {
 
 // Audio //
 #define AUDIO_Y 110
-	SUBWINDOW( 6+(SUBWINDOW_WIDTH_L)+6, AUDIO_Y, (SUBWINDOW_WIDTH_R), 102, _("AUDIO") )
+	SUBWINDOW( 6+(SUBWINDOW_WIDTH_L)+6, AUDIO_Y, (SUBWINDOW_WIDTH_R), 114, _("AUDIO") )
 	CVARFLOATLABEL( 6+(SUBWINDOW_WIDTH_L)+6+2, AUDIO_Y+16, (SUBWINDOW_WIDTH_L)-4, 10, "s_volume", .2, ITEM_ALIGN_RIGHT, $evalfloat((SUBWINDOW_WIDTH_L)-6), 8 )
 	SLIDER( 6+(SUBWINDOW_WIDTH_L)+6+2, AUDIO_Y+16, (SUBWINDOW_WIDTH_L)-4, 10, _("Effects Volume:"), .2, 8, "s_volume" .7 0 1, _("Set the effects volume") )
 	CVARFLOATLABEL( 6+(SUBWINDOW_WIDTH_L)+6+2, AUDIO_Y+28, (SUBWINDOW_WIDTH_L)-4, 10, "s_musicvolume", .2, ITEM_ALIGN_RIGHT, $evalfloat((SUBWINDOW_WIDTH_L)-6), 8 )
@@ -113,21 +113,22 @@ menuDef {
 	YESNO( 6+(SUBWINDOW_WIDTH_L)+6+2, AUDIO_Y+64, (SUBWINDOW_WIDTH_L)-4, 10, _("Mute When Minimized:"), .2, 8, "s_muteWhenMinimized", _("Toggle audio mute when window is minimized") )
 	YESNO( 6+(SUBWINDOW_WIDTH_L)+6+2, AUDIO_Y+76, (SUBWINDOW_WIDTH_L)-4, 10, _("Mute When Unfocused:"), .2, 8, "s_muteWhenUnfocused", _("Toggle audio mute when window is unfocused") )
 	MULTIACTION( 6+(SUBWINDOW_WIDTH_L)+6+2, AUDIO_Y+88, (SUBWINDOW_WIDTH_L)-4, 10, _("Sound System:"), .2, 8, "ui_s_initsound", cvarFloatList { "SDL2" 1 "OpenAL" 2 }, uiScript update "ui_s_initsound", _("Set the sound system backend") )
+	MULTIACTION( 6+(SUBWINDOW_WIDTH_L)+6+2, AUDIO_Y+100, (SUBWINDOW_WIDTH_L)-4, 10, _("SDL Sample Count:"), .2, 8, "s_sdlLevelSamps", cvarFloatList { "Default" 0 "Low" 1 "Very Low" 2 }, uiScript update "ui_s_sdlLevelSamps", _("Set SDL sample count. Lower values improve latency but might break audio.\nSet as low as possible, effects are highly dependant on hardware and SDL audio driver.\ns_sdlDevSamps must be set to 0 for this to work.") )
 
 // Networking //
-#define NETWORK_Y 216
+#define NETWORK_Y 228
 	SUBWINDOW( 6+(SUBWINDOW_WIDTH_L)+6, NETWORK_Y, (SUBWINDOW_WIDTH_R), 42, _("NETWORK") )
 	MULTIACTION( 6+(SUBWINDOW_WIDTH_L)+6+2, NETWORK_Y+16, (SUBWINDOW_WIDTH_L)-4, 10, _("Max Packets:"), .2, 8, "ui_cl_maxpackets", cvarFloatList { "Very Low (15)" 15 "Low (30)" 30 "Medium (60)" 60 "High (100)" 100 "Very High (125)" 125 }, uiScript update "ui_cl_maxpackets", _("Cap for upstream data packet transmissions") )
 	MULTIACTION( 6+(SUBWINDOW_WIDTH_L)+6+2, NETWORK_Y+28, (SUBWINDOW_WIDTH_L)-4, 10, _("Packet Duplication:"), .2, 8, "ui_cl_packetdup", cvarFloatList { "No" 0 "x1" 1 "x2" 2 }, uiScript update "ui_cl_packetdup", _("Set number of duplicates for every data packet sent upstream, minimized packetloss") )
 
 // Downloads //
-#define DOWNLOADS_Y 262
+#define DOWNLOADS_Y 274
 	SUBWINDOW( 6+(SUBWINDOW_WIDTH_L)+6, DOWNLOADS_Y, (SUBWINDOW_WIDTH_R), 42, _("DOWNLOADS") )
 	MULTI( 6+(SUBWINDOW_WIDTH_L)+6+2, DOWNLOADS_Y+16, (SUBWINDOW_WIDTH_L)-4, 10, _("Get Missing Files:"), .2, 8, "cl_allowDownload", cvarFloatList { "Disabled" 0 "Enabled" 1 "Enabled & No sound" 2 }, _("Download missing files when available") )
 	YESNO( 6+(SUBWINDOW_WIDTH_L)+6+2, DOWNLOADS_Y+28, (SUBWINDOW_WIDTH_L)-4, 10, _("Use HTTP/FTP Downloads:"), .2, 8, "cl_wwwDownload", _("Toggle http/ftp downloads") )
 
 // IRC //
-#define IRC_Y 308
+#define IRC_Y 320
 	SUBWINDOW( 6+(SUBWINDOW_WIDTH_L)+6, IRC_Y, (SUBWINDOW_WIDTH_R), 102, _("IRC CLIENT") )
 	MULTI( 6+(SUBWINDOW_WIDTH_L)+6+2, IRC_Y+16, (SUBWINDOW_WIDTH_R)-4, 10, _("Mode:"), .2, 8, "irc_mode", cvarFloatList { "Disabled" 0 "Direct connect" 1 "Override nickname" 2 "Mute channel" 4 "Direct + Override" 3 "Direct + Mute" 5 "Override + Mute" 6 "Direct + Over. + Mute" 7 }, _("Specify IRC client behavior") )
 	EDITFIELD( 6+(SUBWINDOW_WIDTH_L)+6+2, IRC_Y+28, (SUBWINDOW_WIDTH_L)-4, 10, _("Server:"), .2, 8, "irc_server", 25, 18, _("Set IRC server name") )

--- a/src/sdl/sdl_snd.c
+++ b/src/sdl/sdl_snd.c
@@ -206,48 +206,25 @@ int SND_SamplesForFreq(int freq, int level)
 	{
 	case 11025:
 		samples = 256;
-		if (level == 1)
-		{
-			samples /= 2;
-		}
-		else if (level == 2)
-		{
-			samples /= 4;
-		}
 		break;
 	case 22050:
 		samples = 512;
-		if (level == 1)
-		{
-			samples /= 2;
-		}
-		else if (level == 2)
-		{
-			samples /= 4;
-		}
 		break;
 	case 44100:
 		samples = 1024;
-		if (level == 1)
-		{
-			samples /= 2;
-		}
-		else if (level == 2)
-		{
-			samples /= 4;
-		}
 		break;
 	default:     // 48KHz
 		samples = 2048;
-		if (level == 1)
-		{
-			samples /= 2;
-		}
-		else if (level == 2)
-		{
-			samples /= 4;
-		}
 		break;
+	}
+
+	if (level == 1)
+	{
+		samples /= 2;
+	}
+	else if (level == 2)
+	{
+		samples /= 4;
 	}
 
 	return samples;

--- a/src/sdl/sdl_snd.c
+++ b/src/sdl/sdl_snd.c
@@ -49,6 +49,7 @@ cvar_t *s_device;
 cvar_t *s_sdlChannels; // external s_channels (GPL: cvar_t s_numchannels )
 cvar_t *s_sdlDevSamps;
 cvar_t *s_sdlMixSamps;
+cvar_t *s_sdlLevelSamps;
 
 /* The audio callback. All the magic happens here. */
 static int               dmapos    = 0;
@@ -198,6 +199,60 @@ static void SND_DeviceList(void)
 	}
 }
 
+int SND_SamplesForFreq(int freq, int level)
+{
+	int samples;
+	switch (freq)
+	{
+	case 11025:
+		samples = 256;
+		if (level == 1)
+		{
+			samples /= 2;
+		}
+		else if (level == 2)
+		{
+			samples /= 4;
+		}
+		break;
+	case 22050:
+		samples = 512;
+		if (level == 1)
+		{
+			samples /= 2;
+		}
+		else if (level == 2)
+		{
+			samples /= 4;
+		}
+		break;
+	case 44100:
+		samples = 1024;
+		if (level == 1)
+		{
+			samples /= 2;
+		}
+		else if (level == 2)
+		{
+			samples /= 4;
+		}
+		break;
+	default:     // 48KHz
+		samples = 2048;
+		if (level == 1)
+		{
+			samples /= 2;
+		}
+		else if (level == 2)
+		{
+			samples /= 4;
+		}
+		break;
+	}
+
+	return samples;
+}
+
 /**
  * @brief SNDDMA_Init
  * @return
@@ -221,9 +276,10 @@ qboolean SNDDMA_Init(void)
 	s_khz         = Cvar_Get("s_khz", "44", CVAR_LATCH | CVAR_ARCHIVE);
 	s_sdlChannels = Cvar_Get("s_channels", "2", CVAR_LATCH | CVAR_ARCHIVE);
 
-	s_sdlDevSamps = Cvar_Get("s_sdlDevSamps", "0", CVAR_LATCH | CVAR_ARCHIVE);
-	s_sdlMixSamps = Cvar_Get("s_sdlMixSamps", "0", CVAR_LATCH | CVAR_ARCHIVE);
-	s_device      = Cvar_Get("s_device", "-1", CVAR_LATCH | CVAR_ARCHIVE);
+	s_sdlDevSamps   = Cvar_Get("s_sdlDevSamps", "0", CVAR_LATCH | CVAR_ARCHIVE);
+	s_sdlMixSamps   = Cvar_Get("s_sdlMixSamps", "0", CVAR_LATCH | CVAR_ARCHIVE);
+	s_sdlLevelSamps = Cvar_Get("s_sdlLevelSamps", "0", CVAR_LATCH | CVAR_ARCHIVE);
+	s_device        = Cvar_Get("s_device", "-1", CVAR_LATCH | CVAR_ARCHIVE);
 
 	Com_Printf("SDL_Init( SDL_INIT_AUDIO )... ");
 
@@ -269,22 +325,21 @@ qboolean SNDDMA_Init(void)
 	}
 	else
 	{
-		// just pick a sane default.
 		if (desired.freq <= 11025)
 		{
-			desired.samples = 256;
+			desired.samples = SND_SamplesForFreq(desired.freq, s_sdlLevelSamps->integer);
 		}
 		else if (desired.freq <= 22050)
 		{
-			desired.samples = 512;
+			desired.samples = SND_SamplesForFreq(desired.freq, s_sdlLevelSamps->integer);
 		}
 		else if (desired.freq <= 44100)
 		{
-			desired.samples = 1024;
+			desired.samples = SND_SamplesForFreq(desired.freq, s_sdlLevelSamps->integer);
 		}
 		else
 		{
-			desired.samples = 2048;  // (*shrug*)
+			desired.samples = SND_SamplesForFreq(desired.freq, s_sdlLevelSamps->integer); // 48KHz
 		}
 	}
 

--- a/src/ui/ui_main.c
+++ b/src/ui/ui_main.c
@@ -5939,6 +5939,7 @@ void UI_RunMenuScript(char **args)
 			int   ui_m_filter                         = (int)(trap_Cvar_VariableValue("m_filter"));
 			int   ui_s_initsound                      = (int)(trap_Cvar_VariableValue("s_initsound"));
 			int   ui_s_khz                            = (int)(trap_Cvar_VariableValue("s_khz"));
+			int   ui_s_sdlLevelSamps                  = (int)(trap_Cvar_VariableValue("s_sdlLevelSamps"));
 			int   ui_r_detailtextures                 = (int)(trap_Cvar_VariableValue("r_detailtextures"));
 			int   ui_r_ext_texture_filter_anisotropic = (int)(trap_Cvar_VariableValue("r_ext_texture_filter_anisotropic"));
 			int   ui_r_ext_multisample                = (int)(trap_Cvar_VariableValue("r_ext_multisample"));
@@ -5983,6 +5984,7 @@ void UI_RunMenuScript(char **args)
 			trap_Cvar_Set("ui_m_filter", va("%i", ui_m_filter));
 			trap_Cvar_Set("ui_s_initsound", va("%i", ui_s_initsound));
 			trap_Cvar_Set("ui_s_khz", va("%i", ui_s_khz));
+			trap_Cvar_Set("ui_s_sdlLevelSamps", va("%i", ui_s_sdlLevelSamps));
 			trap_Cvar_Set("ui_r_detailtextures", va("%i", ui_r_detailtextures));
 			trap_Cvar_Set("ui_r_ext_texture_filter_anisotropic", va("%i", ui_r_ext_texture_filter_anisotropic));
 			trap_Cvar_Set("ui_r_ext_multisample", va("%i", ui_r_ext_multisample));
@@ -6014,6 +6016,7 @@ void UI_RunMenuScript(char **args)
 			trap_Cvar_Set("ui_m_filter", "");
 			trap_Cvar_Set("ui_s_initsound", "");
 			trap_Cvar_Set("ui_s_khz", "");
+			trap_Cvar_Set("ui_s_sdlLevelSamps", "");
 			trap_Cvar_Set("ui_r_detailtextures", "");
 			trap_Cvar_Set("ui_r_ext_texture_filter_anisotropic", "");
 			trap_Cvar_Set("ui_r_ext_multisample", "");
@@ -6047,6 +6050,7 @@ void UI_RunMenuScript(char **args)
 			int   ui_r_allowextensions                = (int)(trap_Cvar_VariableValue("ui_r_allowextensions"));
 			int   ui_m_filter                         = (int)(trap_Cvar_VariableValue("ui_m_filter"));
 			int   ui_s_initsound                      = (int)(trap_Cvar_VariableValue("ui_s_initsound"));
+			int   ui_s_sdlLevelSamps                  = (int)(trap_Cvar_VariableValue("ui_s_sdlLevelSamps"));
 			int   ui_s_khz                            = (int)(trap_Cvar_VariableValue("ui_s_khz"));
 			int   ui_r_detailtextures                 = (int)(trap_Cvar_VariableValue("ui_r_detailtextures"));
 			int   ui_r_ext_texture_filter_anisotropic = (int)(trap_Cvar_VariableValue("ui_r_ext_texture_filter_anisotropic"));
@@ -6099,6 +6103,7 @@ void UI_RunMenuScript(char **args)
 			trap_Cvar_Set("m_filter", va("%i", ui_m_filter));
 			trap_Cvar_Set("s_initsound", va("%i", ui_s_initsound));
 			trap_Cvar_Set("s_khz", va("%i", ui_s_khz));
+			trap_Cvar_Set("ui_s_sdlLevelSamps", va("%i", ui_s_sdlLevelSamps));
 			trap_Cvar_Set("r_detailtextures", va("%i", ui_r_detailtextures));
 			trap_Cvar_Set("r_ext_texture_filter_anisotropic", va("%i", ui_r_ext_texture_filter_anisotropic));
 			trap_Cvar_Set("r_ext_multisample", va("%i", ui_r_ext_multisample));
@@ -6130,6 +6135,7 @@ void UI_RunMenuScript(char **args)
 			trap_Cvar_Set("ui_m_filter", "");
 			trap_Cvar_Set("ui_s_initsound", "");
 			trap_Cvar_Set("ui_s_khz", "");
+			trap_Cvar_Set("ui_s_sdlLevelSamps", "");
 			trap_Cvar_Set("ui_r_detailtextures", "");
 			trap_Cvar_Set("ui_r_ext_texture_filter_anisotropic", "");
 			trap_Cvar_Set("ui_r_ext_multisample", "");

--- a/src/ui/ui_main.c
+++ b/src/ui/ui_main.c
@@ -6103,7 +6103,7 @@ void UI_RunMenuScript(char **args)
 			trap_Cvar_Set("m_filter", va("%i", ui_m_filter));
 			trap_Cvar_Set("s_initsound", va("%i", ui_s_initsound));
 			trap_Cvar_Set("s_khz", va("%i", ui_s_khz));
-			trap_Cvar_Set("ui_s_sdlLevelSamps", va("%i", ui_s_sdlLevelSamps));
+			trap_Cvar_Set("s_sdlLevelSamps", va("%i", ui_s_sdlLevelSamps));
 			trap_Cvar_Set("r_detailtextures", va("%i", ui_r_detailtextures));
 			trap_Cvar_Set("r_ext_texture_filter_anisotropic", va("%i", ui_r_ext_texture_filter_anisotropic));
 			trap_Cvar_Set("r_ext_multisample", va("%i", ui_r_ext_multisample));

--- a/src/ui/ui_script.c
+++ b/src/ui/ui_script.c
@@ -634,6 +634,7 @@ void Script_ConditionalScript(itemDef_t *item, qboolean *bAbort, char **args)
 				int   ui_cg_shadows                       = (int)(DC->getCVarValue("ui_cg_shadows"));
 				int   ui_s_initsound                      = (int)(DC->getCVarValue("ui_s_initsound"));
 				int   ui_s_khz                            = (int)(DC->getCVarValue("ui_s_khz"));
+				int   ui_s_sdlLevelSamps                  = (int)(DC->getCVarValue("ui_s_sdlLevelSamps"));
 				char  ui_r_texturemode[MAX_CVAR_VALUE_STRING];
 
 				char  cl_lang[MAX_CVAR_VALUE_STRING];
@@ -656,6 +657,7 @@ void Script_ConditionalScript(itemDef_t *item, qboolean *bAbort, char **args)
 				int   cg_shadows                       = (int)(DC->getCVarValue("cg_shadows"));
 				int   s_initsound                      = (int)(DC->getCVarValue("s_initsound"));
 				int   s_khz                            = (int)(DC->getCVarValue("s_khz"));
+				int   s_sdlLevelSamps                  = (int)(DC->getCVarValue("s_sdlLevelSamps"));
 				char  r_texturemode[MAX_CVAR_VALUE_STRING];
 
 				trap_Cvar_VariableStringBuffer("ui_cl_lang", ui_cl_lang, sizeof(ui_cl_lang));
@@ -683,6 +685,7 @@ void Script_ConditionalScript(itemDef_t *item, qboolean *bAbort, char **args)
 				    ui_cg_shadows != cg_shadows ||
 				    ui_s_khz != s_khz ||
 				    ui_s_initsound != s_initsound ||
+				    ui_s_sdlLevelSamps != s_sdlLevelSamps ||
 				    Q_stricmp(r_texturemode, ui_r_texturemode))
 				{
 					Item_RunScript(item, bAbort, script1);


### PR DESCRIPTION
Adds `s_sdlLevelSamps` cvar to enable setting lower sample counts for desired audio frequency. Setting lower sample count improves audio latency, at the cost of potentially introducing audio issues, such as cracking. Defaults level 0 does not change anything from what we have now, but level 1 and 2 decrease the samples by 50/75% respectively.

The effects of this are highly dependant on users hardware, slower PCs might struggle with the lower sample counts, hence the default does not change anything. The audio driver used by SDL also affects this: I noticed generally more improvement on Linux using pulseaudio than on Windows 10 using wasapi.