### PR TITLE
cgame: add compass icon scaling based on distance between players

### DIFF
--- a/src/cgame/cg_commandmap.c
+++ b/src/cgame/cg_commandmap.c
@@ -870,7 +870,7 @@ void CG_DrawMapEntity(mapEntityData_t *mEnt, float x, float y, float w, float h,
 			reviveClr[3] = .5f + .5f * (float)((sin(sqrt((double)msec) * 25 * M_TAU_F) + 1) * 0.5);
 
 			trap_R_SetColor(reviveClr);
-			CG_DrawPic(icon_pos[0] + 2, icon_pos[1] + 2, icon_extends[0] - 2, icon_extends[1] - 2, cgs.media.ccMedicIcon);
+			CG_DrawPic(icon_pos[0], icon_pos[1], icon_extends[0], icon_extends[1], cgs.media.ccMedicIcon);
 		}
 		else
 		{
@@ -2527,11 +2527,6 @@ void CG_DrawCompassIcon(float x, float y, float w, float h, vec3_t origin, vec3_
 		if (shader == cgs.media.medicReviveShader)
 		{
 			iconx += iconWidth * .5f;
-			// why do we need to do this? why is wounded player drawn off center?
-			iconx      += 2;
-			icony      += 2;
-			iconWidth  -= 2;
-			iconHeight -= 2;
 		}
 
 		// is the icon inside map boundaries?

--- a/src/cgame/cg_commandmap.c
+++ b/src/cgame/cg_commandmap.c
@@ -214,8 +214,13 @@ static float CG_PlayerDistanceScaling(mapEntityData_t *player)
 	mapEntityData_t *mEnt, *mEntScale;
 	centity_t       *cent, *centScale;
 	int             i;
-	float           distance, scale, smallest = cg_dynamicIconsMaxScale.value;
+	float           distance, scale, minScale = cg_dynamicIconsMaxScale.value;
 	vec3_t          vec1, vec2;
+
+	if (cg_dynamicIconsMinScale.value == cg_dynamicIconsMaxScale.value || cg_dynamicIconsDistance.integer <= 0)
+	{
+		return minScale;
+	}
 
 	mEnt = player;
 	cent = &cg_entities[mEnt->data];
@@ -273,22 +278,21 @@ static float CG_PlayerDistanceScaling(mapEntityData_t *player)
 
 		// calculate distance and scale
 		distance = VectorDistance(vec1, vec2);
-		distance = distance - (2 * cg_dynamicIconsSize.integer * (cg_automapZoom.value / AUTOMAP_ZOOM));
-		scale    = distance / cg_dynamicIconsDistance.integer; // FIXME: divide by zero check missing
+		scale    = distance / cg_dynamicIconsDistance.integer;
 
-		if (smallest > scale)
+		if (minScale > scale)
 		{
 			if (scale < cg_dynamicIconsMinScale.value)
 			{
 				// found the min scale value
-				smallest = cg_dynamicIconsMinScale.value;
+				minScale = cg_dynamicIconsMinScale.value;
 				break;
 			}
-			smallest = scale;
+			minScale = scale;
 		}
 	}
 
-	return smallest;
+	return minScale;
 }
 
 /**

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2680,6 +2680,11 @@ extern vmCvar_t cg_fov;
 extern vmCvar_t cg_muzzleFlash;
 extern vmCvar_t cg_drawEnvAwareness;
 extern vmCvar_t cg_drawCompassIcons;
+extern vmCvar_t cg_dynamicIcons;
+extern vmCvar_t cg_dynamicIconsDistance;
+extern vmCvar_t cg_dynamicIconsSize;
+extern vmCvar_t cg_dynamicIconsMaxScale;
+extern vmCvar_t cg_dynamicIconsMinScale;
 
 extern vmCvar_t cg_zoomDefaultSniper;
 

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -195,6 +195,11 @@ vmCvar_t cg_blood;
 vmCvar_t cg_predictItems;
 vmCvar_t cg_drawEnvAwareness;
 vmCvar_t cg_drawCompassIcons;
+vmCvar_t cg_dynamicIcons;
+vmCvar_t cg_dynamicIconsDistance;
+vmCvar_t cg_dynamicIconsSize;
+vmCvar_t cg_dynamicIconsMaxScale;
+vmCvar_t cg_dynamicIconsMinScale;
 
 vmCvar_t cg_autoactivate;
 
@@ -442,6 +447,11 @@ static cvarTable_t cvarTable[] =
 	{ &cg_bobbing,                 "cg_bobbing",                 "1",           CVAR_ARCHIVE,                 0 },
 	{ &cg_drawEnvAwareness,        "cg_drawEnvAwareness",        "1",           CVAR_ARCHIVE,                 0 },
 	{ &cg_drawCompassIcons,        "cg_drawCompassIcons",        "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_dynamicIcons,            "cg_dynamicIcons",            "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_dynamicIconsDistance,    "cg_dynamicIconsDistance",    "400",         CVAR_ARCHIVE,                 0 },
+	{ &cg_dynamicIconsSize,        "cg_dynamicIconsSize",        "20",          CVAR_ARCHIVE,                 0 },
+	{ &cg_dynamicIconsMaxScale,    "cg_dynamicIconsMaxScale",    "1.0",         CVAR_ARCHIVE,                 0 },
+	{ &cg_dynamicIconsMinScale,    "cg_dynamicIconsMinScale",    "0.5",         CVAR_ARCHIVE,                 0 },
 
 	{ &cg_autoactivate,            "cg_autoactivate",            "1",           CVAR_ARCHIVE,                 0 },
 


### PR DESCRIPTION
`cg_dynamicIcons` dynamic player icon scaling on/off (default off)
`cg_dynamicIconsDistance` distance between players when scaling down starts
`cg_dynamicIconsSize` player icon size. command map defaults: compass 5, minimap/sc 20
`cg_dynamicIconsMaxScale` max scale
`cg_dynamicIconsMinScale` min scale

It's possible to enable it and set `cg_dynamicIconsMaxScale` and `cg_dynamicIconsMinScale` to the same value and the icons will stay same size, thus controlling just the size of icons.

Default values might not be great for majority of players, at least the icon size.

https://streamable.com/vrovnp