### PR TITLE
cgame: increase CMD_BACKUP to 128 to support 250fps on high pings

### DIFF
--- a/src/cgame/cg_public.h
+++ b/src/cgame/cg_public.h
@@ -38,7 +38,7 @@
 /// Allow a lot of command backups for very fast systems
 /// multiple commands may be combined into a single packet, so this
 /// needs to be larger than PACKET_BACKUP
-#define CMD_BACKUP          64
+#define CMD_BACKUP          128
 #define CMD_MASK            (CMD_BACKUP - 1)
 
 #define MAX_ENTITIES_IN_SNAPSHOT    512


### PR DESCRIPTION
Increasing `CMD_BACKUP` should make playing on 250fps possible up to 400-450pings (up from 150-200pings).