### PR TITLE
ui: fix tooltip parser ui_ prefix logic

### DIFF
--- a/src/ui/ui_parse.c
+++ b/src/ui/ui_parse.c
@@ -2111,6 +2111,12 @@ const char *ItemParse_removeUiCvarPrefix(const char *cvar)
 {
 	if (!Q_strncmp(cvar, "ui_", 3))
 	{
+		// if there isn't a second underscore, it's likely a real
+		// cvar that starts with ui_ prefix (e.g. ui_showtooltips)
+		if (!Q_stristr(cvar + 3, "_"))
+		{
+			return cvar;
+		}
 		return cvar + 3;
 	}
 


### PR DESCRIPTION
Only drop `ui_` prefix when the cvar contains additional underscore, so real cvars that start with `ui_` prefix, such as `ui_showtooltips` still display correctly.

refs #1415 