### PR TITLE
cgame: add dynamic health text coloring

### DIFF
--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -1198,8 +1198,23 @@ static void CG_DrawPlayerHealth(float x, float y)
 	const char *str  = va("%i", cg.snap->ps.stats[STAT_HEALTH]);
 	float      scale = activehud->healthtext.scale;
 	float      w     = CG_Text_Width_Ext(str, scale, 0, &cgs.media.limboFont1);
+	vec4_t     color;
 
-	CG_Text_Paint_Ext(x - w, y, scale, scale, activehud->healthtext.color, str, 0, 0, ITEM_TEXTSTYLE_SHADOWED, &cgs.media.limboFont1);
+	if (cg_healthDynamicColor.integer)
+	{
+		int    clientNum = cg.snap->ps.clientNum;
+		int    cls       = cg.snap->ps.stats[STAT_PLAYER_CLASS];
+		team_t team      = cg.snap->ps.persistant[PERS_TEAM];
+		int    maxHealth = CG_GetPlayerMaxHealth(clientNum, cls, team);
+		CG_GetColorForHealth(cg.snap->ps.stats[STAT_HEALTH], color);
+		color[3] = activehud->healthtext.color[3];
+	}
+	else
+	{
+		Vector4Copy(activehud->healthtext.color, color);
+	}
+
+	CG_Text_Paint_Ext(x - w, y, scale, scale, color, str, 0, 0, ITEM_TEXTSTYLE_SHADOWED, &cgs.media.limboFont1);
 	CG_Text_Paint_Ext(x + 2, y, scale - 0.05f, scale - 0.05f, activehud->healthtext.color, "HP", 0, 0, ITEM_TEXTSTYLE_SHADOWED, &cgs.media.limboFont1);
 }
 
@@ -1217,7 +1232,7 @@ static void CG_DrawPlayerSprint(float x, float y)
 
 	if (cg.snap->ps.powerups[PW_ADRENALINE])
 	{
-        str  = va("%d", (cg.snap->ps.powerups[PW_ADRENALINE] - cg.time) / 1000);
+		str  = va("%d", (cg.snap->ps.powerups[PW_ADRENALINE] - cg.time) / 1000);
 		unit = "s";
 	}
 	else

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2897,6 +2897,8 @@ extern vmCvar_t cg_chatLineWidth;
 
 extern vmCvar_t cg_activateLean;
 
+extern vmCvar_t cg_healthDynamicColor;
+
 // local clock flags
 #define LOCALTIME_ON                0x01
 #define LOCALTIME_SECOND            0x02

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -394,6 +394,8 @@ vmCvar_t cg_chatLineWidth;
 
 vmCvar_t cg_activateLean;
 
+vmCvar_t cg_healthDynamicColor;
+
 typedef struct
 {
 	vmCvar_t *vmCvar;
@@ -685,6 +687,8 @@ static cvarTable_t cvarTable[] =
 	{ &cg_chatLineWidth,           "cg_chatLineWidth",           "70",          CVAR_ARCHIVE,                 0 },
 
 	{ &cg_activateLean,            "cg_activateLean",            "0",           CVAR_ARCHIVE,                 0 },
+
+	{ &cg_healthDynamicColor,      "cg_healthDynamicColor",      "0",           CVAR_ARCHIVE,                 0 },
 };
 
 static const unsigned int cvarTableSize = sizeof(cvarTable) / sizeof(cvarTable[0]);


### PR DESCRIPTION
Allows coloring the digit part of the health text HUD element dynamically, using the same color scheme as the health bar. Overrides color set in custom HUDs, but custom HUD color is still used for the `HP` text, as well as adjusting overall alpha.

https://streamable.com/uk40mv