### PR TITLE
renderer: ignore GLEW_ERROR_NO_GLX_DISPLAY so wayland runs

### DIFF
--- a/src/renderercommon/tr_common.c
+++ b/src/renderercommon/tr_common.c
@@ -44,7 +44,7 @@
 
 cvar_t *r_ext_multisample;
 
- /**
+/**
   * @var imageLoaders
   * @brief Note that the ordering indicates the order of preference used
   * when there are multiple images of different formats available
@@ -570,7 +570,9 @@ int RE_InitOpenGlSubsystems(void)
 
 	glewResult = glewInit();
 
-	if (GLEW_OK != glewResult)
+	// ignore GLEW_ERROR_NO_GLX_DISPLAY for now due to GLEW upstream issue
+	// see https://github.com/nigels-com/glew/issues/172
+	if (GLEW_OK != glewResult && glewResult != GLEW_ERROR_NO_GLX_DISPLAY)
 	{
 		// glewInit failed, something is seriously wrong
 		Ren_Fatal("GLW_StartOpenGL() - could not load OpenGL subsystem: %s", glewGetErrorString(glewResult));


### PR DESCRIPTION
Due to a bug in upstream of GLEW, running on wayland errors out with this error on `glewInit`.

See https://github.com/nigels-com/glew/issues/172

fixes #1905 