### PR TITLE
mod: change handling of player events in client game, refs #1957

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1018,8 +1018,6 @@ typedef struct
 // all cg.stepTime, cg.duckTime, cg.landTime, etc are set to cg.time when the action
 // occurs, and they will have visible effects for #define STEP_TIME or whatever msec after
 
-#define MAX_PREDICTED_EVENTS    16
-
 #define MAX_SPAWN_VARS          64
 #define MAX_SPAWN_VARS_CHARS    2048
 
@@ -1167,9 +1165,6 @@ typedef struct
 	qboolean validPPS;                      ///< clear until the first call to CG_PredictPlayerState
 	int predictedErrorTime;
 	vec3_t predictedError;
-
-	int eventSequence;
-	int predictableEvents[MAX_PREDICTED_EVENTS];
 
 	float stepChange;                       ///< for stair up smoothing
 	int stepTime;
@@ -3141,6 +3136,7 @@ int CG_PointContents(const vec3_t point, int passEntityNum);
 void CG_Trace(trace_t *result, const vec3_t start, const vec3_t mins, const vec3_t maxs, const vec3_t end, int skipNumber, int mask);
 void CG_PredictPlayerState(void);
 float CG_ClientHitboxMaxZ(entityState_t *hitEnt, float def);
+qboolean CG_CheckPredictableEvent(int event);
 
 // cg_edv.c
 void CG_RunBindingBuf(int key, qboolean down, char *buf);

--- a/src/cgame/cg_playerstate.c
+++ b/src/cgame/cg_playerstate.c
@@ -250,26 +250,39 @@ void CG_CheckPlayerstateEvents(playerState_t *ps, playerState_t *ops)
 		CG_EntityEvent(cent, cent->lerpOrigin);
 	}
 
-	cent = &cg.predictedPlayerEntity; // cg_entities[ ps->clientNum ];
+	cent = &cg.predictedPlayerEntity;
 	// go through the predictable events buffer
-	for (i = ps->eventSequence - MAX_EVENTS ; i < ps->eventSequence ; i++)
+	for (i = ps->eventSequence - MAX_EVENTS; i < ps->eventSequence; i++)
 	{
 		// if we have a new predictable event
-		if (i >= ops->eventSequence
-		    // or the server told us to play another event instead of a predicted event we already issued
-		    // or something the server told us changed our prediction causing a different event
-		    || (i > ops->eventSequence - MAX_EVENTS && ps->events[i & (MAX_EVENTS - 1)] != ops->events[i & (MAX_EVENTS - 1)]))
+		if (i >= ops->eventSequence)
 		{
-			event                        = ps->events[i & (MAX_EVENTS - 1)];
+			event = ps->events[i & (MAX_EVENTS - 1)];
+
+			// skip predictable pmove events added by server to avoid unnecessary event effect duplication
+			// after client miss predicted and different order of events came from server
+			// causing correctly predicted events by client to play again
+			if (!cg.demoPlayback && ps->clientNum == cg.clientNum && CG_CheckPredictableEvent(event))
+			{
+				continue;
+			}
+
 			cent->currentState.event     = event;
 			cent->currentState.eventParm = ps->eventParms[i & (MAX_EVENTS - 1)];
 			CG_EntityEvent(cent, cent->lerpOrigin);
-
-			cg.predictableEvents[i & (MAX_PREDICTED_EVENTS - 1)] = event;
-
-			cg.eventSequence++;
 		}
 	}
+
+	// play predictable pmove events added by client
+	for (i = cg.pmext.oldEventSequence; i < cg.pmext.eventSequence; i++)
+	{
+		event                        = cg.pmext.events[i & (MAX_EVENTS - 1)];
+		cent->currentState.event     = event;
+		cent->currentState.eventParm = cg.pmext.eventParms[i & (MAX_EVENTS - 1)];
+		CG_EntityEvent(cent, cent->lerpOrigin);
+	}
+
+	cg.pmext.oldEventSequence = cg.pmext.eventSequence;
 }
 
 /*

--- a/src/game/bg_misc.c
+++ b/src/game/bg_misc.c
@@ -3621,6 +3621,19 @@ void BG_AddPredictableEventToPlayerstate(int newEvent, int eventParm, playerStat
 	ps->eventSequence++;
 }
 
+/**
+* @brief Handles the sequence numbers
+* @param[in] newEvent
+* @param[in] eventParm
+* @param[out] pmext
+*/
+void BG_AddPredictableEventToPmoveExt(int newEvent, int eventParm, pmoveExt_t *pmext)
+{
+	pmext->events[pmext->eventSequence & (MAX_EVENTS - 1)]     = newEvent;
+	pmext->eventParms[pmext->eventSequence & (MAX_EVENTS - 1)] = eventParm;
+	pmext->eventSequence++;
+}
+
 // NOTE: would like to just inline this but would likely break qvm support
 #define SETUP_MOUNTEDGUN_STATUS(ps)                           \
 	switch (ps->persistant[PERS_HWEAPON_USE]) {                \

--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -108,7 +108,11 @@ static void PM_BeginWeaponChange(weapon_t oldWeapon, weapon_t newWeapon, qboolea
  */
 void PM_AddEvent(int newEvent)
 {
+#ifdef GAMEDLL
 	BG_AddPredictableEventToPlayerstate(newEvent, 0, pm->ps);
+#else
+	BG_AddPredictableEventToPmoveExt(newEvent, 0, pm->pmext);
+#endif
 }
 
 /**
@@ -118,7 +122,11 @@ void PM_AddEvent(int newEvent)
  */
 void PM_AddEventExt(int newEvent, int eventParm)
 {
+#ifdef GAMEDLL
 	BG_AddPredictableEventToPlayerstate(newEvent, eventParm, pm->ps);
+#else
+	BG_AddPredictableEventToPmoveExt(newEvent, eventParm, pm->pmext);
+#endif
 }
 
 /**

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -587,6 +587,11 @@ typedef struct pmoveExt_s
 
 	qboolean deadInSolid;          ///< true if legs or head start in solid when we die
 
+	int eventSequence;             ///< pmove generated events on client
+	int events[MAX_EVENTS];
+	int eventParms[MAX_EVENTS];
+	int oldEventSequence;          ///< so we can see which events have been added since last pmove
+
 } pmoveExt_t;  ///< data used both in client and server - store it here
 ///< instead of playerstate to prevent different engine versions of playerstate between XP and MP
 
@@ -2116,6 +2121,7 @@ void BG_EvaluateTrajectoryDelta(const trajectory_t *tr, int atTime, vec3_t resul
 void BG_GetMarkDir(const vec3_t dir, const vec3_t normal, vec3_t out);
 
 void BG_AddPredictableEventToPlayerstate(int newEvent, int eventParm, playerState_t *ps);
+void BG_AddPredictableEventToPmoveExt(int newEvent, int eventParm, pmoveExt_t *pmext);
 
 void BG_PlayerStateToEntityState(playerState_t *ps, entityState_t *s, int time, qboolean snap);
 


### PR DESCRIPTION
The issue of doubled sound occurs when client miss predicted events causing them to play again. For example server sometimes predicts 2 events a `footstep` and `fireweapon` compared to client only predicting fireweapon and if footstep comes before fireweapon, both will be played.

The proposed solution in PR to this is to ignore all predictable server events (except non-predictable server only generated ones). So in above case we will no longer get a secondary fireweapon event and additional footstep that we miss predicted. However nothing changes for server and nothing changes for how other players are perceived as it's server that decides what events they get, so other players will still hear a footstep and fireweapon.

To do this, client will no longer save events to `playerstate_t` but to `pmoveExt_t` and will ignore all predictable events coming from server in playerstate. For prediction we will only check for new non-predictable events and if we find them we will do full prediction as before so we can correctly play them.

refs #1957