### PR TITLE
cgame: colorize bots ping column in scoreboard

### DIFF
--- a/src/cgame/cg_scoreboard.c
+++ b/src/cgame/cg_scoreboard.c
@@ -601,7 +601,7 @@ static void WM_DrawClientScore_Ping(int x, int y, float scaleX, float scaleY, co
 	}
 	else if (score->scoreflags & 2)
 	{
-		CG_Text_Paint_RightAligned_Ext(x, y, scaleX, scaleY, colorWhite, " BOT", 0, 0, ITEM_TEXTSTYLE_SHADOWED, FONT_TEXT);
+		CG_Text_Paint_RightAligned_Ext(x, y, scaleX, scaleY, colorYellow, " BOT", 0, 0, ITEM_TEXTSTYLE_SHADOWED, FONT_TEXT);
 	}
 	else
 	{


### PR DESCRIPTION
Color the `BOT` text in ping column on scoreboard yellow for bots to better differentiate them from human players.