### PR TITLE
cgame: fix long names overlapping in stats screen

### DIFF
--- a/src/cgame/cg_debriefing.c
+++ b/src/cgame/cg_debriefing.c
@@ -2197,7 +2197,7 @@ void CG_DebriefingPlayerList_Draw(panel_button_t *button)
 
 		CG_Text_Paint_Ext(DB_RANK_X + cgs.wideXoffset, y, button->font->scalex, button->font->scaley, button->font->colour, CG_Debriefing_RankNameForClientInfo(ci), 0, 0, 0, button->font->font);
 
-		CG_Text_Paint_Ext(DB_NAME_X + cgs.wideXoffset, y, button->font->scalex, button->font->scaley, colorWhite, ci->name, 0, 28, 0, button->font->font);
+		CG_Text_Paint_Ext(DB_NAME_X + cgs.wideXoffset, y, button->font->scalex, button->font->scaley, colorWhite, ci->name, 0, 23, 0, button->font->font);
 
 		CG_Text_Paint_Ext(DB_TIME_X + cgs.wideXoffset, y, button->font->scalex, button->font->scaley, button->font->colour, va("%i", score ? score->time : 0), 0, 0, 0, button->font->font);
 
@@ -2401,8 +2401,8 @@ void CG_Debriefing_ParseAwards(void)
 	int        i   = 0;
 	char       *cs = (char *)CG_ConfigString(CS_ENDGAME_STATS);
 	const char *token;
-	char       *s;
-	size_t     size, len;
+	char       *s, *val;
+	size_t     size, len, lenVal;
 	int        clientNum;
 	float      value;
 	char       buffer[sizeof(cgs.dbAwardNamesBuffer)];
@@ -2428,13 +2428,25 @@ void CG_Debriefing_ParseAwards(void)
 			Q_strncpyz(s, "", size);
 		}
 
+		len = strlen(s);
+
 		// value
 		token = COM_Parse(&cs);
 		value = atof(token);
 
 		if (value > 0)
 		{
-			Q_strcat(s, size, (value == (int)(value)) ? va("^7 (%i)", (int)(value)) : va("^7 (%.2f)", value));
+			val = (value == (int)(value)) ? va("^7 (%i)", (int)(value)) : va("^7 (%.2f)", value);
+
+			lenVal = strlen(val);
+
+			// 32 is the max chars that can fit before name overlaps with scroll bar
+			if (len + lenVal > 32)
+			{
+				Q_TruncateStr(s, 32 - lenVal);
+			}
+
+			Q_strcat(s, size, val);
 		}
 
 		// award

--- a/src/cgame/cg_debriefing.c
+++ b/src/cgame/cg_debriefing.c
@@ -3259,7 +3259,7 @@ void CG_Debriefing_PlayerName_Draw(panel_button_t *button)
 	{
 		CG_DrawPic(button->rect.x, button->rect.y - 9, 18, 12, ci->team == TEAM_AXIS ? cgs.media.axisFlag : cgs.media.alliedFlag);
 	}
-	CG_Text_Paint_Ext(button->rect.x + 22, button->rect.y, button->font->scalex, button->font->scaley, colorWhite, ci->name, 0, 0, ITEM_TEXTSTYLE_SHADOWED, button->font->font);
+	CG_Text_Paint_Ext(button->rect.x + 22, button->rect.y, button->font->scalex, button->font->scaley, colorWhite, ci->name, 0, 27, ITEM_TEXTSTYLE_SHADOWED, button->font->font);
 }
 
 /**


### PR DESCRIPTION
Truncate long player names in `Roll of Honor` and stats screen.

![image](https://user-images.githubusercontent.com/14221121/166116992-6b897536-f889-4063-ac1d-32dfe098b61d.png)

![image](https://user-images.githubusercontent.com/14221121/166117224-6b7dd313-1266-4431-9309-6681148a10cf.png)
