### PR TITLE
common: prevent etconfig from overwriting init cvars, fixes #1975

### DIFF
--- a/src/qcommon/common.c
+++ b/src/qcommon/common.c
@@ -228,7 +228,7 @@ void QDECL Com_Printf(const char *fmt, ...)
 	char            buffer[MAX_PRINT_MSG];
 	char            *msg, *bufferEnd, *tmpMsg;
 	static qboolean opening_qconsole = qfalse;
-	static qboolean lineWasEnded = qtrue;
+	static qboolean lineWasEnded     = qtrue;
 	int             timestamp;
 
 #ifdef DEDICATED
@@ -1012,7 +1012,7 @@ static void Z_ClearZone(memzone_t *zone, int size)
 	// set the entire zone to one free block
 
 	zone->blocklist.next = zone->blocklist.prev = block =
-													  ( memblock_t * )((byte *)zone + sizeof(memzone_t));
+		( memblock_t * )((byte *)zone + sizeof(memzone_t));
 	zone->blocklist.tag  = 1;   // in use block
 	zone->blocklist.id   = 0;
 	zone->blocklist.size = 0;
@@ -2836,6 +2836,16 @@ void Com_Init(char *commandLine)
 
 	Cbuf_AddText(va("exec %s\n", CONFIG_NAME_DEFAULT));
 
+	com_masterServer = Cvar_Get("com_masterServer", MASTER_SERVER_NAME, CVAR_INIT | CVAR_NOTABCOMPLETE);
+	com_motdServer   = Cvar_Get("com_motdServer", MOTD_SERVER_NAME, CVAR_INIT | CVAR_NOTABCOMPLETE);
+	com_updateServer = Cvar_Get("com_updateServer", UPDATE_SERVER_NAME, CVAR_INIT | CVAR_NOTABCOMPLETE);
+	com_downloadURL  = Cvar_Get("com_downloadURL", DOWNLOAD_SERVER_URL, CVAR_INIT | CVAR_NOTABCOMPLETE);
+
+	// master servers
+	// moved here from SV_Init so they con't be overridden by config
+	Cvar_Get("sv_master1", "etmaster.idsoftware.com", CVAR_PROTECTED);
+	Cvar_Get("sv_master2", com_masterServer->string, CVAR_INIT);
+
 	// skip the etconfig.cfg if "safe" is on the command line
 	if (!Com_SafeMode())
 	{
@@ -2971,7 +2981,7 @@ void Com_Init(char *commandLine)
 	com_introPlayed = Cvar_Get("com_introplayed", "0", CVAR_ARCHIVE);
 
 	// this cvar is the single entry point of the entire extension system
-	Cvar_Get( "//trap_GetValue", va( "%i", COM_TRAP_GETVALUE ), CVAR_PROTECTED | CVAR_ROM | CVAR_NOTABCOMPLETE );
+	Cvar_Get("//trap_GetValue", va("%i", COM_TRAP_GETVALUE), CVAR_PROTECTED | CVAR_ROM | CVAR_NOTABCOMPLETE);
 
 #if idppc
 	com_altivec = Cvar_Get("com_altivec", "1", CVAR_ARCHIVE);
@@ -3010,11 +3020,6 @@ void Com_Init(char *commandLine)
 	Cmd_AddCommand("writeconfig", Com_WriteConfig_f, "Write the config file to a specific name.");
 	Cmd_AddCommand("update", Com_Update_f, "Updates the game to latest version.");
 	Cmd_AddCommand("download", Com_Download_f, "Downloads a pk3 from the URL set in cvar com_downloadURL.");
-
-	com_masterServer = Cvar_Get("com_masterServer", MASTER_SERVER_NAME, CVAR_INIT | CVAR_NOTABCOMPLETE);
-	com_motdServer   = Cvar_Get("com_motdServer", MOTD_SERVER_NAME, CVAR_INIT | CVAR_NOTABCOMPLETE);
-	com_updateServer = Cvar_Get("com_updateServer", UPDATE_SERVER_NAME, CVAR_INIT | CVAR_NOTABCOMPLETE);
-	com_downloadURL  = Cvar_Get("com_downloadURL", DOWNLOAD_SERVER_URL, CVAR_INIT | CVAR_NOTABCOMPLETE);
 
 #ifdef FEATURE_DBMS
 	Cmd_AddCommand("saveDB", DB_SaveMemDB_f, "Saves the internal memory database to disk.");
@@ -3542,7 +3547,7 @@ void Com_CheckDefaultProfileDatExists(void)
 	if (defaultProfile && defaultProfile[0] && !FS_FileExists(DEFAULT_PROFILE_DAT))
 	{
 		fileHandle_t f;
-		char tmpProfile[MAX_CVAR_VALUE_STRING] = {'\0'};
+		char         tmpProfile[MAX_CVAR_VALUE_STRING] = { '\0' };
 		Q_strncpyz(tmpProfile, defaultProfile, sizeof(tmpProfile));
 		Q_CleanStr(tmpProfile);
 		Q_CleanDirName(tmpProfile);

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -859,9 +859,9 @@ void SV_SpawnServer(const char *server)
 		// the server sends these to the clients so they will only
 		// load pk3s also loaded at the server
 		qboolean crazyServer = qfalse;
-		size_t len = 0;
+		size_t   len         = 0;
 
-		p = FS_LoadedPakNames();
+		p   = FS_LoadedPakNames();
 		len = strlen(p);
 
 		// if the maps listing takes more than half of the full buffer, then we just use the reference listings instead
@@ -869,7 +869,7 @@ void SV_SpawnServer(const char *server)
 		if (len > (BIG_INFO_STRING / 2))
 		{
 			crazyServer = qtrue;
-			p = FS_ReferencedPakNames();
+			p           = FS_ReferencedPakNames();
 			Com_Printf(S_COLOR_RED "WARNING: sv_pure set and the amount of pk3 files exceeds normally supported count, using reference values only\n");
 		}
 		else if (len == 0)
@@ -1109,10 +1109,6 @@ void SV_Init(void)
 	sv_allowDownload = Cvar_Get("sv_allowDownload", "1", CVAR_ARCHIVE);
 
 	sv_hidden = Cvar_GetAndDescribe("sv_hidden", "0", CVAR_ARCHIVE, "Hide the server from queries and from master servers.");
-
-	// master servers
-	Cvar_Get("sv_master1", "etmaster.idsoftware.com", CVAR_PROTECTED);
-	Cvar_Get("sv_master2", com_masterServer->string, CVAR_INIT);
 
 	sv_reconnectlimit = Cvar_Get("sv_reconnectlimit", "3", 0);
 	sv_tempbanmessage = Cvar_Get("sv_tempbanmessage", "You have been kicked and are temporarily banned from joining this server.", 0);


### PR DESCRIPTION
Certain `CVAR_INIT` cvars were initalized after etconfig.cfg was loaded, making it possible to set them in config rather than only via command line.