### PR TITLE
mod: fix vsays not working on Steam client, refs #34

### DIFF
--- a/src/cgame/cg_syscalls.c
+++ b/src/cgame/cg_syscalls.c
@@ -39,7 +39,7 @@ static intptr_t(QDECL * syscall)(intptr_t arg, ...) = (intptr_t(QDECL *)(intptr_
 /**
  * @brief dllEntry
  */
-Q_EXPORT void dllEntry(intptr_t(QDECL * syscallptr)(intptr_t arg, ...))
+Q_EXPORT void dllEntry(intptr_t(QDECL *syscallptr)(intptr_t arg, ...))
 {
 	syscall = syscallptr;
 }
@@ -815,7 +815,7 @@ void trap_R_AddPolysToScene(qhandle_t hShader, int numVerts, const polyVert_t *v
 void trap_R_AddLightToScene(const vec3_t org, float radius, float intensity, float r, float g, float b, qhandle_t hShader, int flags)
 {
 	SystemCall(CG_R_ADDLIGHTTOSCENE, org, PASSFLOAT(radius), PASSFLOAT(intensity),
-	        PASSFLOAT(r), PASSFLOAT(g), PASSFLOAT(b), hShader, flags);
+	           PASSFLOAT(r), PASSFLOAT(g), PASSFLOAT(b), hShader, flags);
 }
 
 /**
@@ -1588,14 +1588,8 @@ sfxHandle_t trap_S_RegisterSound(const char *sample, qboolean compressed)
 	CG_DrawInformation(qtrue);
 
 	// only allow compression for ETL clients, GPL source (aka Steam version) doesn't play nice with it
-	if (cg.etLegacyClient)
-	{
-		snd = SystemCall(CG_S_REGISTERSOUND, sample, compressed);
-	}
-	else
-	{
-		snd = SystemCall(CG_S_REGISTERSOUND, sample, qfalse);
-	}
+	snd = SystemCall(CG_S_REGISTERSOUND, sample, cg.etLegacyClient ? compressed : qfalse);
+
 	if (!sample || !sample[0])
 	{
 		Com_Printf("^1trap_S_RegisterSound: Null sample filename\n");
@@ -1772,6 +1766,7 @@ void trap_R_LoadWorldMap(const char *mapname)
 sfxHandle_t trap_S_RegisterSound(const char *sample, qboolean compressed)
 {
 	CG_DrawInformation(qtrue);
+	// only allow compression for ETL clients, GPL source (aka Steam version) doesn't play nice with it
 	return SystemCall(CG_S_REGISTERSOUND, sample, cg.etLegacyClient ? compressed : qfalse);
 }
 

--- a/src/cgame/cg_syscalls.c
+++ b/src/cgame/cg_syscalls.c
@@ -1586,7 +1586,16 @@ sfxHandle_t trap_S_RegisterSound(const char *sample, qboolean compressed)
 	sfxHandle_t snd;
 	DEBUG_REGISTERPROFILE_INIT
 	CG_DrawInformation(qtrue);
-	snd = SystemCall(CG_S_REGISTERSOUND, sample, compressed);
+
+	// only allow compression for ETL clients, GPL source (aka Steam versiion) doesn't play nice with it
+	if (cg.etLegacyClient)
+	{
+		snd = SystemCall(CG_S_REGISTERSOUND, sample, compressed);
+	}
+	else
+	{
+		snd = SystemCall(CG_S_REGISTERSOUND, sample, qfalse);
+	}
 	if (!sample || !sample[0])
 	{
 		Com_Printf("^1trap_S_RegisterSound: Null sample filename\n");
@@ -1763,7 +1772,7 @@ void trap_R_LoadWorldMap(const char *mapname)
 sfxHandle_t trap_S_RegisterSound(const char *sample, qboolean compressed)
 {
 	CG_DrawInformation(qtrue);
-	return SystemCall(CG_S_REGISTERSOUND, sample, compressed);
+	return SystemCall(CG_S_REGISTERSOUND, sample, cg.etLegacyClient ? compressed : qfalse);
 }
 
 /**

--- a/src/cgame/cg_syscalls.c
+++ b/src/cgame/cg_syscalls.c
@@ -1587,7 +1587,7 @@ sfxHandle_t trap_S_RegisterSound(const char *sample, qboolean compressed)
 	DEBUG_REGISTERPROFILE_INIT
 	CG_DrawInformation(qtrue);
 
-	// only allow compression for ETL clients, GPL source (aka Steam versiion) doesn't play nice with it
+	// only allow compression for ETL clients, GPL source (aka Steam version) doesn't play nice with it
 	if (cg.etLegacyClient)
 	{
 		snd = SystemCall(CG_S_REGISTERSOUND, sample, compressed);

--- a/src/ui/ui_syscalls.c
+++ b/src/ui/ui_syscalls.c
@@ -517,7 +517,7 @@ void trap_S_StartLocalSound(sfxHandle_t sfx, int channelNum)
  */
 sfxHandle_t trap_S_RegisterSound(const char *sample, qboolean compressed)
 {
-	int i = SystemCall(UI_S_REGISTERSOUND, sample, compressed);
+	int i = SystemCall(UI_S_REGISTERSOUND, sample, uiInfo.etLegacyClient ? compressed : qfalse);
 
 #ifdef ETLEGACY_DEBUG
 	if (i == 0)

--- a/src/ui/ui_syscalls.c
+++ b/src/ui/ui_syscalls.c
@@ -39,7 +39,7 @@ static intptr_t(QDECL * syscall)(intptr_t arg, ...) = (intptr_t(QDECL *)(intptr_
 /**
  * @brief dllEntry
  */
-Q_EXPORT void dllEntry(intptr_t(QDECL * syscallptr)(intptr_t arg, ...))
+Q_EXPORT void dllEntry(intptr_t(QDECL *syscallptr)(intptr_t arg, ...))
 {
 	syscall = syscallptr;
 }
@@ -385,7 +385,7 @@ void trap_R_AddPolyToScene(qhandle_t hShader, int numVerts, const polyVert_t *ve
 void trap_R_AddLightToScene(const vec3_t org, float radius, float intensity, float r, float g, float b, qhandle_t hShader, int flags)
 {
 	SystemCall(UI_R_ADDLIGHTTOSCENE, org, PASSFLOAT(radius), PASSFLOAT(intensity),
-	        PASSFLOAT(r), PASSFLOAT(g), PASSFLOAT(b), hShader, flags);
+	           PASSFLOAT(r), PASSFLOAT(g), PASSFLOAT(b), hShader, flags);
 }
 
 /**
@@ -517,6 +517,7 @@ void trap_S_StartLocalSound(sfxHandle_t sfx, int channelNum)
  */
 sfxHandle_t trap_S_RegisterSound(const char *sample, qboolean compressed)
 {
+	// only allow compression for ETL clients, GPL source (aka Steam version) doesn't play nice with it
 	int i = SystemCall(UI_S_REGISTERSOUND, sample, uiInfo.etLegacyClient ? compressed : qfalse);
 
 #ifdef ETLEGACY_DEBUG


### PR DESCRIPTION
GPL source (Steam version) does not work properly with compressed sound formats, so force it off for non-ETL clients like other mods do.