### PR TITLE
game: fix prone collision (stuck in walls/going through walls), refs #1208 #1921

### DIFF
--- a/src/game/g_active.c
+++ b/src/game/g_active.c
@@ -1392,6 +1392,8 @@ void ClientThink_real(gentity_t *ent)
 	pm.noWeapClips = qfalse;
 
 	VectorCopy(client->ps.origin, client->oldOrigin);
+	VectorCopy(ent->r.mins, pm.mins);
+	VectorCopy(ent->r.maxs, pm.maxs);
 
 	pm.gametype           = g_gametype.integer;
 	pm.ltChargeTime       = level.fieldopsChargeTime[client->sess.sessionTeam - 1];


### PR DESCRIPTION
Afaik vanilla issue is that (at least one part) during `PM_UpdateViewAngles` there are traces for just legs which would make body BBox enter into solid in some occasions. This was party fixed in legacy by also tracing for body BBox by using `PM_TraceAll` instead. But the `mins` and `maxs` were still not set properly server side (in pmove it is done after `PM_UpdateViewAngles`). Client side it is kept from frame to frame in `cg_pmove`.

refs #1208, #1921