### PR TITLE
mod: extend g_pronedelay with prone delay after jump, fixes #1755

### DIFF
--- a/etmain/configs/legacy1.config
+++ b/etmain/configs/legacy1.config
@@ -125,7 +125,7 @@ init
 	setl g_fixedphysicsfps "125"
 	setl g_campaignfile ""
 
-	setl g_pronedelay "1"
+	setl g_pronedelay "3"
 
 	// set this to disable wolfadmin or enable custom Lua files
 	//setl lua_modules ""

--- a/etmain/configs/legacy3.config
+++ b/etmain/configs/legacy3.config
@@ -126,7 +126,7 @@ init
 	setl g_fixedphysicsfps "125"
 	setl g_campaignfile ""
 
-	setl g_pronedelay "1"
+	setl g_pronedelay "3"
 
 	// set this to disable wolfadmin or enable custom Lua files
 	//setl lua_modules ""

--- a/etmain/configs/legacy5.config
+++ b/etmain/configs/legacy5.config
@@ -125,7 +125,7 @@ init
 	setl g_fixedphysicsfps "125"
 	setl g_campaignfile ""
 
-	setl g_pronedelay "1"
+	setl g_pronedelay "3"
 
 	// set this to disable wolfadmin or enable custom Lua files
 	//setl lua_modules ""

--- a/etmain/configs/legacy6.config
+++ b/etmain/configs/legacy6.config
@@ -125,7 +125,7 @@ init
 	setl g_fixedphysicsfps "125"
 	setl g_campaignfile ""
 
-	setl g_pronedelay "1"
+	setl g_pronedelay "3"
 
 	// set this to disable wolfadmin or enable custom Lua files
 	//setl lua_modules ""


### PR DESCRIPTION
Extending `g_pronedelay` with value 2 - don't allow prone for 850ms after jumping. Enabled by default on comp configs.

The value is now a bitmask, meaning you can enable/disable the general delay between prones and prone jump delay seperately.