### PR TITLE
cgame: clear medic/ammo request voicesprites on respawn

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -3416,6 +3416,7 @@ void CG_parseWeaponStats_cmd(void(txt_dump) (const char *));
 //void CG_scores_cmd(void);
 
 void CG_UpdateSvCvars(void);
+void CG_ResetVoiceSprites(qboolean revived);
 
 /**
  * @struct consoleCommand_t

--- a/src/cgame/cg_playerstate.c
+++ b/src/cgame/cg_playerstate.c
@@ -229,6 +229,9 @@ void CG_Respawn(qboolean revived)
 			oldTeam = cgs.clientinfo[cg.clientNum].team;
 		}
 	}
+
+	// clear medic/ammo request voice chat sprites
+	CG_ResetVoiceSprites(revived);
 }
 
 /**

--- a/src/cgame/cg_servercmds.c
+++ b/src/cgame/cg_servercmds.c
@@ -542,7 +542,7 @@ void CG_ParseServerToggles(void)
 	const char *info;
 	int        value;
 
-	info = CG_ConfigString(CS_SERVERTOGGLES);
+	info  = CG_ConfigString(CS_SERVERTOGGLES);
 	value = Q_atoi(info);
 
 	cgs.matchPaused = (value & CV_SVS_PAUSE) ? qtrue : qfalse;
@@ -1898,6 +1898,26 @@ void CG_VoiceChat(int mode)
 	cmd = CG_Argv(4);
 
 	CG_VoiceChatLocal(mode, voiceOnly, clientNum, color, cmd, origin);
+}
+
+/**
+ * @brief CG_ResetVoiceSprites
+ * @param[in] revived
+ */
+void CG_ResetVoiceSprites(qboolean revived)
+{
+	if (!revived)
+	{
+		if (cg.predictedPlayerEntity.voiceChatSprite == cgs.media.ammoIcon)
+		{
+			cg.predictedPlayerEntity.voiceChatSpriteTime = 0;
+		}
+	}
+
+	if (cg.predictedPlayerEntity.voiceChatSprite == cgs.media.medicIcon)
+	{
+		cg.predictedPlayerEntity.voiceChatSpriteTime = 0;
+	}
 }
 
 /**


### PR DESCRIPTION
Reset voicechat sprite time on respawn if current voice chat sprite is medic/ammo request sprite. Medic sprite will always be cleared, but ammo sprite won't be if player gets revived.