### PR TITLE
cgame: fix incorrect timings for voice chat sprites, refs #1274

### DIFF
--- a/src/cgame/cg_servercmds.c
+++ b/src/cgame/cg_servercmds.c
@@ -1723,26 +1723,26 @@ void CG_PlayVoiceChat(bufferedVoiceChat_t *vchat)
 			if (vchat->clientNum == cg.snap->ps.clientNum)
 			{
 				cg.predictedPlayerEntity.voiceChatSprite = vchat->sprite;
-				if (vchat->sprite == cgs.media.voiceChatShader)
+				if (vchat->sprite == cgs.media.medicIcon || vchat->sprite == cgs.media.ammoIcon)
 				{
-					cg.predictedPlayerEntity.voiceChatSpriteTime = cg.time + cg_voiceSpriteTime.integer;
+					cg.predictedPlayerEntity.voiceChatSpriteTime = cg.time + cg_voiceSpriteTime.integer * 2;
 				}
 				else
 				{
-					cg.predictedPlayerEntity.voiceChatSpriteTime = cg.time + cg_voiceSpriteTime.integer * 2;
+					cg.predictedPlayerEntity.voiceChatSpriteTime = cg.time + cg_voiceSpriteTime.integer;
 				}
 			}
 			else
 			{
 				cg_entities[vchat->clientNum].voiceChatSprite = vchat->sprite;
 				VectorCopy(vchat->origin, cg_entities[vchat->clientNum].lerpOrigin);
-				if (vchat->sprite == cgs.media.voiceChatShader)
+				if (vchat->sprite == cgs.media.medicIcon || vchat->sprite == cgs.media.ammoIcon)
 				{
-					cg_entities[vchat->clientNum].voiceChatSpriteTime = cg.time + cg_voiceSpriteTime.integer;
+					cg_entities[vchat->clientNum].voiceChatSpriteTime = cg.time + cg_voiceSpriteTime.integer * 2;
 				}
 				else
 				{
-					cg_entities[vchat->clientNum].voiceChatSpriteTime = cg.time + cg_voiceSpriteTime.integer * 2;
+					cg_entities[vchat->clientNum].voiceChatSpriteTime = cg.time + cg_voiceSpriteTime.integer;
 				}
 			}
 		}


### PR DESCRIPTION
This code originally made it so that medic/ammo request voice sprites would stay for twice as long as regular voice chat sprite. VET only had these 3 voice chat sprites, but now since we have more, all the new ones we've added would stay for the extended duration as well.