### PR TITLE
server: add sv_serverTimeReset cvar, refs #1098, #1507

### DIFF
--- a/src/server/server.h
+++ b/src/server/server.h
@@ -487,6 +487,8 @@ extern cvar_t *sv_demoTolerant;
 
 extern cvar_t *sv_ipMaxClients; ///< limit client connection
 
+extern cvar_t *sv_serverTimeReset;
+
 //===========================================================
 
 // sv_demo.c

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -777,6 +777,11 @@ void SV_SpawnServer(const char *server)
 	// to load during actual gameplay
 	sv.state = SS_LOADING;
 
+	if (sv_serverTimeReset->integer)
+	{
+		svs.time = 0;
+	}
+
 	// load and spawn all other entities
 	SV_InitGameProgs();
 
@@ -1177,6 +1182,8 @@ void SV_Init(void)
 	svs.serverLoad = -1;
 
 	sv_ipMaxClients = Cvar_Get("sv_ipMaxClients", "0", CVAR_ARCHIVE);
+
+	sv_serverTimeReset = Cvar_GetAndDescribe("sv_serverTimeReset", "0", CVAR_ARCHIVE_ND, "Reset server time on map change.");
 
 #if defined(FEATURE_IRC_SERVER) && defined(DEDICATED)
 	IRC_Init();

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -117,6 +117,8 @@ cvar_t *sv_demoTolerant;
 
 cvar_t *sv_ipMaxClients;
 
+cvar_t *sv_serverTimeReset;
+
 static void SVC_Status(netadr_t from, qboolean force);
 
 /*


### PR DESCRIPTION
When enabled server time (and as consequence `level.time`) will be reset on map change to 0.

refs #1098, #1507