### PR TITLE
engine: fixes VM entry point for Apple Silicon processors (macOS)

### DIFF
--- a/src/qcommon/qcommon.h
+++ b/src/qcommon/qcommon.h
@@ -534,6 +534,8 @@ static ID_INLINE float _vmf(intptr_t x)
 }
 #define VMF(x)  _vmf(args[x])
 
+typedef intptr_t (QDECL *VM_EntryPoint_t)( int, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t );
+
 /*
 ==============================================================
 CMD - Command text buffering and command execution

--- a/src/qcommon/vm_local.h
+++ b/src/qcommon/vm_local.h
@@ -168,7 +168,7 @@ struct vm_s
 
 	// for dynamic linked modules
 	void *dllHandle;
-	intptr_t(QDECL * entryPoint)(int callNum, ...);
+	VM_EntryPoint_t entryPoint;
 
 	// for interpreted modules
 	qboolean currentlyInterpreting;

--- a/src/sys/sys_local.h
+++ b/src/sys/sys_local.h
@@ -79,7 +79,10 @@ void Sys_ErrorDialog(const char *error);
 void Sys_AnsiColorPrint(const char *msg);
 
 void *Sys_LoadDll(const char *name, qboolean useSystemLib);
-void *Sys_LoadGameDll(const char *name, qboolean extract, intptr_t(**entryPoint) (int, ...), intptr_t (*systemcalls)(intptr_t, ...));
+// NOTE: arm64 mac has a different calling convention for fixed parameters vs. variadic parameters.
+//       As the module entryPoints (vmMain) in jk2 use fixed arg0 to arg11 we can't use "..." around here or we end up with undefined behavior.
+//       See: https://developer.apple.com/documentation/apple-silicon/addressing-architectural-differences-in-your-macos-code
+void *Sys_LoadGameDll(const char *name, qboolean extract, VM_EntryPoint_t *entryPoint, intptr_t (*systemcalls)(intptr_t, ...));
 void Sys_UnloadDll(void *dllHandle);
 void Sys_ParseArgs(int argc, char **argv);
 void Sys_BuildCommandLine(int argc, char **argv, char *buffer, size_t bufferSize);

--- a/src/sys/sys_main.c
+++ b/src/sys/sys_main.c
@@ -772,7 +772,7 @@ static void *Sys_TryLibraryLoad(const char *base, const char *gamedir, const cha
  * @return libHandle or NULL
  */
 void *Sys_LoadGameDll(const char *name, qboolean extract,
-                      intptr_t(**entryPoint) (int, ...),
+                      VM_EntryPoint_t *entryPoint,
                       intptr_t (*systemcalls)(intptr_t, ...))
 {
 	void *libHandle;
@@ -882,7 +882,7 @@ void *Sys_LoadGameDll(const char *name, qboolean extract,
 	}
 
 	dllEntry    = (void(QDECL *)(intptr_t(QDECL *)(intptr_t, ...)))Sys_LoadFunction(libHandle, "dllEntry");
-	*entryPoint = (intptr_t(QDECL *)(int, ...))Sys_LoadFunction(libHandle, "vmMain");
+	*entryPoint = (VM_EntryPoint_t)Sys_LoadFunction(libHandle, "vmMain");
 
 	if (!*entryPoint || !dllEntry)
 	{


### PR DESCRIPTION
Allows for VMs to load on M1, changing from variadic to fixed parameters due to architecture differences. Based on a similar change by Daggolin to another id Tech 3 project.

https://github.com/Daggolin/jk2mv/commit/7f9218fcd848c7321a21e3136943526869a6426b

https://developer.apple.com/documentation/apple-silicon/addressing-architectural-differences-in-your-macos-code

More probably needs to be done in order to overcome a pure server issue when connecting with an M1 client but this is a start. 