### PR TITLE
mod: fix demo rewind graphical and camera bugs, refs #696

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -3285,6 +3285,7 @@ void CG_InitLocalEntities(void);
 localEntity_t *CG_AllocLocalEntity(void);
 localEntity_t *CG_FindLocalEntity(int index, int sideNum);
 void CG_AddLocalEntities(void);
+void CG_DemoRewindFixLocalEntities(void);
 
 // cg_locations.c
 // these are called from the console command

--- a/src/cgame/cg_localents.c
+++ b/src/cgame/cg_localents.c
@@ -1401,3 +1401,24 @@ void CG_AddLocalEntities(void)
 		}
 	}
 }
+
+/**
+* @brief CG_DemoRewindFixLocalEntities fix local ents on demo rewind
+*/
+void CG_DemoRewindFixLocalEntities(void)
+{
+	localEntity_t *le, *next;
+
+	le = cg_activeLocalEntities.prev;
+
+	for (; le != &cg_activeLocalEntities; le = next)
+	{
+		next = le->prev;
+
+		if (le->startTime > cg.time || le->endTime <= cg.time)
+		{
+			CG_FreeLocalEntity(le);
+			continue;
+		}
+	}
+}

--- a/src/client/cl_demo.c
+++ b/src/client/cl_demo.c
@@ -377,7 +377,7 @@ alldone:
  */
 static void CL_DemoFastForward(double wantedTime)
 {
-	int loopCount;
+	int loopCount, cmd;
 
 	if (cls.state < CA_CONNECTED)
 	{
@@ -415,6 +415,7 @@ static void CL_DemoFastForward(double wantedTime)
 	DEMODEBUG("fastfowarding from %f to %f\n", (double)cl.serverTime + di.Overf, wantedTime);
 
 	loopCount = 0;
+	cmd       = clc.lastExecutedServerCommand;
 	while ((double)cl.snap.serverTime <= wantedTime)
 	{
 		DEMODEBUG("Servertime: %d wanted time %lf\n", cl.snap.serverTime, wantedTime);
@@ -437,6 +438,13 @@ static void CL_DemoFastForward(double wantedTime)
 			CL_GetServerCommand(clc.lastExecutedServerCommand + 1);
 		}
 		loopCount++;
+
+		// if we are about to go over command buffer let cgame execute them and then continue
+		if (cmd + MAX_RELIABLE_COMMANDS - 10 <= clc.lastExecutedServerCommand)
+		{
+			VM_Call(cgvm, CG_DRAW_ACTIVE_FRAME, cl.snap.serverTime, 0, clc.demo.playing);
+			cmd = clc.lastExecutedServerCommand;
+		}
 	}
 
 	DEMODEBUG("read %d demo messages, cl.snap.serverTime %d, wantedTime %f\n", loopCount, cl.snap.serverTime, wantedTime);
@@ -864,11 +872,11 @@ static void CL_ParseDemo(void)
 	Com_FuncPrinf("parse time %f seconds\n", (double)(Sys_Milliseconds() - tstart) / 1000.0);
 	(void) FS_Seek(clc.demo.file, 0, FS_SEEK_SET);
 	clc.demo.playing = qfalse;
-	demofile        = clc.demo.file;
+	demofile         = clc.demo.file;
 	CL_ClearState();
 	Com_Memset(&clc, 0, sizeof(clc));
 	Com_ClearDownload();
-	clc.demo.file        = demofile;
+	clc.demo.file            = demofile;
 	cls.state                = CA_DISCONNECTED;
 	cl_connectedToPureServer = qfalse;
 


### PR DESCRIPTION
1. This should fix the most annoying bugs with smoke/trails persisting on rewind and camera/animation glitches. 
2. Fast forwarding will correctly execute server commands which fixes gamestate not changing or players characters models being in opposite team/wrong class.
3. This does NOT fix rewinding breaking gamestate or players character models - server commands are still not properly replayed to correct state.

Most effects are simply deleted without checking if it is needed, so this is a bit lazy fix.

refs #696