### PR TITLE
fix #313 removes spread growth cap for mouse moves

### DIFF
--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -3082,10 +3082,6 @@ void PM_AdjustAimSpreadScale(void)
 		{
 			viewchange = 0;
 		}
-		else if (viewchange > (AIMSPREAD_VIEWRATE_RANGE / wpnScale))
-		{
-			viewchange = AIMSPREAD_VIEWRATE_RANGE / wpnScale;
-		}
 
 		// now give us a scale from 0.0 to 1.0 to apply the spread increase
 		viewchange = viewchange / (AIMSPREAD_VIEWRATE_RANGE / wpnScale);


### PR DESCRIPTION
Removes the cap on spread growth for rapid mouse movements and with the +left and +right commands.

This resolves issue #313 with FPS and mouse Hz and also stops an exploit where there is no spread growth when using a 180 turn script. Absolute maximum spread (255) is unchanged.

A side effect of this change is there is no longer an engine related advantage to making very fast mouse movements. Before this change, to control spread growth when playing, it was best to either move the mouse slowly or very quickly (to minimize the number of frames that the maximum amount of spread growth would be applied). There is still a general strategic benefit to moving quickly: the sooner you stop moving, the sooner your spread will settle.