### PR TITLE
cg_shadows 0 default for cvar and preset_normal.cfg

### DIFF
--- a/etmain/preset_normal.cfg
+++ b/etmain/preset_normal.cfg
@@ -9,7 +9,7 @@ seta r_ext_texture_filter_anisotropic 4
 seta r_ext_multisample 0
 seta r_dynamiclight 1
 seta r_fastSky 0
-seta cg_shadows 1
+seta cg_shadows 0
 seta cg_brassTime 2500
 seta r_texturemode GL_LINEAR_MIPMAP_NEAREST
 seta r_detailtextures 0

--- a/etmain/preset_normal_ui.cfg
+++ b/etmain/preset_normal_ui.cfg
@@ -9,7 +9,7 @@ seta ui_r_ext_texture_filter_anisotropic 4
 seta ui_r_ext_multisample 0
 seta ui_r_dynamiclight 1
 seta r_fastSky 0
-seta cg_shadows 1
+seta cg_shadows 0
 seta cg_brassTime 2500
 seta ui_r_texturemode GL_LINEAR_MIPMAP_NEAREST
 seta ui_r_detailtextures 0

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -419,7 +419,7 @@ static cvarTable_t cvarTable[] =
 	{ &cg_fov,                     "cg_fov",                     "90",          CVAR_ARCHIVE,                 0 },
 	{ &cg_muzzleFlash,             "cg_muzzleFlash",             "1",           CVAR_ARCHIVE,                 0 },
 	{ &cg_letterbox,               "cg_letterbox",               "0",           CVAR_TEMP,                    0 },
-	{ &cg_shadows,                 "cg_shadows",                 "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_shadows,                 "cg_shadows",                 "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_gibs,                    "cg_gibs",                    "1",           CVAR_ARCHIVE,                 0 },
 	// we now draw reticles always in non demoplayback
 	//  { &cg_draw2D, "cg_draw2D", "1", CVAR_CHEAT }, // JPW NERVE changed per atvi req to prevent sniper rifle zoom cheats

--- a/src/renderer/tr_init.c
+++ b/src/renderer/tr_init.c
@@ -1168,7 +1168,7 @@ void R_Register(void)
 	r_drawBuffer   = ri.Cvar_Get("r_drawBuffer", "GL_BACK", CVAR_CHEAT);
 	r_lockPvs      = ri.Cvar_Get("r_lockpvs", "0", CVAR_CHEAT);
 	r_noportals    = ri.Cvar_Get("r_noportals", "0", CVAR_CHEAT);
-	r_shadows      = ri.Cvar_Get("cg_shadows", "1", 0);
+	r_shadows      = ri.Cvar_Get("cg_shadows", "0", 0);
 
 	r_screenshotFormat      = ri.Cvar_Get("r_screenshotFormat", "2", CVAR_ARCHIVE_ND);
 	r_screenshotJpegQuality = ri.Cvar_Get("r_screenshotJpegQuality", "90", CVAR_ARCHIVE_ND);

--- a/src/rendererGLES/tr_init.c
+++ b/src/rendererGLES/tr_init.c
@@ -1120,7 +1120,7 @@ void R_Register(void)
 	r_drawBuffer   = ri.Cvar_Get("r_drawBuffer", "GL_BACK", CVAR_CHEAT);
 	r_lockPvs      = ri.Cvar_Get("r_lockpvs", "0", CVAR_CHEAT);
 	r_noportals    = ri.Cvar_Get("r_noportals", "0", CVAR_CHEAT);
-	r_shadows      = ri.Cvar_Get("cg_shadows", "1", 0);
+	r_shadows      = ri.Cvar_Get("cg_shadows", "0", 0);
 
 	r_screenshotFormat      = ri.Cvar_Get("r_screenshotFormat", "2", CVAR_ARCHIVE_ND);
 	r_screenshotJpegQuality = ri.Cvar_Get("r_screenshotJpegQuality", "90", CVAR_ARCHIVE_ND);

--- a/src/ui/ui_main.c
+++ b/src/ui/ui_main.c
@@ -4619,7 +4619,7 @@ void UI_ParseglPreset()
 	         (int)trap_Cvar_VariableValue("ui_r_ext_multisample") == 0 &&
 	         (int)trap_Cvar_VariableValue("ui_r_dynamiclight") == 1 &&
 	         (int)trap_Cvar_VariableValue("r_fastSky") == 0 &&
-	         (int)trap_Cvar_VariableValue("cg_shadows") == 1 &&
+	         (int)trap_Cvar_VariableValue("cg_shadows") == 0 &&
 	         (int)trap_Cvar_VariableValue("cg_brasstime") == 2500 &&
 	         (int)trap_Cvar_VariableValue("ui_r_detailtextures") == 0 &&
 	         (Q_stricmp(UI_Cvar_VariableString("ui_r_texturemode"), "GL_LINEAR_MIPMAP_NEAREST") == 0))


### PR DESCRIPTION
Provides a small to moderate FPS boost to players depending on client hardware. Changes the default config, ui menus, and renderer to cg_shadows 0. The high quality preset still uses cg_shadows 1. 