### PR TITLE
Allow changing `cg_swingSpeed` when cheats are disabled

### DIFF
--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -461,7 +461,7 @@ static cvarTable_t cvarTable[] =
 	{ &cg_autoactivate,            "cg_autoactivate",            "1",           CVAR_ARCHIVE,                 0 },
 
 	// more fluid rotations
-	{ &cg_swingSpeed,              "cg_swingSpeed",              "0.1",         CVAR_CHEAT,                   0 }, // was 0.3 for Q3
+	{ &cg_swingSpeed,              "cg_swingSpeed",              "0.1",         CVAR_ARCHIVE,                 0 }, // was 0.3 for Q3
 	{ &cg_bloodTime,               "cg_bloodTime",               "120",         CVAR_ARCHIVE,                 0 },
 
 	{ &cg_skybox,                  "cg_skybox",                  "1",           CVAR_ARCHIVE,                 0 },

--- a/src/cgame/cg_players.c
+++ b/src/cgame/cg_players.c
@@ -1745,6 +1745,7 @@ static void CG_PlayerAngles(centity_t *cent, vec3_t legs[3], vec3_t torso[3], ve
 	else
 	{
 		float clampTolerance;
+		float swingSpeed = Com_Clamp(0.1f, 0.3f, cg_swingSpeed.value);
 
 		legsAngles[YAW] = headAngles[YAW] + cent->currentState.angles2[YAW];
 
@@ -1762,7 +1763,7 @@ static void CG_PlayerAngles(centity_t *cent, vec3_t legs[3], vec3_t torso[3], ve
 		}
 
 		// torso
-		CG_SwingAngles(torsoAngles[YAW], 25, clampTolerance, cg_swingSpeed.value, &cent->pe.torso.yawAngle, &cent->pe.torso.yawing);
+		CG_SwingAngles(torsoAngles[YAW], 25, clampTolerance, swingSpeed, &cent->pe.torso.yawAngle, &cent->pe.torso.yawing);
 
 		// if the legs are yawing (facing heading direction), allow them to rotate a bit, so we don't keep calling
 		// the legs_turn animation while an AI is firing, and therefore his angles will be randomizing according to their accuracy
@@ -1772,7 +1773,7 @@ static void CG_PlayerAngles(centity_t *cent, vec3_t legs[3], vec3_t torso[3], ve
 		if (BG_GetConditionBitFlag(ci->clientNum, ANIM_COND_MOVETYPE, ANIM_MT_IDLE))
 		{
 			cent->pe.legs.yawing = qfalse; // set it if they really need to swing
-			CG_SwingAngles(legsAngles[YAW], 20, clampTolerance, 0.5f * cg_swingSpeed.value, &cent->pe.legs.yawAngle, &cent->pe.legs.yawing);
+			CG_SwingAngles(legsAngles[YAW], 20, clampTolerance, 0.5f * swingSpeed, &cent->pe.legs.yawAngle, &cent->pe.legs.yawing);
 		}
 		else if (strstr(BG_GetAnimString(character->animModelInfo, legsSet), "strafe"))
 		{
@@ -1780,15 +1781,15 @@ static void CG_PlayerAngles(centity_t *cent, vec3_t legs[3], vec3_t torso[3], ve
 			//if    ( BG_GetConditionValue( ci->clientNum, ANIM_COND_MOVETYPE, qfalse ) & ((1<<ANIM_MT_STRAFERIGHT)|(1<<ANIM_MT_STRAFELEFT)) )
 			cent->pe.legs.yawing = qfalse; // set it if they really need to swing
 			legsAngles[YAW]      = headAngles[YAW];
-			CG_SwingAngles(legsAngles[YAW], 0, clampTolerance, cg_swingSpeed.value, &cent->pe.legs.yawAngle, &cent->pe.legs.yawing);
+			CG_SwingAngles(legsAngles[YAW], 0, clampTolerance, swingSpeed, &cent->pe.legs.yawAngle, &cent->pe.legs.yawing);
 		}
 		else if (cent->pe.legs.yawing)
 		{
-			CG_SwingAngles(legsAngles[YAW], 0, clampTolerance, cg_swingSpeed.value, &cent->pe.legs.yawAngle, &cent->pe.legs.yawing);
+			CG_SwingAngles(legsAngles[YAW], 0, clampTolerance, swingSpeed, &cent->pe.legs.yawAngle, &cent->pe.legs.yawing);
 		}
 		else
 		{
-			CG_SwingAngles(legsAngles[YAW], 40, clampTolerance, cg_swingSpeed.value, &cent->pe.legs.yawAngle, &cent->pe.legs.yawing);
+			CG_SwingAngles(legsAngles[YAW], 40, clampTolerance, swingSpeed, &cent->pe.legs.yawAngle, &cent->pe.legs.yawing);
 		}
 
 		torsoAngles[YAW] = cent->pe.torso.yawAngle;


### PR DESCRIPTION
**Note:** Untested, since I don't have a local buildsystem setup.

This can be used to adjust how fast third-person player animations adjust to players' direction and rotation changes.

The value can be adjusted between 0.1 and 0.3. 0.1 remains the default value (same as vanilla ET and RTCW), while 0.3 is the value used in Q3A.

This closes https://github.com/etlegacy/etlegacy/issues/1992.