### PR TITLE
allows per pixel crosshair position adjustment

### DIFF
--- a/src/cgame/cg_camera.c
+++ b/src/cgame/cg_camera.c
@@ -284,11 +284,12 @@ void CG_CameraEditorDraw(void)
 		                  0, 0, ITEM_TEXTSTYLE_SHADOWED, &cgs.media.limboFont2);
 
 		// render crosshair
-		x = cg_crosshairX.value;
-		y = cg_crosshairY.value;
+		x = y = 0;
 		w = h = cg_crosshairSize.value;
 
 		CG_AdjustFrom640(&x, &y, &w, &h);
+		x = cg_crosshairX.value;
+		y = cg_crosshairY.value;
 
 		trap_R_DrawStretchPic(x + 0.5f * (cg.refdef_current->width - w),
 		                      y + 0.5f * (cg.refdef_current->height - h),

--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -1725,9 +1725,10 @@ static void CG_DrawCrosshair(void)
 	w *= (1 + f * 2.0f);
 	h *= (1 + f * 2.0f);
 
+	x = y = 0;
+	CG_AdjustFrom640(&x, &y, &w, &h);
 	x = cg_crosshairX.integer;
 	y = cg_crosshairY.integer;
-	CG_AdjustFrom640(&x, &y, &w, &h);
 
 	hShader = cgs.media.crosshairShader[cg_drawCrosshair.integer % NUM_CROSSHAIRS];
 
@@ -1736,9 +1737,10 @@ static void CG_DrawCrosshair(void)
 	if (cg.crosshairShaderAlt[cg_drawCrosshair.integer % NUM_CROSSHAIRS])
 	{
 		w = h = cg_crosshairSize.value;
+		x = y = 0;
+		CG_AdjustFrom640(&x, &y, &w, &h);
 		x = cg_crosshairX.integer;
 		y = cg_crosshairY.integer;
-		CG_AdjustFrom640(&x, &y, &w, &h);
 
 		if (cg_crosshairHealth.integer == 0)
 		{

--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -1727,8 +1727,8 @@ static void CG_DrawCrosshair(void)
 
 	x = y = 0;
 	CG_AdjustFrom640(&x, &y, &w, &h);
-	x = cg_crosshairX.integer;
-	y = cg_crosshairY.integer;
+	x = cg_crosshairX.value;
+	y = cg_crosshairY.value;
 
 	hShader = cgs.media.crosshairShader[cg_drawCrosshair.integer % NUM_CROSSHAIRS];
 
@@ -1739,8 +1739,8 @@ static void CG_DrawCrosshair(void)
 		w = h = cg_crosshairSize.value;
 		x = y = 0;
 		CG_AdjustFrom640(&x, &y, &w, &h);
-		x = cg_crosshairX.integer;
-		y = cg_crosshairY.integer;
+		x = cg_crosshairX.value;
+		y = cg_crosshairY.value;
 
 		if (cg_crosshairHealth.integer == 0)
 		{


### PR DESCRIPTION
Currently the effect size of changing cg_crosshairX and cg_crosshairY depends on the client resolution and per pixel adjustments are not possible on higher resolutions.

This patch moves the translational transform to after CG_AdjustFrom640 so that cg_crosshair<X|Y> behaves consistently and allows single pixel adjustments at all resolutions.