### PR TITLE
game: don't hide stats after 2nd round of SW, refs #1177

### DIFF
--- a/src/game/g_match.c
+++ b/src/game/g_match.c
@@ -510,7 +510,7 @@ char *G_createStats(gentity_t *ent)
 	// workaround to always hide previous map stats in warmup
 	// Stats will be cleared correctly when the match actually starts
 	if ((g_gamestate.integer == GS_WARMUP || g_gamestate.integer == GS_WARMUP_COUNTDOWN) &&
-	    !(g_gametype.integer == GT_WOLF_STOPWATCH && g_currentRound.integer == 1))
+	    !(g_gametype.integer == GT_WOLF_STOPWATCH))
 	{
 		dwWeaponMask     = 0;
 		strWeapInfo[0]   = '\0';


### PR DESCRIPTION
Many people like to look at their stats after a match of stopwatch has been played, but the stats are currently hidden unless we're on the warmup of second round. They will now only reset once a new match is started, so players can have a look at their stats with `+stats` from previous match all the way up until a new game is started. This workaround to hide stats display before they are actually properly reset is now done only for other game modes.