### PR TITLE
mod: allow loading loose ttf/otf fonts in pure mode

### DIFF
--- a/src/cgame/cg_loadpanel.c
+++ b/src/cgame/cg_loadpanel.c
@@ -299,10 +299,14 @@ void CG_DrawConnectScreen(qboolean interactive, qboolean forcerefresh)
 
 	if (!bg_loadscreeninited)
 	{
+		char *font1, *font2;
 		trap_Cvar_Set("ui_connecting", "0");
 
-		RegisterFont("ariblk", 27, &cgs.media.bg_loadscreenfont1);
-		RegisterFont("courbd", 30, &cgs.media.bg_loadscreenfont2);
+		font1 = com_customFont1.string[0] != '\0' ? com_customFont1.string : "ariblk";
+		font2 = com_customFont2.string[0] != '\0' ? com_customFont2.string : "courbd";
+
+		RegisterFont(font1, 27, &cgs.media.bg_loadscreenfont1);
+		RegisterFont(font2, 30, &cgs.media.bg_loadscreenfont2);
 
 		bg_axispin    = DC->registerShaderNoMip("gfx/loading/pin_axis");
 		bg_alliedpin  = DC->registerShaderNoMip("gfx/loading/pin_allied");

--- a/src/cgame/cg_loadpanel.c
+++ b/src/cgame/cg_loadpanel.c
@@ -299,14 +299,11 @@ void CG_DrawConnectScreen(qboolean interactive, qboolean forcerefresh)
 
 	if (!bg_loadscreeninited)
 	{
-		char *font1, *font2;
 		trap_Cvar_Set("ui_connecting", "0");
 
-		font1 = cg_customFont1.string[0] != '\0' ? cg_customFont1.string : "ariblk";
-		font2 = cg_customFont2.string[0] != '\0' ? cg_customFont2.string : "courbd";
-
-		RegisterFont(font1, 27, &cgs.media.bg_loadscreenfont1);
-		RegisterFont(font2, 30, &cgs.media.bg_loadscreenfont2);
+		RegisterSharedFonts();
+		cgs.media.bg_loadscreenfont1 = cgDC.Assets.bg_loadscreenfont1;
+		cgs.media.bg_loadscreenfont2 = cgDC.Assets.bg_loadscreenfont2;
 
 		bg_axispin    = DC->registerShaderNoMip("gfx/loading/pin_axis");
 		bg_alliedpin  = DC->registerShaderNoMip("gfx/loading/pin_allied");

--- a/src/cgame/cg_loadpanel.c
+++ b/src/cgame/cg_loadpanel.c
@@ -302,8 +302,8 @@ void CG_DrawConnectScreen(qboolean interactive, qboolean forcerefresh)
 		char *font1, *font2;
 		trap_Cvar_Set("ui_connecting", "0");
 
-		font1 = com_customFont1.string[0] != '\0' ? com_customFont1.string : "ariblk";
-		font2 = com_customFont2.string[0] != '\0' ? com_customFont2.string : "courbd";
+		font1 = cg_customFont1.string[0] != '\0' ? cg_customFont1.string : "ariblk";
+		font2 = cg_customFont2.string[0] != '\0' ? cg_customFont2.string : "courbd";
 
 		RegisterFont(font1, 27, &cgs.media.bg_loadscreenfont1);
 		RegisterFont(font2, 30, &cgs.media.bg_loadscreenfont2);

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2896,6 +2896,9 @@ extern vmCvar_t cg_healthDynamicColor;
 
 extern vmCvar_t cg_drawBreathPuffs;
 
+extern vmCvar_t com_customFont1;
+extern vmCvar_t com_customFont2;
+
 // local clock flags
 #define LOCALTIME_ON                0x01
 #define LOCALTIME_SECOND            0x02

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2896,8 +2896,8 @@ extern vmCvar_t cg_healthDynamicColor;
 
 extern vmCvar_t cg_drawBreathPuffs;
 
-extern vmCvar_t com_customFont1;
-extern vmCvar_t com_customFont2;
+extern vmCvar_t cg_customFont1;
+extern vmCvar_t cg_customFont2;
 
 // local clock flags
 #define LOCALTIME_ON                0x01

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -398,6 +398,9 @@ vmCvar_t cg_healthDynamicColor;
 
 vmCvar_t cg_drawBreathPuffs;
 
+vmCvar_t com_customFont1;
+vmCvar_t com_customFont2;
+
 typedef struct
 {
 	vmCvar_t *vmCvar;
@@ -693,6 +696,9 @@ static cvarTable_t cvarTable[] =
 	{ &cg_healthDynamicColor,      "cg_healthDynamicColor",      "0",           CVAR_ARCHIVE,                 0 },
 
 	{ &cg_drawBreathPuffs,         "cg_drawBreathPuffs",         "1",           CVAR_ARCHIVE,                 0 },
+
+	{ &com_customFont1,            "com_customFont1",            "",            0,                            0 },
+	{ &com_customFont2,            "com_customFont2",            "",            0,                            0 },
 };
 
 static const unsigned int cvarTableSize = sizeof(cvarTable) / sizeof(cvarTable[0]);
@@ -1606,6 +1612,7 @@ static void CG_RegisterGraphics(void)
 		"gfx/2d/numbers/nine_32b",
 		"gfx/2d/numbers/minus_32b",
 	};
+	char *font1, *font2;
 
 	CG_LoadingString(va(" - %s -", cgs.mapname));
 
@@ -2135,10 +2142,13 @@ static void CG_RegisterGraphics(void)
 	cgs.media.medicIcon = trap_R_RegisterShaderNoMip("sprites/voiceMedic");
 	cgs.media.ammoIcon  = trap_R_RegisterShaderNoMip("sprites/voiceAmmo");
 
-	RegisterFont("ariblk", 27, &cgs.media.limboFont1);
-	RegisterFont("ariblk", 16, &cgs.media.limboFont1_lo);
-	RegisterFont("courbd", 30, &cgs.media.limboFont2);
-	RegisterFont("courbd", 21, &cgs.media.limboFont2_lo);
+	font1 = com_customFont1.string[0] != '\0' ? com_customFont1.string : "ariblk";
+	font2 = com_customFont2.string[0] != '\0' ? com_customFont2.string : "courbd";
+
+	RegisterFont(font1, 27, &cgs.media.limboFont1);
+	RegisterFont(font1, 16, &cgs.media.limboFont1_lo);
+	RegisterFont(font2, 30, &cgs.media.limboFont2);
+	RegisterFont(font2, 21, &cgs.media.limboFont2_lo);
 
 	cgs.media.medal_back = trap_R_RegisterShaderNoMip("gfx/limbo/medal_back");
 

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -398,8 +398,8 @@ vmCvar_t cg_healthDynamicColor;
 
 vmCvar_t cg_drawBreathPuffs;
 
-vmCvar_t com_customFont1;
-vmCvar_t com_customFont2;
+vmCvar_t cg_customFont1;
+vmCvar_t cg_customFont2;
 
 typedef struct
 {
@@ -696,9 +696,6 @@ static cvarTable_t cvarTable[] =
 	{ &cg_healthDynamicColor,      "cg_healthDynamicColor",      "0",           CVAR_ARCHIVE,                 0 },
 
 	{ &cg_drawBreathPuffs,         "cg_drawBreathPuffs",         "1",           CVAR_ARCHIVE,                 0 },
-
-	{ &com_customFont1,            "com_customFont1",            "",            0,                            0 },
-	{ &com_customFont2,            "com_customFont2",            "",            0,                            0 },
 };
 
 static const unsigned int cvarTableSize = sizeof(cvarTable) / sizeof(cvarTable[0]);
@@ -717,6 +714,13 @@ void CG_RegisterCvars(void)
 	CG_Printf("%d client cvars in use\n", cvarTableSize);
 
 	trap_Cvar_Set("cg_letterbox", "0");   // force this for people who might have it in their cfg
+
+	// custom fonts, register here since these are ETL-specific features
+	if (cg.etLegacyClient)
+	{
+		trap_Cvar_Register(&cg_customFont1, "cg_customFont1", "", CVAR_ARCHIVE);
+		trap_Cvar_Register(&cg_customFont2, "cg_customFont2", "", CVAR_ARCHIVE);
+	}
 
 	for (i = 0, cv = cvarTable ; i < cvarTableSize ; i++, cv++)
 	{
@@ -820,6 +824,32 @@ void CG_UpdateCvars(void)
 					}
 				}
 			}
+		}
+	}
+
+	if (cg.etLegacyClient)
+	{
+		static int cg_customFont1_lastMod = 1;
+		static int cg_customFont2_lastMod = 1;
+
+		trap_Cvar_Update(&cg_customFont1);
+		trap_Cvar_Update(&cg_customFont2);
+
+		if (cg_customFont1.modificationCount != cg_customFont1_lastMod)
+		{
+			char *font = cg_customFont1.string[0] != '\0' ? cg_customFont1.string : "ariblk";
+			cg_customFont1_lastMod = cg_customFont1.modificationCount;
+
+			RegisterFont(font, 27, &cgs.media.limboFont1);
+			RegisterFont(font, 16, &cgs.media.limboFont1_lo);
+		}
+		else if (cg_customFont2.modificationCount != cg_customFont2_lastMod)
+		{
+			char *font = cg_customFont2.string[0] != '\0' ? cg_customFont2.string : "courbd";
+			cg_customFont2_lastMod = cg_customFont2.modificationCount;
+
+			RegisterFont(font, 30, &cgs.media.limboFont2);
+			RegisterFont(font, 21, &cgs.media.limboFont2_lo);
 		}
 	}
 
@@ -2142,8 +2172,8 @@ static void CG_RegisterGraphics(void)
 	cgs.media.medicIcon = trap_R_RegisterShaderNoMip("sprites/voiceMedic");
 	cgs.media.ammoIcon  = trap_R_RegisterShaderNoMip("sprites/voiceAmmo");
 
-	font1 = com_customFont1.string[0] != '\0' ? com_customFont1.string : "ariblk";
-	font2 = com_customFont2.string[0] != '\0' ? com_customFont2.string : "courbd";
+	font1 = cg_customFont1.string[0] != '\0' ? cg_customFont1.string : "ariblk";
+	font2 = cg_customFont2.string[0] != '\0' ? cg_customFont2.string : "courbd";
 
 	RegisterFont(font1, 27, &cgs.media.limboFont1);
 	RegisterFont(font1, 16, &cgs.media.limboFont1_lo);

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -837,19 +837,13 @@ void CG_UpdateCvars(void)
 
 		if (cg_customFont1.modificationCount != cg_customFont1_lastMod)
 		{
-			char *font = cg_customFont1.string[0] != '\0' ? cg_customFont1.string : "ariblk";
 			cg_customFont1_lastMod = cg_customFont1.modificationCount;
-
-			RegisterFont(font, 27, &cgs.media.limboFont1);
-			RegisterFont(font, 16, &cgs.media.limboFont1_lo);
+			RegisterSharedFonts();
 		}
 		else if (cg_customFont2.modificationCount != cg_customFont2_lastMod)
 		{
-			char *font = cg_customFont2.string[0] != '\0' ? cg_customFont2.string : "courbd";
 			cg_customFont2_lastMod = cg_customFont2.modificationCount;
-
-			RegisterFont(font, 30, &cgs.media.limboFont2);
-			RegisterFont(font, 21, &cgs.media.limboFont2_lo);
+			RegisterSharedFonts();
 		}
 	}
 
@@ -1642,7 +1636,6 @@ static void CG_RegisterGraphics(void)
 		"gfx/2d/numbers/nine_32b",
 		"gfx/2d/numbers/minus_32b",
 	};
-	char *font1, *font2;
 
 	CG_LoadingString(va(" - %s -", cgs.mapname));
 
@@ -2172,13 +2165,11 @@ static void CG_RegisterGraphics(void)
 	cgs.media.medicIcon = trap_R_RegisterShaderNoMip("sprites/voiceMedic");
 	cgs.media.ammoIcon  = trap_R_RegisterShaderNoMip("sprites/voiceAmmo");
 
-	font1 = cg_customFont1.string[0] != '\0' ? cg_customFont1.string : "ariblk";
-	font2 = cg_customFont2.string[0] != '\0' ? cg_customFont2.string : "courbd";
-
-	RegisterFont(font1, 27, &cgs.media.limboFont1);
-	RegisterFont(font1, 16, &cgs.media.limboFont1_lo);
-	RegisterFont(font2, 30, &cgs.media.limboFont2);
-	RegisterFont(font2, 21, &cgs.media.limboFont2_lo);
+	RegisterSharedFonts();
+	cgs.media.limboFont1    = cgDC.Assets.limboFont1;
+	cgs.media.limboFont1_lo = cgDC.Assets.limboFont1_lo;
+	cgs.media.limboFont2    = cgDC.Assets.limboFont2;
+	cgs.media.limboFont2_lo = cgDC.Assets.limboFont2_lo;
 
 	cgs.media.medal_back = trap_R_RegisterShaderNoMip("gfx/limbo/medal_back");
 
@@ -2780,6 +2771,7 @@ void CG_Init(int serverMessageNum, int serverCommandSequence, int clientNum, qbo
 	cgs.screenXScale = cgs.glconfig.vidWidth / 640.0f;
 	cgs.screenYScale = cgs.glconfig.vidHeight / 480.0f;
 
+	cgDC.etLegactClient = cg.etLegacyClient;
 
 	if (cg.etLegacyClient <= 0)
 	{

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -2771,7 +2771,7 @@ void CG_Init(int serverMessageNum, int serverCommandSequence, int clientNum, qbo
 	cgs.screenXScale = cgs.glconfig.vidWidth / 640.0f;
 	cgs.screenYScale = cgs.glconfig.vidHeight / 480.0f;
 
-	cgDC.etLegactClient = cg.etLegacyClient;
+	cgDC.etLegacyClient = cg.etLegacyClient;
 
 	if (cg.etLegacyClient <= 0)
 	{

--- a/src/qcommon/common.c
+++ b/src/qcommon/common.c
@@ -112,8 +112,6 @@ cvar_t *com_fixedtime;
 cvar_t *com_journal;
 cvar_t *com_maxfps;
 cvar_t *com_timedemo;
-cvar_t *com_customFont1;
-cvar_t *com_customFont2;
 cvar_t *com_sv_running;
 cvar_t *com_cl_running;
 cvar_t *com_logfile;        // 1 = buffer log, 2 = flush after each print
@@ -2966,9 +2964,6 @@ void Com_Init(char *commandLine)
 	com_viewlog   = Cvar_Get("viewlog", "0", CVAR_CHEAT);
 	com_speeds    = Cvar_Get("com_speeds", "0", 0);
 	com_timedemo  = Cvar_Get("timedemo", "0", CVAR_CHEAT);
-
-	com_customFont1 = Cvar_GetAndDescribe("com_customFont1", "", CVAR_ARCHIVE_ND | CVAR_LATCH, "Specify custom font for certain HUD elements (case sensitive, no extension)");
-	com_customFont2 = Cvar_GetAndDescribe("com_customFont2", "", CVAR_ARCHIVE_ND | CVAR_LATCH, "Specify custom font for certain HUD elements (case sensitive, no extension)");
 
 #ifdef DEDICATED
 	com_watchdog     = Cvar_Get("com_watchdog", "60", CVAR_ARCHIVE_ND);

--- a/src/qcommon/common.c
+++ b/src/qcommon/common.c
@@ -112,6 +112,8 @@ cvar_t *com_fixedtime;
 cvar_t *com_journal;
 cvar_t *com_maxfps;
 cvar_t *com_timedemo;
+cvar_t *com_customFont1;
+cvar_t *com_customFont2;
 cvar_t *com_sv_running;
 cvar_t *com_cl_running;
 cvar_t *com_logfile;        // 1 = buffer log, 2 = flush after each print
@@ -2964,6 +2966,9 @@ void Com_Init(char *commandLine)
 	com_viewlog   = Cvar_Get("viewlog", "0", CVAR_CHEAT);
 	com_speeds    = Cvar_Get("com_speeds", "0", 0);
 	com_timedemo  = Cvar_Get("timedemo", "0", CVAR_CHEAT);
+
+	com_customFont1 = Cvar_Get("com_customFont1", "", CVAR_ARCHIVE_ND | CVAR_LATCH);
+	com_customFont2 = Cvar_Get("com_customFont2", "", CVAR_ARCHIVE_ND | CVAR_LATCH);
 
 #ifdef DEDICATED
 	com_watchdog     = Cvar_Get("com_watchdog", "60", CVAR_ARCHIVE_ND);

--- a/src/qcommon/common.c
+++ b/src/qcommon/common.c
@@ -2967,8 +2967,8 @@ void Com_Init(char *commandLine)
 	com_speeds    = Cvar_Get("com_speeds", "0", 0);
 	com_timedemo  = Cvar_Get("timedemo", "0", CVAR_CHEAT);
 
-	com_customFont1 = Cvar_Get("com_customFont1", "", CVAR_ARCHIVE_ND | CVAR_LATCH);
-	com_customFont2 = Cvar_Get("com_customFont2", "", CVAR_ARCHIVE_ND | CVAR_LATCH);
+	com_customFont1 = Cvar_GetAndDescribe("com_customFont1", "", CVAR_ARCHIVE_ND | CVAR_LATCH, "Specify custom font for certain HUD elements (case sensitive, no extension)");
+	com_customFont2 = Cvar_GetAndDescribe("com_customFont2", "", CVAR_ARCHIVE_ND | CVAR_LATCH, "Specify custom font for certain HUD elements (case sensitive, no extension)");
 
 #ifdef DEDICATED
 	com_watchdog     = Cvar_Get("com_watchdog", "60", CVAR_ARCHIVE_ND);

--- a/src/qcommon/files.c
+++ b/src/qcommon/files.c
@@ -1688,7 +1688,8 @@ long FS_FOpenFileReadDir(const char *fileName, searchpath_t *search, fileHandle_
 			    !FS_IsExt(fileName, ".glsl", len) &&
 #endif
 			    !FS_IsDemoExt(fileName, len) &&         // demos
-			    !FS_IsExt(fileName, ".ttf", len))       // TrueType ttf fonts
+			    !FS_IsExt(fileName, ".ttf", len) &&		// TrueType ttf fonts
+			    !FS_IsExt(fileName, ".otf", len))       // TrueType otf fonts
 			{
 				*file = 0;
 				return -1;

--- a/src/qcommon/files.c
+++ b/src/qcommon/files.c
@@ -1679,15 +1679,16 @@ long FS_FOpenFileReadDir(const char *fileName, searchpath_t *search, fileHandle_
 		// turned out I used FS_FileExists instead
 		if (!unpure && fs_numServerPaks)
 		{
-			if (!FS_IsExt(fileName, ".cfg", len) &&      // for config files
+			if (!FS_IsExt(fileName, ".cfg", len) &&     // for config files
 			    !FS_IsExt(fileName, ".menu", len) &&    // menu files
 			    !FS_IsExt(fileName, ".game", len) &&    // menu files
-			    !FS_IsExt(fileName, ".dat", len) &&     // for journal files
+			    !FS_IsExt(fileName, ".dat", len) &&     // journal/hud files
 			    !FS_IsExt(fileName, ".bin", len) &&     // glsl shader binary
 #ifdef ETLEGACY_DEBUG
 			    !FS_IsExt(fileName, ".glsl", len) &&
 #endif
-			    !FS_IsDemoExt(fileName, len))           // demos
+			    !FS_IsDemoExt(fileName, len) &&         // demos
+			    !FS_IsExt(fileName, ".ttf", len))       // TrueType ttf fonts
 			{
 				*file = 0;
 				return -1;
@@ -4258,7 +4259,7 @@ static void FS_ReorderLocalFoldersToTop(void)
 			{
 				// Disabled the reordering since we are just pushing local folders up not the pk3's
 				// fs_reordered = qtrue;
-				changed      = qtrue;
+				changed = qtrue;
 				// move this element to the insert list
 				*p_previous     = s->next;
 				s->next         = *p_insert_index;

--- a/src/qcommon/files.c
+++ b/src/qcommon/files.c
@@ -1688,7 +1688,7 @@ long FS_FOpenFileReadDir(const char *fileName, searchpath_t *search, fileHandle_
 			    !FS_IsExt(fileName, ".glsl", len) &&
 #endif
 			    !FS_IsDemoExt(fileName, len) &&         // demos
-			    !FS_IsExt(fileName, ".ttf", len) &&		// TrueType ttf fonts
+			    !FS_IsExt(fileName, ".ttf", len) &&     // TrueType ttf fonts
 			    !FS_IsExt(fileName, ".otf", len))       // TrueType otf fonts
 			{
 				*file = 0;

--- a/src/qcommon/q_unicode.c
+++ b/src/qcommon/q_unicode.c
@@ -110,7 +110,7 @@ int Q_UTF8_WidthCP(int ch)
 qboolean Q_UTF8_ValidateSingle(const char *str)
 {
 	int    i = 0, utfBytes = 0;
-	size_t len = strlen(str);
+	size_t len     = strlen(str);
 	byte   current = str[0];
 
 	if (0x00 <= current && current <= 0x7F)
@@ -138,7 +138,7 @@ qboolean Q_UTF8_ValidateSingle(const char *str)
 		return qfalse;
 	}
 
-	if(utfBytes > len)
+	if (utfBytes > len)
 	{
 		return qfalse;
 	}
@@ -188,7 +188,7 @@ qboolean Q_UTF8_Validate(const char *str)
 			return qfalse;
 		}
 
-		if(utfBytes > (len - i))
+		if (utfBytes > (len - i))
 		{
 			return qfalse;
 		}
@@ -212,8 +212,8 @@ char *Q_Extended_To_UTF8(char *txt)
 	if (!Q_UTF8_Validate(txt))
 	{
 		size_t i;
-		char *tmpPointer = tmpPrintBuffer;
-		size_t len = strlen(txt);
+		char   *tmpPointer = tmpPrintBuffer;
+		size_t len         = strlen(txt);
 		for (i = 0; i < len;)
 		{
 			if (127 < (unsigned char) txt[i] && !Q_UTF8_ValidateSingle(&txt[i]))
@@ -232,7 +232,7 @@ char *Q_Extended_To_UTF8(char *txt)
 				int width = Q_UTF8_Width(&txt[i]);
 
 				// Well width returned something that should not be possible, guard our ass against infinite loop.
-				if(width <= 0)
+				if (width <= 0)
 				{
 					i++;
 					continue;
@@ -551,7 +551,7 @@ uint32_t Q_UTF8_CodePoint(const char *str)
 	}
 
 	// Its an extended char
-	if(!Q_UTF8_ValidateSingle(str))
+	if (!Q_UTF8_ValidateSingle(str))
 	{
 		return (unsigned char)str[0];
 	}
@@ -756,11 +756,11 @@ glyphInfo_t *Q_UTF8_GetGlyphVanilla(void *fontdata, unsigned long codepoint)
  * @param[in] extended
  * @param font_register
  */
-void Q_UTF8_RegisterFont(const char *fontName, int pointSize, fontHelper_t *font, qboolean extended, void (*font_register)(const char *, int, void *))
+qboolean Q_UTF8_RegisterFont(const char *fontName, int pointSize, fontHelper_t *font, qboolean extended, void (*font_register)(const char *, int, void *))
 {
 	if (!font)
 	{
-		return;
+		return qfalse;
 	}
 
 	Q_UTF8_FreeFont(font);
@@ -776,7 +776,15 @@ void Q_UTF8_RegisterFont(const char *fontName, int pointSize, fontHelper_t *font
 		font->GetGlyph = &Q_UTF8_GetGlyphVanilla;
 	}
 
+	Com_Memset(font->fontData, 0, sizeof(&font->fontData));
 	font_register(fontName, pointSize, font->fontData);
+
+	if (((fontInfo_t *)font->fontData)->glyphs[0].glyph == 0)
+	{
+		return qfalse;
+	}
+
+	return qtrue;
 }
 
 /**

--- a/src/qcommon/q_unicode.h
+++ b/src/qcommon/q_unicode.h
@@ -58,7 +58,7 @@ qboolean Q_UTF8_Validate(const char *str);
 char *Q_Extended_To_UTF8(char *txt);
 size_t Q_UTF8_Strlen(const char *str);
 size_t Q_UTF32_Strlen(const uint32_t *str, size_t len);
-char* Q_UTF8_CharAt(char *str, size_t offset);
+char *Q_UTF8_CharAt(char *str, size_t offset);
 int Q_UTF8_PrintStrlen(const char *str);
 int Q_UTF8_PrintStrlenExt(const char *str, int length);
 int Q_UTF8_ByteOffset(const char *str, int offset);
@@ -66,7 +66,7 @@ void Q_UTF8_Insert(char *dest, int size, int offset, int key, qboolean overstrik
 void Q_UTF8_Move(char *buffer, size_t dstOffset, size_t srcOffset, size_t size);
 qboolean Q_UTF8_ContByte(char c);
 uint32_t Q_UTF8_CodePoint(const char *str);
-void Q_UTF8_RegisterFont(const char *fontName, int pointSize, fontHelper_t *font, qboolean extended, void (*font_register)(const char *, int, void *));
+qboolean Q_UTF8_RegisterFont(const char *fontName, int pointSize, fontHelper_t *font, qboolean extended, void (*font_register)(const char *, int, void *));
 void Q_UTF8_FreeFont(fontHelper_t *font);
 char *Q_UTF8_Encode(unsigned long codepoint);
 int Q_UTF8_Store(const char *s);

--- a/src/ui/ui_atoms.c
+++ b/src/ui/ui_atoms.c
@@ -182,7 +182,7 @@ qboolean UI_ConsoleCommand(int realTime)
 			Menus_OpenByName(menu_name);
 		}
 	}
-	else if (Q_stricmp(cmd, "listfonts") == 0)
+	else if (Q_stricmp(cmd, "listfonts") == 0 && uiInfo.etLegacyClient)
 	{
 		UI_ListFonts_f();
 		return qtrue;

--- a/src/ui/ui_atoms.c
+++ b/src/ui/ui_atoms.c
@@ -182,6 +182,11 @@ qboolean UI_ConsoleCommand(int realTime)
 			Menus_OpenByName(menu_name);
 		}
 	}
+	else if (Q_stricmp(cmd, "listfonts") == 0)
+	{
+		UI_ListFonts_f();
+		return qtrue;
+	}
 
 	trap_GetClientState(&cstate);
 	if (cstate.connState == CA_DISCONNECTED)

--- a/src/ui/ui_loadpanel.c
+++ b/src/ui/ui_loadpanel.c
@@ -178,8 +178,8 @@ void UI_DrawLoadPanel(qboolean ownerdraw, qboolean uihack)
 	{
 		char *font1, *font2;
 
-		font1 = com_customFont1.string[0] != '\0' ? com_customFont1.string : "ariblk";
-		font2 = com_customFont2.string[0] != '\0' ? com_customFont2.string : "courbd";
+		font1 = ui_customFont1.string[0] != '\0' ? ui_customFont1.string : "ariblk";
+		font2 = ui_customFont2.string[0] != '\0' ? ui_customFont2.string : "courbd";
 
 		RegisterFont(font1, 27, &uiInfo.uiDC.Assets.bg_loadscreenfont1);
 		RegisterFont(font2, 30, &uiInfo.uiDC.Assets.bg_loadscreenfont2);

--- a/src/ui/ui_loadpanel.c
+++ b/src/ui/ui_loadpanel.c
@@ -176,8 +176,13 @@ void UI_DrawLoadPanel(qboolean ownerdraw, qboolean uihack)
 
 	if (!bg_loadscreeninited)
 	{
-		RegisterFont("ariblk", 27, &uiInfo.uiDC.Assets.bg_loadscreenfont1);
-		RegisterFont("courbd", 30, &uiInfo.uiDC.Assets.bg_loadscreenfont2);
+		char *font1, *font2;
+
+		font1 = com_customFont1.string[0] != '\0' ? com_customFont1.string : "ariblk";
+		font2 = com_customFont2.string[0] != '\0' ? com_customFont2.string : "courbd";
+
+		RegisterFont(font1, 27, &uiInfo.uiDC.Assets.bg_loadscreenfont1);
+		RegisterFont(font2, 30, &uiInfo.uiDC.Assets.bg_loadscreenfont2);
 
 		BG_PanelButtonsSetup(loadpanelButtons);
 		C_PanelButtonsSetup(loadpanelButtons, Cui_WideXoffset());   // convert to possible widescreen coordinates..
@@ -210,11 +215,11 @@ void UI_LoadPanel_RenderHeaderText(panel_button_t *button)
 
 	if ((cstate.connState == CA_DISCONNECTED || cstate.connState == CA_CONNECTED) && *downloadName)
 	{
-		button->text = (char*)(__("DOWNLOADING..."));
+		button->text = (char *)(__("DOWNLOADING..."));
 	}
 	else
 	{
-		button->text = (char*)(__("CONNECTING..."));
+		button->text = (char *)(__("CONNECTING..."));
 	}
 
 	BG_PanelButtonsRender_Text(button);
@@ -229,19 +234,19 @@ void UI_LoadPanel_RenderHeaderText(panel_button_t *button)
  */
 const char *UI_DownloadInfo(const char *downloadName)
 {
-	static int  tleEstimates[ESTIMATES] = { 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60,
-		                                    60,  60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60,
-		                                    60,  60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60,
-		                                    60,  60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60 };
-	static int  tleIndex = 0;
-	char        dlSizeBuf[64], totalSizeBuf[64], xferRateBuf[64], dlTimeBuf[64];
-	int         downloadSize, downloadCount, downloadTime;
+	static int tleEstimates[ESTIMATES] = { 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60,
+		                                   60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60,
+		                                   60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60,
+		                                   60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60 };
+	static int tleIndex = 0;
+	char       dlSizeBuf[64], totalSizeBuf[64], xferRateBuf[64], dlTimeBuf[64];
+	int        downloadSize, downloadCount, downloadTime;
 	const char *dlText, *etaText, *xferText;
-	const char  *s, *ds;
+	const char *s, *ds;
 
-	dlText = __("Downloading:");
-	etaText = __("Estimated time left:");
-	xferText = __("Transfer rate:");
+	dlText        = __("Downloading:");
+	etaText       = __("Estimated time left:");
+	xferText      = __("Transfer rate:");
 	downloadSize  = trap_Cvar_VariableValue("cl_downloadSize");
 	downloadCount = trap_Cvar_VariableValue("cl_downloadCount");
 	downloadTime  = trap_Cvar_VariableValue("cl_downloadTime");
@@ -321,19 +326,19 @@ const char *UI_DownloadInfo(const char *downloadName)
 			{
 				s = va("%s\n %s\n%s\n\n%s\n %s...\n\n%s\n\n%s %s", dlText, ds, totalSizeBuf,
 				       etaText,
-					   __("estimating"),
+				       __("estimating"),
 				       xferText,
 				       dlSizeBuf,
-					   __("copied"));
+				       __("copied"));
 			}
 			else
 			{
 				s = va("%s\n %s\n\n%s\n %s...\n\n%s\n\n%s %s", dlText, ds,
 				       etaText,
-					   __("estimating"),
+				       __("estimating"),
 				       xferText,
 				       dlSizeBuf,
-					   __("copied"));
+				       __("copied"));
 			}
 		}
 	}

--- a/src/ui/ui_loadpanel.c
+++ b/src/ui/ui_loadpanel.c
@@ -176,13 +176,7 @@ void UI_DrawLoadPanel(qboolean ownerdraw, qboolean uihack)
 
 	if (!bg_loadscreeninited)
 	{
-		char *font1, *font2;
-
-		font1 = ui_customFont1.string[0] != '\0' ? ui_customFont1.string : "ariblk";
-		font2 = ui_customFont2.string[0] != '\0' ? ui_customFont2.string : "courbd";
-
-		RegisterFont(font1, 27, &uiInfo.uiDC.Assets.bg_loadscreenfont1);
-		RegisterFont(font2, 30, &uiInfo.uiDC.Assets.bg_loadscreenfont2);
+		RegisterSharedFonts();
 
 		BG_PanelButtonsSetup(loadpanelButtons);
 		C_PanelButtonsSetup(loadpanelButtons, Cui_WideXoffset());   // convert to possible widescreen coordinates..

--- a/src/ui/ui_local.h
+++ b/src/ui/ui_local.h
@@ -350,6 +350,8 @@ void UI_ListCampaigns_f(void);
 void UI_ListFavourites_f(void);
 void UI_RemoveAllFavourites_f(void);
 
+void UI_ListFonts_f(void);
+
 #define GLINFO_LINES        256
 
 // ui_atoms.c

--- a/src/ui/ui_local.h
+++ b/src/ui/ui_local.h
@@ -112,6 +112,9 @@ extern vmCvar_t ui_cg_shoutcastDrawHealth;
 extern vmCvar_t ui_cg_shoutcastGrenadeTrail;
 extern vmCvar_t ui_cg_shoutcastDrawMinimap;
 
+extern vmCvar_t com_customFont1;
+extern vmCvar_t com_customFont2;
+
 // ui_serverBrowserSettings flags
 #define UI_BROWSER_ALLOW_REDIRECT     BIT(0)
 #define UI_BROWSER_ALLOW_HUMANS_COUNT BIT(1)

--- a/src/ui/ui_local.h
+++ b/src/ui/ui_local.h
@@ -112,8 +112,8 @@ extern vmCvar_t ui_cg_shoutcastDrawHealth;
 extern vmCvar_t ui_cg_shoutcastGrenadeTrail;
 extern vmCvar_t ui_cg_shoutcastDrawMinimap;
 
-extern vmCvar_t com_customFont1;
-extern vmCvar_t com_customFont2;
+extern vmCvar_t ui_customFont1;
+extern vmCvar_t ui_customFont2;
 
 // ui_serverBrowserSettings flags
 #define UI_BROWSER_ALLOW_REDIRECT     BIT(0)

--- a/src/ui/ui_main.c
+++ b/src/ui/ui_main.c
@@ -8726,6 +8726,8 @@ void UI_Init(int etLegacyClient, int clientVersion)
 
 	trap_AddCommand("listfavs");
 	trap_AddCommand("removefavs");
+
+	trap_AddCommand("listfonts");
 }
 
 /**
@@ -9766,6 +9768,38 @@ void UI_RemoveAllFavourites_f(void)
 	trap_LAN_RemoveServer(AS_FAVORITES_ALL, "");
 
 	Com_Printf("%s\n", __("All favourite servers removed."));
+}
+
+/**
+ * @brief Lists installed fonts
+ */
+void UI_ListFonts_f(void)
+{
+	int        numFonts, numFontsTotal = 0;
+	char       dirlist[8192];
+	char       *dirptr, fontname[MAX_QPATH];
+	int        i, j;
+	size_t     dirlen;
+	const char *fontTypes[] = { "ttf", "otf" };
+
+	Com_Printf("^2List of available fonts\n\n^*Use these as values for ^3cg_customFont1 ^*and ^3cg_customFont2\n"
+	           "^*to customise fonts used in various HUD elements\n-------------------------------------------------------\n");
+
+	for (i = 0; i < ARRAY_LEN(fontTypes); i++)
+	{
+		numFonts       = trap_FS_GetFileList("fonts", va(".%s", fontTypes[i]), dirlist, sizeof(dirlist));
+		numFontsTotal += numFonts;
+		dirptr         = dirlist;
+		for (j = 0; j < numFonts; j++, dirptr += dirlen + 1)
+		{
+			dirlen = strlen(dirptr);
+			Q_strncpyz(fontname, dirptr, sizeof(fontname));
+			COM_StripExtension(fontname, fontname, sizeof(fontname));
+			Com_Printf("%s\n", fontname);
+		}
+	}
+
+	Com_Printf("\n%d fonts installed.\n", numFontsTotal);
 }
 
 const char *UI_TranslateString(const char *string)

--- a/src/ui/ui_main.c
+++ b/src/ui/ui_main.c
@@ -8580,6 +8580,7 @@ void UI_Init(int etLegacyClient, int clientVersion)
 	{
 		trap_Cvar_Register(&ui_customFont1, "cg_customFont1", "", CVAR_ARCHIVE);
 		trap_Cvar_Register(&ui_customFont2, "cg_customFont2", "", CVAR_ARCHIVE);
+		trap_AddCommand("listfonts");
 	}
 
 	Com_Memset(&uiInfo.demos, 0, sizeof(uiInfo.demos));
@@ -8726,8 +8727,6 @@ void UI_Init(int etLegacyClient, int clientVersion)
 
 	trap_AddCommand("listfavs");
 	trap_AddCommand("removefavs");
-
-	trap_AddCommand("listfonts");
 }
 
 /**

--- a/src/ui/ui_main.c
+++ b/src/ui/ui_main.c
@@ -8566,7 +8566,7 @@ void UI_Init(int etLegacyClient, int clientVersion)
 
 	MOD_CHECK_ETLEGACY(etLegacyClient, clientVersion, uiInfo.etLegacyClient);
 
-	uiInfo.uiDC.etLegactClient = uiInfo.etLegacyClient;
+	uiInfo.uiDC.etLegacyClient = uiInfo.etLegacyClient;
 
 	if (uiInfo.etLegacyClient <= 0)
 	{

--- a/src/ui/ui_main.c
+++ b/src/ui/ui_main.c
@@ -1126,16 +1126,27 @@ qboolean Asset_Parse(int handle)
 			}
 
 			// custom font handling
-			if (!Q_stricmp(tempStr, "ariblk") && ui_customFont1.string[0] != '\0')
+			if (!Q_stricmp(tempStr, "ariblk") && ui_customFont1.string[0] != 0)
 			{
 				tempStr = ui_customFont1.string;
+				if (!RegisterFont(tempStr, pointSize, &uiInfo.uiDC.Assets.fonts[fontIndex]))
+				{
+					RegisterFont("ariblk", pointSize, &uiInfo.uiDC.Assets.fonts[fontIndex]);
+				}
 			}
-			else if (!Q_stricmp(tempStr, "courbd") && ui_customFont2.string[0] != '\0')
+			else if (!Q_stricmp(tempStr, "courbd") && ui_customFont2.string[0] != 0)
 			{
 				tempStr = ui_customFont2.string;
+				if (!RegisterFont(tempStr, pointSize, &uiInfo.uiDC.Assets.fonts[fontIndex]))
+				{
+					RegisterFont("courbd", pointSize, &uiInfo.uiDC.Assets.fonts[fontIndex]);
+				}
+			}
+			else // sanity check, we really shouldn't ever get here
+			{
+				RegisterFont(tempStr, pointSize, &uiInfo.uiDC.Assets.fonts[fontIndex]);
 			}
 
-			RegisterFont(tempStr, pointSize, &uiInfo.uiDC.Assets.fonts[fontIndex]);
 			uiInfo.uiDC.Assets.fontRegistered = qtrue;
 			continue;
 		}
@@ -8555,6 +8566,8 @@ void UI_Init(int etLegacyClient, int clientVersion)
 
 	MOD_CHECK_ETLEGACY(etLegacyClient, clientVersion, uiInfo.etLegacyClient);
 
+	uiInfo.uiDC.etLegactClient = uiInfo.etLegacyClient;
+
 	if (uiInfo.etLegacyClient <= 0)
 	{
 		uiInfo.uiDC.glconfig.windowAspect = (float)uiInfo.uiDC.glconfig.vidWidth / (float)uiInfo.uiDC.glconfig.vidHeight;
@@ -8679,6 +8692,8 @@ void UI_Init(int etLegacyClient, int clientVersion)
 	uiInfo.teamCount      = 0;
 	uiInfo.characterCount = 0;
 	uiInfo.aliasCount     = 0;
+
+	RegisterSharedFonts();
 
 	UI_ParseGameInfo("gameinfo.txt");
 
@@ -9446,18 +9461,14 @@ void UI_UpdateCvars(void)
 
 		if (ui_customFont1.modificationCount != ui_customFont1_lastMod)
 		{
-			char *font = ui_customFont1.string[0] != '\0' ? ui_customFont1.string : "ariblk";
 			ui_customFont1_lastMod = ui_customFont1.modificationCount;
-
-			RegisterFont(font, 27, &uiInfo.uiDC.Assets.bg_loadscreenfont1);
+			RegisterSharedFonts();
 			UI_Load();
 		}
 		else if (ui_customFont2.modificationCount != ui_customFont2_lastMod)
 		{
-			char *font = ui_customFont2.string[0] != '\0' ? ui_customFont2.string : "courbd";
 			ui_customFont2_lastMod = ui_customFont2.modificationCount;
-
-			RegisterFont(font, 30, &uiInfo.uiDC.Assets.bg_loadscreenfont2);
+			RegisterSharedFonts();
 			UI_Load();
 		}
 	}

--- a/src/ui/ui_main.c
+++ b/src/ui/ui_main.c
@@ -9170,6 +9170,9 @@ vmCvar_t ui_cg_shoutcastDrawHealth;
 vmCvar_t ui_cg_shoutcastGrenadeTrail;
 vmCvar_t ui_cg_shoutcastDrawMinimap;
 
+vmCvar_t com_customFont1;
+vmCvar_t com_customFont2;
+
 static cvarTable_t cvarTable[] =
 {
 	{ NULL,                                "ui_textfield_temp",                   "",                           CVAR_TEMP,                      0 },
@@ -9354,6 +9357,9 @@ static cvarTable_t cvarTable[] =
 
 	{ &ui_serverBrowserSettings,           "ui_serverBrowserSettings",            "0",                          CVAR_INIT,                      0 },
 	{ NULL,                                "cg_allowGeoIP",                       "1",                          CVAR_ARCHIVE | CVAR_USERINFO,   0 },
+
+	{ &com_customFont1,                    "com_customFont1",                     "",                           0,                              0 },
+	{ &com_customFont2,                    "com_customFont2",                     "",                           0,                              0 },
 };
 
 static const unsigned int cvarTableSize = sizeof(cvarTable) / sizeof(cvarTable[0]);

--- a/src/ui/ui_shared.c
+++ b/src/ui/ui_shared.c
@@ -1944,10 +1944,10 @@ void RegisterSharedFonts(void)
 		fontTableEntry_t *entry = &fontTable[i];
 		trap_Cvar_VariableStringBuffer(entry->cvarName, buf, sizeof(buf));
 		if (buf[0] == 0 || !Q_UTF8_RegisterFont(buf, entry->pointSize, entry->font,
-		                                        DC->etLegactClient >= UNICODE_SUPPORT_VERSION, &trap_R_RegisterFont))
+		                                        DC->etLegacyClient >= UNICODE_SUPPORT_VERSION, &trap_R_RegisterFont))
 		{
 			Q_UTF8_RegisterFont(entry->defaultFont, entry->pointSize, entry->font,
-			                    DC->etLegactClient >= UNICODE_SUPPORT_VERSION, &trap_R_RegisterFont);
+			                    DC->etLegacyClient >= UNICODE_SUPPORT_VERSION, &trap_R_RegisterFont);
 		}
 	}
 }

--- a/src/ui/ui_shared.c
+++ b/src/ui/ui_shared.c
@@ -1921,3 +1921,33 @@ void C_PanelButtonsSetup(panel_button_t **buttons, float xoffset)
 		button->rect.x += xoffset;
 	}
 }
+
+/**
+ * @brief Registers fonts shared between cgame and ui to either defaults or user-defined custom fonts
+ */
+void RegisterSharedFonts(void)
+{
+	fontTableEntry_t fontTable[FONT_TABLE_NUMFONTS] =
+	{
+		{ &DC->Assets.bg_loadscreenfont1, 27, "cg_customFont1", "ariblk" },
+		{ &DC->Assets.bg_loadscreenfont2, 30, "cg_customFont2", "courbd" },
+		{ &DC->Assets.limboFont1,         27, "cg_customFont1", "ariblk" },
+		{ &DC->Assets.limboFont1_lo,      16, "cg_customFont1", "ariblk" },
+		{ &DC->Assets.limboFont2,         30, "cg_customFont2", "courbd" },
+		{ &DC->Assets.limboFont2_lo,      21, "cg_customFont2", "courbd" },
+	};
+
+	char buf[MAX_QPATH];
+	int  i;
+	for (i = 0; i < FONT_TABLE_NUMFONTS; i++)
+	{
+		fontTableEntry_t *entry = &fontTable[i];
+		trap_Cvar_VariableStringBuffer(entry->cvarName, buf, sizeof(buf));
+		if (buf[0] == 0 || !Q_UTF8_RegisterFont(buf, entry->pointSize, entry->font,
+		                                        DC->etLegactClient >= UNICODE_SUPPORT_VERSION, &trap_R_RegisterFont))
+		{
+			Q_UTF8_RegisterFont(entry->defaultFont, entry->pointSize, entry->font,
+			                    DC->etLegactClient >= UNICODE_SUPPORT_VERSION, &trap_R_RegisterFont);
+		}
+	}
+}

--- a/src/ui/ui_shared.h
+++ b/src/ui/ui_shared.h
@@ -569,7 +569,7 @@ typedef struct
 	qhandle_t cursor;
 	float FPS;
 
-	int etLegactClient;
+	int etLegacyClient;
 } displayContextDef_t;
 
 void PC_SourceError(int handle, const char *format, ...);

--- a/src/ui/ui_shared.h
+++ b/src/ui/ui_shared.h
@@ -406,6 +406,10 @@ typedef struct
 	fontHelper_t fonts[UI_FONT_COUNT];
 	fontHelper_t bg_loadscreenfont1;
 	fontHelper_t bg_loadscreenfont2;
+	fontHelper_t limboFont1;
+	fontHelper_t limboFont1_lo;
+	fontHelper_t limboFont2;
+	fontHelper_t limboFont2_lo;
 	qhandle_t cursor;
 	qhandle_t gradientBar;
 	qhandle_t gradientRound;
@@ -443,6 +447,16 @@ typedef struct
 	qhandle_t crosshairAltShader[NUM_CROSSHAIRS];
 
 } cachedAssets_t;
+
+#define FONT_TABLE_NUMFONTS 6
+
+typedef struct
+{
+	fontHelper_t *font;
+	int pointSize;
+	const char *cvarName;
+	const char *defaultFont;
+} fontTableEntry_t;
 
 /**
  * @struct commandDef_s
@@ -554,6 +568,8 @@ typedef struct
 	qhandle_t gradientImage;
 	qhandle_t cursor;
 	float FPS;
+
+	int etLegactClient;
 } displayContextDef_t;
 
 void PC_SourceError(int handle, const char *format, ...);
@@ -771,6 +787,8 @@ void Cui_WideRect(rectDef_t *rect);
 float Cui_WideX(float x);
 float Cui_WideXoffset(void);
 void C_PanelButtonsSetup(panel_button_t **buttons, float xoffset);      // called from UI & CGAME
+
+void RegisterSharedFonts(void);
 
 //A simple macro to check if a certain functionality is available in the engine version
 #ifdef CGAMEDLL


### PR DESCRIPTION
Allow loading `.ttf` files in pure mode, so ETL clients can replace the default fonts with custom ones if they want to.