### PR TITLE
game: fix prone leg and head collision when rotating, refs #1208

### DIFF
--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -4516,25 +4516,6 @@ void PM_UpdateViewAngles(playerState_t *ps, pmoveExt_t *pmext, usercmd_t *cmd, v
 
 			if (traceres.fraction != 1.f)
 			{
-				// is plane valid, try to find one?
-				if (VectorCompare(traceres.plane.normal, vec3_origin))
-				{
-					pm->trace(&traceres, ps->origin, playerHeadProneMins, playerHeadProneMaxs, end, pm->ps->clientNum, tracemask);
-
-					// still invalid, can't rotate
-					if (VectorCompare(traceres.plane.normal, vec3_origin))
-					{
-						if (pm->debugLevel)
-						{
-							Com_Printf("%i:rotate in solid\n", c_pmove);
-						}
-
-						// starting in a solid, no space
-						ps->viewangles[YAW]   = oldYaw;
-						ps->delta_angles[YAW] = ANGLE2SHORT(ps->viewangles[YAW]) - cmd->angles[YAW];
-					}
-				}
-
 				// adjust position by bumping
 				VectorSubtract(end, start, end);
 
@@ -4577,25 +4558,6 @@ void PM_UpdateViewAngles(playerState_t *ps, pmoveExt_t *pmext, usercmd_t *cmd, v
 
 				if (traceres.fraction != 1.f)
 				{
-					// is plane valid, try to find one?
-					if (VectorCompare(traceres.plane.normal, vec3_origin))
-					{
-						pm->trace(&traceres, ps->origin, playerHeadProneMins, playerHeadProneMaxs, end, pm->ps->clientNum, tracemask);
-
-						// still invalid, can't rotate
-						if (VectorCompare(traceres.plane.normal, vec3_origin))
-						{
-							if (pm->debugLevel)
-							{
-								Com_Printf("%i:rotate in solid\n", c_pmove);
-							}
-
-							// starting in a solid, no space
-							ps->viewangles[YAW]   = oldYaw;
-							ps->delta_angles[YAW] = ANGLE2SHORT(ps->viewangles[YAW]) - cmd->angles[YAW];
-						}
-					}
-
 					// adjust position by bumping
 					VectorSubtract(end, start, end);
 


### PR DESCRIPTION
Note: this ( https://github.com/etlegacy/etlegacy/pull/2025 ) is an important part, else it will still be pretty bad for head collision.

refs #1208