### PR TITLE
server: sv_userInfoFloodProtect to protect against userinfo flooding, refs #1906

### DIFF
--- a/misc/etmain/etl_server.cfg
+++ b/misc/etmain/etl_server.cfg
@@ -64,6 +64,7 @@ set sv_pure "1"                                 // enable hash check of client p
 set sv_protect "1"                              // getstatus response limit protection
 set sv_protectLog "sv_protect.log"              // when set all sv_protect and server security related messages are written into this log file
 set sv_floodProtect "1"                         // prevent server flooding
+set sv_userInfofloodProtect "1"                 // prevent userinfo flooding
 set sv_ipMaxClients "0"                         // limits connections per IP to cvar value (0: no maximum)
 
 // MOD CONFIG - put mod related vars in a separate config

--- a/misc/etmain/etl_server_comp.cfg
+++ b/misc/etmain/etl_server_comp.cfg
@@ -59,6 +59,7 @@ set sv_pure "1"                                 // enable hash check of client p
 set sv_protect "1"                              // getstatus response limit protection
 set sv_protectLog "sv_protect.log"              // when set all sv_protect and server security related messages are written into this log file
 set sv_floodProtect "0"                         // prevent server flooding
+set sv_userInfofloodProtect "1"                 // prevent userinfo flooding
 set sv_ipMaxClients "0"                         // limits connections per IP to cvar value (0: no maximum)
 
 set g_log "game.log"                            // enable game logging if set. Name of game logging file - logs weapon changes, kills, connects etc.

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -443,6 +443,7 @@ extern cvar_t *sv_maxPing;
 extern cvar_t *sv_gametype;
 extern cvar_t *sv_pure;
 extern cvar_t *sv_floodProtect;
+extern cvar_t *sv_userInfoFloodProtect;
 extern cvar_t *sv_lanForceRate;
 extern cvar_t *sv_onlyVisibleClients;
 

--- a/src/server/sv_client.c
+++ b/src/server/sv_client.c
@@ -1790,10 +1790,10 @@ void SV_UpdateUserinfo_f(client_t *cl)
 		return;
 	}
 
-	if ((sv_floodProtect->integer) && (cl->state >= CS_ACTIVE) && (svs.time < cl->nextReliableUserTime))
+	if ((sv_userInfoFloodProtect->integer) && (cl->state >= CS_ACTIVE) && (svs.time < cl->nextReliableUserTime))
 	{
 		Q_strncpyz(cl->userinfobuffer, arg, sizeof(cl->userinfobuffer));
-		SV_SendServerCommand(cl, "print \"^7Command ^1delayed^7 due to sv_floodprotect.\n\"");
+		SV_SendServerCommand(cl, "print \"^7Command ^1delayed^7 due to sv_userInfoFloodProtect.\n\"");
 		return;
 	}
 	cl->userinfobuffer[0]    = 0;

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -1035,19 +1035,20 @@ void SV_Init(void)
 	sv_gametype = Cvar_Get("g_gametype", "4", CVAR_SERVERINFO | CVAR_LATCH);
 	Cvar_Get("sv_keywords", "", CVAR_SERVERINFO); // unused. Kept for GameTracker.com compatibility
 	Cvar_Get("protocol", va("%i", PROTOCOL_VERSION), CVAR_SERVERINFO | CVAR_ROM);
-	sv_mapname        = Cvar_Get("mapname", "nomap", CVAR_SERVERINFO | CVAR_ROM);
-	sv_privateClients = Cvar_Get("sv_privateClients", "0", CVAR_SERVERINFO);
-	sv_hostname       = Cvar_Get("sv_hostname", "ETLHost", CVAR_SERVERINFO | CVAR_ARCHIVE);
-	sv_minRate        = Cvar_Get("sv_minRate", "0", CVAR_ARCHIVE_ND | CVAR_SERVERINFO);
-	sv_maxclients     = Cvar_Get("sv_maxclients", "20", CVAR_SERVERINFO | CVAR_LATCH);
-	sv_maxRate        = Cvar_Get("sv_maxRate", "0", CVAR_ARCHIVE_ND | CVAR_SERVERINFO);
-	sv_dlRate         = Cvar_Get("sv_dlRate", "100", CVAR_ARCHIVE_ND | CVAR_SERVERINFO);
-	sv_minPing        = Cvar_Get("sv_minPing", "0", CVAR_ARCHIVE_ND | CVAR_SERVERINFO);
-	sv_maxPing        = Cvar_Get("sv_maxPing", "0", CVAR_ARCHIVE_ND | CVAR_SERVERINFO);
-	sv_floodProtect   = Cvar_Get("sv_floodProtect", "1", CVAR_ARCHIVE | CVAR_SERVERINFO);
-	sv_friendlyFire   = Cvar_Get("g_friendlyFire", "1", CVAR_SERVERINFO | CVAR_ARCHIVE);
-	sv_maxlives       = Cvar_Get("g_maxlives", "0", CVAR_ARCHIVE | CVAR_LATCH | CVAR_SERVERINFO);
-	sv_needpass       = Cvar_Get("g_needpass", "0", CVAR_SERVERINFO | CVAR_ROM);
+	sv_mapname              = Cvar_Get("mapname", "nomap", CVAR_SERVERINFO | CVAR_ROM);
+	sv_privateClients       = Cvar_Get("sv_privateClients", "0", CVAR_SERVERINFO);
+	sv_hostname             = Cvar_Get("sv_hostname", "ETLHost", CVAR_SERVERINFO | CVAR_ARCHIVE);
+	sv_minRate              = Cvar_Get("sv_minRate", "0", CVAR_ARCHIVE_ND | CVAR_SERVERINFO);
+	sv_maxclients           = Cvar_Get("sv_maxclients", "20", CVAR_SERVERINFO | CVAR_LATCH);
+	sv_maxRate              = Cvar_Get("sv_maxRate", "0", CVAR_ARCHIVE_ND | CVAR_SERVERINFO);
+	sv_dlRate               = Cvar_Get("sv_dlRate", "100", CVAR_ARCHIVE_ND | CVAR_SERVERINFO);
+	sv_minPing              = Cvar_Get("sv_minPing", "0", CVAR_ARCHIVE_ND | CVAR_SERVERINFO);
+	sv_maxPing              = Cvar_Get("sv_maxPing", "0", CVAR_ARCHIVE_ND | CVAR_SERVERINFO);
+	sv_floodProtect         = Cvar_Get("sv_floodProtect", "1", CVAR_ARCHIVE | CVAR_SERVERINFO);
+	sv_userInfoFloodProtect = Cvar_Get("sv_userInfoFloodProtect", "1", CVAR_ARCHIVE | CVAR_SERVERINFO);
+	sv_friendlyFire         = Cvar_Get("g_friendlyFire", "1", CVAR_SERVERINFO | CVAR_ARCHIVE);
+	sv_maxlives             = Cvar_Get("g_maxlives", "0", CVAR_ARCHIVE | CVAR_LATCH | CVAR_SERVERINFO);
+	sv_needpass             = Cvar_Get("g_needpass", "0", CVAR_SERVERINFO | CVAR_ROM);
 
 	// systeminfo
 	// added cvar_t for sv_cheats so server engine can reference it

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -65,6 +65,7 @@ cvar_t *sv_maxPing;
 cvar_t *sv_gametype;
 cvar_t *sv_pure;
 cvar_t *sv_floodProtect;
+cvar_t *sv_userInfoFloodProtect;
 cvar_t *sv_lanForceRate;        // dedicated 1 (LAN) server forces local client rates to 99999 (bug #491)
 cvar_t *sv_onlyVisibleClients;
 cvar_t *sv_friendlyFire;

--- a/src/server/sv_snapshot.c
+++ b/src/server/sv_snapshot.c
@@ -881,10 +881,10 @@ void SV_SendClientIdle(client_t *client)
 	// Add any download data if the client is downloading
 	//SV_WriteDownloadToClient(client, &msg);
 
-    if (SV_CheckForMsgOverflow(client, &msg))
-    {
-        return;
-    }
+	if (SV_CheckForMsgOverflow(client, &msg))
+	{
+		return;
+	}
 
 	SV_SendMessageToClient(&msg, client);
 
@@ -944,10 +944,10 @@ void SV_SendClientSnapshot(client_t *client)
 	// and the playerState_t
 	SV_WriteSnapshotToClient(client, &msg);
 
-    if (SV_CheckForMsgOverflow(client, &msg))
-    {
-        return;
-    }
+	if (SV_CheckForMsgOverflow(client, &msg))
+	{
+		return;
+	}
 
 	SV_SendMessageToClient(&msg, client);
 
@@ -1102,7 +1102,7 @@ void SV_CheckClientUserinfoTimer(void)
 		{
 			continue; // not connected
 		}
-		if ((sv_floodProtect->integer) && (svs.time >= cl->nextReliableUserTime) && (cl->state >= CS_ACTIVE) && (cl->userinfobuffer[0] != 0))
+		if ((sv_userInfoFloodProtect->integer) && (svs.time >= cl->nextReliableUserTime) && (cl->state >= CS_ACTIVE) && (cl->userinfobuffer[0] != 0))
 		{
 			// We have something in the buffer and it's time to process it
 			Com_sprintf(bigbuffer, sizeof(bigbuffer), "userinfo \"%s\"", cl->userinfobuffer);


### PR DESCRIPTION
After the changes made in #1906, `sv_floodProtect` is mostly forced off on legacy servers, since it interferes with mod-sided flood protection. However userinfo flooding was tied to this cvar in https://github.com/etlegacy/etlegacy/commit/25b5628c9e506b40a2a5dd1e23455a25c48e0d25, so it was no longer being protected against. This adds a new cvar `sv_userInfoFloodProtect` which protects specifically against that, so `sv_floodProtect` can be off and server can still be protected against user info flooding.