### PR TITLE
engine: improves output for cl_showTimeDelta and sets up bit flags for future error correction

### DIFF
--- a/src/client/cl_cgame.c
+++ b/src/client/cl_cgame.c
@@ -199,13 +199,14 @@ qboolean CL_GetSnapshot(int snapshotNumber, snapshot_t *snapshot)
  * @brief CL_SetUserCmdValue
  * @param[in] userCmdValue
  * @param[in] flags
+ * @param[in] mask
  * @param[in] sensitivityScale
  * @param[in] mpIdentClient
  */
-void CL_SetUserCmdValue(int userCmdValue, int flags, float sensitivityScale, int mpIdentClient)
+void CL_SetUserCmdValue(int userCmdValue, int flags, int mask, float sensitivityScale, int mpIdentClient)
 {
 	cl.cgameUserCmdValue  = userCmdValue;
-	cl.cgameFlags         = flags;
+	cl.cgameFlags         = (cl.cgameFlags & ~mask) | (flags & mask);
 	cl.cgameSensitivity   = sensitivityScale;
 	cl.cgameMpIdentClient = mpIdentClient;
 }
@@ -872,7 +873,7 @@ intptr_t CL_CgameSystemCalls(intptr_t *args)
 	case CG_GETUSERCMD:
 		return CL_GetUserCmd(args[1], VMA(2));
 	case CG_SETUSERCMDVALUE:
-		CL_SetUserCmdValue(args[1], args[2], VMF(3), args[4]);
+		CL_SetUserCmdValue(args[1], args[2], MASK_CGAMEFLAGS_SHOWGAMEVIEW, VMF(3), args[4]);
 		return 0;
 	case CG_SETCLIENTLERPORIGIN:
 		CL_SetClientLerpOrigin(VMF(1), VMF(2), VMF(3));
@@ -1308,12 +1309,16 @@ void CL_AdjustTimeDelta(void)
 			{
 				cl.extrapolatedSnapshot = qfalse;
 				cl.serverTimeDelta     -= 2;
+				cl.cgameFlags |= MASK_CGAMEFLAGS_SERVERTIMEDELTA_BACKWARD;
+
 				if (cl_showTimeDelta->integer & 1) Com_Printf("serverTimeDelta ADJUSTMENT -2: ");
 			}
 			else
 			{
 				// otherwise, move our sense of time forward to minimize total latency
 				cl.serverTimeDelta++;
+				cl.cgameFlags |= MASK_CGAMEFLAGS_SERVERTIMEDELTA_FORWARD;
+				
 				if (cl_showTimeDelta->integer & 1) Com_Printf("serverTimeDelta ADJUSTMENT +1: ");
 			}
 		}

--- a/src/client/cl_input.c
+++ b/src/client/cl_input.c
@@ -1046,6 +1046,8 @@ void CL_FinishMove(usercmd_t *cmd)
 	}
 }
 
+#define MASK_CGAMEFLAGS_SERVERTIMEDELTA 0b00000110
+
 /**
  * @brief CL_CreateCmd
  * @return
@@ -1095,6 +1097,10 @@ usercmd_t CL_CreateCmd(void)
 
 	// store out the final values
 	CL_FinishMove(&cmd);
+
+	// the flags for serverTimeDelta have been used, so reset them
+	cl.cgameFlags &= ~MASK_CGAMEFLAGS_SERVERTIMEDELTA_FORWARD;
+	cl.cgameFlags &= ~MASK_CGAMEFLAGS_SERVERTIMEDELTA_BACKWARD;
 
 	// draw debug graphs of turning for mouse testing
 	if (cl_debugMove->integer)

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -129,6 +129,7 @@ typedef struct
 	int oldFrameServerTime;                 ///< to check tournament restarts
 	int serverTimeDelta;                    ///< cl.serverTime = cls.realtime + cl.serverTimeDelta
 	                                        ///< this value changes as net lag varies
+	int baselineDelta;                      ///< initial or reset value of serverTimeDelta w/o adjustments
 	qboolean extrapolatedSnapshot;          ///< set if any cgame frame has been forced to extrapolate
 	                                        ///< cleared when CL_AdjustTimeDelta looks at it
 	qboolean newSnapshots;                  ///< set on parse of any valid packet

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -576,6 +576,17 @@ typedef enum
 	NUM_BUTTONS
 } kbuttons_t;
 
+/**
+ * @enum cgameFlagsMaskEnum
+ * @brief
+ */
+enum cgameFlagsMaskEnum
+{
+    MASK_CGAMEFLAGS_SHOWGAMEVIEW             = 0b00000001,
+    MASK_CGAMEFLAGS_SERVERTIMEDELTA_FORWARD  = 0b00000010,
+    MASK_CGAMEFLAGS_SERVERTIMEDELTA_BACKWARD = 0b00000100,
+};
+
 void CL_ClearKeys(void);
 
 void CL_InitInput(void);

--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -3017,6 +3017,13 @@ void PM_CoolWeapons(void)
 #define AIMSPREAD_VIEWRATE_MIN      30.0f       // degrees per second
 #define AIMSPREAD_VIEWRATE_RANGE    120.0f      // degrees per second
 
+#define FORWARD_BIT  1
+#define BACKWARD_BIT 2
+
+#ifdef GAMEDLL
+extern vmCvar_t g_developer;
+#endif
+
 /**
  * @brief PM_AdjustAimSpreadScale
  */
@@ -3033,6 +3040,22 @@ void PM_AdjustAimSpreadScale(void)
 		pm->ps->aimSpreadScaleFloat = AIMSPREAD_MAXSPREAD;
 		return;
 	}
+
+#ifdef GAMEDLL
+	if(g_developer.integer & 2) {
+		if ( pm->cmd.flags & (1 << FORWARD_BIT) ) {
+			Com_Printf("%i +1\n", pm->cmd.serverTime);
+		}
+		else if ( pm->cmd.flags & (1 << BACKWARD_BIT) )
+		{
+			Com_Printf("%i -2\n", pm->cmd.serverTime);
+		}
+		else
+		{
+			Com_Printf("%i  0\n", pm->cmd.serverTime);
+		}
+	}
+#endif
 
 	cmdTime = (pm->cmd.serverTime - pm->oldcmd.serverTime) / 1000.0f;
 


### PR DESCRIPTION
cl_showTimeDelta now responds to three bit flags for more useful output.

1: Shows the change applied and the new value for serverTimeDelta at the start of each snapshot.
2: Shows how much the serverTimeDelta has drifted since it was initialized or last reset.
4: Shows the serverTimeDelta similar to the original behavior of the cvar (still somewhat useful when viewing directly in client).

Also, sets up two bit flags in the user command packet to notify the server that the client sense of time was adjusted this packet. This allows for special handling of serverTime in upcoming bug fixes. Temporary debugging output was added to bg_pmove.c with g_developer 2..