### PR TITLE
Tweak teamkill notification message to avoid being fakeable by players

### DIFF
--- a/src/cgame/cg_event.c
+++ b/src/cgame/cg_event.c
@@ -213,7 +213,7 @@ static void CG_Obituary(entityState_t *ent)
 			}
 			else
 			{
-				s = va("%s %s", CG_TranslateString("You killed ^1TEAMMATE^7"), targetName);
+				s = va("%s %s", CG_TranslateString("^1You killed teammate^7"), targetName);
 			}
 		}
 		else
@@ -235,7 +235,7 @@ static void CG_Obituary(entityState_t *ent)
 			}
 			else
 			{
-				s = va("%s %s %s", attackerName, CG_TranslateString("^7killed ^1TEAMMATE^7"), targetName);
+				s = va("%s %s %s", attackerName, CG_TranslateString("^1killed teammate^7"), targetName);
 			}
 		}
 		else


### PR DESCRIPTION
Previously, a player called "^1TEAMMATE ^7something" could make it look like you killed a teammate, even if they are an enemy.

The new form colors the "You killed" part as well, so the capitalization of "teammate" was removed as it felt redundant.

**Note:** Translations will need to be updated to follow this change.

## Old kill notification

*It looks like a teamkill notification…*

![image](https://user-images.githubusercontent.com/180032/172952746-a41db97c-a14c-481c-9aee-edcf1dca3fd4.png)

## What it looked like in the console

*…but it's not a teamkill. Actual teamkill messages are already fully written in red (even before this PR).*

![image](https://user-images.githubusercontent.com/180032/172952540-a48cde62-3a51-4357-af2e-bd16234acb4e.png)
