### PR TITLE
cmake: generate linux binaries with extension

### DIFF
--- a/cmake/ETLBuildClient.cmake
+++ b/cmake/ETLBuildClient.cmake
@@ -95,6 +95,14 @@ set_target_properties(etl PROPERTIES
 	MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/misc/Info.plist
 )
 
+if(UNIX AND NOT ARM AND NOT APPLE AND NOT ANDROID)
+	if (CROSS_COMPILE32)
+		set_target_properties(etl PROPERTIES SUFFIX ".x86")
+	else()
+		set_target_properties(etl PROPERTIES SUFFIX ".${ARCH}")
+	endif()
+endif()
+
 target_compile_definitions(etl PRIVATE ETL_CLIENT=1)
 
 if(MSVC AND NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/etl.vcxproj.user)

--- a/cmake/ETLBuildServer.cmake
+++ b/cmake/ETLBuildServer.cmake
@@ -15,6 +15,15 @@ set_target_properties(etlded
 	RUNTIME_OUTPUT_DIRECTORY_RELEASE ""
 )
 
+if(UNIX AND NOT ARM AND NOT APPLE AND NOT ANDROID)
+	if (CROSS_COMPILE32)
+		set_target_properties(etlded PROPERTIES SUFFIX ".x86")
+	else()
+		set_target_properties(etlded PROPERTIES SUFFIX ".${ARCH}")
+	endif()
+endif()
+
+
 if(BUNDLED_ZLIB)
 	add_dependencies(etlded bundled_zlib)
 endif()


### PR DESCRIPTION
Append `.x86` or `.x86_64` suffix to Linux binaries, indicating the architecture. Linux is the only platform with both x86/64 binaries, and in order to have both installed, you currently need to either install twice, in separate directories, or manually rename the binaries.

The check for "Linux" seems very stupid, but I couldn't find any other way to detect. Let me know if there's a better way and I'll edit.

Also, there are probably scripts and stuff that need to be updated now, I will take a look at those later.