### PR TITLE
client: reduces latency, improves debugging output, creates error correction flags

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2779,6 +2779,7 @@ extern vmCvar_t demo_pvshint;
 extern vmCvar_t cg_predefineddemokeys;
 #endif
 // engine mappings
+extern vmCvar_t int_cl_extrapolationMargin;
 extern vmCvar_t int_cl_maxpackets;
 extern vmCvar_t int_cl_timenudge;
 extern vmCvar_t int_m_pitch;

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2779,7 +2779,6 @@ extern vmCvar_t demo_pvshint;
 extern vmCvar_t cg_predefineddemokeys;
 #endif
 // engine mappings
-extern vmCvar_t int_cl_extrapolationMargin;
 extern vmCvar_t int_cl_maxpackets;
 extern vmCvar_t int_cl_timenudge;
 extern vmCvar_t int_m_pitch;

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -585,7 +585,7 @@ static cvarTable_t cvarTable[] =
 
 	// Engine mappings
 	
-	{ &int_cl_extrapolationMargin, "cl_extrapolationMargin",     "0",           CVAR_ARCHIVE,                 0 },
+	{ &int_cl_extrapolationMargin, "cl_extrapolationMargin",     "1",           CVAR_ARCHIVE,                 0 },
 	{ &int_cl_maxpackets,          "cl_maxpackets",              "125",         CVAR_ARCHIVE,                 0 },
 	{ &int_cl_timenudge,           "cl_timenudge",               "0",           CVAR_ARCHIVE,                 0 },
 	{ &int_m_pitch,                "m_pitch",                    "0.022",       CVAR_ARCHIVE,                 0 },
@@ -824,17 +824,6 @@ void CG_UpdateCvars(void)
 					else if (cg_errorDecay.value > 500.0f)
 					{
 						trap_Cvar_Set("cg_errorDecay", "500");
-					}
-				}
-				else if (cv->vmCvar == &int_cl_extrapolationMargin)
-				{
-					if (int_cl_extrapolationMargin.integer < -2)
-					{
-						trap_Cvar_Set("cl_extrapolationMargin", "-2");
-					}
-					else if (int_cl_extrapolationMargin.integer > 5)
-					{
-						trap_Cvar_Set("cl_extrapolationMargin", "5");
 					}
 				}
 			}

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -281,7 +281,6 @@ vmCvar_t demo_teamonlymissilecam;
 vmCvar_t cg_predefineddemokeys;
 #endif
 
-vmCvar_t int_cl_extrapolationMargin;
 vmCvar_t int_cl_maxpackets;
 vmCvar_t int_cl_timenudge;
 vmCvar_t int_m_pitch;
@@ -584,8 +583,7 @@ static cvarTable_t cvarTable[] =
 #endif
 
 	// Engine mappings
-	
-	{ &int_cl_extrapolationMargin, "cl_extrapolationMargin",     "1",           CVAR_ARCHIVE,                 0 },
+
 	{ &int_cl_maxpackets,          "cl_maxpackets",              "125",         CVAR_ARCHIVE,                 0 },
 	{ &int_cl_timenudge,           "cl_timenudge",               "0",           CVAR_ARCHIVE,                 0 },
 	{ &int_m_pitch,                "m_pitch",                    "0.022",       CVAR_ARCHIVE,                 0 },

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -281,6 +281,7 @@ vmCvar_t demo_teamonlymissilecam;
 vmCvar_t cg_predefineddemokeys;
 #endif
 
+vmCvar_t int_cl_extrapolationMargin;
 vmCvar_t int_cl_maxpackets;
 vmCvar_t int_cl_timenudge;
 vmCvar_t int_m_pitch;
@@ -583,6 +584,8 @@ static cvarTable_t cvarTable[] =
 #endif
 
 	// Engine mappings
+	
+	{ &int_cl_extrapolationMargin, "cl_extrapolationMargin",     "0",           CVAR_ARCHIVE,                 0 },
 	{ &int_cl_maxpackets,          "cl_maxpackets",              "125",         CVAR_ARCHIVE,                 0 },
 	{ &int_cl_timenudge,           "cl_timenudge",               "0",           CVAR_ARCHIVE,                 0 },
 	{ &int_m_pitch,                "m_pitch",                    "0.022",       CVAR_ARCHIVE,                 0 },
@@ -821,6 +824,17 @@ void CG_UpdateCvars(void)
 					else if (cg_errorDecay.value > 500.0f)
 					{
 						trap_Cvar_Set("cg_errorDecay", "500");
+					}
+				}
+				else if (cv->vmCvar == &int_cl_extrapolationMargin)
+				{
+					if (int_cl_extrapolationMargin.integer < -2)
+					{
+						trap_Cvar_Set("cl_extrapolationMargin", "-2");
+					}
+					else if (int_cl_extrapolationMargin.integer > 5)
+					{
+						trap_Cvar_Set("cl_extrapolationMargin", "5");
 					}
 				}
 			}

--- a/src/client/cl_cgame.c
+++ b/src/client/cl_cgame.c
@@ -1282,16 +1282,7 @@ void CL_AdjustTimeDelta(void)
 	newDelta   = cl.snap.serverTime - cls.realtime;
 	deltaDelta = abs(newDelta - cl.serverTimeDelta);
 
-	if (cl.serverTimeDelta == 0)
-	{
-		cl.baselineDelta = cl.serverTimeDelta = newDelta;
-		cl.oldServerTime   = cl.snap.serverTime; // FIXME: is this a problem for cgame?
-		cl.serverTime      = cl.snap.serverTime;
-
-		if (cl_showTimeDelta->integer & 1) adjustmentMessage = "^4RESET^7 (resetdelta)";
-		if (cl_showTimeDelta->integer & 2) Com_Printf("<RESET> ");
-	}
-	else if (deltaDelta > RESET_TIME)
+	if (deltaDelta > RESET_TIME)
 	{
 		cl.baselineDelta = cl.serverTimeDelta = newDelta;
 		cl.oldServerTime   = cl.snap.serverTime; // FIXME: is this a problem for cgame?

--- a/src/client/cl_input.c
+++ b/src/client/cl_input.c
@@ -1046,7 +1046,7 @@ void CL_FinishMove(usercmd_t *cmd)
 	}
 }
 
-#define MASK_CGAMEFLAGS_SERVERTIMEDELTA 0b00000110
+#define MASK_CGAMEFLAGS_SERVERTIMEDELTA 0x6 // 0b00000110
 
 /**
  * @brief CL_CreateCmd
@@ -1098,7 +1098,7 @@ usercmd_t CL_CreateCmd(void)
 	// store out the final values
 	CL_FinishMove(&cmd);
 
-	// the flags for serverTimeDelta have been used, so reset them
+	// the flags for serverTimeDelta have been used, so clear them
 	cl.cgameFlags &= ~MASK_CGAMEFLAGS_SERVERTIMEDELTA_FORWARD;
 	cl.cgameFlags &= ~MASK_CGAMEFLAGS_SERVERTIMEDELTA_BACKWARD;
 

--- a/src/client/cl_input.c
+++ b/src/client/cl_input.c
@@ -1046,6 +1046,8 @@ void CL_FinishMove(usercmd_t *cmd)
 	}
 }
 
+#define MASK_CGAMEFLAGS_SERVERTIMEDELTA 0b00000110
+
 /**
  * @brief CL_CreateCmd
  * @return
@@ -1095,6 +1097,10 @@ usercmd_t CL_CreateCmd(void)
 
 	// store out the final values
 	CL_FinishMove(&cmd);
+
+	// the flags for serverTimeDelta have been used, so reset them
+	cl.cgameFlags &= ~MASK_CGAMEFLAGS_SERVERTIMEDELTA_FORWARD;
+	cl.cgameFlags &= ~MASK_CGAMEFLAGS_SERVERTIMEDELTA_BACKWARD;
 
 	// draw debug graphs of turning for mouse testing
 	if (cl_debugMove->integer)

--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -2920,7 +2920,8 @@ void CL_Init(void)
 
 	cl_wavefilerecord = Cvar_Get("cl_wavefilerecord", "0", CVAR_TEMP);
 
-	cl_extrapolationMargin = Cvar_Get("cl_extrapolationMargin", "0", CVAR_ARCHIVE);
+	cl_extrapolationMargin = Cvar_Get("cl_extrapolationMargin", "1", CVAR_ARCHIVE);
+	Cvar_CheckRange(cl_extrapolationMargin, 0, 10, qtrue);
 
 	cl_timeNudge          = Cvar_Get("cl_timeNudge", "0", CVAR_TEMP);
 	cl_shownet            = Cvar_Get("cl_shownet", "0", CVAR_TEMP);

--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -63,6 +63,7 @@ cvar_t *cl_timeout;
 cvar_t *cl_maxpackets;
 cvar_t *cl_packetdup;
 cvar_t *cl_timeNudge;
+cvar_t *cl_extrapolationMargin;
 cvar_t *cl_showTimeDelta;
 cvar_t *cl_freezeDemo;
 
@@ -1421,6 +1422,21 @@ void CL_Clip_f(void)
 	// Return to console printing
 	Cvar_Set("cl_noprint", va("%i", noPrint));
 }
+
+/**
+ * @brief CL_RebaseDrift_f 
+ * Resets the baselineDelta used for calculating drift in cl_showTimeDelta debugging output.
+ */
+void CL_RebaseDrift_f(void)
+{
+	cl.baselineDelta = cl.serverTimeDelta;
+	
+	if (cl_showTimeDelta->integer & 1)
+	{
+		Com_Printf("^2REBASE DRIFT^7 (baselineDelta = serverTimeDelta = % i)\n", cl.serverTimeDelta);
+	}
+}
+
 
 #ifdef ETLEGACY_DEBUG
 void CL_ExtendedCharsTest_f(void)
@@ -2904,6 +2920,8 @@ void CL_Init(void)
 
 	cl_wavefilerecord = Cvar_Get("cl_wavefilerecord", "0", CVAR_TEMP);
 
+	cl_extrapolationMargin = Cvar_Get("cl_extrapolationMargin", "0", CVAR_ARCHIVE);
+
 	cl_timeNudge          = Cvar_Get("cl_timeNudge", "0", CVAR_TEMP);
 	cl_shownet            = Cvar_Get("cl_shownet", "0", CVAR_TEMP);
 	cl_shownuments        = Cvar_Get("cl_shownuments", "0", CVAR_TEMP);
@@ -2927,8 +2945,8 @@ void CL_Init(void)
 	cl_pitchspeed    = Cvar_Get("cl_pitchspeed", "140", CVAR_ARCHIVE_ND);
 	cl_anglespeedkey = Cvar_Get("cl_anglespeedkey", "1.5", 0);
 
-	cl_maxpackets = Cvar_Get("cl_maxpackets", "125", CVAR_ARCHIVE);
-	cl_packetdup  = Cvar_Get("cl_packetdup", "1", CVAR_ARCHIVE_ND);
+	cl_maxpackets  = Cvar_Get("cl_maxpackets", "125", CVAR_ARCHIVE);
+	cl_packetdup   = Cvar_Get("cl_packetdup", "1", CVAR_ARCHIVE_ND);
 
 	cl_run         = Cvar_Get("cl_run", "1", CVAR_ARCHIVE_ND);
 	cl_sensitivity = Cvar_Get("sensitivity", "5", CVAR_ARCHIVE);
@@ -3071,6 +3089,8 @@ void CL_Init(void)
 	Cmd_AddCommand("open_homepath", CL_OpenHomePath_f, "Open the home path in a system file explorer.");
 	Cmd_AddCommand("clip", CL_Clip_f, "Put command output to clipboard.");
 
+	Cmd_AddCommand("rebaseDrift", CL_RebaseDrift_f, "Resets the baselineDelta used for calculating drift.");
+
 #ifdef ETLEGACY_DEBUG
 	Cmd_AddCommand("extendedCharsTest", CL_ExtendedCharsTest_f);
 #endif
@@ -3166,6 +3186,8 @@ void CL_Shutdown(void)
 
 	Cmd_RemoveCommand("open_homepath");
 	Cmd_RemoveCommand("clip");
+
+	Cmd_RemoveCommand("rebaseDrift");
 
 #ifdef ETLEGACY_DEBUG
 	Cmd_RemoveCommand("extendedCharsTest");

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -129,6 +129,7 @@ typedef struct
 	int oldFrameServerTime;                 ///< to check tournament restarts
 	int serverTimeDelta;                    ///< cl.serverTime = cls.realtime + cl.serverTimeDelta
 	                                        ///< this value changes as net lag varies
+	int baselineDelta;                      ///< initial or reset value of serverTimeDelta w/o adjustments
 	qboolean extrapolatedSnapshot;          ///< set if any cgame frame has been forced to extrapolate
 	                                        ///< cleared when CL_AdjustTimeDelta looks at it
 	qboolean newSnapshots;                  ///< set on parse of any valid packet
@@ -408,6 +409,7 @@ extern cvar_t *cl_shownuments;
 extern cvar_t *cl_showSend;
 extern cvar_t *cl_showServerCommands;
 extern cvar_t *cl_timeNudge;
+extern cvar_t *cl_extrapolationMargin;
 extern cvar_t *cl_showTimeDelta;
 extern cvar_t *cl_freezeDemo;
 
@@ -574,6 +576,17 @@ typedef enum
 	KB_MLOOK,
 	NUM_BUTTONS
 } kbuttons_t;
+
+/**
+ * @enum cgameFlagsMaskEnum
+ * @brief
+ */
+enum cgameFlagsMaskEnum
+{
+    MASK_CGAMEFLAGS_SHOWGAMEVIEW             = 0b00000001,
+    MASK_CGAMEFLAGS_SERVERTIMEDELTA_FORWARD  = 0b00000010,
+    MASK_CGAMEFLAGS_SERVERTIMEDELTA_BACKWARD = 0b00000100,
+};
 
 void CL_ClearKeys(void);
 

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -128,7 +128,7 @@ typedef struct
 	int oldServerTime;                      ///< to prevent time from flowing bakcwards
 	int oldFrameServerTime;                 ///< to check tournament restarts
 	int serverTimeDelta;                    ///< cl.serverTime = cls.realtime + cl.serverTimeDelta
-	                                        ///< this value changes as net lag varies
+	                                        ///  this value changes as net lag varies
 	int baselineDelta;                      ///< initial or reset value of serverTimeDelta w/o adjustments
 	qboolean extrapolatedSnapshot;          ///< set if any cgame frame has been forced to extrapolate
 	                                        ///< cleared when CL_AdjustTimeDelta looks at it
@@ -583,9 +583,9 @@ typedef enum
  */
 enum cgameFlagsMaskEnum
 {
-    MASK_CGAMEFLAGS_SHOWGAMEVIEW             = 0b00000001,
-    MASK_CGAMEFLAGS_SERVERTIMEDELTA_FORWARD  = 0b00000010,
-    MASK_CGAMEFLAGS_SERVERTIMEDELTA_BACKWARD = 0b00000100,
+    MASK_CGAMEFLAGS_SHOWGAMEVIEW             = 0x1, // 0b00000001
+    MASK_CGAMEFLAGS_SERVERTIMEDELTA_FORWARD  = 0x2, // 0b00000010
+    MASK_CGAMEFLAGS_SERVERTIMEDELTA_BACKWARD = 0x4, // 0b00000100
 };
 
 void CL_ClearKeys(void);
@@ -802,6 +802,7 @@ void CL_UpdateLevelHunkUsage(void);
 void CL_CGameBinaryMessageReceived(const byte *buf, int buflen, int serverTime);
 qboolean CL_GetSnapshot(int snapshotNumber, snapshot_t *snapshot);
 qboolean CL_GetServerCommand(int serverCommandNumber);
+int CL_FindIncrementThreshold(void);
 void CL_AdjustTimeDelta(void);
 
 // cl_ui.c

--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -3017,6 +3017,13 @@ void PM_CoolWeapons(void)
 #define AIMSPREAD_VIEWRATE_MIN      30.0f       // degrees per second
 #define AIMSPREAD_VIEWRATE_RANGE    120.0f      // degrees per second
 
+#define FORWARD_BIT  1
+#define BACKWARD_BIT 2
+
+#ifdef GAMEDLL
+extern vmCvar_t g_developer;
+#endif
+
 /**
  * @brief PM_AdjustAimSpreadScale
  */
@@ -3033,6 +3040,22 @@ void PM_AdjustAimSpreadScale(void)
 		pm->ps->aimSpreadScaleFloat = AIMSPREAD_MAXSPREAD;
 		return;
 	}
+
+#ifdef GAMEDLL
+	if(g_developer.integer & 2) {
+		if ( pm->cmd.flags & (1 << FORWARD_BIT) ) {
+			Com_Printf("%i +1\n", pm->cmd.serverTime);
+		}
+		else if ( pm->cmd.flags & (1 << BACKWARD_BIT) )
+		{
+			Com_Printf("%i -2\n", pm->cmd.serverTime);
+		}
+		else
+		{
+			Com_Printf("%i  0\n", pm->cmd.serverTime);
+		}
+	}
+#endif
 
 	cmdTime = (pm->cmd.serverTime - pm->oldcmd.serverTime) / 1000.0f;
 

--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -3044,11 +3044,11 @@ void PM_AdjustAimSpreadScale(void)
 #ifdef GAMEDLL
 	if(g_developer.integer & 2) {
 		if ( pm->cmd.flags & (1 << FORWARD_BIT) ) {
-			Com_Printf("%i +1\n", pm->cmd.serverTime);
+			Com_Printf("^5%i +1\n", pm->cmd.serverTime);
 		}
 		else if ( pm->cmd.flags & (1 << BACKWARD_BIT) )
 		{
-			Com_Printf("%i -2\n", pm->cmd.serverTime);
+			Com_Printf("^6%i -2\n", pm->cmd.serverTime);
 		}
 		else
 		{


### PR DESCRIPTION
Two bit flags were added to the user command packet to notify the server that the client sense of time was adjusted. This allows for special handling of `serverTime` in the next command received. Temporary debugging output was added to mod code in bg_pmove.c with g_developer 2. This change gives legacy and other mods the information needed to properly respond to incorrect `serverTime` values caused by automatic adjustments to `serverTimeDelta` on the client.

---

Creates`cl_extrapolationMargin` with a default value of 1 and allowed range 0 to 10 to replace a magic number 5 that added unnecessary latency at some client frame rates. This change will typically reduce the client latency by up to 4 ms at the default value. Servers that want to restrict client control can use `sv_cvar` to force default.

When the client sense of time in incremented is now more cautious to accommodate this change instead of always moving forward every snapshot.