### PR TITLE
updates unix clocksource to prefer monotonic time

### DIFF
--- a/src/sys/sys_unix.c
+++ b/src/sys/sys_unix.c
@@ -198,7 +198,7 @@ int Sys_Milliseconds(void)
 		}
 
 		sys_timeBase = (time.tv_sec * 1000) + (time.tv_nsec / 1000000);
-		return sys_timeBase;
+		return 0;
 	}
 
 	clock_gettime(clockid, &time);


### PR DESCRIPTION
This patch replaces `gettimeofday` with `clock_gettime` inside `Sys_Milliseconds` and uses a monotonic clock if available on the system. 

The old clock getting function `gettimeofday` which was marked obsolete by POSIX in 2008. The recommended replacement `clock_gettime` is supposed to be more accurate and should be available on most systems. All systems with `clock_gettime` will have `CLOCK_REALTIME` and most will have `CLOCK_MONOTONIC`.

The Windows clocksource is already monotonic so this will give parity and eliminate rare issues caused by NTP or manual system time changes.