### PR TITLE
cgame: correct the selected weapon so PMF_RESPAWNED flag can be cleared, refs #2003

### DIFF
--- a/src/cgame/cg_playerstate.c
+++ b/src/cgame/cg_playerstate.c
@@ -506,6 +506,11 @@ void CG_TransitionPlayerState(playerState_t *ps, playerState_t *ops)
 		CG_Respawn(ps->persistant[PERS_REVIVE_COUNT] != ops->persistant[PERS_REVIVE_COUNT] ? qtrue : qfalse);
 	}
 
+	if ((ps->pm_flags & PMF_RESPAWNED) && cg.weaponSelect != ps->weapon)
+	{
+		cg.weaponSelect = ps->weapon;
+	}
+
 	if (cg.mapRestart)
 	{
 		CG_Respawn(qfalse);


### PR DESCRIPTION
Steps to reproduce:
- switch weapon to anything but weaponbank 3
- die
- before respawning do `vid_restart`

The issue starts in `CG_ProcessSnapshots`. When `vid_restart` is done first the game will set the initial snapshot, but that snapshot is the oldest one in the buffer, so it doesn't contain the weapon the server wants us when we spawn, it has the weapon we died with, so it sets wrong `cg.weaponSelect`.

Right after that newer snaps are read and transition is done. But playerstate transitions are either not done if player wasn't following another player, or done but the `CG_RESPAWN` is neither called nor the `ps->weapon` is ever correct. At least most of the time the frame when we start reading and processing snapshots again after `vid_restart` the snapshot that would have the correct values doesn't seem to exist yet. 

After that first frame user commands set the wrong weapon and keep it forever because player cannot issue a switch till the `PMF_RESPAWNED` flag is cleared and it will not be cleared in pmove.

https://github.com/etlegacy/etlegacy/blob/3377359300f4f135f9f73679f58ab650a710f16c/src/cgame/cg_weapons.c#L4981-L4991

https://github.com/etlegacy/etlegacy/blob/3377359300f4f135f9f73679f58ab650a710f16c/src/game/bg_pmove.c#L5024-L5034

I believe this is very old vanilla bug that was causing players to spawn with incorrect weapon, it was partly fixed by this commit https://github.com/etlegacy/etlegacy/commit/25dfbddacae03634889da56891d74b98ca3dcc5d but in this case, it would leave player unable to do most actions in the game. 

This solution means that after first prediction with correct snapshot from server that has `PMF_RESPAWNED` flag we will check for  it in `CG_TransitionPlayerState` and correct the `cg.weaponSelect` so the next user command will have the weapon set to what server wants and the flag will get cleared.

refs #2003