### PR TITLE
client: fix escape key not sending a char event

### DIFF
--- a/src/sdl/sdl_input.c
+++ b/src/sdl/sdl_input.c
@@ -1187,6 +1187,10 @@ static void IN_ProcessEvents(void)
 					// 8 == CTRL('h') == BS aka Backspace from ascii table
 					Com_QueueEvent(lasttime, SE_CHAR, CTRL('h'), 0, 0, NULL);
 				}
+				else if (key == K_ESCAPE)
+				{
+					Com_QueueEvent(lasttime, SE_CHAR, key, 0, 0, NULL);
+				}
 				else if ((keys[K_LCTRL].down || keys[K_RCTRL].down) && key >= 'a' && key <= 'z')
 				{
 					Com_QueueEvent(lasttime, SE_CHAR, CTRL(key), 0, 0, NULL);


### PR DESCRIPTION
This readds VET behaviour for escape key. Without it when closing menus like voice chat window (`mp_QuickMessage`) the UI keycatcher would get unset on KeyUp (instead of char event). This would mean that for a time the `BUTTON_TALK` would be getting added to user commands as the ui keycatcher is set and because of this all user move commands would get discarded in pmove.