### PR TITLE
game: fix missing hitsound in some scenarios

### DIFF
--- a/src/game/g_combat.c
+++ b/src/game/g_combat.c
@@ -1375,7 +1375,7 @@ void G_DamageExt(gentity_t *targ, gentity_t *inflictor, gentity_t *attacker, vec
 	}
 
 	// add to the attacker's hit counter (but only if target is a client)
-	if (attacker && attacker->client && targ->client  && targ != attacker && targ->health >= FORCE_LIMBO_HEALTH &&
+	if (attacker && attacker->client && targ->client  && targ != attacker &&
 	    mod != MOD_SWITCHTEAM && mod != MOD_SWAP_PLACES && mod != MOD_SUICIDE)
 	{
 		if (onSameTeam || (targ->client->ps.powerups[PW_OPS_DISGUISED] && (g_friendlyFire.integer & 1)))


### PR DESCRIPTION
Players can reach lower health than `FORCE_LIMBO_HEALTH` without getting gibbed, causing the next hit that will gib them to not play the hitsound. Checking target's health doesn't seem necessary.