### PR TITLE
mod: fixes and changes to game pause, refs #760

### DIFF
--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -4734,7 +4734,7 @@ void CG_DrawMissileCamera(rectDef_t *rect)
 	vec3_t    forward, delta, angles;
 	centity_t *cent;
 
-	if (!cg.latestMissile)
+	if (!cg.latestMissile || cgs.matchPaused)
 	{
 		return;
 	}

--- a/src/cgame/cg_effects.c
+++ b/src/cgame/cg_effects.c
@@ -1227,7 +1227,7 @@ void CG_AddSmokeSprites(void)
 		}
 
 		// Do physics
-		if (!CG_SmokeSpritePhysics(smokesprite, dist))
+		if (!cgs.matchPaused && !CG_SmokeSpritePhysics(smokesprite, dist))
 		{
 			if (smokesprite->smokebomb)
 			{

--- a/src/cgame/cg_ents.c
+++ b/src/cgame/cg_ents.c
@@ -2520,6 +2520,24 @@ void CG_CalcEntityLerpPositions(centity_t *cent)
  */
 static void CG_ProcessEntity(centity_t *cent)
 {
+	if (cgs.matchPaused)
+	{
+		if (cent->trailTime)
+		{
+			cent->trailTime += cg.frametime;
+		}
+
+		if (cent->highlightTime)
+		{
+			cent->highlightTime += cg.frametime;
+		}
+
+		if (cent->lastFuseSparkTime)
+		{
+			cent->lastFuseSparkTime += cg.frametime;
+		}
+	}
+
 	switch (cent->currentState.eType)
 	{
 	default:

--- a/src/cgame/cg_flamethrower.c
+++ b/src/cgame/cg_flamethrower.c
@@ -264,7 +264,7 @@ void CG_FireFlameChunks(centity_t *cent, vec3_t origin, vec3_t angles, float spe
 			f->velSpeed     = FLAME_START_SPEED * (0.5f + 0.5f * speedScale) * (firing ? 1.0f : 4.5f);
 			f->ownerCent    = cent->currentState.number;
 			f->rollAngle    = crandom() * 179;
-			f->ignitionOnly = (qboolean)!firing;
+			f->ignitionOnly = (qboolean) !firing;
 
 			if (!firing)
 			{
@@ -337,7 +337,7 @@ void CG_FireFlameChunks(centity_t *cent, vec3_t origin, vec3_t angles, float spe
 		f->velSpeed     = FLAME_START_SPEED * (0.5f + 0.5f * speedScale);
 		f->ownerCent    = cent->currentState.number;
 		f->rollAngle    = crandom() * 179;
-		f->ignitionOnly = (qboolean)!firing;
+		f->ignitionOnly = (qboolean) !firing;
 		f->speedScale   = speedScale;
 		if (!firing)
 		{
@@ -395,7 +395,7 @@ void CG_ClearFlameChunks(void)
 	activeFlameChunks = NULL;
 	headFlameChunks   = NULL;
 
-    flameChunks[0].nextGlobal = &flameChunks[1];
+	flameChunks[0].nextGlobal = &flameChunks[1];
 
 	for (i = 1 ; i < MAX_FLAME_CHUNKS - 1 ; i++)
 	{
@@ -836,7 +836,7 @@ void CG_AddFlameToScene(flameChunk_t *fHead)
 {
 	flameChunk_t  *f, *fNext;
 	int           blueTrailHead = 0, fuelTrailHead = 0;
-	static vec3_t whiteColor    = { 1, 1, 1 };
+	static vec3_t whiteColor = { 1, 1, 1 };
 	vec3_t        c;
 	float         alpha;
 	float         lived;
@@ -846,7 +846,7 @@ void CG_AddFlameToScene(flameChunk_t *fHead)
 	qboolean      isClientFlame;
 	int           shader;
 	flameChunk_t  *lastBlueChunk = NULL;
-	qboolean      skip           = qfalse, droppedTrail;
+	qboolean      skip = qfalse, droppedTrail;
 	vec3_t        v;
 	vec3_t        lightOrg;         // origin to place light at
 	float         lightSize;
@@ -915,7 +915,7 @@ void CG_AddFlameToScene(flameChunk_t *fHead)
 
 			// is it in the blue ignition section of the flame?
 		}
-		else if (isClientFlame && f->blueLife > (lived / 2.0f))
+		else if (isClientFlame && f->blueLife > (lived / 2.0f) && !cgs.matchPaused)
 		{
 
 			skip = qfalse;
@@ -1283,6 +1283,15 @@ void CG_AddFlameChunks(void)
 	{
 		if (!f->dead)
 		{
+			if (cgs.matchPaused)
+			{
+				f->timeStart        += cg.frametime;
+				f->timeEnd          += cg.frametime;
+				f->baseOrgTime      += cg.frametime;
+				f->lastFriction     += cg.frametime;
+				f->lastFrictionTake += cg.frametime;
+			}
+
 			if (cg.time > f->timeEnd)
 			{
 				f->dead = qtrue;

--- a/src/cgame/cg_localents.c
+++ b/src/cgame/cg_localents.c
@@ -166,9 +166,7 @@ or generates more localentities along a trail.
  */
 void CG_BloodTrail(localEntity_t *le)
 {
-	int    t;
-	int    t2;
-	int    step;
+	int    t, t2, step;
 	vec3_t newOrigin;
 	float  vl;  //bani
 
@@ -176,7 +174,7 @@ void CG_BloodTrail(localEntity_t *le)
 	static vec3_t col = { 1, 1, 1 };
 #endif
 
-	if (!cg_blood.integer)
+	if (!cg_blood.integer || cgs.matchPaused)
 	{
 		return;
 	}
@@ -392,7 +390,7 @@ void CG_AddEmitter(localEntity_t *le)
 {
 	vec3_t dir;
 
-	if (le->breakCount > cg.time)      // using 'breakCount' for 'wait'
+	if (le->breakCount > cg.time || cgs.matchPaused)      // using 'breakCount' for 'wait'
 	{
 		return;
 	}
@@ -763,6 +761,11 @@ void CG_AddSparkElements(localEntity_t *le)
 	float   lifeFrac;
 	float   time = (float)(cg.time - cg.frametime);
 
+	if (cgs.matchPaused)
+	{
+		return;
+	}
+
 	while (1)
 	{
 		// calculate new position
@@ -878,6 +881,11 @@ void CG_AddBloodElements(localEntity_t *le)
 	float   lifeFrac;
 	float   time = (float)(cg.time - cg.frametime);
 	int     numbounces;
+
+	if (cgs.matchPaused)
+	{
+		return;
+	}
 
 	for (numbounces = 0; numbounces < 5; numbounces++)
 	{
@@ -1343,6 +1351,24 @@ void CG_AddLocalEntities(void)
 		// grab next now, so if the local entity is freed we
 		// still have it
 		next = le->prev;
+
+		if (cgs.matchPaused)
+		{
+			le->pos.trTime    += cg.frametime;
+			le->angles.trTime += cg.frametime;
+
+			le->startTime     += cg.frametime;
+			le->endTime       += cg.frametime;
+			le->fadeInTime    += cg.frametime;
+			le->lastTrailTime += cg.frametime;
+			le->onFireStart   += cg.frametime;
+			le->onFireEnd     += cg.frametime;
+
+			if (le->leType == LE_EMITTER)
+			{
+				le->breakCount += cg.frametime;
+			}
+		}
 
 		if (cg.time >= le->endTime)
 		{

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -428,7 +428,7 @@ static cvarTable_t cvarTable[] =
 	//  { &cg_draw2D, "cg_draw2D", "1", CVAR_CHEAT }, // JPW NERVE changed per atvi req to prevent sniper rifle zoom cheats
 	{ &cg_draw2D,                  "cg_draw2D",                  "1",           CVAR_ARCHIVE,                 0 },
 	{ &cg_drawSpreadScale,         "cg_drawSpreadScale",         "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_railTrailTime,           "cg_railTrailTime",           "50",          CVAR_ARCHIVE,                 0 },
+	{ &cg_railTrailTime,           "cg_railTrailTime",           "750",         CVAR_ARCHIVE,                 0 },
 	{ &cg_drawStatus,              "cg_drawStatus",              "1",           CVAR_ARCHIVE,                 0 },
 	{ &cg_drawFPS,                 "cg_drawFPS",                 "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_drawPing,                "cg_drawPing",                "0",           CVAR_ARCHIVE,                 0 },

--- a/src/cgame/cg_particles.c
+++ b/src/cgame/cg_particles.c
@@ -1031,6 +1031,18 @@ void CG_AddParticles(void)
 	{
 		next = p->next;
 
+		if (cgs.matchPaused)
+		{
+			p->time      += cg.frametime;
+			p->endtime   += cg.frametime;
+			p->startfade += cg.frametime;
+
+			if (p->rotate)
+			{
+				p->accumroll -= p->roll;
+			}
+		}
+
 		time = (cg.time - p->time) * 0.001f;
 
 		alpha = p->alpha + time * p->alphavel;

--- a/src/cgame/cg_players.c
+++ b/src/cgame/cg_players.c
@@ -1895,6 +1895,12 @@ static void CG_BreathPuffs(centity_t *cent, refEntity_t *head)
 	{
 		return;
 	}
+
+	if (cgs.matchPaused)
+	{
+		ci->breathPuffTime += cg.frametime;
+	}
+
 	if (ci->breathPuffTime > cg.time)
 	{
 		return;

--- a/src/cgame/cg_trails.c
+++ b/src/cgame/cg_trails.c
@@ -910,6 +910,12 @@ void CG_AddTrails(void)
 	j = activeTrails;
 	while (j)
 	{
+		if (cgs.matchPaused)
+		{
+			j->spawnTime += cg.frametime;
+			j->endTime   += cg.frametime;
+		}
+
 		lifeFrac = (float)(cg.time - j->spawnTime) / (float)(j->endTime - j->spawnTime);
 		if (lifeFrac >= 1.0f)
 		{

--- a/src/cgame/cg_weapons.c
+++ b/src/cgame/cg_weapons.c
@@ -614,7 +614,7 @@ static void CG_GrenadeTrail(centity_t *ent, const weaponInfo_t *wi)
 			                                     startTime,
 			                                     0,
 			                                     origin,
-			                                     750,
+			                                     cg_railTrailTime.integer,
 			                                     0.3f,
 			                                     0.0f,
 			                                     2,
@@ -3700,8 +3700,8 @@ void CG_AddPlayerWeapon(refEntity_t *parent, playerState_t *ps, centity_t *cent)
 			return;
 		}
 
-		// no flamethrower flame on prone moving or dead players
-		if ((cent->currentState.eFlags & EF_FIRING) && !(cent->currentState.eFlags & (EF_PRONE_MOVING | EF_DEAD)))
+		// no flamethrower flame on prone moving or dead players, or during pause
+		if ((cent->currentState.eFlags & EF_FIRING) && !(cent->currentState.eFlags & (EF_PRONE_MOVING | EF_DEAD)) && !cgs.matchPaused)
 		{
 			trace_t trace;
 			vec3_t  muzzlePoint, angles, forward;

--- a/src/game/g_active.c
+++ b/src/game/g_active.c
@@ -1202,9 +1202,8 @@ void ClientThink_real(gentity_t *ent)
 		// if the difference between commandTime and the last command
 		// time is small, you won't move as far since it's doing
 		// velocity*time for updating your position
-		client->ps.commandTime = level.previousTime -
-		                         (frames  * (level.time - level.previousTime));
-		client->warped = qtrue;
+		client->ps.commandTime = level.previousTime - (frames  * level.frameTime);
+		client->warped         = qtrue;
 	}
 
 	client->warping         = qfalse;
@@ -2094,11 +2093,11 @@ void ClientEndFrame(gentity_t *ent)
 	{
 		if (ent->client->sess.sessionTeam == TEAM_AXIS)
 		{
-			ent->client->sess.time_axis += level.time - level.previousTime;
+			ent->client->sess.time_axis += level.frameTime;
 		}
 		else if (ent->client->sess.sessionTeam == TEAM_ALLIES)
 		{
-			ent->client->sess.time_allies += level.time - level.previousTime;
+			ent->client->sess.time_allies += level.frameTime;
 		}
 	}
 
@@ -2111,7 +2110,7 @@ void ClientEndFrame(gentity_t *ent)
 		{
 			ent->client->sess.time_played = 0;
 		}
-		ent->client->sess.time_played += level.time - level.previousTime;
+		ent->client->sess.time_played += level.frameTime;
 	}
 
 #ifdef FEATURE_RATING
@@ -2171,7 +2170,7 @@ void ClientEndFrame(gentity_t *ent)
 		// Make sure we dont let stuff like CTF flags expire.
 		if (level.match_pause != PAUSE_NONE && ent->client->ps.powerups[i] != INT_MAX)
 		{
-			ent->client->ps.powerups[i] += level.time - level.previousTime;
+			ent->client->ps.powerups[i] += level.frameTime;
 		}
 
 		if (ent->client->ps.powerups[i] < level.time)
@@ -2203,18 +2202,16 @@ void ClientEndFrame(gentity_t *ent)
 	//		--> Any new things in ET we should worry about?
 	if (level.match_pause != PAUSE_NONE)
 	{
-		int time_delta = level.time - level.previousTime;
-
-		ent->client->airOutTime         += time_delta;
-		ent->client->inactivityTime     += time_delta;
-		ent->client->lastBurnTime       += time_delta;
-		ent->client->pers.connectTime   += time_delta;
-		ent->client->pers.enterTime     += time_delta;
-		ent->client->ps.classWeaponTime += time_delta;
-		//ent->client->respawnTime += time_delta;
-		ent->lastHintCheckTime  += time_delta;
-		ent->pain_debounce_time += time_delta;
-		ent->s.onFireEnd        += time_delta;
+		ent->client->airOutTime         += level.frameTime;
+		ent->client->inactivityTime     += level.frameTime;
+		ent->client->lastBurnTime       += level.frameTime;
+		ent->client->pers.connectTime   += level.frameTime;
+		ent->client->pers.enterTime     += level.frameTime;
+		ent->client->ps.classWeaponTime += level.frameTime;
+		//ent->client->respawnTime      += level.frameTime;
+		ent->lastHintCheckTime  += level.frameTime;
+		ent->pain_debounce_time += level.frameTime;
+		ent->s.onFireEnd        += level.frameTime;
 	}
 
 	// save network bandwidth

--- a/src/game/g_items.c
+++ b/src/game/g_items.c
@@ -1126,7 +1126,7 @@ void G_BounceItem(gentity_t *ent, trace_t *trace)
 {
 	vec3_t velocity;
 	float  dot;
-	int    hitTime = (int)(level.previousTime + (level.time - level.previousTime) * trace->fraction);
+	int    hitTime = (int)(level.previousTime + (level.frameTime * trace->fraction));
 	int    mask    = ent->clipmask ? ent->clipmask : MASK_SOLID;
 
 	// reflect the velocity on the trace plane
@@ -1282,6 +1282,11 @@ void G_RunItem(gentity_t *ent)
 			ent->s.pos.trType = TR_GRAVITY;
 			ent->s.pos.trTime = level.time;
 		}
+	}
+
+	if (level.match_pause != PAUSE_NONE && ent->s.pos.trType != TR_STATIONARY)
+	{
+		ent->s.pos.trTime += level.frameTime;
 	}
 
 	if (ent->s.pos.trType == TR_STATIONARY) // check think function

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1166,7 +1166,7 @@ typedef struct level_locals_s
 	int time;                                   ///< in msec
 	int overTime;                               ///< workaround for dual objective timelimit bug
 	int previousTime;                           ///< so movers can back up when blocked
-	int frameTime;                              ///< time the frame started, for antilag stuff
+	int frameTime;                              ///< time delta
 
 	int startTime;                              ///< level.time the map was started
 

--- a/src/game/g_missile.c
+++ b/src/game/g_missile.c
@@ -63,7 +63,7 @@ void G_BounceMissile(gentity_t *ent, trace_t *trace)
 	}
 
 	// reflect the velocity on the trace plane
-	hitTime = (int)(level.previousTime + (level.time - level.previousTime) * trace->fraction);
+	hitTime = (int)(level.previousTime + (level.frameTime * trace->fraction));
 	BG_EvaluateTrajectoryDelta(&ent->s.pos, hitTime, velocity, qfalse, ent->s.effect2Time);
 	dot = DotProduct(velocity, trace->plane.normal);
 	VectorMA(velocity, -2 * dot, trace->plane.normal, ent->s.pos.trDelta);

--- a/src/game/g_mover.c
+++ b/src/game/g_mover.c
@@ -334,7 +334,7 @@ qboolean G_TryPushingEntity(gentity_t *check, gentity_t *pusher, vec3_t move, ve
 		// make sure the client's view rotates when on a rotating mover
 		// - this is done client-side now
 		// - only do this if player is ON a rotating mover
-		if(check->s.groundEntityNum == pusher->s.number)
+		if (check->s.groundEntityNum == pusher->s.number)
 		{
 			check->client->ps.delta_angles[YAW] += ANGLE2SHORT(amove[YAW]);
 		}
@@ -751,8 +751,8 @@ void G_MoverTeam(gentity_t *ent)
 		// go back to the previous position
 		for (part = ent ; part ; part = part->teamchain)
 		{
-			part->s.pos.trTime  += level.time - level.previousTime;
-			part->s.apos.trTime += level.time - level.previousTime;
+			part->s.pos.trTime  += level.frameTime;
+			part->s.apos.trTime += level.frameTime;
 			BG_EvaluateTrajectory(&part->s.pos, level.time, part->r.currentOrigin, qfalse, ent->s.effect2Time);
 			BG_EvaluateTrajectory(&part->s.apos, level.time, part->r.currentAngles, qtrue, ent->s.effect2Time);
 			trap_LinkEntity(part);
@@ -824,7 +824,8 @@ void G_RunMover(gentity_t *ent)
 		}
 		else
 		{
-			ent->s.pos.trTime += level.time - level.previousTime;
+			ent->s.pos.trTime  += level.frameTime;
+			ent->s.apos.trTime += level.frameTime;
 		}
 	}
 


### PR DESCRIPTION
Changes to the game pause:

1. Fixed rotating movers were not paused (affected mostly doors)
2. Fixes to flamethrower:
- Flamethrower flame hitboxes are now correctly paused on server
- Flamethrower flames no longer deal damage during pause
- Players can't shoot flamethrower during pause anymore (visual bug only)
- Flamethrower flames are now paused client side
3. Fixed item physics were not paused
4. Fixed sinking player bodies were not paused
5. Fixes to airstrike:
- If game was paused during plane flyby the remaining bombs would not drop
- Plane is now paused client side
- Smoke from canister is now paused client side
6. Fixes to cover ops smoke grenade:
- Smoke grenade time would tick down during pause so after the pause it would disappear too soon
- Smoke is now paused client side
7. Various other things are now also paused client side:
- Artillery smoke marker
- Landmine smoke 
- Grenade trail
- PF trail
- Dynamite yellow tint
- Explosion paritcles (`cg_visualEffects`)
- Explosion visuals
- Bullet casings
- Bullet tracers
- Bullet hit sparks
- Player gibs
- Blood and smoke puffs
- Breath puffs
- And more..

https://streamable.com/iacmie

refs #760