### PR TITLE
game: fix corpses blocking flamethrower hit registration, refs #714

### DIFF
--- a/src/game/g_missile.c
+++ b/src/game/g_missile.c
@@ -924,7 +924,10 @@ void G_BurnTarget(gentity_t *self, gentity_t *body, qboolean directhit)
 	}
 
 	// do a trace to see if there's a wall btwn. body & flame centroid -- prevents damage through walls
+	G_TempTraceIgnoreBodies();
 	trap_Trace(&tr, self->r.currentOrigin, NULL, NULL, point, body->s.number, MASK_SHOT);
+	G_ResetTempTraceIgnoreEnts();
+
 	if (tr.fraction < 1.0f)
 	{
 		return;


### PR DESCRIPTION
Corpses can easily block traces when bodies of wounded players are on top (similiar issue as knife etc.)

refs #714