### PR TITLE
cgame: fix env awareness and compass showing enemy item objective

### DIFF
--- a/etmain/ui/options_customise_hud.menu
+++ b/etmain/ui/options_customise_hud.menu
@@ -32,7 +32,7 @@ menuDef {
 #define HUD_Y 32
 	SUBWINDOW(6, HUD_Y, (SUBWINDOW_WIDTH_L), 256, _("HUD DISPLAY"))
 	YESNO(8, HUD_Y + 16, (SUBWINDOW_WIDTH_L)-4, 10, _("Show Compass:"), .2, 8, "cg_drawCompass", _("Display compass (with icons when near select events)"))
-	MULTI(8, HUD_Y + 28, (SUBWINDOW_WIDTH_L)-4, 10, _("Compass Icons:"), .2, 8, "cg_drawCompassIcons", cvarFloatList { "All" 1 "No secondary objectives" 2 "No primary objectives" 4 "No objectives" 6 }, _("Select icons on compass"))
+	MULTI(8, HUD_Y + 28, (SUBWINDOW_WIDTH_L)-4, 10, _("Compass Icons:"), .2, 8, "cg_drawCompassIcons", cvarFloatList { "Off" 0 "Item objectives" 1 "Secondary objectives" 2 "Primary objectives" 4 "Item + Secondary obj" 3 "Item + Primary obj" 5 "Primary + Secondary obj" 6 "All" 7 }, _("Select icons on compass"))
 	CVARFLOATLABEL(8, HUD_Y + 40, (SUBWINDOW_WIDTH_L)-4, 10, "cg_automapZoom", .2, ITEM_ALIGN_RIGHT, $evalfloat((SUBWINDOW_WIDTH_L)-6), 8)
 	SLIDER(8, HUD_Y + 40, (SUBWINDOW_WIDTH_L)-4, 10, _("Auto Map Zoom:"), .2, 8, "cg_automapZoom" 5.159 1 7.43, _("Set Zoom Level Automatically When Map Loads"))
 	MULTI(8, HUD_Y + 52, (SUBWINDOW_WIDTH_L)-4, 10, _("Mission Timer:"), .2, 8, "cg_drawRoundTimer", cvarFloatList { "Off" 0 "On" 1 }, _("Display remaining mission time"))
@@ -51,7 +51,7 @@ menuDef {
 	YESNO(8, HUD_Y + 208, (SUBWINDOW_WIDTH_L)-4, 10, _("Show Lagometer:"), .2, 8, "cg_lagometer", _("Display lagometer"))
 	MULTI(8, HUD_Y + 220, (SUBWINDOW_WIDTH_L)-4, 10, _("Switch HUD:"), .2, 8, "cg_altHud", cvarFloatList { "Standard Hud" 0 "Alternate Hud 1" 1 "Alternate Hud 2" 2 }, _("Switch between different HUD"))
 	MULTI(8, HUD_Y + 232, (SUBWINDOW_WIDTH_L)-4, 10, _("Modify Selected HUD:"), .2, 8, "cg_altHudFlags", cvarFloatList { "Normal" 0 "Move Round Timer" 1 "Remove Ranks" 2 "Move Popups" 4 "Ranks + Timer" 3 "Timer + Popups" 5 "Ranks + Popups" 6 "Timer + Ranks + Popups" 7 }, _("Customise selected HUD"))
-	MULTI(8, HUD_Y + 244, (SUBWINDOW_WIDTH_L)-4, 10, _("Environment Awareness:"), .2, 8, "cg_drawEnvAwareness", cvarFloatList { "Off" 0 "All" 1 "No secondary objectives" 2 "No primary objectives" 4 "No objectives" 6 }, _("Display objective icons on HUD"))
+	MULTI(8, HUD_Y + 244, (SUBWINDOW_WIDTH_L)-4, 10, _("Environment Awareness:"), .2, 8, "cg_drawEnvAwareness", cvarFloatList { "Off" 0 "Item objectives" 1 "Secondary objectives" 2 "Primary objectives" 4 "Item + Secondary obj" 3 "Item + Primary obj" 5 "Primary + Secondary obj" 6 "All" 7  }, _("Display objective icons on HUD"))
 
 // Gun Display //
 #define WEAPON_Y 292

--- a/src/cgame/cg_commandmap.c
+++ b/src/cgame/cg_commandmap.c
@@ -1988,7 +1988,7 @@ void CG_DrawAutoMap(float basex, float basey, float basew, float baseh)
 				continue;
 			}
 
-			icon = CG_GetCompassIcon(&snap->entities[i], qfalse, qtrue, !(cg_drawCompassIcons.integer & 4), !(cg_drawCompassIcons.integer & 2), qtrue, NULL);
+			icon = CG_GetCompassIcon(&snap->entities[i], qfalse, qtrue, cg_drawCompassIcons.integer & 4, cg_drawCompassIcons.integer & 2, cg_drawCompassIcons.integer & 1, qtrue, NULL);
 
 			if (icon)
 			{

--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -4164,7 +4164,7 @@ static void CG_DrawEnvironmentalAwareness()
 			continue;
 		}
 
-		icon = CG_GetCompassIcon(&snap->entities[i], qfalse, qfalse, !(cg_drawEnvAwareness.integer & 4), !(cg_drawEnvAwareness.integer & 2), qfalse, NULL);
+		icon = CG_GetCompassIcon(&snap->entities[i], qfalse, qfalse, cg_drawEnvAwareness.integer & 4, cg_drawEnvAwareness.integer & 2, cg_drawEnvAwareness.integer & 1, qfalse, NULL);
 
 		if (icon)
 		{

--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -1822,10 +1822,11 @@ void CG_StatsDebugAddText(const char *text)
  * @param[in] drawFireTeam draw fireteam members position
  * @param[in] drawPrimaryObj draw primary objective position
  * @param[in] drawSecondaryObj draw secondary objective position
+ * @param[in] drawItemObj draw item objective position
  * @param[in] drawDynamic draw dynamic elements position (player revive, command map marker)
  * @return A valid compass icon handle otherwise 0
  */
-qhandle_t CG_GetCompassIcon(entityState_t *ent, qboolean drawAllVoicesChat, qboolean drawFireTeam, qboolean drawPrimaryObj, qboolean drawSecondaryObj, qboolean drawDynamic, char *name)
+qhandle_t CG_GetCompassIcon(entityState_t *ent, qboolean drawAllVoicesChat, qboolean drawFireTeam, qboolean drawPrimaryObj, qboolean drawSecondaryObj, qboolean drawItemObj, qboolean drawDynamic, char *name)
 {
 	centity_t *cent = &cg_entities[ent->number];
 
@@ -1896,7 +1897,7 @@ qhandle_t CG_GetCompassIcon(entityState_t *ent, qboolean drawAllVoicesChat, qboo
 
 		item = BG_GetItem(ent->modelindex);
 
-		if (item && item->giType == IT_TEAM)
+		if (drawItemObj && !cg.flagIndicator && item && item->giType == IT_TEAM)
 		{
 			if ((item->giPowerUp == PW_BLUEFLAG && cg.predictedPlayerState.persistant[PERS_TEAM] == TEAM_AXIS)
 			    || (item->giPowerUp == PW_REDFLAG && cg.predictedPlayerState.persistant[PERS_TEAM] == TEAM_ALLIES))

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -3918,7 +3918,7 @@ void CG_CommandMap_DrawHighlightText(void);
 qboolean CG_CommandCentreSpawnPointClick(void);
 
 void CG_DrawNewCompass(rectDef_t location);
-qhandle_t CG_GetCompassIcon(entityState_t *ent, qboolean drawAllVoicesChat, qboolean drawFireTeam, qboolean drawPrimaryObj, qboolean drawSecondaryObj, qboolean drawDynamic, char *name);
+qhandle_t CG_GetCompassIcon(entityState_t *ent, qboolean drawAllVoicesChat, qboolean drawFireTeam, qboolean drawPrimaryObj, qboolean drawSecondaryObj, qboolean drawItemObj, qboolean drawDynamic, char *name);
 void CG_DrawCompassIcon(float x, float y, float w, float h, vec3_t origin, vec3_t dest, qhandle_t shader, float dstScale, float baseSize, mapScissor_t *scissor);
 
 void CG_TransformToCommandMapCoord(float *coord_x, float *coord_y);

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -453,8 +453,8 @@ static cvarTable_t cvarTable[] =
 	{ &cg_gun_z,                   "cg_gunZ",                    "0",           CVAR_TEMP,                    0 },
 	{ &cg_centertime,              "cg_centertime",              "5",           CVAR_ARCHIVE,                 0 }, // changed from 3 to 5
 	{ &cg_bobbing,                 "cg_bobbing",                 "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_drawEnvAwareness,        "cg_drawEnvAwareness",        "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_drawCompassIcons,        "cg_drawCompassIcons",        "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_drawEnvAwareness,        "cg_drawEnvAwareness",        "7",           CVAR_ARCHIVE,                 0 },
+	{ &cg_drawCompassIcons,        "cg_drawCompassIcons",        "7",           CVAR_ARCHIVE,                 0 },
 	{ &cg_dynamicIcons,            "cg_dynamicIcons",            "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_dynamicIconsDistance,    "cg_dynamicIconsDistance",    "400",         CVAR_ARCHIVE,                 0 },
 	{ &cg_dynamicIconsSize,        "cg_dynamicIconsSize",        "20",          CVAR_ARCHIVE,                 0 },


### PR DESCRIPTION
1. Env awareness and compass will only show original position of item flag objectives
2. Changed bitmask values for both to:
- 0 disabled
- 1 item flags objectives
- 2 Secondary objectives
- 4 Primary objectives