### PR TITLE
cgame: fix crosshairnames showing respawning teammate

### DIFF
--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -1907,6 +1907,13 @@ static float CG_ScanForCrosshairEntity(float *zChange, qboolean *hitClient)
 		return dist;
 	}
 
+	cent = &cg_entities[trace.entityNum];
+
+	if (!cent->currentValid)
+	{
+		return dist;
+	}
+
 	// Reset the draw time for the SP crosshair
 	cg.crosshairSPClientTime = cg.time;
 
@@ -1923,8 +1930,6 @@ static float CG_ScanForCrosshairEntity(float *zChange, qboolean *hitClient)
 	{
 		cg.identifyClientRequest = cg.crosshairClientNum;
 	}
-
-	cent = &cg_entities[cg.crosshairClientNum];
 
 	if (cent && (cent->currentState.powerups & (1 << PW_OPS_DISGUISED)))
 	{


### PR DESCRIPTION
When aiming at the place where teammate died trace hits the respawning, but invisible and teleporting to spawn location player causing the crosshairname to show up.