### PR TITLE
client: fix for divide by zero crashes

### DIFF
--- a/src/client/cl_cgame.c
+++ b/src/client/cl_cgame.c
@@ -1262,6 +1262,12 @@ int CL_FindIncrementThreshold(void)
 {
 	clFrameTime = cls.frametime;
 
+	// handles zero duration between frames (often happens on map change)
+	if(clFrameTime == 0 || svFrameTime == 0)
+	{
+		return 0;
+	}
+
 	// calculates the least common multiple of clFrameTime and svFrameTime
 	// the LCM represents how long until the time over-run pattern repeats
 	int LCM = svFrameTime > clFrameTime ? svFrameTime : clFrameTime;


### PR DESCRIPTION
Fixes an intermittent crash caused by divide by a zero for svFrameTime and clFrameTime in `CL_FindIncrementThreshold` introduced in #2043. Crash typically occurred on map change with a zero value for svFrameTime but could potentially occur at other times as well as for clFrameTime.