### PR TITLE
game: reduce LAG_MAX_DELTA to smooth out lagging players, refs #90, , #1993

### DIFF
--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -706,7 +706,7 @@ typedef struct
 
 // zinx etpro antiwarp
 #define LAG_MAX_COMMANDS 512
-#define LAG_MAX_DELTA 75
+#define LAG_MAX_DELTA 25
 #define LAG_MAX_DROP_THRESHOLD 800
 #define LAG_MIN_DROP_THRESHOLD (LAG_MAX_DROP_THRESHOLD - 200)
 #define LAG_DECAY 1.02f


### PR DESCRIPTION
The aim is to fix this https://clips.twitch.tv/BelovedPhilanthropicSamosaThunBeast-rpIjo4i1Mq5Y9Y29

Fix example: https://streamable.com/tkc6wf

refs #90, #1993