### PR TITLE
mod: fix prediction issues

### DIFF
--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -879,7 +879,7 @@ static void CG_DrawStaminaBar(rectDef_t *rect)
 	vec4_t colour = { 0.1f, 1.0f, 0.1f, 0.5f };
 	vec_t  *color = colour;
 	int    flags  = 1 | 4 | 16 | 64;
-	float  frac   = cg.snap->ps.stats[STAT_SPRINTTIME] / (float)SPRINTTIME;
+	float  frac   = cg.pmext.sprintTime / (float)SPRINTTIME;
 
 	if (cg.snap->ps.powerups[PW_ADRENALINE])
 	{
@@ -1237,7 +1237,7 @@ static void CG_DrawPlayerSprint(float x, float y)
 	}
 	else
 	{
-		str  = va("%.0f", (cg.snap->ps.stats[STAT_SPRINTTIME] / (float)SPRINTTIME) * 100);
+		str  = va("%.0f", (cg.pmext.sprintTime / (float)SPRINTTIME) * 100);
 		unit = "%";
 	}
 

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1018,6 +1018,8 @@ typedef struct
 // all cg.stepTime, cg.duckTime, cg.landTime, etc are set to cg.time when the action
 // occurs, and they will have visible effects for #define STEP_TIME or whatever msec after
 
+#define MAX_PREDICTED_EVENTS    16
+
 #define MAX_SPAWN_VARS          64
 #define MAX_SPAWN_VARS_CHARS    2048
 
@@ -1165,6 +1167,9 @@ typedef struct
 	qboolean validPPS;                      ///< clear until the first call to CG_PredictPlayerState
 	int predictedErrorTime;
 	vec3_t predictedError;
+
+	int eventSequence;
+	int predictableEvents[MAX_PREDICTED_EVENTS];
 
 	float stepChange;                       ///< for stair up smoothing
 	int stepTime;
@@ -3144,7 +3149,6 @@ int CG_PointContents(const vec3_t point, int passEntityNum);
 void CG_Trace(trace_t *result, const vec3_t start, const vec3_t mins, const vec3_t maxs, const vec3_t end, int skipNumber, int mask);
 void CG_PredictPlayerState(void);
 float CG_ClientHitboxMaxZ(entityState_t *hitEnt, float def);
-qboolean CG_CheckPredictableEvent(int event);
 
 // cg_edv.c
 void CG_RunBindingBuf(int key, qboolean down, char *buf);

--- a/src/cgame/cg_playerstate.c
+++ b/src/cgame/cg_playerstate.c
@@ -188,8 +188,6 @@ void CG_Respawn(qboolean revived)
 
 	cg.pmext.bAutoReload = (qboolean)(cg_autoReload.integer > 0);
 
-	cg.pmext.sprintTime = SPRINTTIME;
-
 	if (!revived)
 	{
 		cgs.limboLoadoutSelected = qfalse;

--- a/src/cgame/cg_playerstate.c
+++ b/src/cgame/cg_playerstate.c
@@ -253,39 +253,26 @@ void CG_CheckPlayerstateEvents(playerState_t *ps, playerState_t *ops)
 		CG_EntityEvent(cent, cent->lerpOrigin);
 	}
 
-	cent = &cg.predictedPlayerEntity;
+	cent = &cg.predictedPlayerEntity; // cg_entities[ ps->clientNum ];
 	// go through the predictable events buffer
-	for (i = ps->eventSequence - MAX_EVENTS; i < ps->eventSequence; i++)
+	for (i = ps->eventSequence - MAX_EVENTS ; i < ps->eventSequence ; i++)
 	{
 		// if we have a new predictable event
-		if (i >= ops->eventSequence)
+		if (i >= ops->eventSequence
+		    // or the server told us to play another event instead of a predicted event we already issued
+		    // or something the server told us changed our prediction causing a different event
+		    || (i > ops->eventSequence - MAX_EVENTS && ps->events[i & (MAX_EVENTS - 1)] != ops->events[i & (MAX_EVENTS - 1)]))
 		{
-			event = ps->events[i & (MAX_EVENTS - 1)];
-
-			// skip predictable pmove events added by server to avoid unnecessary event effect duplication
-			// after client miss predicted and different order of events came from server
-			// causing correctly predicted events by client to play again
-			if (!cg.demoPlayback && ps->clientNum == cg.clientNum && CG_CheckPredictableEvent(event))
-			{
-				continue;
-			}
-
+			event                        = ps->events[i & (MAX_EVENTS - 1)];
 			cent->currentState.event     = event;
 			cent->currentState.eventParm = ps->eventParms[i & (MAX_EVENTS - 1)];
 			CG_EntityEvent(cent, cent->lerpOrigin);
+
+			cg.predictableEvents[i & (MAX_PREDICTED_EVENTS - 1)] = event;
+
+			cg.eventSequence++;
 		}
 	}
-
-	// play predictable pmove events added by client
-	for (i = cg.pmext.oldEventSequence; i < cg.pmext.eventSequence; i++)
-	{
-		event                        = cg.pmext.events[i & (MAX_EVENTS - 1)];
-		cent->currentState.event     = event;
-		cent->currentState.eventParm = cg.pmext.eventParms[i & (MAX_EVENTS - 1)];
-		CG_EntityEvent(cent, cent->lerpOrigin);
-	}
-
-	cg.pmext.oldEventSequence = cg.pmext.eventSequence;
 }
 
 /*

--- a/src/cgame/cg_predict.c
+++ b/src/cgame/cg_predict.c
@@ -840,7 +840,7 @@ int CG_PredictionOk(playerState_t *ps1, playerState_t *ps2)
 
 	for (i = 0; i < MAX_STATS; i++)
 	{
-		if (ps2->stats[i] != ps1->stats[i])
+		if (ps2->stats[i] != ps1->stats[i] && i != STAT_ANTIWARP_DELAY)
 		{
 			if (cg_showmiss.integer & 8)
 			{

--- a/src/cgame/cg_predict.c
+++ b/src/cgame/cg_predict.c
@@ -723,51 +723,6 @@ static void CG_TouchTriggerPrediction(void)
 #define MAX_PREDICT_VIEWANGLES_DELTA    1.0f
 
 /**
-* @brief CG_CheckPredictableEvent
-* @param[in] event
-* @return
-*/
-qboolean CG_CheckPredictableEvent(int event)
-{
-	switch (event)
-	{
-	case EV_STEP_4:
-	case EV_STEP_8:
-	case EV_STEP_12:
-	case EV_STEP_16:
-	case EV_FALL_NDIE:
-	case EV_FALL_DMG_50:
-	case EV_FALL_DMG_25:
-	case EV_FALL_DMG_15:
-	case EV_FALL_DMG_10:
-	case EV_FALL_SHORT:
-	case EV_FOOTSTEP:
-	case EV_FOOTSPLASH:
-	case EV_SWIM:
-	case EV_WATER_TOUCH:
-	case EV_WATER_LEAVE:
-	case EV_WATER_UNDER:
-	case EV_WATER_CLEAR:
-	case EV_FILL_CLIP:
-	case EV_CHANGE_WEAPON_2:
-	case EV_CHANGE_WEAPON:
-	case EV_NOAMMO:
-	case EV_FIRE_WEAPON_AAGUN:
-	case EV_FIRE_WEAPON_MG42:
-	case EV_FIRE_WEAPON_MOUNTEDMG42:
-	case EV_WEAP_OVERHEAT:
-	case EV_FIRE_WEAPON:
-	case EV_NOFIRE_UNDERWATER:
-	case EV_SPINUP:
-	case EV_FIRE_WEAPONB:
-	case EV_FIRE_WEAPON_LASTSHOT:
-		return qtrue;
-	default:
-		return qfalse;
-	}
-}
-
-/**
  * @brief CG_PredictionOk
  * @param[in] ps1
  * @param[in] ps2
@@ -834,32 +789,19 @@ int CG_PredictionOk(playerState_t *ps1, playerState_t *ps2)
 		return 9;
 	}
 
-	// we don't add predictable events to playerstate but to pmext on client
-	// to avoid unnecessary event effect duplication, thus we always miss predict causing constant full predictions to run,
-	// instead we will check if there are new events from server we can't predict,
-	// so we can play them like before without constant full predictions
-
-	for (i = ps1->eventSequence - MAX_EVENTS; i < ps1->eventSequence; i++)
+	// common with item pickups
+	if (ps2->eventSequence != ps1->eventSequence)
 	{
-		if (i >= ps2->eventSequence && !CG_CheckPredictableEvent(ps1->events[i & (MAX_EVENTS - 1)]))
-		{
-			return 10;
-		}
+		return 11;
 	}
 
-	// common with item pickups
-	//if (ps2->eventSequence != ps1->eventSequence)
-	//{
-	//	return 11;
-	//}
-
-	//for (i = 0; i < MAX_EVENTS; i++)
-	//{
-	//	if (ps2->events[i] != ps1->events[i] || ps2->eventParms[i] != ps1->eventParms[i])
-	//	{
-	//		return 12;
-	//	}
-	//}
+	for (i = 0; i < MAX_EVENTS; i++)
+	{
+		if (ps2->events[i] != ps1->events[i] || ps2->eventParms[i] != ps1->eventParms[i])
+		{
+			return 12;
+		}
+	}
 
 	if (ps2->externalEvent != ps1->externalEvent ||
 	    ps2->externalEventParm != ps1->externalEventParm ||
@@ -992,7 +934,7 @@ const char *predictionStrings[] =
 	"--",                   // 7
 	"speed || delta_angles",
 	"anim || timer",
-	"new server event",     // 10
+	"--",                   // 10
 	"eventSequence",
 	"events || eventParms",
 	"externalEvent",

--- a/src/cgame/cg_shoutcastoverlay.c
+++ b/src/cgame/cg_shoutcastoverlay.c
@@ -543,7 +543,7 @@ static void CG_DrawShoutcastPlayerStaminaBar(float x, float y, int width, int he
 {
 	vec4_t colour = { 0.1f, 1.0f, 0.1f, 0.5f };
 	vec_t  *color = colour;
-	float  frac   = cg.snap->ps.stats[STAT_SPRINTTIME] / (float)SPRINTTIME;
+	float  frac   = cg.pmext.sprintTime / (float)SPRINTTIME;
 
 	if (cg.snap->ps.powerups[PW_ADRENALINE])
 	{

--- a/src/game/bg_misc.c
+++ b/src/game/bg_misc.c
@@ -3621,19 +3621,6 @@ void BG_AddPredictableEventToPlayerstate(int newEvent, int eventParm, playerStat
 	ps->eventSequence++;
 }
 
-/**
-* @brief Handles the sequence numbers
-* @param[in] newEvent
-* @param[in] eventParm
-* @param[out] pmext
-*/
-void BG_AddPredictableEventToPmoveExt(int newEvent, int eventParm, pmoveExt_t *pmext)
-{
-	pmext->events[pmext->eventSequence & (MAX_EVENTS - 1)]     = newEvent;
-	pmext->eventParms[pmext->eventSequence & (MAX_EVENTS - 1)] = eventParm;
-	pmext->eventSequence++;
-}
-
 // NOTE: would like to just inline this but would likely break qvm support
 #define SETUP_MOUNTEDGUN_STATUS(ps)                           \
 	switch (ps->persistant[PERS_HWEAPON_USE]) {                \

--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -4948,6 +4948,9 @@ void PmoveSingle(pmove_t *pmove)
 	pm->watertype  = 0;
 	pm->waterlevel = 0;
 
+	// make server authoritative over stamina
+	pm->pmext->sprintTime = pm->ps->stats[STAT_SPRINTTIME];
+
 	if (pm->ps->stats[STAT_HEALTH] <= 0)
 	{
 		pm->tracemask  &= ~CONTENTS_BODY;   // corpses can fly through bodies
@@ -5308,7 +5311,6 @@ void PmoveSingle(pmove_t *pmove)
 		trap_SnapVector(pm->ps->velocity);
 	}
 
-	// save sprinttime for CG_DrawStaminaBar()
 	pm->ps->stats[STAT_SPRINTTIME] = pm->pmext->sprintTime;
 }
 

--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -2301,7 +2301,7 @@ static void PM_Footsteps(void)
 	}
 
 	// check for footstep / splash sounds
-	old                 = pm->pmext->bobCycle;
+	old                 = (float)pm->ps->bobCycle + fmodf(pm->pmext->bobCycle, 1);
 	pm->pmext->bobCycle = old + bobmove * pml.msec;
 	pm->ps->bobCycle    = pm->pmext->bobCycle;
 

--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -115,11 +115,7 @@ static void PM_BeginWeaponChange(weapon_t oldWeapon, weapon_t newWeapon, qboolea
  */
 void PM_AddEvent(int newEvent)
 {
-#ifdef GAMEDLL
 	BG_AddPredictableEventToPlayerstate(newEvent, 0, pm->ps);
-#else
-	BG_AddPredictableEventToPmoveExt(newEvent, 0, pm->pmext);
-#endif
 }
 
 /**
@@ -129,11 +125,7 @@ void PM_AddEvent(int newEvent)
  */
 void PM_AddEventExt(int newEvent, int eventParm)
 {
-#ifdef GAMEDLL
 	BG_AddPredictableEventToPlayerstate(newEvent, eventParm, pm->ps);
-#else
-	BG_AddPredictableEventToPmoveExt(newEvent, eventParm, pm->pmext);
-#endif
 }
 
 /**

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -587,11 +587,6 @@ typedef struct pmoveExt_s
 
 	qboolean deadInSolid;          ///< true if legs or head start in solid when we die
 
-	int eventSequence;             ///< pmove generated events on client
-	int events[MAX_EVENTS];
-	int eventParms[MAX_EVENTS];
-	int oldEventSequence;          ///< so we can see which events have been added since last pmove
-
 } pmoveExt_t;  ///< data used both in client and server - store it here
 ///< instead of playerstate to prevent different engine versions of playerstate between XP and MP
 
@@ -2121,7 +2116,6 @@ void BG_EvaluateTrajectoryDelta(const trajectory_t *tr, int atTime, vec3_t resul
 void BG_GetMarkDir(const vec3_t dir, const vec3_t normal, vec3_t out);
 
 void BG_AddPredictableEventToPlayerstate(int newEvent, int eventParm, playerState_t *ps);
-void BG_AddPredictableEventToPmoveExt(int newEvent, int eventParm, pmoveExt_t *pmext);
 
 void BG_PlayerStateToEntityState(playerState_t *ps, entityState_t *s, int time, qboolean snap);
 

--- a/src/game/g_active.c
+++ b/src/game/g_active.c
@@ -624,7 +624,7 @@ void SpectatorThink(gentity_t *ent, usercmd_t *ucmd)
 
 	if (ent->flags & FL_NOFATIGUE)
 	{
-		ent->client->pmext.sprintTime = SPRINTTIME;
+		ent->client->ps.stats[STAT_SPRINTTIME] = SPRINTTIME;
 	}
 
 	if (ent->flags & FL_NOSTAMINA)
@@ -1527,7 +1527,7 @@ void ClientThink_real(gentity_t *ent)
 
 	if (ent->flags & FL_NOFATIGUE)
 	{
-		ent->client->pmext.sprintTime = SPRINTTIME;
+		ent->client->ps.stats[STAT_SPRINTTIME] = SPRINTTIME;
 	}
 
 	if (ent->flags & FL_NOSTAMINA)

--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -3006,8 +3006,8 @@ void ClientSpawn(gentity_t *ent, qboolean revived, qboolean teamChange, qboolean
 	client->ps.crouchSpeedScale = 0.25f;
 	client->ps.weaponstate      = WEAPON_READY;
 
-	client->pmext.sprintTime   = SPRINTTIME;
-	client->ps.sprintExertTime = 0;
+	client->ps.stats[STAT_SPRINTTIME] = SPRINTTIME;
+	client->ps.sprintExertTime        = 0;
 
 	client->ps.friction = 1.0f;
 


### PR DESCRIPTION
1. Revert https://github.com/etlegacy/etlegacy/commit/6c9515d434546012d53c89adcaac5e124d378ca9 fixes #2013
2. Fix stamina prediction which in turn fixes #1957 
3. Fix `STAT_ANTIWARP_DELAY` causing full predictions to run when it's just display information.
4. Fix bobcycle not being in sync between client/server in some cases which causes client to miss predict footsteps.
 