### PR TITLE
cgame: fix unfinished unicode encoding crashing clients

### DIFF
--- a/src/qcommon/q_unicode.c
+++ b/src/qcommon/q_unicode.c
@@ -957,10 +957,15 @@ size_t Q_UnescapeUnicode(char *fromStr, char *toStr, const size_t maxSize)
 			size_t numberOffset  = 0;
 			str += 3;
 
-			while (str && str[0] != '}')
+			while (str && str[0] != '}' && str - fromStr < maxSize)
 			{
 				tmpNumber[numberOffset++] = str[0];
 				str++;
+			}
+
+			if (str - fromStr == maxSize) // rather ignore potentially corrupt character
+			{
+				break;
 			}
 
 			if (!numberOffset)


### PR DESCRIPTION
if end of fromStr was `\\u{5555` without `}`, it would access array out of bounds

We could also trim this when sending from client, but probably not big deal to send unnecessary 3 bytes. It doesn't happen often. Usually players send chat messages shorter than 150B (MAX_SAY_TEXT).