### PR TITLE
general: prevent splicing server shutdown message

### DIFF
--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -945,7 +945,7 @@ static void CL_Connect_f(void)
 	if (com_sv_running->integer && !strcmp(server, "localhost"))
 	{
 		// if running a local server, kill it
-		SV_Shutdown("Server quit\n");
+		SV_Shutdown("Server quit");
 	}
 
 	// make sure a local server is killed
@@ -1424,13 +1424,13 @@ void CL_Clip_f(void)
 }
 
 /**
- * @brief CL_RebaseDrift_f 
+ * @brief CL_RebaseDrift_f
  * Resets the baselineDelta used for calculating drift in cl_showTimeDelta debugging output.
  */
 void CL_RebaseDrift_f(void)
 {
 	cl.baselineDelta = cl.serverTimeDelta;
-	
+
 	if (cl_showTimeDelta->integer & 1)
 	{
 		Com_Printf("^2REBASE DRIFT^7 (baselineDelta = serverTimeDelta = % i)\n", cl.serverTimeDelta);
@@ -2946,8 +2946,8 @@ void CL_Init(void)
 	cl_pitchspeed    = Cvar_Get("cl_pitchspeed", "140", CVAR_ARCHIVE_ND);
 	cl_anglespeedkey = Cvar_Get("cl_anglespeedkey", "1.5", 0);
 
-	cl_maxpackets  = Cvar_Get("cl_maxpackets", "125", CVAR_ARCHIVE);
-	cl_packetdup   = Cvar_Get("cl_packetdup", "1", CVAR_ARCHIVE_ND);
+	cl_maxpackets = Cvar_Get("cl_maxpackets", "125", CVAR_ARCHIVE);
+	cl_packetdup  = Cvar_Get("cl_packetdup", "1", CVAR_ARCHIVE_ND);
 
 	cl_run         = Cvar_Get("cl_run", "1", CVAR_ARCHIVE_ND);
 	cl_sensitivity = Cvar_Get("sensitivity", "5", CVAR_ARCHIVE);

--- a/src/qcommon/common.c
+++ b/src/qcommon/common.c
@@ -418,7 +418,7 @@ void QDECL Com_Error(int code, const char *fmt, ...)
 	else if (code == ERR_DROP || code == ERR_DISCONNECT)
 	{
 		Com_Printf("********************\nERROR: %s\n********************\n", com_errorMessage);
-		SV_Shutdown(va("Server crashed: %s\n", com_errorMessage));
+		SV_Shutdown(va("Server crashed: %s", com_errorMessage));
 		CL_Disconnect(qtrue);
 		CL_FlushMemory();
 		com_errorEntered = qfalse;
@@ -446,7 +446,7 @@ void QDECL Com_Error(int code, const char *fmt, ...)
 	else
 	{
 		CL_Shutdown();
-		SV_Shutdown(va("Server fatal crashed: %s\n", com_errorMessage));
+		SV_Shutdown(va("Server fatal crashed: %s", com_errorMessage));
 	}
 
 	Com_Shutdown(code == ERR_VID_FATAL ? qtrue : qfalse);
@@ -462,7 +462,7 @@ void Com_Quit_f(void)
 	// don't try to shutdown if we are in a recursive error
 	if (!com_errorEntered)
 	{
-		SV_Shutdown("Server quit\n");
+		SV_Shutdown("Server quit");
 
 #ifndef DEDICATED
 		CL_ShutdownCGame();

--- a/src/qcommon/update.c
+++ b/src/qcommon/update.c
@@ -102,11 +102,11 @@ void Com_CheckAutoUpdate(void)
 
 	NET_OutOfBandPrint(
 #ifdef DEDICATED
-	    NS_SERVER
+		NS_SERVER
 #else
-	    NS_CLIENT
+		NS_CLIENT
 #endif  // DEDICATED
-	    , autoupdate.autoupdateServer, "getUpdateInfo \"%s\"", info);
+		, autoupdate.autoupdateServer, "getUpdateInfo \"%s\"", info);
 
 	autoupdate.updateChecked = qtrue;
 
@@ -159,7 +159,7 @@ void Com_GetAutoUpdate(void)
 	if (com_sv_running->integer)
 	{
 		// if running a local server, kill it
-		SV_Shutdown("Server quit\n");
+		SV_Shutdown("Server quit");
 	}
 
 	// make sure a local server is killed

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -1589,7 +1589,7 @@ void SV_Frame(int msec)
 	// the menu kills the server with this cvar
 	if (sv_killserver->integer)
 	{
-		SV_Shutdown("Server was killed.\n");
+		SV_Shutdown("Server was killed.");
 		Cvar_Set("sv_killserver", "0");
 		return;
 	}


### PR DESCRIPTION
The strings sent to `SV_Shutdown` should not end in a newline since the string is inserted in the middle of the shutdown message.

Before:
![image](https://user-images.githubusercontent.com/14221121/186673582-c98d9da2-bd01-4441-ac28-2adc328fe02e.png)

After:
![image](https://user-images.githubusercontent.com/14221121/186673374-19627059-d940-458f-b5d3-af24b728b454.png)
