### PR TITLE
mod: fix artillery prediction and sfx

### DIFF
--- a/src/cgame/cg_event.c
+++ b/src/cgame/cg_event.c
@@ -2261,7 +2261,8 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 		break;
 	case EV_FIRE_WEAPON:
 	case EV_FIRE_WEAPONB:
-		if (cent->currentState.clientNum == cg.snap->ps.clientNum && (cg.snap->ps.eFlags & EF_ZOOMING))     // to stop airstrike sfx
+		// to stop artillery sfx
+		if (es->eventParm)
 		{
 			break;
 		}

--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -3584,13 +3584,12 @@ static void PM_Weapon(void)
 	// PC_FIELDOPS needs to zoom to call artillery
 	if ((pm->ps->eFlags & EF_ZOOMING) || pm->ps->weapon == WP_BINOCULARS)
 	{
-#ifdef GAMEDLL
 		if (pm->ps->stats[STAT_PLAYER_CLASS] == PC_FIELDOPS)
 		{
 			pm->ps->weaponTime += 500;
-			PM_AddEvent(EV_FIRE_WEAPON);
+			PM_AddEventExt(EV_FIRE_WEAPON, 1);
 		}
-#endif
+
 		return;
 	}
 


### PR DESCRIPTION
- fixes artillery prediction (weaponTime and event)
- fixes calling artillery still playing gun shot sound in some cases