### PR TITLE
client: fix console drawing with r_scale

### DIFF
--- a/src/client/cl_keys.c
+++ b/src/client/cl_keys.c
@@ -336,7 +336,7 @@ void Field_VariableSizeDraw(field_t *edit, int x, int y, int width, int size, qb
  */
 void Field_Draw(field_t *edit, int x, int y, int width, qboolean showCursor, qboolean noColorEscape)
 {
-	Field_VariableSizeDraw(edit, x, y, width, SMALLCHAR_WIDTH, showCursor, noColorEscape);
+	Field_VariableSizeDraw(edit, x, y, width, smallCharWidth, showCursor, noColorEscape);
 }
 
 /**

--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -2746,6 +2746,17 @@ int CL_ScaledMilliseconds(void)
 extern refexport_t *GetRefAPI(int apiVersion, refimport_t *rimp);
 #endif
 
+
+/**
+ * @brief CL_SetScaling
+ * @return
+ */
+static void CL_SetScaling(float scale)
+{
+	smallCharWidth  = SMALLCHAR_WIDTH * scale;
+	smallCharHeight = SMALLCHAR_HEIGHT * scale;
+}
+
 /**
  * @brief CL_InitRef
  */
@@ -2849,6 +2860,7 @@ void CL_InitRef(void)
 
 	ri.CL_VideoRecording     = CL_VideoRecording;
 	ri.CL_WriteAVIVideoFrame = CL_WriteAVIVideoFrame;
+	ri.CL_SetScaling         = CL_SetScaling;
 
 #ifdef FEATURE_PNG
 	ri.zlib_crc32    = crc32;

--- a/src/client/cl_scrn.c
+++ b/src/client/cl_scrn.c
@@ -151,6 +151,10 @@ void SCR_DrawChar(int x, int y, float w, float h, int ch, qboolean nativeResolut
 		return;
 	}
 
+	// use scaled values to account for r_scale
+	w = smallCharWidth;
+	h = smallCharHeight;
+
 	if (y < -h)
 	{
 		return;
@@ -193,6 +197,10 @@ void SCR_DrawStringExt(int x, int y, float w, float h, const char *string, float
 	vec4_t     color;
 	const char *s;
 	int        xx;
+
+	// use scaled values to account for r_scale
+	w = smallCharWidth;
+	h = smallCharHeight;
 
 	if (dropShadow)
 	{

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -583,9 +583,9 @@ typedef enum
  */
 enum cgameFlagsMaskEnum
 {
-    MASK_CGAMEFLAGS_SHOWGAMEVIEW             = 0x1, // 0b00000001
-    MASK_CGAMEFLAGS_SERVERTIMEDELTA_FORWARD  = 0x2, // 0b00000010
-    MASK_CGAMEFLAGS_SERVERTIMEDELTA_BACKWARD = 0x4, // 0b00000100
+	MASK_CGAMEFLAGS_SHOWGAMEVIEW             = 0x1, // 0b00000001
+	MASK_CGAMEFLAGS_SERVERTIMEDELTA_FORWARD  = 0x2, // 0b00000010
+	MASK_CGAMEFLAGS_SERVERTIMEDELTA_BACKWARD = 0x4, // 0b00000100
 };
 
 void CL_ClearKeys(void);
@@ -625,6 +625,9 @@ qboolean CL_UpdateVisiblePings_f(int source);
 #define NUM_CON_TIMES   10
 
 #define CON_TEXTSIZE    131072
+
+extern int smallCharWidth;      ///< SMALLCHAR_WIDTH with renderer scale accounted for
+extern int smallCharHeight;     ///< SMALLCHAR_HEIGHT with renderer scale accounted for
 
 /**
  * @struct console_t

--- a/src/renderer/tr_init.c
+++ b/src/renderer/tr_init.c
@@ -223,11 +223,14 @@ static void InitOpenGL(void)
 			glConfig.maxTextureSize = 0;
 		}
 
+		ri.CL_SetScaling(1.0f);
+
 		if (r_scale->value)
 		{
 			float scale = Com_Clamp(0.2f, 4.f, r_scale->value);
-			glConfig.vidWidth *= scale;
+			glConfig.vidWidth  *= scale;
 			glConfig.vidHeight *= scale;
+			ri.CL_SetScaling(scale);
 		}
 	}
 
@@ -571,16 +574,16 @@ const void *RB_TakeScreenshotCmd(const void *data)
 
 	switch (cmd->format)
 	{
-		case SSF_TGA:
-			RB_TakeScreenshotTGA(cmd->x, cmd->y, cmd->width, cmd->height, cmd->fileName);
-			break;
-		case SSF_JPEG:
-			RB_TakeScreenshotJPEG(cmd->x, cmd->y, cmd->width, cmd->height, cmd->fileName);
-			break;
+	case SSF_TGA:
+		RB_TakeScreenshotTGA(cmd->x, cmd->y, cmd->width, cmd->height, cmd->fileName);
+		break;
+	case SSF_JPEG:
+		RB_TakeScreenshotJPEG(cmd->x, cmd->y, cmd->width, cmd->height, cmd->fileName);
+		break;
 #ifdef FEATURE_PNG
-		case SSF_PNG:
-			RB_TakeScreenshotPNG(cmd->x, cmd->y, cmd->width, cmd->height, cmd->fileName);
-			break;
+	case SSF_PNG:
+		RB_TakeScreenshotPNG(cmd->x, cmd->y, cmd->width, cmd->height, cmd->fileName);
+		break;
 #endif
 	}
 
@@ -828,19 +831,19 @@ void R_ScreenShot_f(void)
 
 	switch (format)
 	{
-		case SSF_TGA:
-			ext = "tga";
-			break;
-		case SSF_JPEG:
-			ext = "jpg";
-			break;
+	case SSF_TGA:
+		ext = "tga";
+		break;
+	case SSF_JPEG:
+		ext = "jpg";
+		break;
 #ifdef FEATURE_PNG
-		case SSF_PNG:
-			ext = "png";
-			break;
+	case SSF_PNG:
+		ext = "png";
+		break;
 #endif
-		default:
-			return;
+	default:
+		return;
 	}
 
 	if (!strcmp(ri.Cmd_Argv(1), "levelshot"))
@@ -861,7 +864,7 @@ void R_ScreenShot_f(void)
 	if (ri.Cmd_Argc() == 2 && !silent)
 	{
 		// explicit filename
-		const char* fileExt = COM_GetExtension(ri.Cmd_Argv(1));
+		const char *fileExt = COM_GetExtension(ri.Cmd_Argv(1));
 		if (fileExt[0])
 		{
 			char filename[MAX_QPATH];
@@ -869,18 +872,18 @@ void R_ScreenShot_f(void)
 
 			if (COM_CompareExtension(fileExt, "tga"))
 			{
-				ext = "tga";
+				ext    = "tga";
 				format = SSF_TGA;
 			}
 			else if (COM_CompareExtension(fileExt, "jpg") || COM_CompareExtension(fileExt, "jpeg"))
 			{
-				ext = "jpg";
+				ext    = "jpg";
 				format = SSF_JPEG;
 			}
 #ifdef FEATURE_PNG
 			else if (COM_CompareExtension(fileExt, "png"))
 			{
-				ext = "png";
+				ext    = "png";
 				format = SSF_PNG;
 			}
 #endif
@@ -1389,9 +1392,9 @@ void R_DebugPolygon(int color, int numPoints, float *points);
  * @param[in] rimp
  * @return
  */
-Q_EXPORT refexport_t * QDECL GetRefAPI(int apiVersion, refimport_t *rimp)
+Q_EXPORT refexport_t *QDECL GetRefAPI(int apiVersion, refimport_t *rimp)
 #else
-refexport_t * GetRefAPI(int apiVersion, refimport_t * rimp)
+refexport_t *GetRefAPI(int apiVersion, refimport_t *rimp)
 #endif
 {
 	static refexport_t re;

--- a/src/renderercommon/tr_public.h
+++ b/src/renderercommon/tr_public.h
@@ -175,10 +175,10 @@ typedef struct
 typedef struct
 {
 	/// print message on the local console
-	void(QDECL * Printf)(int printLevel, const char *fmt, ...) _attribute ((format(printf, 2, 3)));
+	void(QDECL * Printf)(int printLevel, const char *fmt, ...) _attribute((format(printf, 2, 3)));
 
 	/// abort the game
-	void(QDECL * Error)(int errorLevel, const char *fmt, ...) _attribute ((noreturn, format(printf, 2, 3)));
+	void(QDECL * Error)(int errorLevel, const char *fmt, ...) _attribute((noreturn, format(printf, 2, 3)));
 
 	/// milliseconds should only be used for profiling, never
 	/// for anything game related. Get time from the refdef
@@ -189,23 +189,23 @@ typedef struct
 	/// won't be freed
 	void (*Hunk_Clear)(void);
 #ifdef HUNK_DEBUG
-	void * (*Hunk_AllocDebug)(size_t size, ha_pref pref, char *label, char *file, int line);
+	void *(*Hunk_AllocDebug)(size_t size, ha_pref pref, char *label, char *file, int line);
 #else
-	void * (*Hunk_Alloc)(size_t size, ha_pref pref);
+	void *(*Hunk_Alloc)(size_t size, ha_pref pref);
 #endif
-	void * (*Hunk_AllocateTempMemory)(size_t size);
+	void *(*Hunk_AllocateTempMemory)(size_t size);
 	void (*Hunk_FreeTempMemory)(void *block);
 
 	/// dynamic memory allocator for things that need to be freed
 #ifdef ZONE_DEBUG
-	void * (*Z_MallocDebug)(int bytes, char *label, char *file, int line);
+	void *(*Z_MallocDebug)(int bytes, char *label, char *file, int line);
 #else
-	void * (*Z_Malloc)(int bytes);
+	void *(*Z_Malloc)(int bytes);
 #endif
 	void (*Free)(void *buf);
 	void (*Tag_Free)(void);
 
-	cvar_t * (*Cvar_Get)(const char *name, const char *value, int flags);
+	cvar_t *(*Cvar_Get)(const char *name, const char *value, int flags);
 	void (*Cvar_Set)(const char *name, const char *value);
 	void (*Cvar_CheckRange)(cvar_t *cv, float minVal, float maxVal, qboolean shouldBeIntegral);
 	void (*Cvar_SetDescription)(cvar_t *cv, const char *description);
@@ -215,7 +215,7 @@ typedef struct
 	void (*Cmd_RemoveSystemCommand)(const char *name);
 
 	int (*Cmd_Argc)(void);
-	char * (*Cmd_Argv)(int i);
+	char *(*Cmd_Argv)(int i);
 
 	void (*Cmd_ExecuteText)(int exec_when, const char *text);
 
@@ -228,7 +228,7 @@ typedef struct
 	int (*FS_FileIsInPAK)(const char *name, int *pChecksum);
 	int (*FS_ReadFile)(const char *name, void **buf);
 	void (*FS_FreeFile)(void *buf);
-	char ** (*FS_ListFiles)(const char *name, const char *extension, int *numfilesfound);
+	char **(*FS_ListFiles)(const char *name, const char *extension, int *numfilesfound);
 	void (*FS_FreeFileList)(char **filelist);
 	void (*FS_WriteFile)(const char *qpath, const void *buffer, int size);
 	qboolean (*FS_FileExists)(const char *file);
@@ -244,10 +244,11 @@ typedef struct
 	/// avi output stuff
 	qboolean (*CL_VideoRecording)(void);
 	void (*CL_WriteAVIVideoFrame)(const byte *buffer, int size);
+	void (*CL_SetScaling)(float scale);
 
 #ifdef FEATURE_PNG
-	int (*zlib_compress) (Bytef *dest, uLongf *destLen, const Bytef *source, uLong sourceLen);
-	uLong (*zlib_crc32) (uLong crc, const Bytef *buf, uInt len);
+	int (*zlib_compress)(Bytef *dest, uLongf *destLen, const Bytef *source, uLong sourceLen);
+	uLong (*zlib_crc32)(uLong crc, const Bytef *buf, uInt len);
 #endif
 
 	void (*Sys_GLimpSafeInit)(void);
@@ -269,7 +270,7 @@ typedef struct
 /// If the module can't init to a valid rendering state, NULL will be
 /// returned.
 #ifdef USE_RENDERER_DLOPEN
-typedef refexport_t * (QDECL * GetRefAPI_t)(int apiVersion, refimport_t *rimp);
+typedef refexport_t *(QDECL *GetRefAPI_t)(int apiVersion, refimport_t *rimp);
 #else
 //refexport_t *GetRefAPI(int apiVersion, refimport_t *rimp);
 #endif


### PR DESCRIPTION
Fixes console char set scaling when `r_scale` is used. Only for vanilla renderer since it's the only one with `r_scale` anyway.

refs 43a6a111bfad54a29f887c9eac0c9763c01f43e7