### PR TITLE
game: fix spawnPointState out of bound access, refs #2129

### DIFF
--- a/src/game/g_team.c
+++ b/src/game/g_team.c
@@ -2360,7 +2360,7 @@ void G_UpdateSpawnPointStatePlayerCounts()
 void G_UpdateSpawnPointState(gentity_t *ent)
 {
 	static char cs[MAX_STRING_CHARS];
-	if (ent == NULL)
+	if (ent == NULL || !ent->count)
 	{
 		return;
 	}


### PR DESCRIPTION
The issue is `G_UpdateSpawnPointState` can be called before `objective_Register` on game init. Checking `ent->count` should ensure that spawnpoint was already initialized in `objective_Register`. This can happen on other maps not only radar.

https://github.com/etlegacy/etlegacy/blob/737c75b45cd042674fcb70d750fbf5ac4565a484/src/game/g_utils.c#L1320-L1324
https://github.com/etlegacy/etlegacy/blob/737c75b45cd042674fcb70d750fbf5ac4565a484/src/game/g_utils.c#L1478-L1482
https://github.com/etlegacy/etlegacy/blob/71436a1cda20d4444658b97b630709d7041d6546/src/game/g_team.c#L996-L1012

refs #2129