### PR TITLE
cgame: fix team chat flag

### DIFF
--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -1062,6 +1062,10 @@ void CG_DrawTeamInfo(hudComponent_t *comp)
 				{
 					flag = cgs.media.alliedFlag;
 				}
+				else
+				{
+					flag = 0;
+				}
 			}
 
 			// get the longest chat message on screen, use that for the width of chat background


### PR DESCRIPTION
The flag variable was not set back to 0 for next iteration resulting in whenever someone types a message after spectator the spectator message(s) get flag set to that player's team.