### PR TITLE
qcommon: fix precision in patch collide generation to avoid "MAX_PATCH_PLANES" errors (from q3e/ETe), refs #2128

### DIFF
--- a/src/qcommon/cm_patch.h
+++ b/src/qcommon/cm_patch.h
@@ -73,7 +73,9 @@ properly.
 */
 
 #define MAX_FACETS          1024
-#define MAX_PATCH_PLANES    2048
+#define MAX_PATCH_PLANES    (2048+128)
+
+
 
 /**
  * @struct patchPlane_s

--- a/src/qcommon/cm_polylib.c
+++ b/src/qcommon/cm_polylib.c
@@ -270,13 +270,13 @@ winding_t *BaseWindingForPlane(vec3_t normal, vec_t dist)
 		break;
 	}
 
-	v = DotProduct(vup, normal);
+	v = DotProductDP(vup, normal);
 	VectorMA(vup, -v, normal, vup);
-	vec3_norm2(vup, vup);
+	VectorNormalizeDP(vup, vup);
 
 	VectorScale(normal, dist, org);
 
-	vec3_cross(vup, normal, vright);
+	CrossProductDP(vup, normal, vright);
 
 	VectorScale(vup, MAX_MAP_BOUNDS, vup);
 	VectorScale(vright, MAX_MAP_BOUNDS, vright);
@@ -356,18 +356,17 @@ void ClipWindingEpsilon(winding_t *in, vec3_t normal, vec_t dist,
 	vec_t        dists[MAX_POINTS_ON_WINDING + 4] = { 0 };
 	int          sides[MAX_POINTS_ON_WINDING + 4] = { 0 };
 	int          counts[3]                        = { 0, 0, 0 };
-	static vec_t dot;           // VC 4.2 optimizer bug if not static
 	int          i, j;
 	vec_t        *p1, *p2;
 	vec3_t       mid;
 	winding_t    *f, *b;
 	int          maxpts;
+	double       dot, d1, d2;
 
 	// determine sides for each point
 	for (i = 0 ; i < in->numpoints ; i++)
 	{
-		dot      = DotProduct(in->p[i], normal);
-		dot     -= dist;
+		dot      = DotProductDPf(in->p[i], normal) - dist;
 		dists[i] = dot;
 		if (dot > epsilon)
 		{
@@ -438,7 +437,9 @@ void ClipWindingEpsilon(winding_t *in, vec3_t normal, vec_t dist,
 		// generate a split point
 		p2 = in->p[(i + 1) % in->numpoints];
 
-		dot = dists[i] / (dists[i] - dists[i + 1]);
+		d1  = dists[i];
+		d2  = dists[i + 1];
+		dot = d1 / (d1 - d2);
 		for (j = 0 ; j < 3 ; j++) // avoid round off error when possible
 		{
 			if (normal[j] == 1.f)
@@ -451,7 +452,9 @@ void ClipWindingEpsilon(winding_t *in, vec3_t normal, vec_t dist,
 			}
 			else
 			{
-				mid[j] = p1[j] + dot * (p2[j] - p1[j]);
+				d1     = p1[j];
+				d2     = p2[j];
+				mid[j] = d1 + dot * (d2 - d1);
 			}
 		}
 
@@ -484,12 +487,12 @@ void ChopWindingInPlace(winding_t **w, vec3_t normal, vec_t dist, vec_t epsilon)
 	vec_t        dists[MAX_POINTS_ON_WINDING + 4];
 	int          sides[MAX_POINTS_ON_WINDING + 4];
 	int          counts[3] = { 0, 0, 0 };
-	static vec_t dot;           // VC 4.2 optimizer bug if not static
 	int          i, j;
 	vec_t        *p1, *p2;
 	vec3_t       mid;
 	winding_t    *f;
 	int          maxpts;
+	double       dot, d1, d2;
 
 	Com_Memset(dists, 0, sizeof(dists));
 	Com_Memset(sides, 0, sizeof(sides));
@@ -497,8 +500,7 @@ void ChopWindingInPlace(winding_t **w, vec3_t normal, vec_t dist, vec_t epsilon)
 	// determine sides for each point
 	for (i = 0 ; i < in->numpoints ; i++)
 	{
-		dot      = DotProduct(in->p[i], normal);
-		dot     -= dist;
+		dot      = DotProductDPf(in->p[i], normal) - dist;
 		dists[i] = dot;
 		if (dot > epsilon)
 		{
@@ -559,7 +561,9 @@ void ChopWindingInPlace(winding_t **w, vec3_t normal, vec_t dist, vec_t epsilon)
 		// generate a split point
 		p2 = in->p[(i + 1) % in->numpoints];
 
-		dot = dists[i] / (dists[i] - dists[i + 1]);
+		d1  = dists[i];
+		d2  = dists[i + 1];
+		dot = d1 / (d1 - d2);
 		for (j = 0 ; j < 3 ; j++) // avoid round off error when possible
 		{
 			if (normal[j] == 1.f)
@@ -572,7 +576,9 @@ void ChopWindingInPlace(winding_t **w, vec3_t normal, vec_t dist, vec_t epsilon)
 			}
 			else
 			{
-				mid[j] = p1[j] + dot * (p2[j] - p1[j]);
+				d1     = p1[j];
+				d2     = p2[j];
+				mid[j] = d1 + dot * (d2 - d1);
 			}
 		}
 

--- a/src/qcommon/q_math.h
+++ b/src/qcommon/q_math.h
@@ -486,6 +486,11 @@ float DistanceFromVectorSquared(vec3_t p, vec3_t lp1, vec3_t lp2);
 // Vector multiply & add
 #define VectorMA(v, s, b, o) vec3_ma(v, s, b, o)
 
+// forced double-precison functions
+#define DotProductDP(x, y)       ((double)(x)[0] * (y)[0] + (double)(x)[1] * (y)[1] + (double)(x)[2] * (y)[2])
+#define VectorSubtractDP(a, b, c) ((c)[0] = (double)((a)[0] - (b)[0]), (c)[1] = (double)((a)[1] - (b)[1]), (c)[2] = (double)((a)[2] - (b)[2]))
+#define VectorAddDP(a, b, c)      ((c)[0] = (double)((a)[0] + (b)[0]), (c)[1] = (double)((a)[1] + (b)[1]), (c)[2] = (double)((a)[2] + (b)[2]))
+
 #define MatrixMultiply(in1, in2, o) mat3_mult(in1, in2, o)
 
 #else
@@ -552,6 +557,47 @@ static ID_INLINE int VectorCompareEpsilon(const vec3_t v1, const vec3_t v2, floa
 	}
 
 	return 1;
+}
+
+static ID_INLINE double DotProductDPf(const float *v1, const float *v2)
+{
+	double x[3], y[3];
+	VectorCopy(v1, x);
+	VectorCopy(v2, y);
+	return x[0] * y[0] + x[1] * y[1] + x[2] * y[2];
+}
+
+
+static ID_INLINE void CrossProductDP(const vec3_t v1, const vec3_t v2, vec3_t cross)
+{
+	double d1[3], d2[3];
+	VectorCopy(v1, d1);
+	VectorCopy(v2, d2);
+	cross[0] = d1[1] * d2[2] - d1[2] * d2[1];
+	cross[1] = d1[2] * d2[0] - d1[0] * d2[2];
+	cross[2] = d1[0] * d2[1] - d1[1] * d2[0];
+}
+
+
+static ID_INLINE vec_t VectorNormalizeDP(vec3_t v)
+{
+	double length, ilength, d[3];
+
+	VectorCopy(v, d);
+	length = d[0] * d[0] + d[1] * d[1] + d[2] * d[2];
+
+	if (length)
+	{
+		/* writing it this way allows gcc to recognize that rsqrt can be used */
+		ilength = 1.0 / (double)sqrt(length);
+		/* sqrt(length) = length * (1 / sqrt(length)) */
+		length *= ilength;
+		v[0]    = d[0] * ilength;
+		v[1]    = d[1] * ilength;
+		v[2]    = d[2] * ilength;
+	}
+
+	return length;
 }
 
 #define AngleMod angle_mod


### PR DESCRIPTION
Because in etl `NORMAL_EPSILON` and `DIST_EPSILON` has been increased here https://github.com/etlegacy/etlegacy/commit/da2e0fd4312aa8a79f99bb2f0c8f594faf638eaa only increasing `MAX_PATCH_PLANES` by `128` would solve the issue. But for better or worse I decided to revert them to vanilla values and port the precision fix from q3e. 
https://github.com/ec-/Quake3e/commit/447cf6dff3568882b855b38e437e48ac78c652fd
https://github.com/ec-/Quake3e/commit/50ed15b5a8db8a005d5a78f62334f6538957398d

refs #2128