### PR TITLE
renderer: fix integer overflow, refs #2093

### DIFF
--- a/src/renderercommon/nanosvg/nanosvgrast.h
+++ b/src/renderercommon/nanosvg/nanosvgrast.h
@@ -956,7 +956,7 @@ static float nsvg__clampf(float a, float mn, float mx) { return a < mn ? mn : (a
 
 static unsigned int nsvg__RGBA(unsigned char r, unsigned char g, unsigned char b, unsigned char a)
 {
-	return (r) | (g << 8) | (b << 16) | (a << 24);
+	return (unsigned int)(r) | ((unsigned int)g << 8) | ((unsigned int)b << 16) | ((unsigned int)a << 24);
 }
 
 static unsigned int nsvg__lerpRGBA(unsigned int c0, unsigned int c1, float u)


### PR DESCRIPTION
`r` `g` `b` `a` arguments get promoted to `int` type automatically but it is too small still, so explicitly converting the type to `unsigned int` should fix the overflow.

For the other issue my only idea would be to check if `dxdy >= INT_MAX / NSVG__FIX` (for positives and negatives) and limit them to `INT_MAX / NSVG__FIX`, but i don't know.

refs #2093