### PR TITLE
renderer: fix decals modulation going out of range, refs #2075

### DIFF
--- a/src/renderer/tr_decals.c
+++ b/src/renderer/tr_decals.c
@@ -933,6 +933,13 @@ void R_AddDecalSurface(decal_t *decal)
 		return;
 	}
 
+	// free temporary decal
+	if (decal->fadeEndTime < tr.refdef.time)
+	{
+		decal->shader = NULL;
+		return;
+	}
+
 	// get decal surface
 	srf = &tr.refdef.decals[tr.refdef.numDecals];
 	tr.refdef.numDecals++;
@@ -972,12 +979,6 @@ void R_AddDecalSurface(decal_t *decal)
 	// add surface to scene
 	R_AddDrawSurf((void *) srf, decal->shader, decal->fogIndex, 0, dlightMap);
 	tr.pc.c_decalSurfaces++;
-
-	// free temporary decal
-	if (decal->fadeEndTime <= tr.refdef.time)
-	{
-		decal->shader = NULL;
-	}
 }
 
 /**


### PR DESCRIPTION
This is quite easy to reproduce by using PVS which is probably the biggest reason the issue exists too. When decal is of out PVS it will not be drawn (I think because of viewCount? iirc it is used as a way to know if something is in PVS or not in current frame, but not exactly sure). 

Because of that decal's `fadeEndTime` can go below `tr.refdef.time` and on the first frame where it goes back into PVS the `fade` will be negative and only at the end decal will be freed. 

Not exactly sure if freeing at the start is the best way to fix it but I think it's fine.

refs #2075