### PR TITLE
renderer: fix decal projector culling, refs #2072

### DIFF
--- a/src/renderer/tr_decals.c
+++ b/src/renderer/tr_decals.c
@@ -1024,8 +1024,8 @@ void R_CullDecalProjectors(void)
 			*dp                                           = temp;
 		}
 
-		decalBits |= (1 << numDecalProjectors);
-		numDecalProjectors++;
+		numDecalProjectors = i + 1;
+		decalBits         |= (1 << i);
 
 		// bitmask limit
 		if (numDecalProjectors == MAX_USED_DECAL_PROJECTORS)


### PR DESCRIPTION
The issue is caused by https://github.com/etlegacy/etlegacy/commit/efc95a2a77d39417e7dafe668d0902b31aaac2a4 I believe. Bringing back part of VET code fixes the issue, I think the change broke frustum culling of decals in `R_RecursiveWorldNode` - decalBits were changed without adjusting `R_RecursiveWorldNode`.

There were more changes so I'm not really sure if this is compatible with the rest of changes, especially `if (numDecalProjectors == MAX_USED_DECAL_PROJECTORS)` check (and like with the previous decals fix I'm not too familiar with the renderer logic), but it seemingly didn't break anything after some testing.

refs #2072