### PR TITLE
renderers: fix wrong decal projectors being culled, refs #2072

### DIFF
--- a/src/renderer/tr_decals.c
+++ b/src/renderer/tr_decals.c
@@ -1015,22 +1015,30 @@ void R_CullDecalProjectors(void)
 			continue;
 		}
 
-		// put all active projectors at the beginning
-		if (tr.refdef.numDecalProjectors > MAX_USED_DECAL_PROJECTORS && dp != &tr.refdef.decalProjectors[numDecalProjectors])
+		if (tr.refdef.numDecalProjectors > MAX_USED_DECAL_PROJECTORS)
 		{
-			// swap them
-			temp                                          = tr.refdef.decalProjectors[numDecalProjectors];
-			tr.refdef.decalProjectors[numDecalProjectors] = *dp;
-			*dp                                           = temp;
+			// put all active projectors at the beginning
+			if (dp != &tr.refdef.decalProjectors[numDecalProjectors])
+			{
+				// swap them
+				temp                                          = tr.refdef.decalProjectors[numDecalProjectors];
+				tr.refdef.decalProjectors[numDecalProjectors] = *dp;
+				*dp                                           = temp;
+			}
+
+			decalBits |= (1 << numDecalProjectors);
+			numDecalProjectors++;
+
+			// bitmask limit
+			if (numDecalProjectors == MAX_USED_DECAL_PROJECTORS)
+			{
+				break;
+			}
 		}
-
-		decalBits |= (1 << numDecalProjectors);
-		numDecalProjectors++;
-
-		// bitmask limit
-		if (numDecalProjectors == MAX_USED_DECAL_PROJECTORS)
+		else
 		{
-			break;
+			decalBits |= (1 << i);
+			numDecalProjectors = i + 1;
 		}
 	}
 

--- a/src/renderer2/tr_decals.c
+++ b/src/renderer2/tr_decals.c
@@ -1002,22 +1002,30 @@ void R_CullDecalProjectors(void)
 			continue;
 		}
 
-		// put all active projectors at the beginning
-		if (tr.refdef.numDecalProjectors > MAX_USED_DECAL_PROJECTORS && dp != &tr.refdef.decalProjectors[numDecalProjectors])
+		if (tr.refdef.numDecalProjectors > MAX_USED_DECAL_PROJECTORS)
 		{
-			// swap them
-			temp                                          = tr.refdef.decalProjectors[numDecalProjectors];
-			tr.refdef.decalProjectors[numDecalProjectors] = *dp;
-			*dp                                           = temp;
+			// put all active projectors at the beginning
+			if (dp != &tr.refdef.decalProjectors[numDecalProjectors])
+			{
+				// swap them
+				temp                                          = tr.refdef.decalProjectors[numDecalProjectors];
+				tr.refdef.decalProjectors[numDecalProjectors] = *dp;
+				*dp                                           = temp;
+			}
+
+			decalBits |= (1 << numDecalProjectors);
+			numDecalProjectors++;
+
+			// bitmask limit
+			if (numDecalProjectors == MAX_USED_DECAL_PROJECTORS)
+			{
+				break;
+			}
 		}
-
-		decalBits |= (1 << numDecalProjectors);
-		numDecalProjectors++;
-
-		// bitmask limit
-		if (numDecalProjectors == MAX_USED_DECAL_PROJECTORS)
+		else
 		{
-			break;
+			decalBits |= (1 << i);
+			numDecalProjectors = i + 1;
 		}
 	}
 

--- a/src/rendererGLES/tr_decals.c
+++ b/src/rendererGLES/tr_decals.c
@@ -1015,22 +1015,30 @@ void R_CullDecalProjectors(void)
 			continue;
 		}
 
-		// put all active projectors at the beginning
-		if (tr.refdef.numDecalProjectors > MAX_USED_DECAL_PROJECTORS && dp != &tr.refdef.decalProjectors[numDecalProjectors])
+		if (tr.refdef.numDecalProjectors > MAX_USED_DECAL_PROJECTORS)
 		{
-			// swap them
-			temp                                          = tr.refdef.decalProjectors[numDecalProjectors];
-			tr.refdef.decalProjectors[numDecalProjectors] = *dp;
-			*dp                                           = temp;
+			// put all active projectors at the beginning
+			if (dp != &tr.refdef.decalProjectors[numDecalProjectors])
+			{
+				// swap them
+				temp                                          = tr.refdef.decalProjectors[numDecalProjectors];
+				tr.refdef.decalProjectors[numDecalProjectors] = *dp;
+				*dp                                           = temp;
+			}
+
+			decalBits |= (1 << numDecalProjectors);
+			numDecalProjectors++;
+
+			// bitmask limit
+			if (numDecalProjectors == MAX_USED_DECAL_PROJECTORS)
+			{
+				break;
+			}
 		}
-
-		decalBits |= (1 << numDecalProjectors);
-		numDecalProjectors++;
-
-		// bitmask limit
-		if (numDecalProjectors == MAX_USED_DECAL_PROJECTORS)
+		else
 		{
-			break;
+			decalBits |= (1 << i);
+			numDecalProjectors = i + 1;
 		}
 	}
 


### PR DESCRIPTION
Fix for #2072 based on https://github.com/etlegacy/etlegacy/pull/2146. It compiles but I haven't visually checked it due to unrelated issues running ETLegacy.

----

The wrong decal projectors may be culled if not all are visible and there are less than or equal to 32 decal projectors.

decalBits and numDecalProjectors were always set as if the active decal projectors were moved to the beginning of the list. However this only happened if there was more than 32 decal projectors.

The issue was introduced in commit 410d717e91ff7008430751cdce46842a66d3a841, "renderers: make decals work with multiple world scenes".