### PR TITLE
server: allow setting interval for attack log entries

### DIFF
--- a/src/server/server.h
+++ b/src/server/server.h
@@ -161,6 +161,7 @@ typedef struct
 	playerState_t demoPlayerStates[MAX_CLIENTS];
 	svdemoPlayerStats_t demoPlayerStats[100];
 
+	int lastAttackLogTime;                  ///< timestamp of latest attack log entry
 } server_t;
 
 /**
@@ -471,6 +472,7 @@ extern cvar_t *sv_advert;
 
 extern cvar_t *sv_protect;
 extern cvar_t *sv_protectLog;
+extern cvar_t *sv_protectLogInterval;
 
 #ifdef FEATURE_ANTICHEAT
 extern cvar_t *sv_wh_active;

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -955,7 +955,6 @@ void SV_WriteAttackLog(const char *log)
 {
 	int now = Sys_Milliseconds();
 
-	printf("SV_WriteAttackLog: %d\n", now);
 	if (now > sv.lastAttackLogTime + sv_protectLogInterval->integer)
 	{
 		if (attHandle > 0)

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -953,19 +953,29 @@ void SV_SpawnServer(const char *server)
  */
 void SV_WriteAttackLog(const char *log)
 {
-	if (attHandle > 0)
-	{
-		char    string[512]; // 512 chars seem enough here
-		qtime_t time;
+	int now = Sys_Milliseconds();
 
-		Com_RealTime(&time);
-		Com_sprintf(string, sizeof(string), "%i/%02i/%02i %02i:%02i:%02i %s", 1900 + time.tm_year, time.tm_mday, time.tm_mon + 1, time.tm_hour, time.tm_min, time.tm_sec, log);
-		(void) FS_Write(string, strlen(string), attHandle);
-	}
-
-	if (sv_protect->integer & SVP_CONSOLE)
+	printf("SV_WriteAttackLog: %d\n", now);
+	if (now > sv.lastAttackLogTime + sv_protectLogInterval->integer)
 	{
-		Com_Printf("%s", log);
+		if (attHandle > 0)
+		{
+			char    string[512]; // 512 chars seem enough here
+			qtime_t time;
+
+			Com_RealTime(&time);
+			Com_sprintf(string, sizeof(string), "%i/%02i/%02i %02i:%02i:%02i %s",
+			            1900 + time.tm_year, time.tm_mday, time.tm_mon + 1,
+			            time.tm_hour, time.tm_min, time.tm_sec, log);
+			(void)FS_Write(string, strlen(string), attHandle);
+		}
+
+		if (sv_protect->integer & SVP_CONSOLE)
+		{
+			Com_Printf("%s", log);
+		}
+
+		sv.lastAttackLogTime = now;
 	}
 }
 
@@ -1163,8 +1173,9 @@ void SV_Init(void)
 
 	sv_advert = Cvar_Get("sv_advert", "1", CVAR_ARCHIVE);
 
-	sv_protect    = Cvar_Get("sv_protect", "0", CVAR_ARCHIVE);
-	sv_protectLog = Cvar_Get("sv_protectLog", "", CVAR_ARCHIVE);
+	sv_protect            = Cvar_Get("sv_protect", "0", CVAR_ARCHIVE);
+	sv_protectLog         = Cvar_Get("sv_protectLog", "", CVAR_ARCHIVE);
+	sv_protectLogInterval = Cvar_Get("sv_protectLogInterval", "1000", CVAR_ARCHIVE);
 	SV_InitAttackLog();
 
 	// init the server side demo recording stuff

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -102,6 +102,7 @@ cvar_t *sv_protect;     // 0 - unprotected
                         // 2 - OpenWolf method
                         // 4 - prints attack info to console (when ioquake3 or OPenWolf method is set)
 cvar_t *sv_protectLog;  // name of log file
+cvar_t *sv_protectLogInterval; // how often to write attack log entries
 
 #ifdef FEATURE_ANTICHEAT
 cvar_t *sv_wh_active;


### PR DESCRIPTION
`sv_protectLogInterval` to control time in milliseconds between attack log entires (default 1000). Helps at keeping attack logs at reasonable sizes so they don't get spammed 100+ lines per second when someone runs server scanning.