### PR TITLE
qcommon: prevent overwriting default configs

### DIFF
--- a/src/qcommon/common.c
+++ b/src/qcommon/common.c
@@ -3176,6 +3176,14 @@ void Com_WriteConfig_f(void)
 		return;
 	}
 
+	if (!FS_FilenameCompare(filename, "default.cfg")
+	    || !FS_FilenameCompare(filename, "default_left.cfg")
+	    || !FS_FilenameCompare(filename, "default_android.cfg"))
+	{
+		Com_Printf("Com_WriteConfig_f: filename '%s' is reserved.\n", filename);
+		return;
+	}
+
 	Com_Printf("Writing %s.\n", filename);
 	Com_WriteConfigToFile(filename);
 }


### PR DESCRIPTION
Don't allow `writeconfig` to write configs called `default.cfg`, `default_left.cfg` or `default_android.cfg`.