### PR TITLE
cgame: bring back granular bobbing control, default to off

### DIFF
--- a/etmain/ui/options_customise_game.menu
+++ b/etmain/ui/options_customise_game.menu
@@ -42,7 +42,8 @@ menuDef {
 // Movement //
 #define MOVEMENT_Y 112
 	SUBWINDOW(6, MOVEMENT_Y, (SUBWINDOW_WIDTH_L), 28, _("MOVEMENT"))
-	YESNO(8, MOVEMENT_Y + 16, (SUBWINDOW_WIDTH_L)-4, 10, _("Bobbing effect:"), .2, 8, "cg_bobbing", _("Toggle bobbing"))
+	CVARFLOATLABEL(8, MOVEMENT_Y + 16, (SUBWINDOW_WIDTH_L)-4, 10, "cg_bobbing", .2, ITEM_ALIGN_RIGHT, $evalfloat((SUBWINDOW_WIDTH_L)-6), 8 )
+	SLIDER( 8, MOVEMENT_Y + 16, (SUBWINDOW_WIDTH_L)-4, 10, _("View bobbing scale:"), .2, 8, "cg_bobbing" 0 0 5, _("Scale of view bobbing effect") )
 
 // Weapons //
 #define WEAPONS_Y 146

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -401,7 +401,7 @@ static cvarTable_t cvarTable[] =
 	{ &cg_gun_y,                   "cg_gunY",                    "0",           CVAR_TEMP,                    0 },
 	{ &cg_gun_z,                   "cg_gunZ",                    "0",           CVAR_TEMP,                    0 },
 	{ &cg_centertime,              "cg_centertime",              "5",           CVAR_ARCHIVE,                 0 }, // changed from 3 to 5
-	{ &cg_bobbing,                 "cg_bobbing",                 "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_bobbing,                 "cg_bobbing",                 "0.0",         CVAR_ARCHIVE,                 0 },
 	{ &cg_drawEnvAwareness,        "cg_drawEnvAwareness",        "7",           CVAR_ARCHIVE,                 0 },
 	{ &cg_dynamicIcons,            "cg_dynamicIcons",            "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_dynamicIconsDistance,    "cg_dynamicIconsDistance",    "400",         CVAR_ARCHIVE,                 0 },


### PR DESCRIPTION
* Turn `cg_bobbing` into a scalar for the bobbing effect, scaling the old default values for bobbing variables. The old bobbing components cannot be changed individually like in VET, but you still have granular control over the overall intensity now.
* Default to `0.0`.

Closes #2162 