### PR TITLE
game: fix g_corpses value checking logic

### DIFF
--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -284,7 +284,7 @@ void InitBodyQue(void)
 	gentity_t *ent;
 
 	// no need to init when dyn BQ is set
-	if (g_corpses.integer > 0)
+	if (g_corpses.integer)
 	{
 		return;
 	}


### PR DESCRIPTION
Fixes `g_corpses` value to act as a boolean, as it is checked to be `== 0` when deciding if a corpse is put into body queue or if a new entity is created. Since the initialization was checking for `> 0`, it was possible to init the body queue but not put any corpses to it by setting it to negative value.