### PR TITLE
mod: fix chatlog timestamp format and menu entry

### DIFF
--- a/etmain/ui/options_customise_game.menu
+++ b/etmain/ui/options_customise_game.menu
@@ -83,7 +83,7 @@ menuDef {
 	YESNO(6 + (SUBWINDOW_WIDTH_L)+6 + 2, MISC_Y + 28, (SUBWINDOW_WIDTH_R)-4, 10, _("Log Important Messages:"), .2, 8, "cg_printObjectiveInfo", _("Print important game messages to the console"))
 	MULTI(6 + (SUBWINDOW_WIDTH_L)+6 + 2, MISC_Y + 40, (SUBWINDOW_WIDTH_R)-4, 10, _("Auto-Action:"), .2, 8, "cg_autoAction", cvarFloatList { "None" 0 "Demo" 1 "Screenshot" 2 "Stats Dump" 4 "Demo + SS" 3 "Demo + Stats" 5 "SS + Stats" 6 "Demo + SS + Stats" 7 }, _("Perform automatic actions at the start or end of a round"))
 	YESNO(6 + (SUBWINDOW_WIDTH_L)+6 + 2, MISC_Y + 52, (SUBWINDOW_WIDTH_R)-4, 10, _("Show Tool Tips:"), .2, 8, "ui_showtooltips", _("Display Tool Tips in the UI"))
-	EDITFIELD(6 + (SUBWINDOW_WIDTH_L)+6 + 2, MISC_Y + 64, (SUBWINDOW_WIDTH_R)-4, 10, _("Log File:"), .2, 8, "cg_logFile", 15, 13, _("Set the name of the log file (if empty logging is disabled)"))
+	EDITFIELD(6 + (SUBWINDOW_WIDTH_L)+6 + 2, MISC_Y + 64, (SUBWINDOW_WIDTH_R)-4, 10, _("Chat Log:"), .2, 8, "cg_logFile", 15, 13, _("Set the name of the chat log file (if empty logging is disabled)"))
 	EDITFIELD(6 + (SUBWINDOW_WIDTH_L)+6 + 2, MISC_Y + 76, (SUBWINDOW_WIDTH_R)-4, 10, _("Sharetimer Custom Text:"), .2, 8, "cg_sharetimerText", 64, 18, _("Specify a custom text to announce the next enemy spawn.\nUse ${nextspawn} and ${enemylimbotime} as variables."))
 
 // Buttons //

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -3018,11 +3018,9 @@ char *CG_GetRealTime(void)
 	qtime_t tm;
 
 	trap_RealTime(&tm);
-	return va("%2i:%s%i:%s%i",
+	return va("%02i:%02i:%02i",
 	          tm.tm_hour,
-	          (tm.tm_min > 9 ? "" : "0"),  // minute padding
 	          tm.tm_min,
-	          (tm.tm_sec > 9 ? "" : "0"),  // second padding
 	          tm.tm_sec);
 }
 


### PR DESCRIPTION
Fix chatlog timestamp formatting to actually work and not be stupid, and rename the menu entry to `Chat Log` to avoid confusion with `logfile`