### PR TITLE
cgame: don't draw other comp rects when dragging a comp, refs #1967

### DIFF
--- a/src/cgame/cg_hud_editor.c
+++ b/src/cgame/cg_hud_editor.c
@@ -1860,7 +1860,7 @@ static void CG_HudEditorUpdateFields(panel_button_t *button)
 }
 
 /**
-* @brief CG_HudEditorRender draw borders for hud elements
+* @brief CG_HudEditor_Render draw borders for hud elements
 * @param[in] button
 */
 static void CG_HudEditor_Render(panel_button_t *button)
@@ -1874,7 +1874,7 @@ static void CG_HudEditor_Render(panel_button_t *button)
 	{
 		color = &colorYellow;
 	}
-	else if (showAllLayout || BG_CursorInRect(&button->rect))
+	else if (showAllLayout || (BG_CursorInRect(&button->rect) && !lastFocusComponentMoved))
 	{
 		color = comp->visible ? &colorMdGreen : &colorMdRed;
 	}


### PR DESCRIPTION
Don't draw bounding boxes of other components if we're currently dragging another component.