### PR TITLE
mod: scale text shadow/outline based off text size

### DIFF
--- a/etmain/ui/menudef.h
+++ b/etmain/ui/menudef.h
@@ -65,6 +65,10 @@
 #define ITEM_TEXTSTYLE_OUTLINESHADOWED  5   // drop shadow ( need a color for this )
 #define ITEM_TEXTSTYLE_SHADOWEDMORE     6   // drop shadow ( need a color for this )
 
+#define TEXTSTYLE_SHADOWED_OFFSET         3.5f
+#define TEXTSTYLE_SHADOWEDMORE_OFFSET     7.0f
+#define TEXTSTYLE_OUTLINED_OFFSET         3.5f
+
 #define WINDOW_BORDER_NONE          0       // no border
 #define WINDOW_BORDER_FULL          1       // full border based on border color ( single pixel )
 #define WINDOW_BORDER_HORZ          2       // horizontal borders only

--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -345,10 +345,10 @@ void CG_Text_Paint_Ext(float x, float y, float scalex, float scaley, vec4_t colo
 
 				if (style == ITEM_TEXTSTYLE_SHADOWED || style == ITEM_TEXTSTYLE_SHADOWEDMORE || style == ITEM_TEXTSTYLE_OUTLINESHADOWED)
 				{
-					float ofs = style == ITEM_TEXTSTYLE_SHADOWEDMORE ? 2 : 1;
+					const float ofs = style == ITEM_TEXTSTYLE_SHADOWED ? TEXTSTYLE_SHADOWED_OFFSET : TEXTSTYLE_SHADOWEDMORE_OFFSET;
 					colorBlack[3] = newColor[3];
 					trap_R_SetColor(colorBlack);
-					CG_Text_PaintChar_Ext(x + (glyph->pitch * scalex) + ofs, y - yadj + ofs, glyph->imageWidth, glyph->imageHeight, scalex, scaley, glyph->s, glyph->t, glyph->s2, glyph->t2, glyph->glyph);
+					CG_Text_PaintChar_Ext(x + (glyph->pitch * scalex) + ofs * scalex, y - yadj + ofs * scaley, glyph->imageWidth, glyph->imageHeight, scalex, scaley, glyph->s, glyph->t, glyph->s2, glyph->t2, glyph->glyph);
 					colorBlack[3] = 1.0f;
 					trap_R_SetColor(newColor);
 				}
@@ -357,9 +357,8 @@ void CG_Text_Paint_Ext(float x, float y, float scalex, float scaley, vec4_t colo
 
 				if (style == ITEM_TEXTSTYLE_OUTLINED || style == ITEM_TEXTSTYLE_OUTLINESHADOWED)
 				{
-					CG_Text_PaintChar_Ext(x + (glyph->pitch * scalex) - 1, y - yadj - 1, glyph->imageWidth, glyph->imageHeight, scalex, scaley, glyph->s, glyph->t, glyph->s2, glyph->t2, glyph->glyph);
+					CG_Text_PaintChar_Ext(x + (glyph->pitch * scalex) - TEXTSTYLE_OUTLINED_OFFSET * scalex, y - yadj - TEXTSTYLE_OUTLINED_OFFSET * scaley, glyph->imageWidth, glyph->imageHeight, scalex, scaley, glyph->s, glyph->t, glyph->s2, glyph->t2, glyph->glyph);
 				}
-
 				x += (glyph->xSkip * scalex) + adjust;
 				s += Q_UTF8_Width(s);
 				count++;
@@ -428,11 +427,11 @@ void CG_Text_PaintWithCursor_Ext(float x, float y, float scale, vec4_t color, co
 
 			if (style == ITEM_TEXTSTYLE_SHADOWED || style == ITEM_TEXTSTYLE_SHADOWEDMORE)
 			{
-				int ofs = style == ITEM_TEXTSTYLE_SHADOWED ? 1 : 2;
+				const float ofs = style == ITEM_TEXTSTYLE_SHADOWED ? TEXTSTYLE_SHADOWED_OFFSET : TEXTSTYLE_SHADOWEDMORE_OFFSET;
 
 				colorBlack[3] = newColor[3];
 				trap_R_SetColor(colorBlack);
-				CG_Text_PaintChar(x + (glyph->pitch * useScale) + ofs, y - yadj + ofs,
+				CG_Text_PaintChar(x + (glyph->pitch * useScale) + ofs * useScale, y - yadj + ofs * useScale,
 				                  glyph->imageWidth,
 				                  glyph->imageHeight,
 				                  useScale,
@@ -2450,8 +2449,8 @@ void CG_DrawVote(hudComponent_t *comp)
 {
 	const char *str = NULL;
 	char       str1[32], str2[32];
-    
-    if (cgs.complaintEndTime > cg.time && !cg.demoPlayback && (comp->style & 1) && cgs.complaintClient >= 0)
+
+	if (cgs.complaintEndTime > cg.time && !cg.demoPlayback && (comp->style & 1) && cgs.complaintClient >= 0)
 	{
 		CG_GetBindingKeyForVote(str1, str2);
 

--- a/src/cgame/cg_drawtools.c
+++ b/src/cgame/cg_drawtools.c
@@ -1243,10 +1243,10 @@ void CG_DrawMultilineText(float x, float y, float scalex, float scaley, vec4_t c
 
 		if (style == ITEM_TEXTSTYLE_SHADOWED || style == ITEM_TEXTSTYLE_SHADOWEDMORE || style == ITEM_TEXTSTYLE_OUTLINESHADOWED)
 		{
-			float ofs = style == ITEM_TEXTSTYLE_SHADOWEDMORE ? 2 : 1;
+			const float ofs = style == ITEM_TEXTSTYLE_SHADOWED ? TEXTSTYLE_SHADOWED_OFFSET : TEXTSTYLE_SHADOWEDMORE_OFFSET;
 			colorBlack[3] = newColor[3];
 			trap_R_SetColor(colorBlack);
-			CG_Text_PaintChar_Ext(lineX + (glyph->pitch * fontSizeX) + ofs, lineY - yadj + ofs, glyph->imageWidth, glyph->imageHeight, fontSizeX, fontSizeY, glyph->s, glyph->t, glyph->s2, glyph->t2, glyph->glyph);
+			CG_Text_PaintChar_Ext(lineX + (glyph->pitch * fontSizeX) + ofs * fontSizeX, lineY - yadj + ofs * fontSizeY, glyph->imageWidth, glyph->imageHeight, fontSizeX, fontSizeY, glyph->s, glyph->t, glyph->s2, glyph->t2, glyph->glyph);
 			colorBlack[3] = 1.0;
 			trap_R_SetColor(newColor);
 		}
@@ -1255,7 +1255,7 @@ void CG_DrawMultilineText(float x, float y, float scalex, float scaley, vec4_t c
 
 		if (style == ITEM_TEXTSTYLE_OUTLINED || style == ITEM_TEXTSTYLE_OUTLINESHADOWED)
 		{
-			CG_Text_PaintChar_Ext(lineX + (glyph->pitch * fontSizeX) - 1, lineY - yadj - 1, glyph->imageWidth, glyph->imageHeight, fontSizeX, fontSizeY, glyph->s, glyph->t, glyph->s2, glyph->t2, glyph->glyph);
+			CG_Text_PaintChar_Ext(lineX + (glyph->pitch * fontSizeX) - TEXTSTYLE_OUTLINED_OFFSET * fontSizeX, lineY - yadj - TEXTSTYLE_OUTLINED_OFFSET * fontSizeY, glyph->imageWidth, glyph->imageHeight, fontSizeX, fontSizeY, glyph->s, glyph->t, glyph->s2, glyph->t2, glyph->glyph);
 		}
 
 		lineX += (glyph->xSkip * fontSizeX) + adjust;

--- a/src/ui/ui_main.c
+++ b/src/ui/ui_main.c
@@ -619,12 +619,12 @@ void Text_Paint_Ext(float x, float y, float scalex, float scaley, vec4_t color, 
 
 				if (style == ITEM_TEXTSTYLE_SHADOWED || style == ITEM_TEXTSTYLE_SHADOWEDMORE)
 				{
-					int ofs = style == ITEM_TEXTSTYLE_SHADOWED ? 1 : 2;
+					const float ofs = style == ITEM_TEXTSTYLE_SHADOWED ? TEXTSTYLE_SHADOWED_OFFSET : TEXTSTYLE_SHADOWEDMORE_OFFSET;
 
 					colorBlack[3] = newColor[3];
 
 					trap_R_SetColor(colorBlack);
-					Text_PaintCharExt(x + (glyph->pitch * scalex) + ofs, y - yadj + ofs, glyph->imageWidth, glyph->imageHeight, scalex, scaley, glyph->s, glyph->t, glyph->s2, glyph->t2, glyph->glyph);
+					Text_PaintCharExt(x + (glyph->pitch * scalex) + ofs * scalex, y - yadj + ofs * scaley, glyph->imageWidth, glyph->imageHeight, scalex, scaley, glyph->s, glyph->t, glyph->s2, glyph->t2, glyph->glyph);
 					trap_R_SetColor(newColor);
 
 					colorBlack[3] = 1.0;
@@ -699,11 +699,11 @@ void Text_PaintWithCursor_Ext(float x, float y, float scale, vec4_t color, const
 
 			if (style == ITEM_TEXTSTYLE_SHADOWED || style == ITEM_TEXTSTYLE_SHADOWEDMORE)
 			{
-				int ofs = style == ITEM_TEXTSTYLE_SHADOWED ? 1 : 2;
+				const float ofs = style == ITEM_TEXTSTYLE_SHADOWED ? TEXTSTYLE_SHADOWED_OFFSET : TEXTSTYLE_SHADOWEDMORE_OFFSET;
 
 				colorBlack[3] = newColor[3];
 				trap_R_SetColor(colorBlack);
-				Text_PaintChar(x + (glyph->pitch * useScale) + ofs, y - yadj + ofs,
+				Text_PaintChar(x + (glyph->pitch * useScale) + ofs * useScale, y - yadj + ofs * useScale,
 				               glyph->imageWidth,
 				               glyph->imageHeight,
 				               useScale,
@@ -6384,10 +6384,10 @@ void UI_RunMenuScript(char **args)
 			trap_Cvar_Set("ui_browserModFilter", "0");
 			trap_Cvar_Set("ui_browserOssFilter", "0");
 		}
-        else if (Q_stricmp(name, "edithud") == 0)
-        {
-            trap_Cmd_ExecuteText(EXEC_APPEND, "edithud\n");
-        }
+		else if (Q_stricmp(name, "edithud") == 0)
+		{
+			trap_Cmd_ExecuteText(EXEC_APPEND, "edithud\n");
+		}
 		else if (Q_stricmp(name, "SetFontScale") == 0)
 		{
 			Com_Printf("^3WARNING: deprecated/unused %s\n", name);


### PR DESCRIPTION
Use scaling relative to text size rather than hard-coded 1/2px offset for drawing shadows and outline on text elements. This greatly improves readability especially on small text sizes, because the amount of shadowing now shrinks together with the text size, keeping the "ratio" of text/shadow the same. Bigger text on the other hand becomes slightly less readable when going to big sizes, but this is only really going to start to matter on text sizes which are so big that nobody is likely going to use.

The initial offset that gets scaled based off text size is just an arbitrary value picked by me, it can definitely be changed if the proposed value produces too little or too much shadowing.

Some comparisons:

Before (fixed shadow offset)
![2022-10-27-085036-goldrush](https://user-images.githubusercontent.com/14221121/198204961-651dfa32-5b18-4d75-a560-938d950ea2a2.png)

After (scaled shadow offset)
![2022-10-27-084848-goldrush](https://user-images.githubusercontent.com/14221121/198205036-660f500a-2d02-4d16-8aa3-d0b5d287d63a.png)

200% scale ready up text before
![image](https://user-images.githubusercontent.com/14221121/198205122-1003c9b5-d601-49a7-bc16-d3fabcdc69ba.png)

After
![image](https://user-images.githubusercontent.com/14221121/198205155-c4816ab6-8fe4-42da-bc4c-cf8e7ff7b4a1.png)

50% scale ready up text before
![image](https://user-images.githubusercontent.com/14221121/198205232-03c9d0ec-c029-4836-aded-7a98757c0191.png)

After
![image](https://user-images.githubusercontent.com/14221121/198205256-eaee4985-1178-4fd4-9a89-2633500a9e75.png)
