### PR TITLE
cgame: fix integer overflow in CG_DrawGrid

### DIFF
--- a/src/cgame/cg_commandmap.c
+++ b/src/cgame/cg_commandmap.c
@@ -600,7 +600,8 @@ static void CG_DrawGrid(float x, float y, float w, float h, mapScissor_t *scisso
 	}
 	else
 	{
-		char   coord_char[3], coord_int;
+		char   coord_char[3];
+		signed char coord_int;
 		float  text_width, text_height;
 		vec2_t textOrigin;
 


### PR DESCRIPTION
This happens on android and Raspberry Pi and causes console to be spammed with:
"ERROR: Com_sprintf output length 3 too short, require 4 bytes."