### PR TITLE
cgame: add spawnpoint visualization

### DIFF
--- a/etmain/scripts/legacy.shader
+++ b/etmain/scripts/legacy.shader
@@ -30,3 +30,14 @@ textures/sfx/shoutcast_landmine
 		tcMod scroll 0.025 -0.07625
 	}
 }
+
+textures/sfx/spawnpoint_marker
+{
+	cull none
+	noPicmip
+	{
+		clampMap ui/assets/gradientround.tga
+		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
+		rgbGen vertex
+	}
+}

--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -4113,7 +4113,8 @@ static void CG_Draw2D(void)
 		return;
 	}
 
-	if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_SPECTATOR || cgs.clientinfo[cg.clientNum].shoutcaster || cg.demoPlayback || cgs.sv_cheats)
+	if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_SPECTATOR || cgs.clientinfo[cg.clientNum].shoutcaster
+	    || cg.demoPlayback || cgs.sv_cheats || cg_drawSpawnpoints.integer)
 	{
 		CG_DrawOnScreenLabels();
 		CG_DrawOnScreenBars();

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1384,6 +1384,7 @@ typedef struct
 
 	int numMiscGameModels;
 	int numCoronas;
+	int numSpawnpointEnts;
 
 	qboolean showCampaignBriefing;
 	qboolean showGameView;
@@ -1981,6 +1982,8 @@ typedef struct
 
 	qhandle_t countryFlags;         ///< GeoIP
 
+	qhandle_t spawnpointMarker;
+
 } cgMedia_t;
 
 /**
@@ -2042,6 +2045,21 @@ typedef struct cg_corona_s
 	vec3_t org;
 	vec3_t color;
 } cg_corona_t;
+
+/**
+ * @struct cg_spawnpoint_s
+ * @typedef cg_spawnpoint_t
+ * @brief
+ */
+typedef struct cg_spawnpoint_s
+{
+	vec3_t origin;
+	vec3_t color;
+	team_t team;
+	int id;
+	qboolean isMajor;
+	char name[MAX_QPATH];
+} cg_spawnpoint_t;
 
 /**
  * @struct cg_weaponstats_s
@@ -2509,6 +2527,7 @@ typedef struct cgs_s
 
 	cg_gamemodel_t miscGameModels[MAX_STATIC_GAMEMODELS];
 	cg_corona_t corona[MAX_GAMECORONAS];
+	cg_spawnpoint_t spawnpointEnt[MAX_GENTITIES];
 
 	vec2_t ccMenuPos;
 	qboolean ccMenuShowing;
@@ -2863,6 +2882,8 @@ extern vmCvar_t cg_drawBreathPuffs;
 
 extern vmCvar_t cg_customFont1;
 extern vmCvar_t cg_customFont2;
+
+extern vmCvar_t cg_drawSpawnpoints;
 
 // local clock flags
 enum

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -353,6 +353,8 @@ vmCvar_t cg_drawBreathPuffs;
 vmCvar_t cg_customFont1;
 vmCvar_t cg_customFont2;
 
+vmCvar_t cg_drawSpawnpoints;
+
 typedef struct
 {
 	vmCvar_t *vmCvar;
@@ -597,6 +599,8 @@ static cvarTable_t cvarTable[] =
 	{ &cg_activateLean,            "cg_activateLean",            "0",           CVAR_ARCHIVE,                 0 },
 
 	{ &cg_drawBreathPuffs,         "cg_drawBreathPuffs",         "1",           CVAR_ARCHIVE,                 0 },
+
+	{ &cg_drawSpawnpoints,         "cg_drawSpawnpoints",         "0",           CVAR_ARCHIVE,                 0 },
 };
 
 static const unsigned int cvarTableSize = sizeof(cvarTable) / sizeof(cvarTable[0]);
@@ -2162,6 +2166,8 @@ static void CG_RegisterGraphics(void)
 	cgs.media.cm_arrow_spec = trap_R_RegisterShaderNoMip("ui/assets/mp_arrow_spec");
 
 	cgs.media.fireteamIcon = trap_R_RegisterShaderNoMip("sprites/fireteam");
+
+	cgs.media.spawnpointMarker = trap_R_RegisterShaderNoMip("textures/sfx/spawnpoint_marker");
 
 	// NOTE: load smoke puff as last shader to always draw on top of other shaders
 	// because renderer order the draw depth level by register index

--- a/src/cgame/cg_spawn.c
+++ b/src/cgame/cg_spawn.c
@@ -363,6 +363,45 @@ void SP_trigger_objective_info(void)
 	cg.numOIDtriggers2++;
 }
 
+void CG_Spawnpoint(void)
+{
+	char            *classname;
+	cg_spawnpoint_t *spawnpoint;
+
+	spawnpoint = &cgs.spawnpointEnt[cg.numSpawnpointEnts++];
+
+	spawnpoint->isMajor = qfalse;
+	CG_SpawnString("classname", "", &classname);
+
+	if (!Q_stricmp(classname, "team_CTF_redspawn"))
+	{
+		VectorCopy(colorRed, spawnpoint->color);
+		spawnpoint->team = TEAM_AXIS;
+	}
+	else
+	{
+		VectorCopy(colorLtBlue, spawnpoint->color);
+		spawnpoint->team = TEAM_ALLIES;
+	}
+
+	CG_SpawnVector("origin", "0 0 0", spawnpoint->origin);
+	CG_SpawnInt("id", "", &spawnpoint->id);
+
+}
+
+void SP_team_WOLF_objective(void)
+{
+	cg_spawnpoint_t *spawnpoint;
+	char            *desc;
+
+	spawnpoint = &cgs.spawnpointEnt[cg.numSpawnpointEnts++];
+
+	spawnpoint->isMajor = qtrue;
+	CG_SpawnString("description", "WARNING: No objective description set", &desc);
+	Q_strncpyz(spawnpoint->name, desc, sizeof(spawnpoint->name));
+	CG_SpawnVector("origin", "0 0 0", spawnpoint->origin);
+}
+
 typedef struct
 {
 	const char *name;
@@ -379,6 +418,9 @@ spawn_t spawns[] =
 	{ "trigger_objective_info",    SP_trigger_objective_info },
 	{ "misc_gamemodel",            SP_misc_gamemodel         },
 	{ "corona",                    CG_corona                 },
+	{ "team_CTF_redspawn",         CG_Spawnpoint             },
+	{ "team_CTF_bluespawn",        CG_Spawnpoint             },
+	{ "team_WOLF_objective",       SP_team_WOLF_objective    },
 };
 
 #define NUMSPAWNS (int)(sizeof(spawns) / sizeof(spawn_t))
@@ -700,6 +742,7 @@ void CG_ParseEntitiesFromString(void)
 	cg.numSpawnVars      = 0;
 	cg.numMiscGameModels = 0;
 	cg.numCoronas        = 0;
+	cg.numSpawnpointEnts = 0;
 
 	// the worldspawn is not an actual entity, but it still
 	// has a "spawn" function to perform any global setup


### PR DESCRIPTION
Adds option to visualize spawnpoints in the map with `cg_drawSpawnpoints`. Displays major spawnpoint name & number, and individual spawnpoints where players spawn. If `id` key is present in the spawnpoint, it's visualized as well. Only spawnpoints available for your team are drawn. Available in warmup, or if cheats are enabled.

![2022-11-01-161515-etl_adlernest](https://user-images.githubusercontent.com/14221121/199254658-4af2f980-b157-441a-8f3a-90b77e280cfb.png)
![2022-11-01-161536-etl_adlernest](https://user-images.githubusercontent.com/14221121/199254665-22bfbc45-4da0-4bd3-abac-48f6902e2655.png)
![2022-11-01-161559-radar](https://user-images.githubusercontent.com/14221121/199254668-42c3363d-754d-41f4-9fc7-2ed74c6834e6.png)
