### PR TITLE
etmain: use shadowed text for demo list

### DIFF
--- a/etmain/ui/viewreplay.menu
+++ b/etmain/ui/viewreplay.menu
@@ -40,6 +40,7 @@ menuDef {
 		rect			6 32 596 386
 		type			ITEM_TYPE_LISTBOX
 		textfont		UI_FONT_COURBD_21
+		textstyle		ITEM_TEXTSTYLE_SHADOWED
 		textscale		.2
 		textaligny		-3
 		forecolor		.6 .6 .6 1


### PR DESCRIPTION
Better readability, especially for users with high gamma.