### PR TITLE
cgame: fix powerup icon flickering in hud editor, refs #1967

### DIFF
--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -4528,10 +4528,6 @@ static void CG_NoiseGenerator()
 		CG_AddPMItem(PM_OBJECTIVE, "Nunc vero inanes flatus quorundam vile esse", " ", cgs.media.pmImages[PM_TEAM], 0, 0, colorWhite);
 	}
 
-	// powerups
-	cg.snap->ps.powerups[PW_REDFLAG]  = 1;
-	cg.snap->ps.powerups[PW_BLUEFLAG] = 1;
-
 	// objective indicator simulation
 	cg.flagIndicator |= (1 << PW_NUM_POWERUPS);
 

--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -1949,7 +1949,7 @@ void CG_DrawPowerUps(hudComponent_t *comp)
 	}
 
 	// draw treasure icon if we have the flag
-	if (ps->powerups[PW_REDFLAG] || ps->powerups[PW_BLUEFLAG])
+	if (ps->powerups[PW_REDFLAG] || ps->powerups[PW_BLUEFLAG] || cg.editingHud)
 	{
 		trap_R_SetColor(NULL);
 		CG_DrawPic(comp->location.x, comp->location.y, comp->location.w, comp->location.h, cgs.media.objectiveShader);


### PR DESCRIPTION
Instead of setting the powerup on ps every frame (and actually not working on some `com_maxfps` values), just draw the icon via the drawing function if hud editor is enabled.