### PR TITLE
cgame: fix multiline text linebreaks, refs #1967

### DIFF
--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -1164,7 +1164,7 @@ void CG_CenterPrint(const char *str)
 void CG_PriorityCenterPrint(const char *str, int priority)
 {
 	int   maxLineChars;
-	float scale;
+	float scale, w;
 
 	// don't draw if this print message is less important
 	if (cg.centerPrintTime && priority < cg.centerPrintPriority)
@@ -1172,8 +1172,10 @@ void CG_PriorityCenterPrint(const char *str, int priority)
 		return;
 	}
 
-	scale        = CG_ComputeScale(&CG_GetActiveHUD()->centerprint /*CG_GetActiveHUD()->centerprint.location.h, CG_GetActiveHUD()->centerprint.scale, &cgs.media.limboFont2*/);
-	maxLineChars = CG_GetActiveHUD()->centerprint.location.w / CG_Text_Width_Ext("A", scale, 0, &cgs.media.limboFont2);
+	scale = CG_ComputeScale(&CG_GetActiveHUD()->centerprint /*CG_GetActiveHUD()->centerprint.location.h, CG_GetActiveHUD()->centerprint.scale, &cgs.media.limboFont2*/);
+	w     = CG_GetActiveHUD()->centerprint.location.w;
+
+	maxLineChars = CG_GetMaxCharsPerLine(str, scale, &cgs.media.limboFont2, w);
 
 	CG_WordWrapString(CG_TranslateString(str), maxLineChars, cg.centerPrint, sizeof(cg.centerPrint));
 	cg.centerPrintPriority = priority;
@@ -3628,11 +3630,12 @@ static void CG_DrawFlashBlendBehindHUD(void)
 void CG_ObjectivePrint(const char *str)
 {
 	int   maxLineChars;
-	float scale;
+	float scale, w;
 
-	scale        = CG_ComputeScale(&CG_GetActiveHUD()->objectivetext /*CG_GetActiveHUD()->objectivetext.location.h, CG_GetActiveHUD()->objectivetext.scale, &cgs.media.limboFont2*/);
-	maxLineChars = CG_GetActiveHUD()->objectivetext.location.w / CG_Text_Width_Ext("A", scale, 0, &cgs.media.limboFont2);
+	scale = CG_ComputeScale(&CG_GetActiveHUD()->objectivetext /*CG_GetActiveHUD()->objectivetext.location.h, CG_GetActiveHUD()->objectivetext.scale, &cgs.media.limboFont2*/);
+	w     = CG_GetActiveHUD()->objectivetext.location.w;
 
+	maxLineChars = CG_GetMaxCharsPerLine(str, scale, &cgs.media.limboFont2, w);
 	CG_WordWrapString(CG_TranslateString(str), maxLineChars, cg.oidPrint, sizeof(cg.oidPrint));
 	cg.oidPrintTime = cg.time;
 }

--- a/src/cgame/cg_drawtools.c
+++ b/src/cgame/cg_drawtools.c
@@ -1024,6 +1024,39 @@ void CG_AddOnScreenBar(float fraction, vec4_t colorStart, vec4_t colorEnd, vec4_
 }
 
 /**
+ * @brief CG_GetMaxCharsPerLine returns maximum number of character that fit into given width
+ * @param[in]  str
+ * @param[in]  textScale
+ * @param[in]  font
+ * @param[in]  width
+ * @param[out] maxLineChars
+ */
+int CG_GetMaxCharsPerLine(const char *str, float textScale, fontHelper_t *font, float width)
+{
+	int maxLineChars = 0;
+	int limit        = 0;
+
+	while (str != NULL)
+	{
+		if (CG_Text_Width_Ext_Float(str, textScale, 0, font) < width)
+		{
+			maxLineChars = Q_PrintStrlen(str);
+			break;
+		}
+
+		limit++;
+		maxLineChars++;
+
+		if (CG_Text_Width_Ext_Float(str, textScale, limit, font) > width)
+		{
+			break;
+		}
+	}
+
+	return maxLineChars;
+}
+
+/**
  * @brief CG_WordWrapString breaks string onto lines respecting the maxLineChars
  * @param[in]  input
  * @param[in]  maxLineChars

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2997,6 +2997,7 @@ qboolean CG_WorldCoordToScreenCoordFloat(vec3_t point, float *x, float *y);
 void CG_AddOnScreenText(const char *text, vec3_t origin, qboolean fade);
 void CG_AddOnScreenBar(float fraction, vec4_t colorStart, vec4_t colorEnd, vec4_t colorBack, vec3_t origin);
 
+int CG_GetMaxCharsPerLine(const char *str, float textScale, fontHelper_t *font, float width);
 // string word wrapper
 char *CG_WordWrapString(const char *input, int maxLineChars, char *output, int maxOutputSize);
 // draws multiline strings

--- a/src/cgame/cg_servercmds.c
+++ b/src/cgame/cg_servercmds.c
@@ -903,7 +903,7 @@ void CG_TeamRestrictionsChanged(void)
 	Q_strncpyz(cg.maxMachineguns, Info_ValueForKey(info, "w2"), sizeof(cg.maxMachineguns));
 	Q_strncpyz(cg.maxRockets, Info_ValueForKey(info, "w3"), sizeof(cg.maxRockets));
 	Q_strncpyz(cg.maxRiflegrenades, Info_ValueForKey(info, "w4"), sizeof(cg.maxRiflegrenades));
-    Q_strncpyz(cg.maxLandmines, Info_ValueForKey(info, "w5"), sizeof(cg.maxLandmines));
+	Q_strncpyz(cg.maxLandmines, Info_ValueForKey(info, "w5"), sizeof(cg.maxLandmines));
 	cg.maxPlayers = Q_atoi(Info_ValueForKey(info, "m"));
 }
 
@@ -1159,7 +1159,7 @@ void CG_AddToTeamChat(const char *str, int clientnum) // FIXME: add disguise?
 		return;
 	}
 
-    scale = CG_ComputeScale(&CG_GetActiveHUD()->chat /*CG_GetActiveHUD()->chat.location.h / ((cg_teamChatHeight.integer < TEAMCHAT_HEIGHT) ? cg_teamChatHeight.integer : TEAMCHAT_HEIGHT), CG_GetActiveHUD()->chat.scale, &cgs.media.limboFont2*/);
+	scale = CG_ComputeScale(&CG_GetActiveHUD()->chat /*CG_GetActiveHUD()->chat.location.h / ((cg_teamChatHeight.integer < TEAMCHAT_HEIGHT) ? cg_teamChatHeight.integer : TEAMCHAT_HEIGHT), CG_GetActiveHUD()->chat.scale, &cgs.media.limboFont2*/);
 
 	len       = 0;
 	chatWidth = (cgs.gamestate == GS_INTERMISSION) ? TEAMCHAT_WIDTH + 30
@@ -2934,14 +2934,15 @@ void CG_dumpStats(void)
 
 void CG_AddToBannerPrint(const char *str)
 {
-    int   maxLineChars;
-    float scale;
-    
-    scale        = CG_ComputeScale(&CG_GetActiveHUD()->banner /*CG_GetActiveHUD()->banner.location.h, CG_GetActiveHUD()->banner.scale, &cgs.media.limboFont2*/);
-    maxLineChars = CG_GetActiveHUD()->banner.location.w / CG_Text_Width_Ext("A", scale, 0, &cgs.media.limboFont2);
-    
-    CG_WordWrapString(str, maxLineChars, cg.bannerPrint, sizeof(cg.bannerPrint));
-    cg.bannerPrintTime = cg.time;
+	int   maxLineChars;
+	float scale, w;
+
+	scale = CG_ComputeScale(&CG_GetActiveHUD()->banner /*CG_GetActiveHUD()->banner.location.h, CG_GetActiveHUD()->banner.scale, &cgs.media.limboFont2*/);
+	w     = CG_GetActiveHUD()->banner.location.w;
+
+	maxLineChars = CG_GetMaxCharsPerLine(str, scale, &cgs.media.limboFont2, w);
+	CG_WordWrapString(str, maxLineChars, cg.bannerPrint, sizeof(cg.bannerPrint));
+	cg.bannerPrintTime = cg.time;
 }
 
 #define ENTNFO_HASH         78985
@@ -3564,7 +3565,7 @@ static void CG_ServerCommand(void)
 		return;
 	case BP_HASH: // "bp"
 	{
-        CG_AddToBannerPrint(CG_Argv(1));
+		CG_AddToBannerPrint(CG_Argv(1));
 		break;
 	}
 	default:


### PR DESCRIPTION
Correctly calculate the positions of linebreaks in multiline text elements, by iterating through the actual string character by character while the width is in constraints of the element width. Custom font friendly as well since it reads the actual string instead of an arbitrary glyph.

This also fixes the issue where scaling below ~15% text scale would cause massive FPS drops.