### PR TITLE
cgame: don't spam noise generator stuff to console, refs #1967

### DIFF
--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -4499,6 +4499,8 @@ void CG_Coronas(void)
  */
 static void CG_NoiseGenerator()
 {
+	trap_Cvar_Set("cl_noprint", "1");
+
 	// banner
 	CG_AddToBannerPrint("Iaculatores coniunctis: incesserit servitium castrensi post velut et deinde virgae.");
 
@@ -4540,6 +4542,8 @@ static void CG_NoiseGenerator()
 
 	// missile camera
 	cg.latestMissile = &cg_entities[cg.snap->ps.clientNum];
+
+	trap_Cvar_Set("cl_noprint", "0");
 }
 
 /**


### PR DESCRIPTION
Set `cl_noprint 1` for the duration which `CG_NoiseGenerator` runs so console output stays clean.