### PR TITLE
game: don't let missiles fly through horizontal, upwards facing skyboxes

### DIFF
--- a/src/game/g_missile.c
+++ b/src/game/g_missile.c
@@ -648,12 +648,14 @@ void G_RunMissile(gentity_t *ent)
 
 	if (tr.fraction != 1.f)
 	{
-		if (ent->r.contents != CONTENTS_CORPSE && (tr.surfaceFlags & SURF_SKY))
+		if (ent->r.contents != CONTENTS_CORPSE && (tr.surfaceFlags & SURF_SKY)
+		    && tr.plane.normal[2] != 1) // don't go through horizontal, upwards facing skyboxes,
+		                                // e.g. karsiah_te2 axis 2nd spawn roof
 		{
 			// goes through sky
 			ent->count = 1;
 			// omit unlinking entity for missile camera
-			if (!g_cheats.integer && ent->s.weapon != WP_GRENADE_LAUNCHER && ent->s.weapon != WP_GRENADE_PINEAPPLE && ent->s.weapon != WP_GPG40 && ent->s.weapon != WP_M7 && ent->s.weapon != WP_MORTAR2_SET && ent->s.weapon != WP_MORTAR_SET && ent->s.weapon != WP_SMOKE_MARKER && ent->s.weapon != WP_SMOKE_BOMB)
+			if (!g_cheats.integer && GetWeaponFireTableData(ent->s.weapon)->eType != ET_MISSILE)
 			{
 				trap_UnlinkEntity(ent);
 			}


### PR DESCRIPTION
Notably this fixes being able to throw nades/airstrike/mortar etc. through the 2nd Axis spawn of karsiah_te2, since it lacks a tracemap. Tracemap check was removed in abf688c362c29c786be4039c49c28033d6a0b842 to allow mortar/riflenades (and other missiles for that matter) to be shot through skyboxes over the map, since in the absence of tracemap, they would be immediately removed upon hitting skybox.

Also simplified the check for missilecamera.