### PR TITLE
game: fix arty/airstrike bombs potentially spawning indoors

### DIFF
--- a/src/game/g_weapon.c
+++ b/src/game/g_weapon.c
@@ -2657,7 +2657,7 @@ trace_t G_BombTrace(trace_t tr, vec3_t start, vec3_t end, gentity_t *ent)
 		trap_Trace(&tr, start, NULL, NULL, end, ent->s.number, CONTENTS_SOLID);
 
 		// reached map limit and no sky found
-		if (start[2] > MAX_MAP_SIZE)
+		if (start[2] > MAX_MAP_SIZE || tr.fraction == 1.0f)
 		{
 			break;
 		}

--- a/src/game/g_weapon.c
+++ b/src/game/g_weapon.c
@@ -2650,11 +2650,23 @@ trace_t G_BombTrace(trace_t tr, vec3_t start, vec3_t end, gentity_t *ent)
 {
 	trap_Trace(&tr, start, NULL, NULL, end, ent->s.number, CONTENTS_SOLID);
 
-	// if we can't trace back to sky, we spawned indoors - redo trace from MAX_MAP_SIZE
-	if (!(tr.surfaceFlags & SURF_SKY))
+	// found sky, return this trace
+	if (tr.surfaceFlags & SURF_SKY)
 	{
-		start[2] = MAX_MAP_SIZE;
+		return tr;
+	}
+
+	// if we can't trace back to sky, we likely spawned indoors - keep nudging start position up until we find skybox
+	while (!(tr.surfaceFlags & SURF_SKY))
+	{
+		start[2] += 64;
 		trap_Trace(&tr, start, NULL, NULL, end, ent->s.number, CONTENTS_SOLID);
+
+		// reached map limit and no sky found
+		if (start[2] > MAX_MAP_SIZE)
+		{
+			break;
+		}
 	}
 
 	return tr;

--- a/src/game/g_weapon.c
+++ b/src/game/g_weapon.c
@@ -2650,12 +2650,6 @@ trace_t G_BombTrace(trace_t tr, vec3_t start, vec3_t end, gentity_t *ent)
 {
 	trap_Trace(&tr, start, NULL, NULL, end, ent->s.number, CONTENTS_SOLID);
 
-	// found sky, return this trace
-	if (tr.surfaceFlags & SURF_SKY)
-	{
-		return tr;
-	}
-
 	// if we can't trace back to sky, we likely spawned indoors - keep nudging start position up until we find skybox
 	while (!(tr.surfaceFlags & SURF_SKY))
 	{


### PR DESCRIPTION
Arty/airstrike bombs took their Z origin from the initial trace where player called arty, or threw airstrike canister. Because the actual bombs spawned as a result don't all fall in the exact same position, this made it possible for the bombs to spawn inside buildings/interiors, in scenarios where the initial trace to skybox resulted in lower Z height than a neighboring interior ceiling.

Example, goldrush bank ceiling vs skybox at the back of the bank. If you threw an airstrike at the back of the bank, the bombs could potentially spawn inside the bank, because the starting point was lower than the ceiling.
![image](https://user-images.githubusercontent.com/14221121/200175501-728a62b0-f18d-4cbc-8a04-f88da5d7ba37.png)

As a fix, we always trace back up from ground and look for `SURF_SKY`, because we ofc don't want the bombs to drop from anything else than sky. If we can't trace back to sky, this means we spawned indoors. If that happens, re-trace from `MAX_MAP_SIZE` down to ensure we never spawn inside buildings, and just hit their ceilings.