### PR TITLE
cgame: scale shadowed pic shadow offset based off size

### DIFF
--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -721,7 +721,9 @@ void CG_ReadHudScripts(void)
 static void CG_DrawPicShadowed(float x, float y, float w, float h, qhandle_t icon)
 {
 	trap_R_SetColor(colorBlack);
-	CG_DrawPic(x + 2, y + 2, w, h, icon);
+	float ofsX = (w * 1.07f) - w;
+	float ofsY = (h * 1.07f) - h;
+	CG_DrawPic(x + ofsX, y + ofsY, w, h, icon);
 	trap_R_SetColor(NULL);
 	CG_DrawPic(x, y, w, h, icon);
 }
@@ -867,7 +869,7 @@ void CG_DrawCompMultilineText(hudComponent_t *comp, const char *str, vec4_t colo
 
 	if (comp->autoAdjust)
 	{
-        h2 = MIN(h2 + paddingH * (lineNumber + 1), comp->location.h);
+		h2 = MIN(h2 + paddingH * (lineNumber + 1), comp->location.h);
 		y += ((comp->location.h - h2) * .5f);
 	}
 


### PR DESCRIPTION
Replace hardcoded integer offset for `CG_DrawPicShadowed` with a scaled shadow size based off image size, similar to text shadow.

Before/after
![image](https://user-images.githubusercontent.com/14221121/200434616-a087f9f3-15a1-4a11-8de1-6d728cec5535.png) ![image](https://user-images.githubusercontent.com/14221121/200434537-e9bb21de-2143-453a-8bc7-c3077e2944df.png)
