### PR TITLE
cgame: fix non-adjustable color/alpha for several hud elements, refs #1967

### DIFF
--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -1195,15 +1195,14 @@ void CG_DrawCenterString(hudComponent_t *comp)
 		return;
 	}
 
-	color = CG_FadeColor(cg.centerPrintTime, (int)(1000 * cg_centertime.value));
+	Vector4Copy(comp->colorMain, textColor);
+	color = CG_FadeColor_Ext(cg.centerPrintTime, (int)(1000 * cg_centertime.value), textColor[3]);
 	if (!color)
 	{
 		cg.centerPrintTime     = 0;
 		cg.centerPrintPriority = 0;
 		return;
 	}
-
-	VectorCopy(comp->colorMain, textColor);
 	textColor[3] = color[3];
 
 	CG_DrawCompMultilineText(comp, cg.centerPrint, textColor, comp->alignText, comp->styleText, &cgs.media.limboFont2);
@@ -2226,11 +2225,37 @@ void CG_DrawCrosshairHealthBar(hudComponent_t *comp)
 }
 
 /**
+ * @brief CG_GetCrosshairNameString returns a colorized or single color name string for crosshair info
+ * @param[in] comp
+ */
+const char *CG_GetCrosshairNameString(hudComponent_t *comp)
+{
+	char *s;
+	char colorized[MAX_NAME_LENGTH + 2] = { 0 };
+
+	if (comp->style & 1)
+	{
+		// Draw them with full colors
+		s = va("%s", cgs.clientinfo[cg.crosshairClientNum].name);
+	}
+	else
+	{
+		// Draw them with a single color
+		Q_ColorizeString('*', cgs.clientinfo[cg.crosshairClientNum].cleanname, colorized, MAX_NAME_LENGTH + 2);
+		s = va("%s", colorized);
+	}
+
+	return s;
+}
+
+/**
  * @brief CG_DrawCrosshairNames
+ * @param[in] comp
  */
 void CG_DrawCrosshairNames(hudComponent_t *comp)
 {
 	float      *color;
+	vec4_t     textColor;
 	const char *s = NULL;
 	float      zChange;
 	qboolean   hitClient = qfalse;
@@ -2246,10 +2271,14 @@ void CG_DrawCrosshairNames(hudComponent_t *comp)
 		return;
 	}
 
+	Vector4Copy(comp->colorMain, textColor);
+
 	// dyna > mine
 	if (cg.crosshairDyna > -1)
 	{
-		color = CG_FadeColor(cg.crosshairDynaTime, 1000);
+		// FIXME: CG_ScanForCrosshairDyna isn't called from here,
+		// fade doens't work because cg.crosshairDynaTime isn't updated correctly
+		color = CG_FadeColor_Ext(cg.crosshairDynaTime, 1000, textColor[3]);
 
 		if (!color)
 		{
@@ -2257,9 +2286,11 @@ void CG_DrawCrosshairNames(hudComponent_t *comp)
 			return;
 		}
 
-		s = va(CG_TranslateString("%s^7\'s dynamite"), cgs.clientinfo[cg.crosshairDyna].name);
+		textColor[3] = color[3];
 
-		CG_DrawCompText(comp, s, color, comp->styleText, &cgs.media.limboFont2);
+		s = va(CG_TranslateString("%s^*\'s dynamite"), CG_GetCrosshairNameString(comp));
+
+		CG_DrawCompText(comp, s, textColor, comp->styleText, &cgs.media.limboFont2);
 
 		cg.crosshairDyna = -1;
 		return;
@@ -2268,7 +2299,9 @@ void CG_DrawCrosshairNames(hudComponent_t *comp)
 	// mine id's
 	if (cg.crosshairMine > -1)
 	{
-		color = CG_FadeColor(cg.crosshairMineTime, 1000);
+		// FIXME: CG_ScanForCrosshairMine isn't called from here,
+		// fade doens't work because cg.crosshairMineTime isn't updated correctly
+		color = CG_FadeColor_Ext(cg.crosshairMineTime, 1000, textColor[3]);
 
 		if (!color)
 		{
@@ -2276,8 +2309,10 @@ void CG_DrawCrosshairNames(hudComponent_t *comp)
 			return;
 		}
 
-		s = va(CG_TranslateString("%s^7\'s mine"), cgs.clientinfo[cg.crosshairMine].name);
-		CG_DrawCompText(comp, s, color, comp->styleText, &cgs.media.limboFont2);
+		textColor[3] = *color;
+
+		s = va(CG_TranslateString("%s^*\'s mine"), CG_GetCrosshairNameString(comp));
+		CG_DrawCompText(comp, s, textColor, comp->styleText, &cgs.media.limboFont2);
 
 		cg.crosshairMine = -1;
 		return;
@@ -2312,14 +2347,15 @@ void CG_DrawCrosshairNames(hudComponent_t *comp)
 
 	if (cg.crosshairClientNum >= MAX_CLIENTS)
 	{
-		// draw the name of the player being looked at
-		color = CG_FadeColor(cg.crosshairClientTime, 1000);
+		color = CG_FadeColor_Ext(cg.crosshairClientTime, 1000, textColor[3]);
 
 		if (!color)
 		{
 			trap_R_SetColor(NULL);
 			return;
 		}
+
+		textColor[3] = color[3];
 
 		if (cgs.clientinfo[cg.snap->ps.clientNum].team != TEAM_SPECTATOR || cgs.clientinfo[cg.clientNum].shoutcaster)
 		{
@@ -2334,7 +2370,7 @@ void CG_DrawCrosshairNames(hudComponent_t *comp)
 
 			if (s && *s)
 			{
-				CG_DrawCompText(comp, s, color, comp->styleText, &cgs.media.limboFont2);
+				CG_DrawCompText(comp, s, textColor, comp->styleText, &cgs.media.limboFont2);
 			}
 		}
 		return;
@@ -2351,8 +2387,7 @@ void CG_DrawCrosshairNames(hudComponent_t *comp)
 
 		if (BG_IsSkillAvailable(cgs.clientinfo[cg.snap->ps.clientNum].skill, SK_SIGNALS, SK_FIELDOPS_ENEMY_RECOGNITION) && cgs.clientinfo[cg.snap->ps.clientNum].cls == PC_FIELDOPS)
 		{
-			// draw the name of the player being looked at
-			color = CG_FadeColor(cg.crosshairClientTime, 1000);
+			color = CG_FadeColor_Ext(cg.crosshairClientTime, 1000, textColor[3]);
 
 			if (!color)
 			{
@@ -2360,8 +2395,10 @@ void CG_DrawCrosshairNames(hudComponent_t *comp)
 				return;
 			}
 
+			textColor[3] = color[3];
+
 			s = CG_TranslateString("Disguised Enemy!");
-			CG_DrawCompText(comp, s, color, comp->styleText, &cgs.media.limboFont2);
+			CG_DrawCompText(comp, s, textColor, comp->styleText, &cgs.media.limboFont2);
 			return;
 		}
 
@@ -2376,9 +2413,7 @@ void CG_DrawCrosshairNames(hudComponent_t *comp)
 	// draw the name of the player being looked at
 	if (clientNum != -1)
 	{
-		char colorized[MAX_NAME_LENGTH + 2] = { 0 };
-
-		color = CG_FadeColor(cg.crosshairClientTime, 1000);
+		color = CG_FadeColor_Ext(cg.crosshairClientTime, 1000, textColor[3]);
 
 		if (!color)
 		{
@@ -2386,19 +2421,10 @@ void CG_DrawCrosshairNames(hudComponent_t *comp)
 			return;
 		}
 
-		if (comp->style & 1)
-		{
-			// Draw them with full colors
-			s = va("%s", cgs.clientinfo[cg.crosshairClientNum].name);
-		}
-		else
-		{
-			// Draw them with a single color (white)
-			Q_ColorizeString('7', cgs.clientinfo[cg.crosshairClientNum].cleanname, colorized, MAX_NAME_LENGTH + 2);
-			s = colorized;
-		}
+		textColor[3] = color[3];
 
-		CG_DrawCompText(comp, s, color, comp->styleText, &cgs.media.limboFont2);
+		s = CG_GetCrosshairNameString(comp);
+		CG_DrawCompText(comp, s, textColor, comp->styleText, &cgs.media.limboFont2);
 	}
 
 	trap_R_SetColor(NULL);
@@ -2949,15 +2975,15 @@ void CG_DrawLimboMessage(hudComponent_t *comp)
 		// coloured respawn counter when deployment is close to bring attention to next respawn
 		if (reinfTime > 2)
 		{
-			str1 = va(CG_TranslateString("Deploying in ^3%d ^7seconds"), reinfTime);
+			str1 = va(CG_TranslateString("Deploying in ^3%d ^*seconds"), reinfTime);
 		}
 		else if (reinfTime > 1)
 		{
-			str1 = va(CG_TranslateString("Deploying in %s%d ^7seconds"), cgs.clientinfo[cg.clientNum].health == 0 ? "^1" : "^3", reinfTime);
+			str1 = va(CG_TranslateString("Deploying in %s%d ^*seconds"), cgs.clientinfo[cg.clientNum].health == 0 ? "^1" : "^3", reinfTime);
 		}
 		else
 		{
-			str1 = va(CG_TranslateString("Deploying in %s%d ^7second"), cgs.clientinfo[cg.clientNum].health == 0 ? "^1" : "^3", reinfTime);
+			str1 = va(CG_TranslateString("Deploying in %s%d ^*second"), cgs.clientinfo[cg.clientNum].health == 0 ? "^1" : "^3", reinfTime);
 		}
 	}
 
@@ -3052,11 +3078,11 @@ void CG_DrawFollow(hudComponent_t *comp)
 
 					if (reinfDepTime > 1)
 					{
-						sprintf(deploytime, CG_TranslateString("Bonus Life! Deploying in ^3%d ^7seconds"), reinfDepTime);
+						sprintf(deploytime, CG_TranslateString("Bonus Life! Deploying in ^3%d ^*seconds"), reinfDepTime);
 					}
 					else
 					{
-						sprintf(deploytime, CG_TranslateString("Bonus Life! Deploying in ^3%d ^7second"), reinfDepTime);
+						sprintf(deploytime, CG_TranslateString("Bonus Life! Deploying in ^3%d ^*second"), reinfDepTime);
 					}
 				}
 				else
@@ -3071,11 +3097,11 @@ void CG_DrawFollow(hudComponent_t *comp)
 				// coloured respawn counter when deployment is close to bring attention to next respawn
 				if (reinfTime > 1)
 				{
-					sprintf(deploytime, CG_TranslateString("Deploying in ^3%d ^7seconds"), reinfTime);
+					sprintf(deploytime, CG_TranslateString("Deploying in ^3%d ^*seconds"), reinfTime);
 				}
 				else
 				{
-					sprintf(deploytime, CG_TranslateString("Deploying in ^3%d ^7second"), reinfTime);
+					sprintf(deploytime, CG_TranslateString("Deploying in ^3%d ^*second"), reinfTime);
 				}
 			}
 
@@ -3105,7 +3131,7 @@ void CG_DrawFollow(hudComponent_t *comp)
 				endRank = -charWidth;
 			}
 
-			CG_Text_Paint_Ext(comp->location.x, y + heightTextOffset, scale, scale, colorWhite, va("(%s", follow), 0, 0, comp->styleText, &cgs.media.limboFont2);
+			CG_Text_Paint_Ext(comp->location.x, y + heightTextOffset, scale, scale, comp->colorMain, va("(%s", follow), 0, 0, comp->styleText, &cgs.media.limboFont2);
 			CG_Text_Paint_Ext(comp->location.x + startClass + lineHeight + 2 + charWidth, y + heightTextOffset, scale, scale, colorWhite, w, 0, 0, comp->styleText, &cgs.media.limboFont2);
 			CG_Text_Paint_Ext(comp->location.x + startClass + startRank + endRank, y + heightTextOffset, scale, scale, colorWhite, ")", 0, 0, comp->styleText, &cgs.media.limboFont2);
 		}
@@ -3127,7 +3153,7 @@ void CG_DrawFollow(hudComponent_t *comp)
 			CG_DrawPic(comp->location.x + startClass + startRank, y + heightIconsOffset, lineHeight + 2, lineHeight + 2, rankicons[cgs.clientinfo[cg.snap->ps.clientNum].rank][cgs.clientinfo[cg.snap->ps.clientNum].team == TEAM_AXIS ? 1 : 0][0].shader);
 		}
 
-		CG_Text_Paint_Ext(comp->location.x, y + heightTextOffset, scale, scale, colorWhite, follow, 0, 0, comp->styleText, &cgs.media.limboFont2);
+		CG_Text_Paint_Ext(comp->location.x, y + heightTextOffset, scale, scale, comp->colorMain, follow, 0, 0, comp->styleText, &cgs.media.limboFont2);
 		CG_Text_Paint_Ext(comp->location.x + startClass + lineHeight + 2 + charWidth, y + heightTextOffset, scale, scale, colorWhite, w, 0, 0, comp->styleText, &cgs.media.limboFont2);
 	}
 }
@@ -3155,11 +3181,11 @@ void CG_DrawWarmupTitle(hudComponent_t *comp)
 
 		if (cgs.minclients > 0)
 		{
-			s = va(CG_TranslateString("^3WARMUP:^7 Waiting on ^2%i^7 %s"), cgs.minclients, cgs.minclients == 1 ? CG_TranslateString("player") : CG_TranslateString("players"));
+			s = va(CG_TranslateString("^3WARMUP:^* Waiting on ^2%i^* %s"), cgs.minclients, cgs.minclients == 1 ? CG_TranslateString("player") : CG_TranslateString("players"));
 		}
 		else
 		{
-			s = va("%s", CG_TranslateString("^3WARMUP:^7 All players ready!"));
+			s = va("%s", CG_TranslateString("^3WARMUP:^* All players ready!"));
 		}
 	}
 	else
@@ -3168,11 +3194,11 @@ void CG_DrawWarmupTitle(hudComponent_t *comp)
 
 		if (sec <= 0)
 		{
-			s = CG_TranslateString("^3WARMUP:^7 Match begins now!"); // " Timelimit at start: ^3%i min", cgs.timelimit
+			s = CG_TranslateString("^3WARMUP:^* Match begins now!"); // " Timelimit at start: ^3%i min", cgs.timelimit
 		}
 		else
 		{
-			s = va("%s %s%i", CG_TranslateString("^3WARMUP:^7 Match begins in"), sec  < 4 ? "^1" : "^2", sec);
+			s = va("%s %s%i", CG_TranslateString("^3WARMUP:^* Match begins in"), sec  < 4 ? "^1" : "^2", sec);
 		}
 
 		// pre start actions
@@ -3233,11 +3259,11 @@ void CG_DrawWarmupText(hudComponent_t *comp)
 				Q_strncpyz(str1, Binding_FromName("notready"), 32);
 				if (!Q_stricmp(str1, "(?" "?" "?)"))
 				{
-					s2 = CG_TranslateString("Type ^3\\notready^7 in the console to unready");
+					s2 = CG_TranslateString("Type ^3\\notready^* in the console to unready");
 				}
 				else
 				{
-					s2 = va(CG_TranslateString("^7Press ^3%s^7 to unready"), str1);
+					s2 = va(CG_TranslateString("^7Press ^3%s^* to unready"), str1);
 					s2 = CG_TranslateString(s2);
 				}
 			}
@@ -3246,11 +3272,11 @@ void CG_DrawWarmupText(hudComponent_t *comp)
 				Q_strncpyz(str1, Binding_FromName("ready"), 32);
 				if (!Q_stricmp(str1, "(?" "?" "?)"))
 				{
-					s2 = CG_TranslateString("Type ^3\\ready^7 in the console to start");
+					s2 = CG_TranslateString("Type ^3\\ready^* in the console to start");
 				}
 				else
 				{
-					s2 = va(CG_TranslateString("Press ^3%s^7 to start"), str1);
+					s2 = va(CG_TranslateString("Press ^3%s^* to start"), str1);
 					s2 = CG_TranslateString(s2);
 				}
 			}
@@ -3658,7 +3684,8 @@ void CG_DrawObjectiveInfo(hudComponent_t *comp)
 		return;
 	}
 
-	color = CG_FadeColor(cg.oidPrintTime, 250);
+	Vector4Copy(comp->colorMain, textColor);
+	color = CG_FadeColor_Ext(cg.oidPrintTime, 250, textColor[3]);
 
 	if (!color)
 	{
@@ -3666,7 +3693,6 @@ void CG_DrawObjectiveInfo(hudComponent_t *comp)
 		return;
 	}
 
-	VectorCopy(comp->colorMain, textColor);
 	textColor[3] = color[3];
 
 	CG_DrawCompMultilineText(comp, cg.oidPrint, textColor, comp->alignText, comp->styleText, &cgs.media.limboFont2);

--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -2227,6 +2227,7 @@ void CG_DrawCrosshairHealthBar(hudComponent_t *comp)
 /**
  * @brief CG_GetCrosshairNameString returns a colorized or single color name string for crosshair info
  * @param[in] comp
+ * @param[out] s
  */
 const char *CG_GetCrosshairNameString(hudComponent_t *comp)
 {
@@ -3105,7 +3106,7 @@ void CG_DrawFollow(hudComponent_t *comp)
 				}
 			}
 
-			CG_Text_Paint_Ext(comp->location.x, y + heightTextOffset, scale, scale, colorWhite, deploytime, 0, 0, comp->styleText, &cgs.media.limboFont2);
+			CG_Text_Paint_Ext(comp->location.x, y + heightTextOffset, scale, scale, comp->colorMain, deploytime, 0, 0, comp->styleText, &cgs.media.limboFont2);
 			y += lineHeight;
 		}
 

--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -867,7 +867,7 @@ void CG_DrawCompMultilineText(hudComponent_t *comp, const char *str, vec4_t colo
 
 	if (comp->autoAdjust)
 	{
-        h2 = MIN(h2 + paddingH * (lineNumber + 1), comp->location.h);
+		h2 = MIN(h2 + paddingH * (lineNumber + 1), comp->location.h);
 		y += ((comp->location.h - h2) * .5f);
 	}
 
@@ -3260,7 +3260,7 @@ static void CG_DrawRoundTimerSimple(hudComponent_t *comp)
 
 	blink = CG_SpawnTimersText(&s, &rt);
 
-	mt = va("%s%s", "^7", CG_RoundTimerText());
+	mt = va("%s", CG_RoundTimerText());
 
 	CG_DrawCompText(comp, mt, comp->colorMain, blink ? ITEM_TEXTSTYLE_BLINK : comp->styleText, &cgs.media.limboFont1);
 }
@@ -3282,7 +3282,7 @@ static void CG_DrawRoundTimerNormal(hudComponent_t *comp)
 
 	blink = CG_SpawnTimersText(&s, &rt);
 
-	mt = va("%s%s", "^7", CG_RoundTimerText());
+	mt = va("%s%s", "^*", CG_RoundTimerText());
 
 	if (s)
 	{

--- a/src/cgame/cg_drawtools.c
+++ b/src/cgame/cg_drawtools.c
@@ -644,9 +644,11 @@ float *CG_FadeColor(int startMsec, int totalMsec)
 }
 
 /**
- * @brief CG_FadeColor fade colors with support for variable starting alpha
+ * @brief CG_FadeColor_Ext fade colors with support for variable starting alpha
  * @param[in] startMsec
  * @param[in] totalMsec
+ * @param[in] alpha
+ * @param[out] color
  * @return
  */
 float *CG_FadeColor_Ext(int startMsec, int totalMsec, float alpha)

--- a/src/cgame/cg_drawtools.c
+++ b/src/cgame/cg_drawtools.c
@@ -644,6 +644,43 @@ float *CG_FadeColor(int startMsec, int totalMsec)
 }
 
 /**
+ * @brief CG_FadeColor fade colors with support for variable starting alpha
+ * @param[in] startMsec
+ * @param[in] totalMsec
+ * @return
+ */
+float *CG_FadeColor_Ext(int startMsec, int totalMsec, float alpha)
+{
+	static vec4_t color;
+	int           t;
+
+	if (startMsec == 0)
+	{
+		return NULL;
+	}
+
+	t = cg.time - startMsec;
+
+	if (t >= totalMsec)
+	{
+		return NULL;
+	}
+
+	// fade out
+	if (totalMsec - t < FADE_TIME)
+	{
+		color[3] = (totalMsec - t) * alpha / FADE_TIME;
+	}
+	else
+	{
+		color[3] = alpha;
+	}
+	color[0] = color[1] = color[2] = alpha;
+
+	return color;
+}
+
+/**
  * @brief CG_LerpColorWithAttack, interpolates colors
  * @param[in] from
  * @param[in] to

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2987,6 +2987,7 @@ float CG_DropdownBox(float x, float y, float w, float h, float scalex, float sca
 void CG_DrawStretchPic(float x, float y, float width, float height, qhandle_t hShader);
 
 float *CG_FadeColor(int startMsec, int totalMsec);
+float *CG_FadeColor_Ext(int startMsec, int totalMsec, float alpha);
 float *CG_LerpColorWithAttack(vec4_t from, vec4_t to, int startMsec, int totalMsec, int attackMsec);
 float *CG_TeamColor(int team);
 void CG_TileClear(void);


### PR DESCRIPTION
Fixes non-adjustable colors for:
* followtext
* limbotext
* spectatortext
* crosshairnames (when using single color)
* warmuptitle
* warmuptext
* roundtimer

Fixes non-adjustable alpha for:
* centerprint
* crosshairnames
* objectivetext

Some elements still have hardcoded, non-adjustable colors, such as `warmuptext` button bind prompts, but all the other text in those elements are now fully adjustable. Alpha adjustments will work on these hardcoded colors however.

Landmine/dynamite hints (with `g_misc 8/16`) now also respect crosshairnames single/full color setting.