### PR TITLE
game: fix missile collision issues with skyboxes

### DIFF
--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -548,6 +548,8 @@ struct gentity_s
 #ifdef FEATURE_OMNIBOT
 	int numPlanted;                     ///< Omni-bot increment dyno count
 #endif
+
+	int lastSurfaceFlags;
 };
 
 /**
@@ -2892,7 +2894,7 @@ void G_RailBox(vec_t *origin, vec_t *mins, vec_t *maxs, vec_t *color, int index)
 typedef struct weapFireTable_t
 {
 	weapon_t weapon;
-	gentity_t *(*fire)(gentity_t * ent);  ///< -
+	gentity_t *(*fire)(gentity_t *ent);   ///< -
 	void (*think)(gentity_t *ent);        ///< -
 	void (*free)(gentity_t *ent);         ///< -
 	int eType;                            ///< -

--- a/src/game/g_missile.c
+++ b/src/game/g_missile.c
@@ -551,10 +551,24 @@ void G_RunMissile(gentity_t *ent)
 					return;     // keep flying
 				}
 
+				// only re-enter through a skybox
+				if (!(tr.surfaceFlags & SURF_SKY))
+				{
+					gentity_t *tent;
+
+					tent              = G_TempEntity(ent->r.currentOrigin, EV_MORTAR_MISS);
+					tent->s.clientNum = ent->r.ownerNum;
+					tent->r.svFlags  |= SVF_BROADCAST;
+					tent->s.density   = 0; // direct
+
+					G_FreeEntity(ent);  // delete it
+					return;
+				}
+
 				tmp[2] = -MAX_MAP_SIZE;
 				trap_Trace(&tr, origin, NULL, NULL, tmp, ent->s.number, ent->clipmask);
 
-				// is ent go under the ground limit
+				// is ent under the ground limit
 				if (tr.fraction == 1.f)
 				{
 					gentity_t *tent;
@@ -564,8 +578,7 @@ void G_RunMissile(gentity_t *ent)
 					tent->r.svFlags  |= SVF_BROADCAST;
 					tent->s.density   = 0;  // direct
 
-					//G_ExplodeMissile(ent);  // play explode sound
-					G_FreeEntity(ent);      // and delete it
+					G_FreeEntity(ent);  // delete it
 					return;
 				}
 
@@ -643,12 +656,17 @@ void G_RunMissile(gentity_t *ent)
 	{
 		tr.fraction = 0;
 	}
+	// store the last surfaceflags in case missile is traveling through a 2-sided skybox brush
+	else
+	{
+		ent->lastSurfaceFlags = tr.surfaceFlags;
+	}
 
 	trap_LinkEntity(ent);
 
 	if (tr.fraction != 1.f)
 	{
-		if (ent->r.contents != CONTENTS_CORPSE && (tr.surfaceFlags & SURF_SKY))
+		if (ent->r.contents != CONTENTS_CORPSE && (tr.surfaceFlags & SURF_SKY || ent->lastSurfaceFlags & SURF_SKY))
 		{
 			// goes through sky
 			ent->count = 1;

--- a/src/game/surfaceflags.h
+++ b/src/game/surfaceflags.h
@@ -62,7 +62,7 @@
 #define CONTENTS_DONOTENTER_LARGE   0x00400000  ///< unused in ETL
 #define CONTENTS_ORIGIN             0x01000000  ///< removed before bsping an entity
 #define CONTENTS_BODY               0x02000000  ///< should never be on a brush, only in game
-#define CONTENTS_CORPSE             0x04000000
+#define CONTENTS_CORPSE             0x04000000  ///< also assigned to landmines, dynamites, satchels and flamechunks
 #define CONTENTS_DETAIL             0x08000000  ///< brushes not used for the bsp
 
 #define CONTENTS_STRUCTURAL     0x10000000      ///< brushes used for the bsp


### PR DESCRIPTION
This contains fixes for both missiles traveling through a single skybox brush, as well missiles exiting and re-entering playable area.

Firstly, this fixes missiles potentially getting stuck inside skybox brushes due to trace starting inside a solid, by storing the last valid surfaceflags and ignoring failed traces if previous surfaceflags included `SURF_SKY`. This fixes for example throwing nades over Goldrush 1st stage main, where grenades would get stuck there often on `sv_fps 40` due to double precision trace resulting in a trace which started inside a solid, when the grenade traveled through the skybox brush.

Secondly, this fixes missiles being allowed to re-enter playable area through a non-skybox surface. When a missile exits the playable area through a skybox, it is no longer allowed to re-enter playable area again, unless the exit surface is a `SURF_SKY`. This incidentally also provides the same fix, but in a much better form as in #2187.