### PR TITLE
game: swap shield check on shove from ent to victim

### DIFF
--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -4302,6 +4302,12 @@ qboolean G_PushPlayer(gentity_t *ent, gentity_t *victim)
 		return qfalse;
 	}
 
+	// if a player cannot move at this moment, don't allow him to get pushed..
+	if (victim->client->ps.pm_flags & PMF_TIME_LOCKPLAYER)
+	{
+		return qfalse;
+	}
+
 	// Don't allow pushing when player is using mg
 	if (victim->client->ps.persistant[PERS_HWEAPON_USE])
 	{

--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -4296,14 +4296,8 @@ qboolean G_PushPlayer(gentity_t *ent, gentity_t *victim)
 		return qfalse;
 	}
 
-	// Prevent possible cheating, as well as annoying push after revive and spawning
-	if (ent->client->ps.powerups[PW_INVULNERABLE])
-	{
-		return qfalse;
-	}
-
-	// if a player cannot move at this moment, don't allow him to get pushed..
-	if (victim->client->ps.pm_flags & PMF_TIME_LOCKPLAYER)
+	// Prevent boosting players who have shield
+	if (victim->client->ps.powerups[PW_INVULNERABLE])
 	{
 		return qfalse;
 	}


### PR DESCRIPTION
Swap the check for `PW_INVULNERABLE` to be on the `victim` (the client getting shoved) rather than on the player doing the shove. This will make it so that it's possible to push players without a shield right after spawning or after getting revived, but you still cannot boost teammates out of spawn instantly, since they also have a shield at that point. This is how shove is checked in ETPro as well, and seemingly what was the intention when implementing shove into legacy back in 2013, [judging by the comment here originally](https://github.com/etlegacy/etlegacy/blob/e48a50c37f817fadb7b43614b30871d4a97207a6/src/game/g_cmds.c#L3316-L3321), but it seems that `ent` was mixed with `victim` and nobody ever fixed it.

The check for `PMF_TIME_LOCKPLAYER` is no longer required as it's only set to players when they get revived, and shield will always last for longer than the movement lock.