### PR TITLE
game: fix free fireteams initalization

### DIFF
--- a/src/game/g_fireteams.c
+++ b/src/game/g_fireteams.c
@@ -298,7 +298,10 @@ int G_FindFreeFireteamIdent(team_t team)
 	qboolean freeIdent[MAX_FIRETEAMS / 2];
 	int      i;
 
-	Com_Memset(freeIdent, qtrue, sizeof(freeIdent));
+	for (i = 0; i < (MAX_FIRETEAMS / 2); i++)
+	{
+		freeIdent[i] = qtrue;
+	}
 
 	for (i = 0; i < MAX_FIRETEAMS; i++)
 	{


### PR DESCRIPTION
Using memset is wrong here since it works on bytes, which fills the entire array with `0x01010101`, thus producing runtime errors since it's an invalid value for `qboolean`.