### PR TITLE
game: fix scores command showing followed players xp counts

### DIFF
--- a/src/game/g_match.c
+++ b/src/game/g_match.c
@@ -846,7 +846,7 @@ void G_printMatchInfo(gentity_t *ent)
 			tot_dr += cl->sess.damage_received;
 			tot_tdg += cl->sess.team_damage_given;
 			tot_tdr += cl->sess.team_damage_received;
-			tot_xp += (g_gametype.integer == GT_WOLF_LMS) ? cl->ps.persistant[PERS_SCORE] : cl->ps.stats[STAT_XP];
+			tot_xp += (g_gametype.integer == GT_WOLF_LMS || g_gametype.integer == GT_WOLF_STOPWATCH) ? cl->ps.persistant[PERS_SCORE] : cl->ps.stats[STAT_XP];
 
 			eff = (cl->sess.deaths + cl->sess.kills == 0) ? 0 : 100 * cl->sess.kills / (cl->sess.deaths + cl->sess.kills);
 			if (eff < 0)
@@ -890,7 +890,7 @@ void G_printMatchInfo(gentity_t *ent)
 			                                            cl->sess.damage_received,
 			                                            cl->sess.team_damage_given,
 			                                            cl->sess.team_damage_received,
-			                                            (g_gametype.integer == GT_WOLF_LMS) ? cl->ps.persistant[PERS_SCORE] : cl->ps.stats[STAT_XP]
+			                                            (g_gametype.integer == GT_WOLF_LMS || g_gametype.integer == GT_WOLF_STOPWATCH) ? cl->ps.persistant[PERS_SCORE] : cl->ps.stats[STAT_XP]
 #ifdef FEATURE_RATING
 			                                            ,
 			                                            Com_RoundFloatWithNDecimal(cl->sess.mu - 3 * cl->sess.sigma, 2),


### PR DESCRIPTION
`scores` cmd would show followed players xp instead of actual player xp, leading to for example whole team having same xp if they all follow same player and also would lead to incorrect total team xp. This is probably still an issue with other gamemodes but cba testing if always using `persistant[PERS_SCORE]` would be fine, because I don't know why such distinction came to be in the first place.