### PR TITLE
game: fix potential crash in trigger_multiple activation

### DIFF
--- a/src/game/g_trigger.c
+++ b/src/game/g_trigger.c
@@ -106,7 +106,15 @@ void multi_trigger(gentity_t *ent, gentity_t *activator)
 		}
 	}
 
-	G_Script_ScriptEvent(ent, "activate", activator->client->sess.sessionTeam == TEAM_AXIS ? "axis" : "allies");
+	// only pass in team if activator is a client
+	if (activator->client)
+	{
+		G_Script_ScriptEvent(ent, "activate", activator->client->sess.sessionTeam == TEAM_AXIS ? "axis" : "allies");
+	}
+	else
+	{
+		G_Script_ScriptEvent(ent, "activate", NULL);
+	}
 
 	if (ent->nextthink)
 	{


### PR DESCRIPTION
Make sure `activator->client` is a valid pointer before we try to check for team to pass into `G_Script_ScriptEvent`, since this is not always true for cases where activation is done by a non-player entity which wasn't activated by the client.