### PR TITLE
cgame: fix players incorrect character models on demo rewind, refs #696

### DIFF
--- a/src/cgame/cg_view.c
+++ b/src/cgame/cg_view.c
@@ -1970,11 +1970,14 @@ static void CG_DemoRewindFixEffects(void)
 {
 	int i;
 
+	trap_GetGameState(&cgs.gameState);
+
 	// fix player entities animations
 	Com_Memset(&cg.predictedPlayerEntity.pe, 0, sizeof(playerEntity_t));
 
 	for (i = 0; i < MAX_CLIENTS; i++)
 	{
+		CG_NewClientInfo(i);
 		Com_Memset(&cg_entities[i].pe, 0, sizeof(playerEntity_t));
 	}
 

--- a/src/cgame/cg_view.c
+++ b/src/cgame/cg_view.c
@@ -1972,6 +1972,12 @@ static void CG_DemoRewindFixEffects(void)
 
 	trap_GetGameState(&cgs.gameState);
 
+	CG_ParseSysteminfo();
+	CG_ParseServerinfo();
+	CG_ParseWolfinfo();
+	CG_ParseServerToggles();
+	CG_SetConfigValues();
+
 	// fix player entities animations
 	Com_Memset(&cg.predictedPlayerEntity.pe, 0, sizeof(playerEntity_t));
 


### PR DESCRIPTION
This should fix players character models not updating when rewinding demo to correct team and class. This should be the last (at least known to me) bug with demo rewind.

refs #696