### PR TITLE
Revert "server: fix svs.time division by 0, refs #2086"

### DIFF
--- a/src/game/g_active.c
+++ b/src/game/g_active.c
@@ -2220,7 +2220,7 @@ void ClientEndFrame(gentity_t *ent)
 	AddMedicTeamBonus(ent->client);
 
 	// all players are init in game, we can set properly starting health
-	if (level.startTime == level.time - ((GAME_INIT_FRAMES + 1) * FRAMETIME))
+	if (level.startTime == level.time - (GAME_INIT_FRAMES * FRAMETIME))
 	{
 		if (BG_IsSkillAvailable(ent->client->sess.skill, SK_BATTLE_SENSE, SK_BATTLE_SENSE_HEALTH))
 		{

--- a/src/server/sv_ccmds.c
+++ b/src/server/sv_ccmds.c
@@ -323,8 +323,8 @@ static void SV_MapRestart_f(void)
 	// run a few frames to allow everything to settle
 	for (i = 0; i < GAME_INIT_FRAMES; i++)
 	{
-		svs.time += FRAMETIME;
 		VM_Call(gvm, GAME_RUN_FRAME, svs.time);
+		svs.time += FRAMETIME;
 	}
 
 	sv.state      = SS_GAME;
@@ -386,8 +386,8 @@ static void SV_MapRestart_f(void)
 	}
 
 	// run another frame to allow things to look at all the players
-	svs.time += FRAMETIME;
 	VM_Call(gvm, GAME_RUN_FRAME, svs.time);
+	svs.time += FRAMETIME;
 }
 
 //===============================================================

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -788,8 +788,8 @@ void SV_SpawnServer(const char *server)
 	// run a few frames to allow everything to settle
 	for (i = 0 ; i < GAME_INIT_FRAMES ; i++)
 	{
-		svs.time += FRAMETIME;
 		VM_Call(gvm, GAME_RUN_FRAME, svs.time);
+		svs.time += FRAMETIME;
 	}
 
 	// create a baseline for more efficient communications
@@ -848,8 +848,9 @@ void SV_SpawnServer(const char *server)
 	}
 
 	// run another frame to allow things to look at all the players
-	svs.time += FRAMETIME;
 	VM_Call(gvm, GAME_RUN_FRAME, svs.time);
+
+	svs.time += FRAMETIME;
 
 	// the server sends these to the clients so they can figure
 	// out which pk3s should be auto-downloaded


### PR DESCRIPTION
This reverts commit 8f480d33a25987ba22ef5f0b02d1ce03263a2445.

This causes timing issues with mapscripts. This means that #2086 is again an issue, and another solution should be implemented to prevent that.

Fixes #2235 