### PR TITLE
client: added support for server blocking

### DIFF
--- a/src/client/cl_ui.c
+++ b/src/client/cl_ui.c
@@ -543,6 +543,7 @@ static void LAN_GetServerInfo(int source, int n, char *buf, size_t buflen)
 		Info_SetValueForKey(info, "weaprestrict", va("%i", server->weaprestrict));
 		Info_SetValueForKey(info, "balancedteams", va("%i", server->balancedteams));
 		Info_SetValueForKey(info, "g_oss", va("%i", server->oss));
+		Info_SetValueForKey(info, "blocked", va("%i", server->blocked));
 #ifdef _WIN64
 		if (buflen > 1024)
 		{
@@ -596,6 +597,11 @@ static int LAN_GetServerPing(int source, int n)
 	}
 	if (server)
 	{
+		if (server->blocked)
+		{
+			return -2;
+		}
+
 		return server->ping;
 	}
 	return -1;

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -338,6 +338,7 @@ typedef struct
 	int32_t weaprestrict;
 	int32_t balancedteams;
 	uint32_t oss;
+	qboolean blocked;
 	char gameName[MAX_NAME_LENGTH];
 } serverInfo_t;
 
@@ -390,6 +391,12 @@ typedef struct
 
 	int32_t numfavoriteservers;
 	serverInfo_t favoriteServers[MAX_FAVOURITE_SERVERS];
+
+	int numBlockedServerAddresses;
+	netadr_t blockedServerAddresses[MAX_GLOBAL_SERVERS];
+	netadr_t masterAddr;
+
+	int blockedServersChecked;      ///< last time the blocked servers were requested
 
 	int pingUpdateSource;           ///< source currently pinging or updating
 
@@ -641,6 +648,7 @@ void CL_ServerInfoPacket(netadr_t from, msg_t *msg);
 void CL_ServerInfoPacketCheck(netadr_t from, msg_t *msg);
 void CL_LocalServers_f(void);
 void CL_GlobalServers_f(void);
+void CL_GlobalBlockedServers_f(void);
 void CL_Ping_f(void);
 qboolean CL_UpdateVisiblePings_f(int source);
 


### PR DESCRIPTION
The Legacy master can tranfer a list of servers that should be blocked due to being malicious. The list is shared to clients due to the fact that we have no control over the idmaster and that has very little filtering.