### PR TITLE
client: move listfonts from ui to client, refs #2021

### DIFF
--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -1495,6 +1495,38 @@ static void CL_CompleteTTFFontName(char *args, int argNum)
 #endif
 
 /**
+ * @brief CL_ListFonts_f
+ * Lists installed fonts
+ */
+void CL_ListFonts_f(void)
+{
+	int        numFonts, numFontsTotal = 0;
+	char       dirlist[8192];
+	char       *dirptr, fontname[MAX_QPATH];
+	int        i, j;
+	size_t     dirlen;
+	const char *fontTypes[] = { "ttf", "otf" };
+
+	Com_Printf("^2List of installed fonts\n\n");
+
+	for (i = 0; i < ARRAY_LEN(fontTypes); i++)
+	{
+		numFonts       = FS_GetFileList("fonts", va(".%s", fontTypes[i]), dirlist, sizeof(dirlist));
+		numFontsTotal += numFonts;
+		dirptr         = dirlist;
+		for (j = 0; j < numFonts; j++, dirptr += dirlen + 1)
+		{
+			dirlen = strlen(dirptr);
+			Q_strncpyz(fontname, dirptr, sizeof(fontname));
+			COM_StripExtension(fontname, fontname, sizeof(fontname));
+			Com_Printf("%s\n", fontname);
+		}
+	}
+
+	Com_Printf("\n%d fonts installed.\n", numFontsTotal);
+}
+
+/**
  * @brief CL_AddFavServer_f
  * DO NOT ACTIVATE UNTIL WE HAVE CLARIFIED SECURITY! (command execution vie ascripts)
 void CL_AddFavServer_f(void)
@@ -3168,6 +3200,7 @@ void CL_Init(void)
 	Cmd_AddCommand("extendedCharsTest", CL_ExtendedCharsTest_f);
 	Cmd_AddCommand("cl_font", CL_ConsoleFont_f, "Switches console font", CL_CompleteTTFFontName);
 #endif
+	Cmd_AddCommand("listfonts", CL_ListFonts_f, "Lists all installed fonts");
 
 	CIN_Init();
 

--- a/src/ui/ui_atoms.c
+++ b/src/ui/ui_atoms.c
@@ -182,11 +182,6 @@ qboolean UI_ConsoleCommand(int realTime)
 			Menus_OpenByName(menu_name);
 		}
 	}
-	else if (Q_stricmp(cmd, "listfonts") == 0 && uiInfo.etLegacyClient)
-	{
-		UI_ListFonts_f();
-		return qtrue;
-	}
 
 	trap_GetClientState(&cstate);
 	if (cstate.connState == CA_DISCONNECTED)

--- a/src/ui/ui_local.h
+++ b/src/ui/ui_local.h
@@ -344,8 +344,6 @@ void UI_ListCampaigns_f(void);
 void UI_ListFavourites_f(void);
 void UI_RemoveAllFavourites_f(void);
 
-void UI_ListFonts_f(void);
-
 #define GLINFO_LINES        256
 
 // ui_atoms.c

--- a/src/ui/ui_main.c
+++ b/src/ui/ui_main.c
@@ -8591,7 +8591,6 @@ void UI_Init(int etLegacyClient, int clientVersion)
 	{
 		trap_Cvar_Register(&ui_customFont1, "cg_customFont1", "", CVAR_ARCHIVE);
 		trap_Cvar_Register(&ui_customFont2, "cg_customFont2", "", CVAR_ARCHIVE);
-		trap_AddCommand("listfonts");
 	}
 
 	Com_Memset(&uiInfo.demos, 0, sizeof(uiInfo.demos));
@@ -9739,38 +9738,6 @@ void UI_RemoveAllFavourites_f(void)
 	trap_LAN_RemoveServer(AS_FAVORITES_ALL, "");
 
 	Com_Printf("%s\n", __("All favourite servers removed."));
-}
-
-/**
- * @brief Lists installed fonts
- */
-void UI_ListFonts_f(void)
-{
-	int        numFonts, numFontsTotal = 0;
-	char       dirlist[8192];
-	char       *dirptr, fontname[MAX_QPATH];
-	int        i, j;
-	size_t     dirlen;
-	const char *fontTypes[] = { "ttf", "otf" };
-
-	Com_Printf("^2List of available fonts\n\n^*Use these as values for ^3cg_customFont1 ^*and ^3cg_customFont2\n"
-	           "^*to customise fonts used in various HUD elements\n-------------------------------------------------------\n");
-
-	for (i = 0; i < ARRAY_LEN(fontTypes); i++)
-	{
-		numFonts       = trap_FS_GetFileList("fonts", va(".%s", fontTypes[i]), dirlist, sizeof(dirlist));
-		numFontsTotal += numFonts;
-		dirptr         = dirlist;
-		for (j = 0; j < numFonts; j++, dirptr += dirlen + 1)
-		{
-			dirlen = strlen(dirptr);
-			Q_strncpyz(fontname, dirptr, sizeof(fontname));
-			COM_StripExtension(fontname, fontname, sizeof(fontname));
-			Com_Printf("%s\n", fontname);
-		}
-	}
-
-	Com_Printf("\n%d fonts installed.\n", numFontsTotal);
 }
 
 const char *UI_TranslateString(const char *string)


### PR DESCRIPTION
Moves `listfonts` command from legacy UI to client engine, since `con_fontName` can now be used on any mod, and the legacy-specific `cg_customFont1/2` require ETL client anyway.