### PR TITLE
cgame: show player status as color in ft and allow forced white names

### DIFF
--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -58,7 +58,7 @@ const hudComponentFields_t hudComponentFields[] =
 	{ HUDF(statsdisplay),     CG_DrawSkills,             0.25f,  { "Column" } },
 	{ HUDF(weaponicon),       CG_DrawGunIcon,            0.19f,  { "Icon Flash" } },
 	{ HUDF(weaponammo),       CG_DrawAmmoCount,          0.25f,  { "Dynamic Color" } },
-	{ HUDF(fireteam),         CG_DrawFireTeamOverlay,    0.20f,  { "Latched Class", "No Header" } },// FIXME: outside cg_draw_hud
+	{ HUDF(fireteam),         CG_DrawFireTeamOverlay,    0.20f,  { "Latched Class", "No Header",    "Colorless Name","Status Color Name", "Status Color Row" } },// FIXME: outside cg_draw_hud
 	{ HUDF(popupmessages),    CG_DrawPM,                 0.22f,  { "No Connect",    "No TeamJoin",  "No Mission",    "No Pickup", "No Death", "Weapon Icon", "Alt Weap Icons", "Swap V<->K", "Force Colors", "Scroll Down"} }, // FIXME: outside cg_draw_hud
 	{ HUDF(popupmessages2),   CG_DrawPM,                 0.22f,  { "No Connect",    "No TeamJoin",  "No Mission",    "No Pickup", "No Death", "Weapon Icon", "Alt Weap Icons", "Swap V<->K", "Force Colors", "Scroll Down"} }, // FIXME: outside cg_draw_hud
 	{ HUDF(popupmessages3),   CG_DrawPM,                 0.22f,  { "No Connect",    "No TeamJoin",  "No Mission",    "No Pickup", "No Death", "Weapon Icon", "Alt Weap Icons", "Swap V<->K", "Force Colors", "Scroll Down"} }, // FIXME: outside cg_draw_hud

--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -46,27 +46,27 @@ static lagometer_t lagometer;
 */
 const hudComponentFields_t hudComponentFields[] =
 {
-	{ HUDF(crosshair),        CG_DrawCrosshair,          0.19f,  { "Pulse",         "Pulse Alt",    "Dynamic Color", "Dynamic Color Alt" } },          // FIXME: outside cg_draw_hud
-	{ HUDF(compass),          CG_DrawNewCompass,         0.19f,  { "Square",        "Draw Item",    "Draw Sec Obj",  "Draw Prim Obj", "Decor", "Direction", "Cardinal Pts", "Always Draw"} },
-	{ HUDF(staminabar),       CG_DrawStaminaBar,         0.19f,  { "Left",          "Center",       "Vertical",      "No Alpha", "Bar Bckgrnd", "X0 Y5", "X0 Y0", "Lerp Color", "Bar Border", "Border Tiny", "Decor", "Icon"} },
-	{ HUDF(breathbar),        CG_DrawBreathBar,          0.19f,  { "Left",          "Center",       "Vertical",      "No Alpha", "Bar Bckgrnd", "X0 Y5", "X0 Y0", "Lerp Color", "Bar Border", "Border Tiny", "Decor", "Icon"} },
-	{ HUDF(healthbar),        CG_DrawPlayerHealthBar,    0.19f,  { "Left",          "Center",       "Vertical",      "No Alpha", "Bar Bckgrnd", "X0 Y5", "X0 Y0", "Lerp Color", "Bar Border", "Border Tiny", "Decor", "Icon", "Dynamic Color"} },
-	{ HUDF(weaponchargebar),  CG_DrawWeapRecharge,       0.19f,  { "Left",          "Center",       "Vertical",      "No Alpha", "Bar Bckgrnd", "X0 Y5", "X0 Y0", "Lerp Color", "Bar Border", "Border Tiny", "Decor", "Icon"} },
+	{ HUDF(crosshair),        CG_DrawCrosshair,          0.19f,  { "Pulse",         "Pulse Alt",    "Dynamic Color",  "Dynamic Color Alt" } },         // FIXME: outside cg_draw_hud
+	{ HUDF(compass),          CG_DrawNewCompass,         0.19f,  { "Square",        "Draw Item",    "Draw Sec Obj",   "Draw Prim Obj", "Decor", "Direction", "Cardinal Pts", "Always Draw"} },
+	{ HUDF(staminabar),       CG_DrawStaminaBar,         0.19f,  { "Left",          "Center",       "Vertical",       "No Alpha", "Bar Bckgrnd", "X0 Y5", "X0 Y0", "Lerp Color", "Bar Border", "Border Tiny", "Decor", "Icon"} },
+	{ HUDF(breathbar),        CG_DrawBreathBar,          0.19f,  { "Left",          "Center",       "Vertical",       "No Alpha", "Bar Bckgrnd", "X0 Y5", "X0 Y0", "Lerp Color", "Bar Border", "Border Tiny", "Decor", "Icon"} },
+	{ HUDF(healthbar),        CG_DrawPlayerHealthBar,    0.19f,  { "Left",          "Center",       "Vertical",       "No Alpha", "Bar Bckgrnd", "X0 Y5", "X0 Y0", "Lerp Color", "Bar Border", "Border Tiny", "Decor", "Icon", "Dynamic Color"} },
+	{ HUDF(weaponchargebar),  CG_DrawWeapRecharge,       0.19f,  { "Left",          "Center",       "Vertical",       "No Alpha", "Bar Bckgrnd", "X0 Y5", "X0 Y0", "Lerp Color", "Bar Border", "Border Tiny", "Decor", "Icon"} },
 	{ HUDF(healthtext),       CG_DrawPlayerHealth,       0.25f,  { "Dynamic Color" } },
 	{ HUDF(xptext),           CG_DrawXP,                 0.25f,  { 0 } },
 	{ HUDF(ranktext),         CG_DrawRank,               0.20f,  { 0 } },
 	{ HUDF(statsdisplay),     CG_DrawSkills,             0.25f,  { "Column" } },
 	{ HUDF(weaponicon),       CG_DrawGunIcon,            0.19f,  { "Icon Flash" } },
 	{ HUDF(weaponammo),       CG_DrawAmmoCount,          0.25f,  { "Dynamic Color" } },
-	{ HUDF(fireteam),         CG_DrawFireTeamOverlay,    0.20f,  { "Latched Class", "No Header",    "Colorless Name","Status Color Name", "Status Color Row" } },// FIXME: outside cg_draw_hud
-	{ HUDF(popupmessages),    CG_DrawPM,                 0.22f,  { "No Connect",    "No TeamJoin",  "No Mission",    "No Pickup", "No Death", "Weapon Icon", "Alt Weap Icons", "Swap V<->K", "Force Colors", "Scroll Down"} }, // FIXME: outside cg_draw_hud
-	{ HUDF(popupmessages2),   CG_DrawPM,                 0.22f,  { "No Connect",    "No TeamJoin",  "No Mission",    "No Pickup", "No Death", "Weapon Icon", "Alt Weap Icons", "Swap V<->K", "Force Colors", "Scroll Down"} }, // FIXME: outside cg_draw_hud
-	{ HUDF(popupmessages3),   CG_DrawPM,                 0.22f,  { "No Connect",    "No TeamJoin",  "No Mission",    "No Pickup", "No Death", "Weapon Icon", "Alt Weap Icons", "Swap V<->K", "Force Colors", "Scroll Down"} }, // FIXME: outside cg_draw_hud
+	{ HUDF(fireteam),         CG_DrawFireTeamOverlay,    0.20f,  { "Latched Class", "No Header",    "Colorless Name", "Status Color Name", "Status Color Row"} },// FIXME: outside cg_draw_hud
+	{ HUDF(popupmessages),    CG_DrawPM,                 0.22f,  { "No Connect",    "No TeamJoin",  "No Mission",     "No Pickup", "No Death", "Weapon Icon", "Alt Weap Icons", "Swap V<->K", "Force Colors", "Scroll Down"} }, // FIXME: outside cg_draw_hud
+	{ HUDF(popupmessages2),   CG_DrawPM,                 0.22f,  { "No Connect",    "No TeamJoin",  "No Mission",     "No Pickup", "No Death", "Weapon Icon", "Alt Weap Icons", "Swap V<->K", "Force Colors", "Scroll Down"} }, // FIXME: outside cg_draw_hud
+	{ HUDF(popupmessages3),   CG_DrawPM,                 0.22f,  { "No Connect",    "No TeamJoin",  "No Mission",     "No Pickup", "No Death", "Weapon Icon", "Alt Weap Icons", "Swap V<->K", "Force Colors", "Scroll Down"} }, // FIXME: outside cg_draw_hud
 	{ HUDF(powerups),         CG_DrawPowerUps,           0.19f,  { 0 } },
 	{ HUDF(objectives),       CG_DrawObjectiveStatus,    0.19f,  { 0 } },
 	{ HUDF(hudhead),          CG_DrawPlayerStatusHead,   0.19f,  { 0 } },
 	{ HUDF(cursorhints),      CG_DrawCursorhint,         0.19f,  { "Size Pulse",    "Strobe Pulse", "Alpha Pulse" } },// FIXME: outside cg_draw_hud
-	{ HUDF(weaponstability),  CG_DrawWeapStability,      0.19f,  { "Always",        "Left",         "Center",        "Vertical", "No Alpha", "Bar Bckgrnd", "X0 Y5", "X0 Y0", "Lerp Color", "Bar Border", "Border Tiny", "Decor", "Icon"} }, // FIXME: outside cg_draw_hud
+	{ HUDF(weaponstability),  CG_DrawWeapStability,      0.19f,  { "Always",        "Left",         "Center",         "Vertical", "No Alpha", "Bar Bckgrnd", "X0 Y5", "X0 Y0", "Lerp Color", "Bar Border", "Border Tiny", "Decor", "Icon"} }, // FIXME: outside cg_draw_hud
 	{ HUDF(livesleft),        CG_DrawLivesLeft,          0.19f,  { 0 } },
 	{ HUDF(roundtimer),       CG_DrawRoundTimer,         0.19f,  { "Simple" } },
 	{ HUDF(reinforcement),    CG_DrawRespawnTimer,       0.19f,  { 0 } },
@@ -96,9 +96,9 @@ const hudComponentFields_t hudComponentFields[] =
 	{ HUDF(centerprint),      CG_DrawCenterString,       0.22f,  { 0 } },           // FIXME: outside cg_draw_hud
 	{ HUDF(banner),           CG_DrawBannerPrint,        0.23f,  { 0 } },           // FIXME: outside cg_draw_hud
 	{ HUDF(crosshairtext),    CG_DrawCrosshairNames,     0.25f,  { "Full Color" } },// FIXME: outside cg_draw_hud
-	{ HUDF(crosshairbar),     CG_DrawCrosshairHealthBar, 0.25f,  { "Class",         "Rank",         "Prestige",      "Left", "Center", "Vertical", "No Alpha", "Bar Bckgrnd", "X0 Y5", "X0 Y0", "Lerp Color", "Bar Border", "Border Tiny", "Decor", "Icon", "Dynamic Color"} }, // FIXME: outside cg_draw_hud
-	{ HUDF(stats),            CG_DrawPlayerStats,        0.19f,  { "Kill",          "Death",        "Self Kill",     "DmgGiven", "DmgRcvd"} },
-	{ HUDF(xpgain),           CG_DrawPMItemsXPGain,      0.22f,  { "Scroll Down", "No Reason" } },// FIXME: outside cg_draw_hud
+	{ HUDF(crosshairbar),     CG_DrawCrosshairHealthBar, 0.25f,  { "Class",         "Rank",         "Prestige",       "Left", "Center", "Vertical", "No Alpha", "Bar Bckgrnd", "X0 Y5", "X0 Y0", "Lerp Color", "Bar Border", "Border Tiny", "Decor", "Icon", "Dynamic Color"} }, // FIXME: outside cg_draw_hud
+	{ HUDF(stats),            CG_DrawPlayerStats,        0.19f,  { "Kill",          "Death",        "Self Kill",      "DmgGiven", "DmgRcvd"} },
+	{ HUDF(xpgain),           CG_DrawPMItemsXPGain,      0.22f,  { "Scroll Down",   "No Reason" } },// FIXME: outside cg_draw_hud
 	{ NULL,                   0,                         qfalse, NULL, 0.00f,{ 0 } },
 };
 
@@ -2468,7 +2468,7 @@ void CG_DrawNewCompass(hudComponent_t *comp)
 	if (cgs.autoMapExpanded)
 	{
 		if (cgs.clientinfo[cg.clientNum].team != TEAM_SPECTATOR
-			&& cg.time - cgs.autoMapExpandTime < 100.f * expandedMapFrac)
+		    && cg.time - cgs.autoMapExpandTime < 100.f * expandedMapFrac)
 		{
 			if (!(comp->style & COMPASS_ALWAYS_DRAW))
 			{
@@ -2488,8 +2488,8 @@ void CG_DrawNewCompass(hudComponent_t *comp)
 	else
 	{
 		if (cg.time - cgs.autoMapExpandTime <= 150.f * expandedMapFrac
-			|| cg.time - cgs.autoMapExpandTime <= 250.f * expandedMapFrac
-			&& cgs.clientinfo[cg.clientNum].team == TEAM_SPECTATOR)
+		    || cg.time - cgs.autoMapExpandTime <= 250.f * expandedMapFrac
+		    && cgs.clientinfo[cg.clientNum].team == TEAM_SPECTATOR)
 		{
 			CG_DrawExpandedAutoMap();
 

--- a/src/cgame/cg_fireteamoverlay.c
+++ b/src/cgame/cg_fireteamoverlay.c
@@ -476,7 +476,7 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 			locwidth = 0;
 		}
 
-		if (cg_fireteamNameColorless.integer || (cg_fireteamStatusColors.integer == 1 && (ci->health <= 0 || ci->ping >= 999)))
+		if (comp->style & BIT(2) || (comp->style & BIT(3) && (ci->health <= 0 || ci->ping >= 999)))
 		{
 			Q_strncpyz(name[i], ci->cleanname, sizeof(name[i]));
 		}
@@ -631,12 +631,12 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 			break;
 		}
 
-		if (cg_fireteamStatusColors.integer)
+		if (comp->style & BIT(3) || comp->style & BIT(4))
 		{
 			fireteamMemberStatusEnum_t status = CG_FireTeamMemberStatus(ci);
 
 			Com_Memcpy(&nameColor, CG_FireTeamNameColor(status), sizeof(vec4_t));
-			if (cg_fireteamStatusColors.integer == 2 && status != NONE)
+			if (comp->style & BIT(4) && status != NONE)
 			{
 				vec4_t rowColor;
 				Com_Memcpy(&rowColor, nameColor, sizeof(vec4_t));

--- a/src/cgame/cg_fireteamoverlay.c
+++ b/src/cgame/cg_fireteamoverlay.c
@@ -366,11 +366,6 @@ clientInfo_t *CG_SortedFireTeamPlayerForPosition(int pos)
 
 // Main Functions
 
-static vec4_t textWhite  = { 1.0f, 1.0f, 1.0f, 1.0f };               // regular text
-static vec4_t textYellow = { 1.0f, 1.0f, 0.0f, 1.0f };               // yellow text for health drawing
-static vec4_t textRed    = { 1.0f, 0.0f, 0.0f, 1.0f };               // red text for health drawing
-static vec4_t textOrange = { 1.0f, 0.6f, 0.0f, 1.0f };               // orange text for health drawing
-
 typedef enum
 {
 	TIMEOUT,
@@ -412,6 +407,12 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 	vec4_t FT_select                = { 0.5f, 0.5f, 0.2f, 0.3f }; // selected member
 	vec4_t iconColor                = { 1.0f, 1.0f, 1.0f, 1.0f }; // icon "color", used for alpha adjustments
 	vec4_t iconColorSemitransparent = { 1.0f, 1.0f, 1.0f, 0.5f };
+	vec4_t textWhite                = { 1.0f, 1.0f, 1.0f, 1.0f }; // regular text
+	vec4_t textYellow               = { 1.0f, 1.0f, 0.0f, 1.0f }; // yellow text for health drawing
+	vec4_t textRed                  = { 1.0f, 0.0f, 0.0f, 1.0f }; // red text for health drawing
+	vec4_t textOrange               = { 1.0f, 0.6f, 0.0f, 1.0f }; // orange text for ping issues
+	vec4_t nameColor                = { 1.0f, 1.0f, 1.0f, 1.0f };
+
 
 	if (cgs.clientinfo[cg.clientNum].shoutcaster)
 	{
@@ -575,12 +576,13 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 	// fireteam alpha adjustments
 
 	// set background alpha first
-	FT_select[3]   *= comp->colorMain[3];
-	iconColor[3]   *= comp->colorMain[3];
-	colorWhite[3]  *= comp->colorMain[3];
-	colorYellow[3] *= comp->colorMain[3];
-	colorRed[3]    *= comp->colorMain[3];
-	colorOrange[3] *= comp->colorMain[3];
+	FT_select[3]  *= comp->colorMain[3];
+	iconColor[3]  *= comp->colorMain[3];
+	textWhite[3]  *= comp->colorMain[3];
+	textYellow[3] *= comp->colorMain[3];
+	textRed[3]    *= comp->colorMain[3];
+	textOrange[3] *= comp->colorMain[3];
+	nameColor[3]  *= comp->colorMain[3];
 
 	if (comp->showBackGround)
 	{
@@ -616,7 +618,6 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 	for (i = 0; i < MAX_FIRETEAM_MEMBERS; i++)
 	{
 		x = lineX;
-		vec4_t nameColor;
 
 		if (i != 0 || !(comp->style & BIT(1)))
 		{
@@ -634,19 +635,18 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 		if (comp->style & BIT(3) || comp->style & BIT(4))
 		{
 			fireteamMemberStatusEnum_t status = CG_FireTeamMemberStatus(ci);
-
-			Com_Memcpy(&nameColor, CG_FireTeamNameColor(status), sizeof(vec4_t));
+			vec3_copy(*CG_FireTeamNameColor(status), nameColor);
 			if (comp->style & BIT(4) && status != NONE)
 			{
 				vec4_t rowColor;
-				Com_Memcpy(&rowColor, nameColor, sizeof(vec4_t));
+				vec4_copy(nameColor, rowColor);
 				rowColor[3] = comp->colorBackground[3];
 				CG_FillRect(x, y, w, h, rowColor);
 			}
 		}
 		else
 		{
-			Com_Memcpy(&nameColor, &colorWhite, sizeof(vec4_t));
+			vec4_copy(textWhite, nameColor);
 		}
 
 		if (ci->selected)
@@ -765,27 +765,27 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 		else if (ci->health >= 10)
 		{
 			x += spacing;
-			CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, ci->health > 80 ? comp->colorMain : colorYellow, va("%i", ci->health), 0, 0, comp->styleText, FONT_TEXT);
+			CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, ci->health > 80 ? comp->colorMain : textYellow, va("%i", ci->health), 0, 0, comp->styleText, FONT_TEXT);
 			x += spacing * 2;
 		}
 		else if (ci->health > 0)
 		{
 			x += spacing * 2;
-			CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, colorYellow, va("%i", ci->health), 0, 0, comp->styleText, FONT_TEXT);
+			CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, textYellow, va("%i", ci->health), 0, 0, comp->styleText, FONT_TEXT);
 			x += spacing;
 		}
 		else if (ci->health == 0)
 		{
 			x += spacing;
-			CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, ((cg.time % 500) > 250)  ? colorWhite : colorRed, "*", 0, 0, comp->styleText, FONT_TEXT);
+			CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, ((cg.time % 500) > 250)  ? textWhite : textRed, "*", 0, 0, comp->styleText, FONT_TEXT);
 			x += spacing;
-			CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, ((cg.time % 500) > 250)  ? colorRed : colorWhite, "0", 0, 0, comp->styleText, FONT_TEXT);
+			CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, ((cg.time % 500) > 250)  ? textRed : textWhite, "0", 0, 0, comp->styleText, FONT_TEXT);
 			x += spacing;
 		}
 		else
 		{
 			x += spacing * 2;
-			CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, colorRed, "0", 0, 0, comp->styleText, FONT_TEXT);
+			CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, textRed, "0", 0, 0, comp->styleText, FONT_TEXT);
 			x += spacing;
 		}
 

--- a/src/cgame/cg_fireteamoverlay.c
+++ b/src/cgame/cg_fireteamoverlay.c
@@ -575,12 +575,12 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 	// fireteam alpha adjustments
 
 	// set background alpha first
-	FT_select[3]  *= comp->colorMain[3];
-	iconColor[3]  *= comp->colorMain[3];
-	textWhite[3]  *= comp->colorMain[3];
-	textYellow[3] *= comp->colorMain[3];
-	textRed[3]    *= comp->colorMain[3];
-	textOrange[3] *= comp->colorMain[3];
+	FT_select[3]   *= comp->colorMain[3];
+	iconColor[3]   *= comp->colorMain[3];
+	colorWhite[3]  *= comp->colorMain[3];
+	colorYellow[3] *= comp->colorMain[3];
+	colorRed[3]    *= comp->colorMain[3];
+	colorOrange[3] *= comp->colorMain[3];
 
 	if (comp->showBackGround)
 	{
@@ -646,7 +646,7 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 		}
 		else
 		{
-			Com_Memcpy(&nameColor, &textWhite, sizeof(vec4_t));
+			Com_Memcpy(&nameColor, &colorWhite, sizeof(vec4_t));
 		}
 
 		if (ci->selected)
@@ -765,27 +765,27 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 		else if (ci->health >= 10)
 		{
 			x += spacing;
-			CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, ci->health > 80 ? comp->colorMain : textYellow, va("%i", ci->health), 0, 0, comp->styleText, FONT_TEXT);
+			CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, ci->health > 80 ? comp->colorMain : colorYellow, va("%i", ci->health), 0, 0, comp->styleText, FONT_TEXT);
 			x += spacing * 2;
 		}
 		else if (ci->health > 0)
 		{
 			x += spacing * 2;
-			CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, textYellow, va("%i", ci->health), 0, 0, comp->styleText, FONT_TEXT);
+			CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, colorYellow, va("%i", ci->health), 0, 0, comp->styleText, FONT_TEXT);
 			x += spacing;
 		}
 		else if (ci->health == 0)
 		{
 			x += spacing;
-			CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, ((cg.time % 500) > 250)  ? textWhite : textRed, "*", 0, 0, comp->styleText, FONT_TEXT);
+			CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, ((cg.time % 500) > 250)  ? colorWhite : colorRed, "*", 0, 0, comp->styleText, FONT_TEXT);
 			x += spacing;
-			CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, ((cg.time % 500) > 250)  ? textRed : textWhite, "0", 0, 0, comp->styleText, FONT_TEXT);
+			CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, ((cg.time % 500) > 250)  ? colorRed : colorWhite, "0", 0, 0, comp->styleText, FONT_TEXT);
 			x += spacing;
 		}
 		else
 		{
 			x += spacing * 2;
-			CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, textRed, "0", 0, 0, comp->styleText, FONT_TEXT);
+			CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, colorRed, "0", 0, 0, comp->styleText, FONT_TEXT);
 			x += spacing;
 		}
 
@@ -842,14 +842,14 @@ static vec4_t * CG_FireTeamNameColor(fireteamMemberStatusEnum_t status)
 	switch (status)
 	{
 	case TIMEOUT:
-		return &textOrange;
+		return &colorOrange;
 	case WOUNDED:
-		return &textYellow;
+		return &colorYellow;
 	case DEAD:
-		return &textRed;
+		return &colorRed;
 	case NONE:
 	default:
-		return &textWhite;
+		return &colorWhite;
 	}
 }
 

--- a/src/cgame/cg_fireteamoverlay.c
+++ b/src/cgame/cg_fireteamoverlay.c
@@ -373,10 +373,10 @@ static vec4_t textOrange = { 1.0f, 0.6f, 0.0f, 1.0f };               // orange t
 
 typedef enum
 {
-    TIMEOUT,
-    WOUNDED,
-    DEAD,
-    NONE
+	TIMEOUT,
+	WOUNDED,
+	DEAD,
+	NONE
 } fireteamMemberStatusEnum_t;
 
 static fireteamMemberStatusEnum_t CG_FireTeamMemberStatus(clientInfo_t *ci);
@@ -616,7 +616,7 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 	for (i = 0; i < MAX_FIRETEAM_MEMBERS; i++)
 	{
 		x = lineX;
-        vec4_t nameColor;
+		vec4_t nameColor;
 
 		if (i != 0 || !(comp->style & BIT(1)))
 		{

--- a/src/cgame/cg_fireteamoverlay.c
+++ b/src/cgame/cg_fireteamoverlay.c
@@ -366,10 +366,21 @@ clientInfo_t *CG_SortedFireTeamPlayerForPosition(int pos)
 
 // Main Functions
 
-vec4_t textWhite  = { 1.0f, 1.0f, 1.0f, 1.0f };               // regular text
-vec4_t textYellow = { 1.0f, 1.0f, 0.0f, 1.0f };               // yellow text for health drawing
-vec4_t textRed    = { 1.0f, 0.0f, 0.0f, 1.0f };               // red text for health drawing
-vec4_t textOrange = { 1.0f, 0.6f, 0.0f, 1.0f };               // orange text for health drawing
+static vec4_t textWhite  = { 1.0f, 1.0f, 1.0f, 1.0f };               // regular text
+static vec4_t textYellow = { 1.0f, 1.0f, 0.0f, 1.0f };               // yellow text for health drawing
+static vec4_t textRed    = { 1.0f, 0.0f, 0.0f, 1.0f };               // red text for health drawing
+static vec4_t textOrange = { 1.0f, 0.6f, 0.0f, 1.0f };               // orange text for health drawing
+
+typedef enum
+{
+    TIMEOUT,
+    WOUNDED,
+    DEAD,
+    NONE
+} fireteamMemberStatusEnum_t;
+
+static fireteamMemberStatusEnum_t CG_FireTeamMemberStatus(clientInfo_t *ci);
+static vec4_t * CG_FireTeamNameColor(fireteamMemberStatusEnum_t status);
 
 
 /**
@@ -806,7 +817,7 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 	trap_R_SetColor(NULL);
 }
 
-fireteamMemberStatusEnum_t CG_FireTeamMemberStatus(clientInfo_t *ci)
+static fireteamMemberStatusEnum_t CG_FireTeamMemberStatus(clientInfo_t *ci)
 {
 	if (ci->ping >= 999)
 	{
@@ -826,7 +837,7 @@ fireteamMemberStatusEnum_t CG_FireTeamMemberStatus(clientInfo_t *ci)
 	}
 }
 
-vec4_t * CG_FireTeamNameColor(fireteamMemberStatusEnum_t status)
+static vec4_t * CG_FireTeamNameColor(fireteamMemberStatusEnum_t status)
 {
 	switch (status)
 	{

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -648,6 +648,7 @@ typedef struct clientInfo_s
 	int breathPuffTime;
 	int cls;
 	int latchedcls;
+    int ping;
 
 	int rank;
 
@@ -2863,6 +2864,8 @@ extern vmCvar_t cg_altHud;
 extern vmCvar_t cg_tracers;
 extern vmCvar_t cg_fireteamNameMaxChars;
 extern vmCvar_t cg_fireteamNameAlign;
+extern vmCvar_t cg_fireteamNameColorless;
+extern vmCvar_t cg_fireteamStatusColors;
 extern vmCvar_t cg_fireteamSprites;
 
 extern vmCvar_t cg_simpleItems;
@@ -3815,10 +3818,20 @@ void CG_DrawUISelectedSoldier(void);
 void CG_UICurrentSquadSetup(void);
 void CG_CampaignBriefingSetup(void);
 
+typedef enum
+{
+    TIMEOUT,
+    WOUNDED,
+    DEAD,
+    NONE
+} fireteamMemberStatusEnum_t;
+
 // Fireteam stuff
 fireteamData_t *CG_IsOnFireteam(int clientNum);
 fireteamData_t *CG_IsOnSameFireteam(int clientNum, int clientNum2);
 fireteamData_t *CG_IsFireTeamLeader(int clientNum);
+fireteamMemberStatusEnum_t CG_FireTeamMemberStatus(clientInfo_t* ci);
+vec4_t * CG_FireTeamNameColor(fireteamMemberStatusEnum_t status);
 
 //clientInfo_t *CG_ClientInfoForPosition(int pos, int max);
 //fireteamData_t *CG_FireTeamForPosition(int pos, int max);

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2864,8 +2864,6 @@ extern vmCvar_t cg_altHud;
 extern vmCvar_t cg_tracers;
 extern vmCvar_t cg_fireteamNameMaxChars;
 extern vmCvar_t cg_fireteamNameAlign;
-extern vmCvar_t cg_fireteamNameColorless;
-extern vmCvar_t cg_fireteamStatusColors;
 extern vmCvar_t cg_fireteamSprites;
 
 extern vmCvar_t cg_simpleItems;

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -648,7 +648,7 @@ typedef struct clientInfo_s
 	int breathPuffTime;
 	int cls;
 	int latchedcls;
-    int ping;
+	int ping;
 
 	int rank;
 
@@ -3818,20 +3818,10 @@ void CG_DrawUISelectedSoldier(void);
 void CG_UICurrentSquadSetup(void);
 void CG_CampaignBriefingSetup(void);
 
-typedef enum
-{
-    TIMEOUT,
-    WOUNDED,
-    DEAD,
-    NONE
-} fireteamMemberStatusEnum_t;
-
 // Fireteam stuff
 fireteamData_t *CG_IsOnFireteam(int clientNum);
 fireteamData_t *CG_IsOnSameFireteam(int clientNum, int clientNum2);
 fireteamData_t *CG_IsFireTeamLeader(int clientNum);
-fireteamMemberStatusEnum_t CG_FireTeamMemberStatus(clientInfo_t* ci);
-vec4_t * CG_FireTeamNameColor(fireteamMemberStatusEnum_t status);
 
 //clientInfo_t *CG_ClientInfoForPosition(int pos, int max);
 //fireteamData_t *CG_FireTeamForPosition(int pos, int max);

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -310,8 +310,6 @@ vmCvar_t cg_altHud;
 vmCvar_t cg_tracers;
 vmCvar_t cg_fireteamNameMaxChars;
 vmCvar_t cg_fireteamNameAlign;
-vmCvar_t cg_fireteamNameColorless;
-vmCvar_t cg_fireteamStatusColors;
 vmCvar_t cg_fireteamSprites;
 
 vmCvar_t cg_weapaltReloads;
@@ -589,8 +587,6 @@ static cvarTable_t cvarTable[] =
 	{ &cg_tracers,                  "cg_tracers",                  "1",           CVAR_ARCHIVE,                 0 }, // Draw tracers
 	{ &cg_fireteamNameMaxChars,     "cg_fireteamNameMaxChars",     "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_fireteamNameAlign,        "cg_fireteamNameAlign",        "0",           CVAR_ARCHIVE,                 0 },
-    { &cg_fireteamNameColorless,    "cg_fireteamNameColorless",    "0",           CVAR_ARCHIVE,                 0 },
-    { &cg_fireteamStatusColors,     "cg_fireteamStatusColors",     "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_fireteamSprites,          "cg_fireteamSprites",          "1",           CVAR_ARCHIVE,                 0 },
 
 	{ &cg_simpleItems,              "cg_simpleItems",              "0",           CVAR_ARCHIVE,                 0 }, // Bugged atm

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -310,6 +310,8 @@ vmCvar_t cg_altHud;
 vmCvar_t cg_tracers;
 vmCvar_t cg_fireteamNameMaxChars;
 vmCvar_t cg_fireteamNameAlign;
+vmCvar_t cg_fireteamNameColorless;
+vmCvar_t cg_fireteamStatusColors;
 vmCvar_t cg_fireteamSprites;
 
 vmCvar_t cg_weapaltReloads;
@@ -587,6 +589,8 @@ static cvarTable_t cvarTable[] =
 	{ &cg_tracers,                  "cg_tracers",                  "1",           CVAR_ARCHIVE,                 0 }, // Draw tracers
 	{ &cg_fireteamNameMaxChars,     "cg_fireteamNameMaxChars",     "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_fireteamNameAlign,        "cg_fireteamNameAlign",        "0",           CVAR_ARCHIVE,                 0 },
+    { &cg_fireteamNameColorless,    "cg_fireteamNameColorless",    "0",           CVAR_ARCHIVE,                 0 },
+    { &cg_fireteamStatusColors,     "cg_fireteamStatusColors",     "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_fireteamSprites,          "cg_fireteamSprites",          "1",           CVAR_ARCHIVE,                 0 },
 
 	{ &cg_simpleItems,              "cg_simpleItems",              "0",           CVAR_ARCHIVE,                 0 }, // Bugged atm

--- a/src/cgame/cg_servercmds.c
+++ b/src/cgame/cg_servercmds.c
@@ -150,7 +150,7 @@ static void CG_ParseScore(team_t team)
 	}
 }
 
-#define TEAMINFOARGS 6
+#define TEAMINFOARGS 7
 
 /**
  * @brief CG_ParseTeamInfo
@@ -188,6 +188,7 @@ static void CG_ParseTeamInfo(void)
 		cgs.clientinfo[client].location[2] = Q_atoi(CG_Argv(i * TEAMINFOARGS + 5));
 		cgs.clientinfo[client].health      = Q_atoi(CG_Argv(i * TEAMINFOARGS + 6));
 		cgs.clientinfo[client].powerups    = Q_atoi(CG_Argv(i * TEAMINFOARGS + 7));
+		cgs.clientinfo[client].ping        = Q_atoi(CG_Argv(i * TEAMINFOARGS + 8));
 	}
 }
 

--- a/src/game/g_team.c
+++ b/src/game/g_team.c
@@ -792,7 +792,7 @@ void TeamplayInfoMessage(team_t team)
 				}
 			}
 
-			Com_sprintf(entry, sizeof(entry), " %i %i %i %i %i %i", level.sortedClients[i], player->client->pers.teamState.location[0], player->client->pers.teamState.location[1], player->client->pers.teamState.location[2], h, player->s.powerups);
+			Com_sprintf(entry, sizeof(entry), " %i %i %i %i %i %i %i", level.sortedClients[i], player->client->pers.teamState.location[0], player->client->pers.teamState.location[1], player->client->pers.teamState.location[2], h, player->s.powerups, player->client->ps.ping);
 
 			j = strlen(entry);
 			if (stringlength + j > sizeof(string) - 10) // reserve some chars for tinfo prefix


### PR DESCRIPTION
add cg_fireteamNameColorless to clean teammate names color in fireteam and cg_fireteamStatusColors to show teammates health status better through name coloring or full row background color

See: https://streamable.com/8ycuew