### PR TITLE
mod: fix func_fakebrush prediction, fixes #2242

### DIFF
--- a/src/cgame/cg_predict.c
+++ b/src/cgame/cg_predict.c
@@ -216,27 +216,6 @@ static void CG_ClipMoveToEntities(const vec3_t start, const vec3_t mins, const v
 		else
 		{
 			if (ent->eFlags & EF_FAKEBMODEL)
-<<<<<<< HEAD
-			{
-				// repurposed origin2 and angles2 to receive mins and maxs of func_fakebrush
-				VectorCopy(ent->origin2, bmins);
-				VectorCopy(ent->angles2, bmaxs);
-			}
-			else
-			{
-				// encoded bbox
-				x  = (ent->solid & 255);
-				zd = ((ent->solid >> 8) & 255);
-				zu = ((ent->solid >> 16) & 255) - 32;
-
-				bmins[0] = bmins[1] = -x;
-				bmaxs[0] = bmaxs[1] = x;
-				bmins[2] = -zd;
-			}
-			// client-side hitbox prediction code
-			if (ent->eType == ET_PLAYER && cg.bulletTrace)
-=======
->>>>>>> 8e34a0da9 (mod: fix func_fakebrush prediction, fixes #2242)
 			{
 				// repurposed origin2 and angles2 to receive mins and maxs of func_fakebrush
 				VectorCopy(ent->origin2, bmins);

--- a/src/cgame/cg_predict.c
+++ b/src/cgame/cg_predict.c
@@ -215,23 +215,53 @@ static void CG_ClipMoveToEntities(const vec3_t start, const vec3_t mins, const v
 		}
 		else
 		{
-			// encoded bbox
-			x  = (ent->solid & 255);
-			zd = ((ent->solid >> 8) & 255);
-			zu = ((ent->solid >> 16) & 255) - 32;
-
-			bmins[0] = bmins[1] = -x;
-			bmaxs[0] = bmaxs[1] = x;
-			bmins[2] = -zd;
-
-			// client-side hitbox prediction code
-			if (ent->eType == ET_PLAYER && cg.bulletTrace)
+			if (ent->eFlags & EF_FAKEBMODEL)
+<<<<<<< HEAD
 			{
-				bmaxs[2] = CG_ClientHitboxMaxZ(ent, zu);
+				// repurposed origin2 and angles2 to receive mins and maxs of func_fakebrush
+				VectorCopy(ent->origin2, bmins);
+				VectorCopy(ent->angles2, bmaxs);
 			}
 			else
 			{
-				bmaxs[2] = zu;
+				// encoded bbox
+				x  = (ent->solid & 255);
+				zd = ((ent->solid >> 8) & 255);
+				zu = ((ent->solid >> 16) & 255) - 32;
+
+				bmins[0] = bmins[1] = -x;
+				bmaxs[0] = bmaxs[1] = x;
+				bmins[2] = -zd;
+			}
+			// client-side hitbox prediction code
+			if (ent->eType == ET_PLAYER && cg.bulletTrace)
+=======
+>>>>>>> 8e34a0da9 (mod: fix func_fakebrush prediction, fixes #2242)
+			{
+				// repurposed origin2 and angles2 to receive mins and maxs of func_fakebrush
+				VectorCopy(ent->origin2, bmins);
+				VectorCopy(ent->angles2, bmaxs);
+			}
+			else
+			{
+				// encoded bbox
+				x  = (ent->solid & 255);
+				zd = ((ent->solid >> 8) & 255);
+				zu = ((ent->solid >> 16) & 255) - 32;
+
+				bmins[0] = bmins[1] = -x;
+				bmaxs[0] = bmaxs[1] = x;
+				bmins[2] = -zd;
+
+				// client-side hitbox prediction code
+				if (ent->eType == ET_PLAYER && cg.bulletTrace)
+				{
+					bmaxs[2] = CG_ClientHitboxMaxZ(ent, zu);
+				}
+				else
+				{
+					bmaxs[2] = zu;
+				}
 			}
 
 			//cmodel = trap_CM_TempCapsuleModel( bmins, bmaxs );

--- a/src/game/g_spawn.c
+++ b/src/game/g_spawn.c
@@ -127,7 +127,7 @@ qboolean G_SpawnVectorExt(const char *key, const char *defaultString, float *out
 	qboolean present;
 
 	present = G_SpawnStringExt(key, defaultString, &s, file, line);
-    Q_sscanf(s, "%f %f %f", &out[0], &out[1], &out[2]);
+	Q_sscanf(s, "%f %f %f", &out[0], &out[1], &out[2]);
 	return present;
 }
 
@@ -146,7 +146,7 @@ qboolean G_SpawnVector2DExt(const char *key, const char *defaultString, float *o
 	qboolean present;
 
 	present = G_SpawnStringExt(key, defaultString, &s, file, line);
-    Q_sscanf(s, "%f %f", &out[0], &out[1]);
+	Q_sscanf(s, "%f %f", &out[0], &out[1]);
 	return present;
 }
 
@@ -757,7 +757,7 @@ void G_ParseField(const char *key, const char *value, gentity_t *ent)
 				*( char ** )(b + f->ofs) = G_NewString(value);
 				break;
 			case F_VECTOR:
-                Q_sscanf(value, "%f %f %f", &vec[0], &vec[1], &vec[2]);
+				Q_sscanf(value, "%f %f %f", &vec[0], &vec[1], &vec[2]);
 				(( float * )(b + f->ofs))[0] = vec[0];
 				(( float * )(b + f->ofs))[1] = vec[1];
 				(( float * )(b + f->ofs))[2] = vec[2];
@@ -1023,6 +1023,10 @@ void SP_func_fakebrush(gentity_t *ent)
 {
 	ent->s.eFlags |= EF_FAKEBMODEL;
 	G_SetOrigin(ent, ent->s.origin);
+
+	// repurpose origin2 and angles2 for client prediction
+	VectorCopy(ent->r.mins, ent->s.origin2);
+	VectorCopy(ent->r.maxs, ent->s.angles2);
 
 	return;
 }


### PR DESCRIPTION
Inspired by etjump, this fix repurposes origin2 and angles2 to send mins and maxs for prediction. It's a bit hacky - is there a better way?