### PR TITLE
cgame: fixed timerSet breaking resetTimer display, fixes #1713

### DIFF
--- a/src/cgame/cg_consolecmds.c
+++ b/src/cgame/cg_consolecmds.c
@@ -1303,6 +1303,7 @@ static void CG_TimerReset_f(void)
 		return;
 	}
 
+	trap_Cvar_Set("cg_spawnTimer_period", 0);
 	trap_Cvar_Set("cg_spawnTimer_set", va("%d", cg.time - cgs.levelStartTime));
 }
 


### PR DESCRIPTION
Using `timerSet >0` will set `cg_spawnTimer_period >0`, after which `resetTimer` essentially won't work. Technically it will set the timer, but the correct time won't be displayed until client uses `timerSet 0`, which is confusing to a lot of players and AFAIK is also the source of #1713 being thought of as a bug. At least I've never encountered that bug without having first used something like `timerSet 20`

`resetTimer` doesn't have any description I can find, but the general consensus among players about it is "it will always set the spawntimer correctly to the enemy spawn time and display that time" and in my opinion that's all it should do. Currently players would need to bind `timerSet 0; resetTimer` to ensure that's always the case even if they have (sometimes accidentally) used something like `timerSet 30` previously.