### PR TITLE
client: stop sounds when rewinding/fastforwarding a demo, refs #696

### DIFF
--- a/src/client/cl_demo.c
+++ b/src/client/cl_demo.c
@@ -412,6 +412,8 @@ static void CL_DemoFastForward(double wantedTime)
 		return;
 	}
 
+	S_StopAllSounds();
+
 	DEMODEBUG("fastfowarding from %f to %f\n", (double)cl.serverTime + di.Overf, wantedTime);
 
 	loopCount = 0;
@@ -443,6 +445,7 @@ static void CL_DemoFastForward(double wantedTime)
 		if (cmd + MAX_RELIABLE_COMMANDS - 10 <= clc.lastExecutedServerCommand)
 		{
 			VM_Call(cgvm, CG_DRAW_ACTIVE_FRAME, cl.snap.serverTime, 0, clc.demo.playing);
+			S_StopAllSounds();
 			cmd = clc.lastExecutedServerCommand;
 		}
 	}


### PR DESCRIPTION
Fixes sound bug (long stuttering sound) and clears queued sounds (such as announcers fe. `FIGHT!` sound) when rewinding/fastforwarding.

refs #696