### PR TITLE
game: add missing SVF_BROADCAST flag, refs #714

### DIFF
--- a/src/game/g_weapon.c
+++ b/src/game/g_weapon.c
@@ -4019,6 +4019,7 @@ gentity_t *Weapon_FlamethrowerFire(gentity_t *ent)
 
 	// flamethrower exploit fix
 	ent->client->flametime = level.time + 2500;
+	ent->r.svFlags        |= SVF_BROADCAST;
 
 	VectorCopy(forward, dir);
 	VectorNormalize(dir);


### PR DESCRIPTION
Fixes flamethrower being invisible if player shoots it outside of PVS.

refs #714, https://github.com/etlegacy/etlegacy/commit/7f7266463bf285c6978552c060a5787b6e49ae3e