### PR TITLE
mod: remove WBUTTON_ATTACK2 (+attack2)

### DIFF
--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -3588,7 +3588,7 @@ static void PM_Weapon(void)
 	// check for fire
 	// if not on fire button and there's not a delayed shot this frame...
 	// consider also leaning, with delayed attack reset
-	if ((!(pm->cmd.buttons & BUTTON_ATTACK) && !(pm->cmd.wbuttons & WBUTTON_ATTACK2) && !delayedFire) ||
+	if ((!(pm->cmd.buttons & BUTTON_ATTACK) && !delayedFire) ||
 	    (pm->ps->leanf != 0.f && !GetWeaponTableData(pm->ps->weapon)->grenadeTime))
 	{
 		pm->ps->weaponTime  = 0;
@@ -5059,7 +5059,6 @@ void PmoveSingle(pmove_t *pmove)
 		// don't clear if a weapon change is needed to prevent early weapon change
 		if (pm->ps->stats[STAT_HEALTH] > 0 &&
 		    !(pm->cmd.buttons & BUTTON_ATTACK) &&  // & (BUTTON_ATTACK /*| BUTTON_USE_HOLDABLE
-		    !(pm->cmd.wbuttons & WBUTTON_ATTACK2) &&
 		    (pm->ps->weapon == pm->cmd.weapon))       // bit hacky, stop the slight lag from client -> server even on locahost, switching back to the weapon you were holding
 		                                              // and then back to what weapon you should have, became VERY noticible for the kar98/carbine + gpg40, esp now i've added the
 		                                              // animation locking

--- a/src/game/g_active.c
+++ b/src/game/g_active.c
@@ -665,9 +665,7 @@ void SpectatorThink(gentity_t *ent, usercmd_t *ucmd)
 	{
 		Cmd_FollowCycle_f(ent, 1, (client->buttons & BUTTON_SPRINT));
 	}
-	// FIXME: WBUTTON_ATTACK2
-	else if ((client->wbuttons & WBUTTON_ATTACK2) && !(client->oldwbuttons & WBUTTON_ATTACK2) &&
-	         !(client->buttons & BUTTON_ACTIVATE))
+	else if (!(client->buttons & BUTTON_ACTIVATE))
 	{
 		Cmd_FollowCycle_f(ent, -1, (client->buttons & BUTTON_SPRINT));
 	}
@@ -734,7 +732,7 @@ qboolean ClientInactivityTimer(gclient_t *client)
 
 	// the client is still active?
 	if (client->pers.cmd.forwardmove || client->pers.cmd.rightmove || client->pers.cmd.upmove ||
-	    (client->pers.cmd.wbuttons & (WBUTTON_ATTACK2 | WBUTTON_LEANLEFT | WBUTTON_LEANRIGHT))  ||
+	    (client->pers.cmd.wbuttons & (WBUTTON_LEANLEFT | WBUTTON_LEANRIGHT))  ||
 	    (client->pers.cmd.buttons & BUTTON_ATTACK) ||
 	    BG_PlayerMounted(client->ps.eFlags) ||
 	    ((client->ps.eFlags & EF_PRONE) && (client->ps.weapon == WP_MOBILE_MG42_SET || client->ps.weapon == WP_MOBILE_BROWNING_SET)) ||


### PR DESCRIPTION
It seems to me that `WBUTTON_ATTACK2` should mirror `BUTTON_ATTACK` inside pmove but is not. This makes current implementation inconsistent, buggy and there are some exploits because of that. I don't see a point of making `+attack2` exactly same as `+attack` though if there is nothing in the game using it anyway. I guess it was added as alternative fire but there also is no such thing in weapontable so both attacks use same values currently but `+attack2` lacks important code to behave exactly as `+attack`.