### PR TITLE
cgame: fix kick angles framerate dependency, refs #2264

### DIFF
--- a/src/cgame/cg_view.c
+++ b/src/cgame/cg_view.c
@@ -438,7 +438,7 @@ void CG_KickAngles(void)
 	float        idealCenterSpeed, kickChange;
 	int          i, frametime, t;
 	float        ft;
-#define STEP 20
+#define STEP 3
 	char buf[32];
 
 	// this code is frametime-dependant, so split it up into small chunks


### PR DESCRIPTION
Reduced the step so the kick angles are properly split up into smaller chunks. This isn't perfect as it means everyone will play now with kick angles as if they are playing on 333 fps, also it assumes that 333fps is max possible fps and going above it will result in smaller kick angles again. This is the easiest way to fix the issue without reworking everything most likely.

refs #2264