### PR TITLE
game: remove adding velocity of ground entity for missiles, refs #1852

### DIFF
--- a/src/game/g_misc.c
+++ b/src/game/g_misc.c
@@ -3032,16 +3032,7 @@ void G_PreFilledMissileEntity(gentity_t *ent, int weaponNum, int realWeapon, int
 	VectorCopy(start, ent->s.pos.trBase);
 	VectorCopy(dir, ent->s.pos.trDelta);
 
-	// add velocity of player (:sigh: guess people don't like it)
-	//VectorAdd( bolt->s.pos.trDelta, self->s.pos.trDelta, bolt->s.pos.trDelta );
-
-	// add velocity of ground entity
-	if (ent->s.pos.trType == TR_GRAVITY && ent->s.groundEntityNum != ENTITYNUM_NONE && ent->s.groundEntityNum != ENTITYNUM_WORLD)
-	{
-		VectorAdd(ent->s.pos.trDelta, g_entities[ent->s.groundEntityNum].instantVelocity, ent->s.pos.trDelta);
-	}
-
-	SnapVector(ent->s.pos.trDelta);            // save net bandwidth
+	SnapVector(ent->s.pos.trDelta); // save net bandwidth
 }
 
 /**


### PR DESCRIPTION
Adding velocity from ground entity was bugged since 2018, it was adding `instantVelocity` from `clientnum 0`. Mostly noticeable if that client was dropping packets and there were no usercmds for a server frame (that's when `instantVelocity` would most likely be non-zero).

Since it was not working for many years and almost noone noticed and complained I propose to remove it instead of fixing it.

https://streamable.com/7sxtrt

refs #1852