### PR TITLE
mod: remove unnecessary trace

### DIFF
--- a/src/cgame/cg_event.c
+++ b/src/cgame/cg_event.c
@@ -2372,18 +2372,18 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 		//}
 		break;
 	case EV_MG42BULLET_HIT_WALL:
-		CG_Bullet(es->weapon, es->pos.trBase, es->otherEntityNum, qfalse, ENTITYNUM_WORLD, es->otherEntityNum2, es->origin2[0], es->effect1Time);
+		CG_Bullet(es->weapon, es->pos.trBase, es->otherEntityNum, qfalse, ENTITYNUM_WORLD, es->otherEntityNum2, es->effect1Time);
 		break;
 	case EV_MG42BULLET_HIT_FLESH:
 		CG_PlayHitSound(es->otherEntityNum2, es->modelindex);
-		CG_Bullet(es->weapon, es->pos.trBase, es->otherEntityNum, qtrue, es->eventParm, es->otherEntityNum2, 0, es->effect1Time);
+		CG_Bullet(es->weapon, es->pos.trBase, es->otherEntityNum, qtrue, es->eventParm, es->otherEntityNum2, es->effect1Time);
 		break;
 	case EV_BULLET_HIT_WALL:
-		CG_Bullet(es->weapon, es->pos.trBase, es->otherEntityNum, qfalse, ENTITYNUM_WORLD, es->otherEntityNum2, es->origin2[0], 0);
+		CG_Bullet(es->weapon, es->pos.trBase, es->otherEntityNum, qfalse, ENTITYNUM_WORLD, es->otherEntityNum2, 0);
 		break;
 	case EV_BULLET_HIT_FLESH:
 		CG_PlayHitSound(es->otherEntityNum, es->modelindex);
-		CG_Bullet(es->weapon, es->pos.trBase, es->otherEntityNum, qtrue, es->eventParm, es->otherEntityNum2, 0, 0);
+		CG_Bullet(es->weapon, es->pos.trBase, es->otherEntityNum, qtrue, es->eventParm, es->otherEntityNum2, 0);
 		break;
 	case EV_GENERAL_SOUND:
 	{

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -3214,7 +3214,7 @@ void CG_MortarEFX(centity_t *cent);
 
 void CG_MissileHitPlayer(int entityNum, int weapon, vec3_t origin, vec3_t dir, int fleshEntityNum);
 qboolean CG_CalcMuzzlePoint(int entityNum, vec3_t muzzle);
-void CG_Bullet(int weapon, vec3_t end, int sourceEntityNum, qboolean flesh, int fleshEntityNum, int otherEntNum2, float waterfraction, int seed);
+void CG_Bullet(int weapon, vec3_t end, int sourceEntityNum, qboolean flesh, int fleshEntityNum, int otherEntNum2, int seed);
 
 void CG_RailTrail(vec3_t color, vec3_t start, vec3_t end, int type, int index);
 void CG_RailTrail2(vec3_t color, vec3_t start, vec3_t end, int index, int sideNum);

--- a/src/game/g_weapon.c
+++ b/src/game/g_weapon.c
@@ -3603,7 +3603,6 @@ qboolean Bullet_Fire_Extended(gentity_t *source, gentity_t *attacker, vec3_t sta
 	}
 	else
 	{
-		trace_t tr2;
 		// bullet impact should reflect off surface
 		vec3_t reflect;
 		float  dot;
@@ -3632,21 +3631,6 @@ qboolean Bullet_Fire_Extended(gentity_t *source, gentity_t *attacker, vec3_t sta
 		}
 
 		tent = G_TempEntity(impactPos, EV_BULLET_HIT_WALL);
-
-		G_Trace(source, &tr2, start, NULL, NULL, end, source->s.number, MASK_WATER | MASK_SHOT);
-
-		if ((tr.entityNum != tr2.entityNum && tr2.fraction != 1.f))
-		{
-			vec3_t v;
-
-			VectorSubtract(tr.endpos, start, v);
-
-			tent->s.origin2[0] = (8192 * tr2.fraction) / VectorLength(v);
-		}
-		else
-		{
-			tent->s.origin2[0] = 0;
-		}
 
 		dot = DotProduct(forward, tr.plane.normal);
 		VectorMA(forward, -2 * dot, tr.plane.normal, reflect);


### PR DESCRIPTION
Removed additional `G_Trace` from `Bullet_Fire_Extended` that was tracing for water for some better visual "hitmark" when player missed. That trace meant that for every missed shot server would re-do all head hitboxes for everyone on server when it was already determined that it hit noone. That additional trace for water is also already done client side too as far as I know so it is pure waste of time.