### PR TITLE
game: fix spectator following, refs #2265

### DIFF
--- a/src/game/g_active.c
+++ b/src/game/g_active.c
@@ -665,10 +665,6 @@ void SpectatorThink(gentity_t *ent, usercmd_t *ucmd)
 	{
 		Cmd_FollowCycle_f(ent, 1, (client->buttons & BUTTON_SPRINT));
 	}
-	else if (!(client->buttons & BUTTON_ACTIVATE))
-	{
-		Cmd_FollowCycle_f(ent, -1, (client->buttons & BUTTON_SPRINT));
-	}
 #ifdef ETLEGACY_DEBUG
 #ifdef FEATURE_OMNIBOT
 	// activate button swaps places with bot


### PR DESCRIPTION
Removing `+attack2` broke spectator. Removed follow cycle to previous `clientnum` (`weapalt` already does it so nothing is lost).

refs #2265