### PR TITLE
game: antilag and hitreg optimization

### DIFF
--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -2281,6 +2281,12 @@ void trap_SnapVector(float *v);
 qboolean trap_SendMessage(int clientNum, char *buf, int buflen);
 messageStatus_t trap_MessageStatus(int clientNum);
 
+// extension interface
+qboolean trap_GetValue(char *value, int valueSize, const char *key);
+qboolean trap_wasInPVS(int clientnum, int client);
+extern int dll_com_trapGetValue;
+extern int dll_trap_wasInPVS;
+
 void G_ExplodeMissile(gentity_t *ent);
 
 void Svcmd_StartMatch_f(void);
@@ -2296,6 +2302,8 @@ void G_HistoricalTraceBegin(gentity_t *ent);
 void G_HistoricalTraceEnd(gentity_t *ent);
 void G_Trace(gentity_t *ent, trace_t *results, const vec3_t start, const vec3_t mins, const vec3_t maxs, const vec3_t end, int passEntityNum, int contentmask);
 void G_PredictPmove(gentity_t *ent, float frametime);
+
+qboolean G_ClientWasInPVS(gentity_t *ent, gentity_t *client, qboolean checkAngle);
 
 #define BODY_VALUE(ENT) ENT->watertype
 #define BODY_TEAM(ENT) ENT->s.modelindex

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -71,6 +71,9 @@ g_campaignInfo_t g_campaigns[MAX_CAMPAIGNS];
 
 mapEntityData_Team_t mapEntityData[2];
 
+int dll_com_trapGetValue;
+int dll_trap_wasInPVS;
+
 const char *gameNames[] =
 {
 	"Single Player",        // Obsolete
@@ -2290,6 +2293,31 @@ void G_GetMapXP(void)
 	trap_SetConfigstring(CS_ALLIED_MAPS_XP, s);
 }
 
+static ID_INLINE void G_SetupExtensionTrap(char *value, int valueSize, int *trap, const char *name)
+{
+	if (trap_GetValue(value, valueSize, name))
+	{
+		*trap = Q_atoi(value);
+	}
+	else
+	{
+		*trap = qfalse;
+	}
+}
+
+static ID_INLINE void G_SetupExtensions(void)
+{
+	char value[MAX_CVAR_VALUE_STRING];
+
+	trap_Cvar_VariableStringBuffer("//trap_GetValue", value, sizeof(value));
+	if (value[0])
+	{
+		dll_com_trapGetValue = Q_atoi(value);
+
+		G_SetupExtensionTrap(value, MAX_CVAR_VALUE_STRING, &dll_trap_wasInPVS, "trap_wasInPVS_Legacy");
+	}
+}
+
 /**
  * @brief G_InitGame
  * @param[in] levelTime
@@ -2316,6 +2344,8 @@ void G_InitGame(int levelTime, int randomSeed, int restart, int etLegacyServer, 
 	G_Printf("gamedate: %s\n", __DATE__);
 
 	srand(randomSeed);
+
+	G_SetupExtensions();
 
 	G_RegisterCvars();
 

--- a/src/game/g_public.h
+++ b/src/game/g_public.h
@@ -265,7 +265,8 @@ typedef enum
 	G_MESSAGESTATUS,
 
 	///< engine extensions padding
-	G_TRAP_GETVALUE = COM_TRAP_GETVALUE
+	G_TRAP_GETVALUE = COM_TRAP_GETVALUE,
+	G_WAS_IN_PVS
 
 } gameImport_t;
 

--- a/src/game/g_syscalls.c
+++ b/src/game/g_syscalls.c
@@ -39,7 +39,7 @@ static intptr_t(QDECL * syscall)(intptr_t arg, ...) = (intptr_t(QDECL *)(intptr_
 /**
  * @brief dllEntry
  */
-Q_EXPORT void dllEntry(intptr_t(QDECL * syscallptr)(intptr_t arg, ...))
+Q_EXPORT void dllEntry(intptr_t(QDECL *syscallptr)(intptr_t arg, ...))
 {
 	syscall = syscallptr;
 }
@@ -808,4 +808,34 @@ qboolean trap_SendMessage(int clientNum, char *buf, int buflen)
 messageStatus_t trap_MessageStatus(int clientNum)
 {
 	return (messageStatus_t)(SystemCall(G_MESSAGESTATUS, clientNum));
+}
+
+// extension interface
+
+/**
+* @brief Entry point for additional system calls without breaking compatibility with other engines
+* @param[out] value
+* @param[in] valueSize
+* @param[in] key
+* @return
+*/
+qboolean trap_GetValue(char *value, int valueSize, const char *key)
+{
+	return (qboolean)(SystemCall(dll_com_trapGetValue, value, valueSize, key));
+}
+
+/**
+* @brief Extension for checking if client was in PVS in last acknowledged snapshot
+* @param[in] clientnum
+* @param[in] client
+* @return qtrue if client was in PVS or if engine doesn't support the extension
+*/
+qboolean trap_wasInPVS(int clientnum, int client)
+{
+	if (dll_trap_wasInPVS)
+	{
+		return (qboolean)SystemCall(dll_trap_wasInPVS, clientnum, client);
+	}
+
+	return qtrue;
 }

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -180,6 +180,7 @@ typedef struct
 	int messageSent;                    ///< time the message was transmitted
 	int messageAcked;                   ///< time the message was acked
 	int messageSize;                    ///< used to rate drop packets
+	unsigned int clientbits[2];         ///< bits of clients that were added to snapshot
 } clientSnapshot_t;
 
 /**
@@ -619,6 +620,8 @@ int SV_LoadTag(const char *mod_name);
 void SV_GameSendServerCommand(int clientNum, const char *text, qboolean demoPlayback);
 
 void SV_GameBinaryMessageReceived(int cno, const char *buf, int buflen, int commandTime);
+
+qboolean SV_wasInPVS(int clientnum, int client);
 
 // sv_bot.c
 int SV_BotAllocateClient(int clientNum);


### PR DESCRIPTION
Server will keep track in snapshot history who was added to it in `clientbits` field. Added engine extension (`trap_wasInPVS`) for accessing that information from mod. Trap call will return if specified client was in ent's last acknowledged snapshot (will also return `qtrue` if nums are incorrect).

When bullet trace is done we use this to look into the past and know if certain clients were in clients PVS when they shot. Based on that entities are excluded from being antilagged and from computing animations and creating head hitboxes which can save time.

It does not seem possible to fully trust PVS when it comes to using it for puting clients back in time or not because of ping (PVS is too strict in some places on some maps). Before the usercmd packet gets to server client could already be in PVS and past the corner, so he has to be put back in time even though player that shot couldn't see him. This step could be omitted and keep antilagging every single player on server for every shot, but instead I added check for players viewangle (I'm not sure if doing that is worth it though). If player is in 55-10 degree angle scaled over 30-500 distance then player will be treated as in PVS even if he is not.

PVS check should be safe for adjusting player's height or creating head bboxes regardless of ping.

Because this requires server changes it would only work on ETL server engine.

The goal is to reduce amount of time whole process of hit registration needs. For example if there is 30 players alive and player `A` shoots, 29 other players will be adjusted back in time and head bboxes will be created for them even if only just 1 player is in PVS of player `A` (so rest 28 players are impossible to hit). This change tries to reduce the amount of clients that need to be processed to that 1 player.

refs #1408