### PR TITLE
Find cjson on Fedora, where cmake config is missing

### DIFF
--- a/cmake/ETLSetupFeatures.cmake
+++ b/cmake/ETLSetupFeatures.cmake
@@ -383,7 +383,7 @@ endif()
 if(NOT BUNDLED_CJSON)
 	if(NOT ANDROID)
 		find_package(cJSON REQUIRED)
-		target_link_libraries(etl_json INTERFACE ${CJSON_LIBRARY})
+		target_link_libraries(etl_json INTERFACE ${CJSON_LIBRARIES})
 	else()
 		#It fails with linking CJSON_LIBRARY at Android NDK Path do it manually
 		target_link_libraries(etl_json INTERFACE ${CMAKE_ANDROID_NATIVE_LIB_DIRECTORIES}"cjson")

--- a/cmake/FindcJSON.cmake
+++ b/cmake/FindcJSON.cmake
@@ -1,8 +1,8 @@
 # Simple wrapper for locating cJSON package even if cmake config is not available
+# that is missing on Fedora cjson-1.7.14-7.fc38 for example
 find_package(PkgConfig)
 if (PKG_CONFIG_FOUND)
 	pkg_check_modules(CJSON libcjson)
-	set (CJSON_LIBRARY ${CJSON_LIBRARIES})
 endif()
 
 if (NOT CJSON_FOUND)
@@ -12,9 +12,7 @@ if (NOT CJSON_FOUND)
 	if (CJSON_INCLUDE_DIRS AND CJSON_LIBRARIES)
 		message(STATUS "Found cJSON: ${CJSON_LIBRARIES}")
 		set (CJSON_FOUND TRUE)
-		# Should this one be name like all other variables too?
-		set (CJSON_LIBRARY ${CJSON_LIBRARIES})
 	endif()
 endif()
 
-MARK_AS_ADVANCED(CJSON_INCLUDE_DIRS CJSON_LIBRARIES CJSON_LIBRARY)
+MARK_AS_ADVANCED(CJSON_INCLUDE_DIRS CJSON_LIBRARIES)

--- a/cmake/FindcJSON.cmake
+++ b/cmake/FindcJSON.cmake
@@ -1,8 +1,14 @@
 # Simple wrapper for locating cJSON package even if cmake config is not available
 # that is missing on Fedora cjson-1.7.14-7.fc38 for example
-find_package(PkgConfig)
-if (PKG_CONFIG_FOUND)
-	pkg_check_modules(CJSON libcjson)
+find_package(cJSON CONFIG)
+
+if (NOT cJSON_FOUND)
+	find_package(PkgConfig)
+	if (PKG_CONFIG_FOUND)
+		pkg_check_modules(CJSON libcjson)
+	endif()
+else()
+	set (CJSON_FOUND ${cJSON_FOUND})
 endif()
 
 if (NOT CJSON_FOUND)
@@ -13,6 +19,5 @@ if (NOT CJSON_FOUND)
 		message(STATUS "Found cJSON: ${CJSON_LIBRARIES}")
 		set (CJSON_FOUND TRUE)
 	endif()
+	MARK_AS_ADVANCED(CJSON_INCLUDE_DIRS CJSON_LIBRARIES)
 endif()
-
-MARK_AS_ADVANCED(CJSON_INCLUDE_DIRS CJSON_LIBRARIES)

--- a/cmake/FindcJSON.cmake
+++ b/cmake/FindcJSON.cmake
@@ -1,0 +1,20 @@
+# Simple wrapper for locating cJSON package even if cmake config is not available
+find_package(PkgConfig)
+if (PKG_CONFIG_FOUND)
+	pkg_check_modules(CJSON libcjson)
+	set (CJSON_LIBRARY ${CJSON_LIBRARIES})
+endif()
+
+if (NOT CJSON_FOUND)
+	find_path(CJSON_INCLUDE_DIRS NAMES cjson.h PATH_SUFFIXES cjson)
+	find_library(CJSON_LIBRARIES NAMES cjson)
+
+	if (CJSON_INCLUDE_DIRS AND CJSON_LIBRARIES)
+		message(STATUS "Found cJSON: ${CJSON_LIBRARIES}")
+		set (CJSON_FOUND TRUE)
+		# Should this one be name like all other variables too?
+		set (CJSON_LIBRARY ${CJSON_LIBRARIES})
+	endif()
+endif()
+
+MARK_AS_ADVANCED(CJSON_INCLUDE_DIRS CJSON_LIBRARIES CJSON_LIBRARY)


### PR DESCRIPTION
Current fedora packages do not ship cmake config on cjson-devel package in any release. That should get fixed, but allow locating of cjson via pkg-config in that case.