### PR TITLE
cgame: fix crosshair name revealing disguised enemy covert ops

### DIFF
--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -2280,12 +2280,18 @@ const char *CG_GetCrosshairNameString(hudComponent_t *comp)
 {
 	char *s;
 	char colorized[MAX_NAME_LENGTH + 2] = { 0 };
-	int  clientNum                      = cg.crosshairClientNum;
+	int  clientNum;
 
-	// disguised covert ops, no signals lvl 3
-	if (cgs.clientinfo[cg.crosshairClientNum].team != cgs.clientinfo[cg.snap->ps.clientNum].team)
+	// disguised covert ops, not in the same team
+	if ((cg_entities[cg.crosshairClientNum].currentState.powerups & (1 << PW_OPS_DISGUISED) &&
+		cgs.clientinfo[cg.crosshairClientNum].team != cgs.clientinfo[cg.snap->ps.clientNum].team) &&
+		cgs.clientinfo[cg.snap->ps.clientNum].team != TEAM_SPECTATOR))
 	{
 		clientNum = cgs.clientinfo[cg.crosshairClientNum].disguiseClientNum;
+	}
+	else
+	{
+		clientNum = cg.crosshairClientNum;
 	}
 
 	if (comp->style & 1)

--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -2280,16 +2280,23 @@ const char *CG_GetCrosshairNameString(hudComponent_t *comp)
 {
 	char *s;
 	char colorized[MAX_NAME_LENGTH + 2] = { 0 };
+	int  clientNum                      = cg.crosshairClientNum;
+
+	// disguised covert ops, no signals lvl 3
+	if (cgs.clientinfo[cg.crosshairClientNum].team != cgs.clientinfo[cg.snap->ps.clientNum].team)
+	{
+		clientNum = cgs.clientinfo[cg.crosshairClientNum].disguiseClientNum;
+	}
 
 	if (comp->style & 1)
 	{
 		// Draw them with full colors
-		s = va("%s", cgs.clientinfo[cg.crosshairClientNum].name);
+		s = va("%s", cgs.clientinfo[clientNum].name);
 	}
 	else
 	{
 		// Draw them with a single color
-		Q_ColorizeString('*', cgs.clientinfo[cg.crosshairClientNum].cleanname, colorized, MAX_NAME_LENGTH + 2);
+		Q_ColorizeString('*', cgs.clientinfo[clientNum].cleanname, colorized, MAX_NAME_LENGTH + 2);
 		s = va("%s", colorized);
 	}
 


### PR DESCRIPTION
Since adding color support for crosshair names, the name of a disguised enemy covert ops is shown, instead of the player whose uniform was stolen.

I'm not sure if it makes sense to check it the way I do in this PR, but it works. And from what I can tell, `CG_DrawCrosshairNames` is meant to be refactored and moved to `cg_draw_hud.c` eventually anyway, so maybe this can act as a hotfix until then..?