### PR TITLE
cgame: Abbreviate large scores for long time players.

### DIFF
--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -1503,7 +1503,7 @@ void CG_DrawXP(hudComponent_t *comp)
 		clr = comp->colorMain;
 	}
 
-	str = va("%i XP", cg.snap->ps.stats[STAT_XP]);
+	str = va("%s XP", Com_ScaleNumberPerThousand((float) cg.snap->ps.stats[STAT_XP], 2));
 
 	CG_DrawCompText(comp, str, clr, comp->styleText, &cgs.media.limboFont1);
 }

--- a/src/cgame/cg_scoreboard.c
+++ b/src/cgame/cg_scoreboard.c
@@ -560,22 +560,6 @@ static void WM_DrawClientScore_Medals(int x, int y, float scaleX, float scaleY, 
 	}
 }
 
-/**
- * @brief Shortens a score like "4560000" to "4.56M" for the scoreboard.
- * @details Two decimal places are used, unless the displayed digits after the decimal would be zeros.
- * @param[in] int
- * @return
- */
-static char *AbbreviateScore(int score) {
-    if (score > 1000000) {
-        return va("^7%6gM", Com_RoundFloatWithNDecimal(((float) score) / ((float) 1000000), 2));
-    }
-    if (score > 1000) {
-        return va("^7%6gK", Com_RoundFloatWithNDecimal(((float) score) / ((float) 1000), 2));
-    }
-    return va("^7%6i", score);
-}
-
 static void WM_DrawClientScore_Score(int x, int y, float scaleX, float scaleY, const score_t *score)
 {
 #ifdef FEATURE_RATING
@@ -593,7 +577,7 @@ static void WM_DrawClientScore_Score(int x, int y, float scaleX, float scaleY, c
 	else
 #endif
 	{
-		CG_Text_Paint_RightAligned_Ext(x, y, scaleX, scaleY, colorWhite, AbbreviateScore(score->score), 0, 0, ITEM_TEXTSTYLE_SHADOWED, FONT_TEXT);
+		CG_Text_Paint_RightAligned_Ext(x, y, scaleX, scaleY, colorWhite, Com_ScaleNumberPerThousand(score->score, 2), 0, 0, ITEM_TEXTSTYLE_SHADOWED, FONT_TEXT);
 	}
 }
 

--- a/src/cgame/cg_scoreboard.c
+++ b/src/cgame/cg_scoreboard.c
@@ -577,7 +577,7 @@ static void WM_DrawClientScore_Score(int x, int y, float scaleX, float scaleY, c
 	else
 #endif
 	{
-		CG_Text_Paint_RightAligned_Ext(x, y, scaleX, scaleY, colorWhite, Com_ScaleNumberPerThousand(score->score, 2), 0, 0, ITEM_TEXTSTYLE_SHADOWED, FONT_TEXT);
+		CG_Text_Paint_RightAligned_Ext(x, y, scaleX, scaleY, colorWhite, Com_ScaleNumberPerThousand((float) score->score, 2), 0, 0, ITEM_TEXTSTYLE_SHADOWED, FONT_TEXT);
 	}
 }
 

--- a/src/cgame/cg_scoreboard.c
+++ b/src/cgame/cg_scoreboard.c
@@ -560,6 +560,21 @@ static void WM_DrawClientScore_Medals(int x, int y, float scaleX, float scaleY, 
 	}
 }
 
+/**
+ * @brief Shortens a score like "4560000" to "4.56M" for the scoreboard.
+ * @param[in] int
+ * @return
+ */
+static char *AbbreviateScore(int score) {
+    if (score > 1000000) {
+        return va("^7%6gM", Com_RoundFloatWithNDecimal(((float) score) / ((float) 1000000), 2));
+    }
+    if (score > 1000) {
+        return va("^7%6gK", Com_RoundFloatWithNDecimal(((float) score) / ((float) 1000), 2));
+    }
+    return va("^7%6i", score);
+}
+
 static void WM_DrawClientScore_Score(int x, int y, float scaleX, float scaleY, const score_t *score)
 {
 #ifdef FEATURE_RATING
@@ -577,7 +592,7 @@ static void WM_DrawClientScore_Score(int x, int y, float scaleX, float scaleY, c
 	else
 #endif
 	{
-		CG_Text_Paint_RightAligned_Ext(x, y, scaleX, scaleY, colorWhite, va("^7%6i", score->score), 0, 0, ITEM_TEXTSTYLE_SHADOWED, FONT_TEXT);
+		CG_Text_Paint_RightAligned_Ext(x, y, scaleX, scaleY, colorWhite, AbbreviateScore(score->score), 0, 0, ITEM_TEXTSTYLE_SHADOWED, FONT_TEXT);
 	}
 }
 

--- a/src/cgame/cg_scoreboard.c
+++ b/src/cgame/cg_scoreboard.c
@@ -562,6 +562,7 @@ static void WM_DrawClientScore_Medals(int x, int y, float scaleX, float scaleY, 
 
 /**
  * @brief Shortens a score like "4560000" to "4.56M" for the scoreboard.
+ * @details Two decimal places are used, unless the displayed digits after the decimal would be zeros.
  * @param[in] int
  * @return
  */

--- a/src/qcommon/q_shared.c
+++ b/src/qcommon/q_shared.c
@@ -2998,6 +2998,26 @@ float Com_RoundFloatWithNDecimal(float value, unsigned int decimalCount)
 }
 
 /**
+ * @brief Shortens a values by thousands and keeping wanted decimal values (i.e  "4560000" to "4.56M")
+ * @param[in] value The number to shorten
+ * @param[in] decimalCount The number of decimal to be displayed
+ * @return Down scaled value string with suffixed unit
+ */
+char *Com_ScaleNumberPerThousand(float value, unsigned int decimalCount)
+{
+	static const char *units[] = { "", "k", "M", "G", "T" };
+	unsigned int      i        = 0;
+
+	while (value > 1000 && i < sizeof(units))
+	{
+		value /= 1000;
+		++i;
+	}
+
+	return va("%g%s", Com_RoundFloatWithNDecimal(value, decimalCount), units[i]);
+}
+
+/**
  * @brief Convert a string to an integer
  * @details Convert a string to an integer, with the same behavior that the engine converts
  * cvars to their integer representation:

--- a/src/qcommon/q_shared.h
+++ b/src/qcommon/q_shared.h
@@ -2061,6 +2061,7 @@ static ID_INLINE int Q_sscanfc(const char *str, int count, const char *fmt, ...)
 #endif
 
 float Com_RoundFloatWithNDecimal(float value, unsigned int decimalCount);
+char *Com_ScaleNumberPerThousand(float value, unsigned int decimalCount);
 
 int ExtractInt(const char *src);
 


### PR DESCRIPTION
Ref: https://github.com/etlegacy/etlegacy/issues/2313

People have been playing Enemy Territory forever. Personally, I've played it since like 2005 :)

Some folks have really high XP in some servers which makes the scoreboard look messy, and some new people might look at it and think it's broken. We can make the scoreboard look nicer and maybe better show off the high XP :)

Some examples:

XP: 4500000:
![etlegacy-abbreviated-scores](https://user-images.githubusercontent.com/1733933/233862900-298d67ab-12b8-4a65-9f19-4c777e7dbd0c.png)


XP: 45000:
![etlegacy-abbreviated-scores-45k](https://user-images.githubusercontent.com/1733933/233862922-95ce1be3-f9c8-4365-8ac6-c5069332eef9.png)


Low XP:
![etlegacy-abbreviated-scores-500](https://user-images.githubusercontent.com/1733933/233862934-59d58342-7326-4181-8cf3-103db1fa5fc8.png)


Out of scope:
- The XP in the bottom left of the client.
- The XP of each player in the Server Info window.

I will address these in separate PRs.
