### PR TITLE
game: Voting Improvements (Require 50% To Fail Vote)

### DIFF
--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -4559,7 +4559,11 @@ void CheckVote(void)
 			total = level.voteInfo.numVotingClients;
 		}
 
-		if (level.voteInfo.voteYes > pcnt * total / 100)
+        int yesThreshold = pcnt * total / 100;
+        int noThreshold = (int) ceilf(((float) pcnt) * ((float) total) / 100.0f);
+
+        // Must do voteYes > and not voteYes >=, otherwise vote will pass with 2 players with only one vote.
+		if (level.voteInfo.voteYes > yesThreshold)
 		{
 			// execute the command, then remove the vote
 			if (level.voteInfo.voteYes > total + 1)
@@ -4576,7 +4580,7 @@ void CheckVote(void)
 			else
 			{
 				AP(va("cpm \"^5Vote passed! ^7(^2Y:%d^7-^1N:%d^7) ^7(%s)\n\"", level.voteInfo.voteYes, level.voteInfo.voteNo, level.voteInfo.voteString));
-				G_LogPrintf("Vote Passed: (Y:%d-N:%d) %s\n", level.voteInfo.voteYes, level.voteInfo.voteNo, level.voteInfo.voteString);
+				G_LogPrintf("Vote Passed: (Y:%d-N:%d) %s (Required:%d, Voting Clients:%d)\n", level.voteInfo.voteYes, level.voteInfo.voteNo, level.voteInfo.voteString, yesThreshold, total);
 			}
 
 			// Perform the passed vote
@@ -4594,17 +4598,18 @@ void CheckVote(void)
 			}
 
 		}
-		else if (level.voteInfo.voteNo && (level.voteInfo.voteNo >= (100 - pcnt) * total / 100))
+        // Only fail vote if more than half vote no.
+		else if (level.voteInfo.voteNo && (level.voteInfo.voteNo >= noThreshold))
 		{
 			// same behavior as a no response vote
 			AP(va("cpm \"^1Vote FAILED! ^7(^2Y:%d^7-^1N:%d^7) ^7(%s)\n\"", level.voteInfo.voteYes, level.voteInfo.voteNo, level.voteInfo.voteString));
-			G_LogPrintf("Vote Failed: (Y:%d-N:%d) %s\n", level.voteInfo.voteYes, level.voteInfo.voteNo, level.voteInfo.voteString);
+			G_LogPrintf("Vote Failed: (Y:%d-N:%d) %s (Required:%d, Voting Clients:%d)\n", level.voteInfo.voteYes, level.voteInfo.voteNo, level.voteInfo.voteString, yesThreshold, total);
 		}
 		else if (level.time - level.voteInfo.voteTime >= VOTE_TIME) // timeout, no enough vote
 		{
 			// same behavior as a no response vote
-			AP(va("cpm \"^1Vote TIMEOUT! No enough voters to pass vote ^7(^1%d^7/^2%d^7) ^7(%s)\n\"", level.voteInfo.voteYes, pcnt * total / 100, level.voteInfo.voteString));
-			G_LogPrintf("Vote TIMEOUT! No enough voters to pass vote (%d/%d) %s\n", level.voteInfo.voteYes, pcnt * total / 100, level.voteInfo.voteString);
+			AP(va("cpm \"^1Vote TIMEOUT! No enough voters to pass vote ^7(^1%d^7/^2%d^7) ^7(%s)\n\"", level.voteInfo.voteYes, yesThreshold, level.voteInfo.voteString));
+			G_LogPrintf("Vote TIMEOUT! No enough voters to pass vote (%d/%d) %s\n", level.voteInfo.voteYes, yesThreshold, level.voteInfo.voteString);
 		}
 		else
 		{

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -4559,11 +4559,9 @@ void CheckVote(void)
 			total = level.voteInfo.numVotingClients;
 		}
 
-        int yesThreshold = pcnt * total / 100;
-        int noThreshold = (int) ceilf(((float) pcnt) * ((float) total) / 100.0f);
+        int threshold = pcnt * total / 100;
 
-        // Must do voteYes > and not voteYes >=, otherwise vote will pass with 2 players with only one vote.
-		if (level.voteInfo.voteYes > yesThreshold)
+		if (level.voteInfo.voteYes > 1 && level.voteInfo.voteYes >= threshold)
 		{
 			// execute the command, then remove the vote
 			if (level.voteInfo.voteYes > total + 1)
@@ -4580,7 +4578,7 @@ void CheckVote(void)
 			else
 			{
 				AP(va("cpm \"^5Vote passed! ^7(^2Y:%d^7-^1N:%d^7) ^7(%s)\n\"", level.voteInfo.voteYes, level.voteInfo.voteNo, level.voteInfo.voteString));
-				G_LogPrintf("Vote Passed: (Y:%d-N:%d) %s (Required:%d, Voting Clients:%d)\n", level.voteInfo.voteYes, level.voteInfo.voteNo, level.voteInfo.voteString, yesThreshold, total);
+				G_LogPrintf("Vote Passed: (Y:%d-N:%d) %s (Required:%d, Voting Clients:%d)\n", level.voteInfo.voteYes, level.voteInfo.voteNo, level.voteInfo.voteString, threshold, total);
 			}
 
 			// Perform the passed vote
@@ -4599,17 +4597,17 @@ void CheckVote(void)
 
 		}
         // Only fail vote if more than half vote no.
-		else if (level.voteInfo.voteNo && (level.voteInfo.voteNo >= noThreshold))
+		else if (level.voteInfo.voteNo > 1 && level.voteInfo.voteNo >= threshold)
 		{
 			// same behavior as a no response vote
 			AP(va("cpm \"^1Vote FAILED! ^7(^2Y:%d^7-^1N:%d^7) ^7(%s)\n\"", level.voteInfo.voteYes, level.voteInfo.voteNo, level.voteInfo.voteString));
-			G_LogPrintf("Vote Failed: (Y:%d-N:%d) %s (Required:%d, Voting Clients:%d)\n", level.voteInfo.voteYes, level.voteInfo.voteNo, level.voteInfo.voteString, yesThreshold, total);
+			G_LogPrintf("Vote Failed: (Y:%d-N:%d) %s (Required:%d, Voting Clients:%d)\n", level.voteInfo.voteYes, level.voteInfo.voteNo, level.voteInfo.voteString, threshold, total);
 		}
 		else if (level.time - level.voteInfo.voteTime >= VOTE_TIME) // timeout, no enough vote
 		{
 			// same behavior as a no response vote
-			AP(va("cpm \"^1Vote TIMEOUT! No enough voters to pass vote ^7(^1%d^7/^2%d^7) ^7(%s)\n\"", level.voteInfo.voteYes, yesThreshold, level.voteInfo.voteString));
-			G_LogPrintf("Vote TIMEOUT! No enough voters to pass vote (%d/%d) %s\n", level.voteInfo.voteYes, yesThreshold, level.voteInfo.voteString);
+			AP(va("cpm \"^1Vote TIMEOUT! No enough voters to pass vote ^7(^1%d^7/^2%d^7) ^7(%s)\n\"", level.voteInfo.voteYes, threshold, level.voteInfo.voteString));
+			G_LogPrintf("Vote TIMEOUT! No enough voters to pass vote (%d/%d) %s\n", level.voteInfo.voteYes, threshold, level.voteInfo.voteString);
 		}
 		else
 		{

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -4561,7 +4561,7 @@ void CheckVote(void)
 
         int threshold = pcnt * total / 100;
 
-		if (level.voteInfo.voteYes > 1 && level.voteInfo.voteYes >= threshold)
+		if (level.voteInfo.voteYes > 1 && level.voteInfo.voteYes > threshold)
 		{
 			// execute the command, then remove the vote
 			if (level.voteInfo.voteYes > total + 1)


### PR DESCRIPTION
As title says, more than 50% of voting clients are now required to fail a vote, vs just one before, in some scenarios.

refs: https://github.com/etlegacy/etlegacy/issues/2308
Also adds more helpful logs to server.
![ksnip_20230428-214145](https://user-images.githubusercontent.com/1733933/235285191-2d637938-1006-41b3-a446-0f6142e5b73a.png)

Tested scenarios:

With 3 players on allies:
Vote Failed: (Y:1-N:2) Surrender [ALLIES] (Required:2, Voting Clients:3)
Vote Passed: (Y:2-N:0) Surrender [ALLIES]

With 2 players on allies:
Vote Failed: (Y:1-N:1) Surrender [ALLIES] (Required:2, Voting Clients:2)

