### PR TITLE
ui: Retain Server Browser Selection During Load

### DIFF
--- a/src/ui/ui_main.c
+++ b/src/ui/ui_main.c
@@ -6483,12 +6483,23 @@ static void UI_InsertServerIntoDisplayList(int num, int position)
 		return;
 	}
 
+    int currentServerBeforeInsert = uiInfo.serverStatus.currentServer;
+
 	uiInfo.serverStatus.numDisplayServers++;
 	for (i = uiInfo.serverStatus.numDisplayServers; i > position; i--)
 	{
 		uiInfo.serverStatus.displayServers[i] = uiInfo.serverStatus.displayServers[i - 1];
 	}
 	uiInfo.serverStatus.displayServers[position] = num;
+
+    // If we're inserting a server before the currently selected one, increment the selected item.
+    // This has improved UX over changing the item out from under the user, who might want to select a server
+    // and so something with it before the list finishes loading, which can take a while.
+    if (position < currentServerBeforeInsert) {
+        uiInfo.serverStatus.currentServer++;
+        menuDef_t *menu = Menus_FindByName("serverList");
+        Menu_SetFeederSelection(menu, FEEDER_SERVERS, uiInfo.serverStatus.currentServer, NULL);
+    }
 }
 
 /**

--- a/src/ui/ui_main.c
+++ b/src/ui/ui_main.c
@@ -6483,8 +6483,6 @@ static void UI_InsertServerIntoDisplayList(int num, int position)
 		return;
 	}
 
-    int currentServerBeforeInsert = uiInfo.serverStatus.currentServer;
-
 	uiInfo.serverStatus.numDisplayServers++;
 	for (i = uiInfo.serverStatus.numDisplayServers; i > position; i--)
 	{
@@ -6495,7 +6493,7 @@ static void UI_InsertServerIntoDisplayList(int num, int position)
     // If we're inserting a server before the currently selected one, increment the selected item.
     // This has improved UX over changing the item out from under the user, who might want to select a server
     // and so something with it before the list finishes loading, which can take a while.
-    if (position < currentServerBeforeInsert) {
+    if (position < uiInfo.serverStatus.currentServer) {
         uiInfo.serverStatus.currentServer++;
         menuDef_t *menu = Menus_FindByName("serverList");
         Menu_SetFeederSelection(menu, FEEDER_SERVERS, uiInfo.serverStatus.currentServer, NULL);


### PR DESCRIPTION
Proposed change: Don't change the user's selected item while we're loading the server browser.

This can prevent frustration when clicking an item and then going to click "Server Info" or "Join Server", but the browser has updated before you click those buttons, causing you to select the wrong server.

The interaction **before** was:

Servers:
- A
- [C] (selected)
- D

Then B pops in, now your selection is changed for you:
- A
- [B] (selected)
- C
- D

**Now**:

Servers:
- A
- [C] (selected)
- D

Then B pops in, now your selection is not lost:
- A
- B
- [C] (selected)
- D
