### PR TITLE
ui: Focus Connect to IP TextBox When Opened

### DIFF
--- a/etmain/ui/main_quickconnect.menu
+++ b/etmain/ui/main_quickconnect.menu
@@ -23,7 +23,7 @@ menuDef {
 	onOpen {
 		setitemcolor background backcolor 0 0 0 0 ;
 		fadein background ;
-		//setEditFocus "efleftServer IP:"
+		setEditFocus "efleftactionServer IP:"
 	}
 
 	onESC {

--- a/etmain/ui/playonline_connecttoip.menu
+++ b/etmain/ui/playonline_connecttoip.menu
@@ -23,7 +23,7 @@ menuDef {
 	onOpen {
 		setitemcolor background backcolor 0 0 0 0 ;
 		fadein background ;
-		setEditFocus "efleftServer IP:"
+		setEditFocus "efleftactionServer IP:"
 	}
 
 	onESC {

--- a/src/ui/ui_script.c
+++ b/src/ui/ui_script.c
@@ -1276,6 +1276,8 @@ void Script_SetEditFocus(itemDef_t *item, qboolean *bAbort, char **args)
 			// the stupidest idea ever, let's just override the console, every ui element, user choice, etc
 			// nuking this
 			//DC->setOverstrikeMode(qtrue);
+		} else {
+			Com_Printf("Script_SetEditFocus: Can't find %s.\n", name);
 		}
 	}
 }


### PR DESCRIPTION
This way you don't have to click in the textbox, which is annoying. You can start typing the IP (or paste) right away.

Also adds a log to catch these kinds of errors easier in the future.