### PR TITLE
Support both endians for PPC64

### DIFF
--- a/src/qcommon/q_platform.h
+++ b/src/qcommon/q_platform.h
@@ -203,7 +203,11 @@
 #define idx64 1
 #define ARCH_STRING "x86_64"
 #elif defined __powerpc64__
+#if BYTE_ORDER == BIG_ENDIAN
 #define ARCH_STRING "ppc64"
+#else
+#define ARCH_STRING "ppc64le"
+#endif
 #elif defined __powerpc__
 #define ARCH_STRING "ppc"
 #elif defined __s390__


### PR DESCRIPTION
This is my second attempt to get the game properly compiled on the PowerPC64 Little Endian.

Two years ago I created a PR to convince the team to accept this change but unfortunately the PR got denied on the ground that the team does not want to support this architecture and there is not enough add-ons that is compatible and working.

I'd like to report that most add-ons does work correctly, for example Omnibot. I have been hosting games with friends within PowerPC community and we all love to see this PR merge to avoid introducing this downstream patch in various distros.

Thanks the core team for the consideration