### PR TITLE
mod: fix intermission impkd stats showing only zeros for some players

### DIFF
--- a/src/cgame/cg_debriefing.c
+++ b/src/cgame/cg_debriefing.c
@@ -713,18 +713,18 @@ static panel_button_t debriefPlayerInfoHitRegions =
 };
 
 #define PLAYERHEADER_SKILLS(number)           \
-	static panel_button_t debriefPlayerInfoSkills ## number = {      \
-		NULL,                                       \
-		NULL,                                       \
-		{ 24,                            136 + (number * 14), 12, 12 }, \
-		{ number,                        0,                   0,  0, 0, 0, 0, 0},  \
-		&debriefPlayerInfoFont,          /* font     */  \
-		NULL,                            /* keyDown  */  \
-		NULL,                            /* keyUp    */  \
-		CG_Debriefing_PlayerSkills_Draw,            \
-		NULL,                                       \
-		0,                                       \
-	}
+		static panel_button_t debriefPlayerInfoSkills ## number = {      \
+			NULL,                                       \
+			NULL,                                       \
+			{ 24,                            136 + (number * 14), 12, 12 }, \
+			{ number,                        0,                   0,  0, 0, 0, 0, 0},  \
+			&debriefPlayerInfoFont,          /* font     */  \
+			NULL,                            /* keyDown  */  \
+			NULL,                            /* keyUp    */  \
+			CG_Debriefing_PlayerSkills_Draw,            \
+			NULL,                                       \
+			0,                                       \
+		}
 
 PLAYERHEADER_SKILLS(0);
 PLAYERHEADER_SKILLS(1);
@@ -781,18 +781,18 @@ static panel_button_text_t teamDebriefTitle =
 };
 
 #define TDB_SKILL_TITLES_XP(number, title, x)             \
-	static panel_button_t teamDebriefSkillXPText_ ## number = {          \
-		NULL,                                                   \
-		title,                                                  \
-		{ 100 + (number * 65),      304 - (x * 12),                 20, 200 },      \
-		{ 0,                        0,                              0,  0, 0, 0, 0, 0},                             \
-		&teamDebriefTitleSmall,     /* font     */              \
-		NULL,                       /* keyDown  */                      \
-		NULL,                       /* keyUp    */                  \
-		BG_PanelButtonsRender_Text,                             \
-		NULL,                                                   \
-		0,                                                   \
-	}
+		static panel_button_t teamDebriefSkillXPText_ ## number = {          \
+			NULL,                                                   \
+			title,                                                  \
+			{ 100 + (number * 65),      304 - (x * 12),                 20, 200 },      \
+			{ 0,                        0,                              0,  0, 0, 0, 0, 0},                             \
+			&teamDebriefTitleSmall,     /* font     */              \
+			NULL,                       /* keyDown  */                      \
+			NULL,                       /* keyUp    */                  \
+			BG_PanelButtonsRender_Text,                             \
+			NULL,                                                   \
+			0,                                                   \
+		}
 
 TDB_SKILL_TITLES_XP(0, "Battle Sense", 0);
 TDB_SKILL_TITLES_XP(1, "Engineer", 1);
@@ -804,32 +804,32 @@ TDB_SKILL_TITLES_XP(6, "Covert Ops", 0);
 TDB_SKILL_TITLES_XP(7, "Total", 1);
 
 #define TDB_SKILL_AXIS_XP(number)                         \
-	static panel_button_t teamDebriefSkillXPText0_ ## number = {         \
-		NULL,                                                   \
-		NULL,                                                   \
-		{ 110 + (number * 65),             320,                  470, 200 },                \
-		{ 0,                               number,               0,   0, 0, 0, 0, 0},                        \
-		&teamDebriefTitle,                 /* font     */                  \
-		NULL,                              /* keyDown  */                      \
-		NULL,                              /* keyUp    */                  \
-		CG_TeamDebriefingTeamSkillXP_Draw,                      \
-		NULL,                                                   \
-		0,                                                   \
-	}
+		static panel_button_t teamDebriefSkillXPText0_ ## number = {         \
+			NULL,                                                   \
+			NULL,                                                   \
+			{ 110 + (number * 65),             320,                  470, 200 },                \
+			{ 0,                               number,               0,   0, 0, 0, 0, 0},                        \
+			&teamDebriefTitle,                 /* font     */                  \
+			NULL,                              /* keyDown  */                      \
+			NULL,                              /* keyUp    */                  \
+			CG_TeamDebriefingTeamSkillXP_Draw,                      \
+			NULL,                                                   \
+			0,                                                   \
+		}
 
 #define TDB_SKILL_ALLIES_XP(number)                       \
-	static panel_button_t teamDebriefSkillXPText1_ ## number = {         \
-		NULL,                                                   \
-		NULL,                                                   \
-		{ 110 + (number * 65),             340,                  470, 200 },                \
-		{ 1,                               number,               0,   0, 0, 0, 0, 0},                        \
-		&teamDebriefTitle,                 /* font     */                  \
-		NULL,                              /* keyDown  */                      \
-		NULL,                              /* keyUp    */                  \
-		CG_TeamDebriefingTeamSkillXP_Draw,                      \
-		NULL,                                                   \
-		0,                                                   \
-	}
+		static panel_button_t teamDebriefSkillXPText1_ ## number = {         \
+			NULL,                                                   \
+			NULL,                                                   \
+			{ 110 + (number * 65),             340,                  470, 200 },                \
+			{ 1,                               number,               0,   0, 0, 0, 0, 0},                        \
+			&teamDebriefTitle,                 /* font     */                  \
+			NULL,                              /* keyDown  */                      \
+			NULL,                              /* keyUp    */                  \
+			CG_TeamDebriefingTeamSkillXP_Draw,                      \
+			NULL,                                                   \
+			0,                                                   \
+		}
 
 TDB_SKILL_AXIS_XP(0);
 TDB_SKILL_AXIS_XP(1);
@@ -963,87 +963,87 @@ static panel_button_t charPanelEdit =
 };
 
 static panel_button_t buttonPanelWindow =
-    {
-        NULL,
-        "PANELS",
-        { DB_BUTTONS_PANEL_X,        DB_BUTTONS_PANEL_Y,              DB_BUTTONS_PANEL_WIDTH, DB_BUTTONS_PANEL_HEIGHT },
-        { 0,                         0,                               0,                      0, 0, 0, 0, 0           },
-        NULL,                        // font
-        NULL,                        // keyDown
-        NULL,                        // keyUp
-        CG_PanelButtonsRender_Window,
-        NULL,
-        0
+{
+	NULL,
+	"PANELS",
+	{ DB_BUTTONS_PANEL_X,        DB_BUTTONS_PANEL_Y,              DB_BUTTONS_PANEL_WIDTH, DB_BUTTONS_PANEL_HEIGHT },
+	{ 0,                         0,                               0,                      0, 0, 0, 0, 0           },
+	NULL,                        // font
+	NULL,                        // keyDown
+	NULL,                        // keyUp
+	CG_PanelButtonsRender_Window,
+	NULL,
+	0
 };
 
 static panel_button_t buttonsPanelScoreboard =
-    {
-        NULL,
-        "SCOREBOARD",
-        { DB_BUTTONS_PANEL_X + DB_BUTTON_WIDTH_MARGIN_X,DB_BUTTONS_PANEL_Y2 + DB_BUTTON_HEIGHT_MARGIN_Y,                                     DB_BUTTON_WIDTH, DB_BUTTON_HEIGHT },
-        { 0,                          0,                                                                                   0,               0, 0, 0, 0, 0    },
-        NULL,                         // font
-        CG_Debriefing_PanelButton_KeyDown,// keyDown
-        NULL,                         // keyUp
-        CG_Debriefing_NextButton_Draw,
-        NULL,
-        0
+{
+	NULL,
+	"SCOREBOARD",
+	{ DB_BUTTONS_PANEL_X + DB_BUTTON_WIDTH_MARGIN_X,DB_BUTTONS_PANEL_Y2 + DB_BUTTON_HEIGHT_MARGIN_Y,                                     DB_BUTTON_WIDTH, DB_BUTTON_HEIGHT },
+	{ 0,                          0,                                                                                   0,               0, 0, 0, 0, 0    },
+	NULL,                         // font
+	CG_Debriefing_PanelButton_KeyDown,// keyDown
+	NULL,                         // keyUp
+	CG_Debriefing_NextButton_Draw,
+	NULL,
+	0
 };
 
 static panel_button_t buttonsPanelAwards =
-    {
-        NULL,
-        "AWARDS",
-        { DB_BUTTONS_PANEL_X + DB_BUTTON_WIDTH_MARGIN_X,DB_BUTTONS_PANEL_Y2 + DB_BUTTON_HEIGHT + DB_BUTTON_HEIGHT_MARGIN_Y * 2,                                         DB_BUTTON_WIDTH, DB_BUTTON_HEIGHT },
-        { 0,                          0,                                                                                                              0,               1, 0, 0, 0, 0    },
-        NULL,                         // font
-        CG_Debriefing_PanelButton_KeyDown,// keyDown
-        NULL,                         // keyUp
-        CG_Debriefing_NextButton_Draw,
-        NULL,
-        0
+{
+	NULL,
+	"AWARDS",
+	{ DB_BUTTONS_PANEL_X + DB_BUTTON_WIDTH_MARGIN_X,DB_BUTTONS_PANEL_Y2 + DB_BUTTON_HEIGHT + DB_BUTTON_HEIGHT_MARGIN_Y * 2,                                         DB_BUTTON_WIDTH, DB_BUTTON_HEIGHT },
+	{ 0,                          0,                                                                                                              0,               1, 0, 0, 0, 0    },
+	NULL,                         // font
+	CG_Debriefing_PanelButton_KeyDown,// keyDown
+	NULL,                         // keyUp
+	CG_Debriefing_NextButton_Draw,
+	NULL,
+	0
 };
 
 static panel_button_t buttonsPanelStats =
-    {
-        NULL,
-        "STATS",
-        { DB_BUTTONS_PANEL_X + DB_BUTTON_WIDTH_MARGIN_X,DB_BUTTONS_PANEL_Y2 + DB_BUTTON_HEIGHT * 2 + DB_BUTTON_HEIGHT_MARGIN_Y * 3,                                          DB_BUTTON_WIDTH, DB_BUTTON_HEIGHT },
-        { 0,                          0,                                                                                                                   0,               2, 0, 0, 0, 0    },
-        NULL,                         // font
-        CG_Debriefing_PanelButton_KeyDown,// keyDown
-        NULL,                         // keyUp
-        CG_Debriefing_NextButton_Draw,
-        NULL,
-        0
+{
+	NULL,
+	"STATS",
+	{ DB_BUTTONS_PANEL_X + DB_BUTTON_WIDTH_MARGIN_X,DB_BUTTONS_PANEL_Y2 + DB_BUTTON_HEIGHT * 2 + DB_BUTTON_HEIGHT_MARGIN_Y * 3,                                          DB_BUTTON_WIDTH, DB_BUTTON_HEIGHT },
+	{ 0,                          0,                                                                                                                   0,               2, 0, 0, 0, 0    },
+	NULL,                         // font
+	CG_Debriefing_PanelButton_KeyDown,// keyDown
+	NULL,                         // keyUp
+	CG_Debriefing_NextButton_Draw,
+	NULL,
+	0
 };
 
 static panel_button_t buttonsPanelMapVote =
-    {
-        NULL,
-        "VOTE NOW",
-        { DB_BUTTONS_PANEL_X + DB_BUTTON_WIDTH_MARGIN_X,DB_BUTTONS_PANEL_Y2 + DB_BUTTON_HEIGHT * 3 + DB_BUTTON_HEIGHT_MARGIN_Y * 4,                                       DB_BUTTON_WIDTH, DB_BUTTON_HEIGHT },
-        { 0,                          0,                                                                                                                0,               3, 0, 0, 0, 0    },
-        NULL,                         // font
-        CG_Debriefing_PanelButton_KeyDown,// keyDown
-        NULL,                         // keyUp
-        CG_Debriefing_VoteButton_Draw,
-        NULL,
-        0
+{
+	NULL,
+	"VOTE NOW",
+	{ DB_BUTTONS_PANEL_X + DB_BUTTON_WIDTH_MARGIN_X,DB_BUTTONS_PANEL_Y2 + DB_BUTTON_HEIGHT * 3 + DB_BUTTON_HEIGHT_MARGIN_Y * 4,                                       DB_BUTTON_WIDTH, DB_BUTTON_HEIGHT },
+	{ 0,                          0,                                                                                                                0,               3, 0, 0, 0, 0    },
+	NULL,                         // font
+	CG_Debriefing_PanelButton_KeyDown,// keyDown
+	NULL,                         // keyUp
+	CG_Debriefing_VoteButton_Draw,
+	NULL,
+	0
 };
 
 static panel_button_t buttonsNextButton =
-    {
-        NULL,
-        "NEXT",
-        { DB_BUTTONS_PANEL_X + DB_BUTTON_WIDTH_MARGIN_X,DB_BUTTONS_PANEL_Y2 + DB_BUTTON_HEIGHT * 4 + DB_BUTTON_HEIGHT_MARGIN_Y * 5,                                           DB_BUTTON_WIDTH, DB_BUTTON_HEIGHT },
-        { 0,                          0,                                                                                                                    0,               0, 0, 0, 0, 0    },
-        NULL,                         // font
-        CG_Debriefing_NextButton_KeyDown,// keyDown
-        NULL,                         // keyUp
-        CG_Debriefing_NextButton_Draw,
-        NULL,
-        0
+{
+	NULL,
+	"NEXT",
+	{ DB_BUTTONS_PANEL_X + DB_BUTTON_WIDTH_MARGIN_X,DB_BUTTONS_PANEL_Y2 + DB_BUTTON_HEIGHT * 4 + DB_BUTTON_HEIGHT_MARGIN_Y * 5,                                           DB_BUTTON_WIDTH, DB_BUTTON_HEIGHT },
+	{ 0,                          0,                                                                                                                    0,               0, 0, 0, 0, 0    },
+	NULL,                         // font
+	CG_Debriefing_NextButton_KeyDown,// keyDown
+	NULL,                         // keyUp
+	CG_Debriefing_NextButton_Draw,
+	NULL,
+	0
 };
 
 // MAPVOTE
@@ -2431,11 +2431,22 @@ void CG_Debriefing_ParsePrestige(void)
 /**
  * @brief CG_Debriefing_ParsePlayerKillsDeaths
  */
-void CG_Debriefing_ParsePlayerKillsDeaths(void)
+void CG_Debriefing_ParsePlayerKillsDeaths(qboolean secondPart)
 {
-	int i;
+	int i, max;
 
-	for (i = 0; i < cgs.maxclients; i++)
+	if (secondPart)
+	{
+		i   = cgs.maxclients / 2;
+		max = cgs.maxclients;
+	}
+	else
+	{
+		i   = 0;
+		max = cgs.maxclients / 2;
+	}
+
+	for (i; i < max; i++)
 	{
 		cgs.clientinfo[i].kills     = Q_atoi(CG_Argv((i * 6) + 1));
 		cgs.clientinfo[i].deaths    = Q_atoi(CG_Argv((i * 6) + 2));

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -4079,7 +4079,7 @@ void CG_Debriefing_MouseEvent(int x, int y);
 
 void CG_Debriefing_ParseWeaponAccuracies(void);
 void CG_Debriefing_ParseWeaponStats(void);
-void CG_Debriefing_ParsePlayerKillsDeaths(void);
+void CG_Debriefing_ParsePlayerKillsDeaths(qboolean secondPart);
 void CG_Debriefing_ParsePlayerTime(void);
 void CG_Debriefing_ParseAwards(void);
 void CG_Debriefing_ParseSkillRating(void);

--- a/src/cgame/cg_servercmds.c
+++ b/src/cgame/cg_servercmds.c
@@ -2981,7 +2981,8 @@ void CG_AddToBannerPrint(const char *str)
 #define SETSPAWNPT_HASH     137482
 #define IMWA_HASH           51808
 #define IMWS_HASH           54004
-#define IMPKD_HASH          64481
+#define IMPKD0_HASH         70433
+#define IMPKD1_HASH         70557
 #define IMPT_HASH           53279
 #define IMSR_HASH           53398
 #define SR_HASH             27365
@@ -3473,8 +3474,10 @@ static void CG_ServerCommand(void)
 	case IMWS_HASH:                                        // "imws"
 		CG_Debriefing_ParseWeaponStats();
 		return;
-	case IMPKD_HASH:                                       // "impkd"
-		CG_Debriefing_ParsePlayerKillsDeaths();
+	case IMPKD0_HASH:                                      // "impkd0"
+		CG_Debriefing_ParsePlayerKillsDeaths(qfalse);
+	case IMPKD1_HASH:                                      // "impkd1"
+		CG_Debriefing_ParsePlayerKillsDeaths(qtrue);
 		return;
 	case IMPT_HASH:                                        // "impt"
 		CG_Debriefing_ParsePlayerTime();
@@ -3575,7 +3578,7 @@ static void CG_ServerCommand(void)
 	}
 	case XPGAIN_HASH:   // "xpgain"
 	{
-        CG_AddPMItemXP(Q_atoi(CG_Argv(2)) < 0, va("%s", CG_Argv(2)), va("%s",CG_Argv(3)), cgs.media.skillPics[Q_atoi(CG_Argv(1))]);
+		CG_AddPMItemXP(Q_atoi(CG_Argv(2)) < 0, va("%s", CG_Argv(2)), va("%s", CG_Argv(3)), cgs.media.skillPics[Q_atoi(CG_Argv(1))]);
 		break;
 	}
 	default:

--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -4710,7 +4710,7 @@ void Cmd_IntermissionReady_f(gentity_t *ent, unsigned int dwCommand, int value)
  */
 void Cmd_IntermissionPlayerKillsDeaths_f(gentity_t *ent, unsigned int dwCommand, int value)
 {
-	char buffer[1024];
+	char buffer[MAX_STRING_CHARS];
 	int i;
 
 	if (!ent || !ent->client)
@@ -4718,9 +4718,15 @@ void Cmd_IntermissionPlayerKillsDeaths_f(gentity_t *ent, unsigned int dwCommand,
 		return;
 	}
 
-	Q_strncpyz(buffer, "impkd ", sizeof(buffer));
+	Q_strncpyz(buffer, "impkd0 ", sizeof(buffer));
 	for (i = 0; i < g_maxclients.integer; i++)
 	{
+		if (i == g_maxclients.integer / 2)
+		{
+			trap_SendServerCommand(ent - g_entities, buffer);
+			Q_strncpyz(buffer, "impkd1 ", sizeof(buffer));
+		}
+
 		if (g_entities[i].inuse)
 		{
 			Q_strcat(buffer, sizeof(buffer), va("%i %i %i %i %i %i ", level.clients[i].sess.kills, level.clients[i].sess.deaths, level.clients[i].sess.gibs, level.clients[i].sess.self_kills, level.clients[i].sess.team_kills, level.clients[i].sess.team_gibs));

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -2402,7 +2402,7 @@ void G_InitGame(int levelTime, int randomSeed, int restart, int etLegacyServer, 
 	}
 
 	G_SetupExtensions();
-	trap_DemoSupport("gstats\\sgstats\\sc0\\score\\sc1\\score\\impt\\impt\\imsr\\imsr\\impr\\impr\\impkd\\impkd\\imwa\\imwa\\imws\\imws");
+	trap_DemoSupport("gstats\\sgstats\\sc0\\score\\sc1\\score\\impt\\impt\\imsr\\imsr\\impr\\impr\\impkd0\\impkd\\impkd1\\impkd\\imwa\\imwa\\imws\\imws");
 
 	level.time            = levelTime;
 	level.startTime       = levelTime;


### PR DESCRIPTION
impkd command can exceeded MAX_STRING_TOKENS with more than 42 players on server, causing remaining players stats to be shown as 0. This will evenly split stats into 2 commands.