### PR TITLE
renderer: fix garbage font bug, refs #1864

### DIFF
--- a/src/renderercommon/tr_font.c
+++ b/src/renderercommon/tr_font.c
@@ -618,7 +618,7 @@ static qboolean R_LoadScalableFont(const char *fontName, int pointSize, fontInfo
 				imageBuff[left++] = ((float)out[k] * max);
 			}
 
-			Com_sprintf(name, sizeof(name), "fonts/%s_%i_%i.tga", fontName, imageNumber++, pointSize);
+			Com_sprintf(name, sizeof(name), "fonts/%s_%i_%i_scalable.tga", fontName, imageNumber++, pointSize);
 			//if (r_saveFontData->integer)
 			//{
 			//	RE_SaveTGA(name, imageBuff, imageSize, imageSize, qtrue);


### PR DESCRIPTION
`R_LoadScalableFont` creates same hashed images as `R_LoadPreRenderedFont` but they are not compatible. Because of cache these functions will not always create new proper image when font is being registered since they have same hash. This fix should make sure the images will not share same hash so they won't be reused where they shouldn't.

It mostly happend on `sv_pure 0` because image cache is not forced to be cleared while on `sv_pure 1` it is.

refs #1864