### PR TITLE
mod: fix various weapon issues on respawn/revive

### DIFF
--- a/src/cgame/cg_weapons.c
+++ b/src/cgame/cg_weapons.c
@@ -114,7 +114,7 @@ void CG_MachineGunEjectBrass(centity_t *cent)
 	localEntity_t *le;
 	refEntity_t   *re;
 	vec3_t        velocity, xvelocity;
-	vec3_t        offset = { 0, 0, 0 };
+	vec3_t        offset     = { 0, 0, 0 };
 	float         waterScale = 1.0f;
 	vec3_t        v[3], end;
 	qboolean      isFirstPerson = ((cent->currentState.clientNum == cg.snap->ps.clientNum) && !cg.renderingThirdPerson);
@@ -3477,8 +3477,8 @@ void CG_AddPlayerWeapon(refEntity_t *parent, playerState_t *ps, centity_t *cent)
 
 				if (anim == WEAP_ALTSWITCHFROM || anim == WEAP_ALTSWITCHTO || anim == WEAP_IDLE1 || anim == WEAP_IDLE2)
 				{
-					// prevent the flying nade effect (much visible with M7 when swapping while raising)
-					if (weaponNum == cent->currentState.nextWeapon)
+					// prevent the flying nade effect (best visible with M7 when swapping while raising)
+					if (weaponNum == cg.snap->ps.nextWeapon && !(cg.snap->ps.pm_flags & PMF_RESPAWNED))
 					{
 						barrel.hModel = weapon->modModels[0];
 

--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -5051,11 +5051,6 @@ void PmoveSingle(pmove_t *pmove)
 
 	if (pm->ps->pm_flags & PMF_RESPAWNED)
 	{
-		if (pm->ps->stats[STAT_PLAYER_CLASS] == PC_COVERTOPS)
-		{
-			pm->pmext->silencedSideArm |= 1;
-		}
-
 		// clear the respawned flag if attack button are cleared
 		// don't clear if a weapon change is needed to prevent early weapon change
 		if (pm->ps->stats[STAT_HEALTH] > 0 &&

--- a/src/game/g_weapon.c
+++ b/src/game/g_weapon.c
@@ -327,10 +327,7 @@ void ReviveEntity(gentity_t *ent, gentity_t *traceEnt)
 {
 	vec3_t  org;
 	trace_t tr;
-	int     healamt, headshot, oldweapon, oldclasstime = 0;
-	int     ammo[MAX_WEAPONS];          // total amount of ammo
-	int     ammoclip[MAX_WEAPONS];      // ammo in clip
-	int     weapons[MAX_WEAPONS / (sizeof(int) * 8)];   // 64 bits for weapons held
+	int     healamt, headshot, oldclasstime = 0;
 
 	// heal the dude
 	// copy some stuff out that we'll wanna restore
@@ -347,14 +344,8 @@ void ReviveEntity(gentity_t *ent, gentity_t *traceEnt)
 		healamt = (int)(traceEnt->client->ps.stats[STAT_MAX_HEALTH] * 0.5);
 	}
 
-	oldweapon = traceEnt->client->ps.weapon;
-
 	// keep class special weapon time to keep them from exploiting revives
 	oldclasstime = traceEnt->client->ps.classWeaponTime;
-
-	Com_Memcpy(ammo, traceEnt->client->ps.ammo, sizeof(int) * MAX_WEAPONS);
-	Com_Memcpy(ammoclip, traceEnt->client->ps.ammoclip, sizeof(int) * MAX_WEAPONS);
-	Com_Memcpy(weapons, traceEnt->client->ps.weapons, sizeof(int) * (MAX_WEAPONS / (sizeof(int) * 8)));
 
 	ClientSpawn(traceEnt, qtrue, qfalse, qtrue);
 
@@ -363,16 +354,12 @@ void ReviveEntity(gentity_t *ent, gentity_t *traceEnt)
 #endif
 
 	traceEnt->client->ps.stats[STAT_PLAYER_CLASS] = traceEnt->client->sess.playerType;
-	Com_Memcpy(traceEnt->client->ps.ammo, ammo, sizeof(int) * MAX_WEAPONS);
-	Com_Memcpy(traceEnt->client->ps.ammoclip, ammoclip, sizeof(int) * MAX_WEAPONS);
-	Com_Memcpy(traceEnt->client->ps.weapons, weapons, sizeof(int) * (MAX_WEAPONS / (sizeof(int) * 8)));
 
 	if (headshot)
 	{
 		traceEnt->client->ps.eFlags |= EF_HEADSHOT;
 	}
 
-	traceEnt->client->ps.weapon          = oldweapon;
 	traceEnt->client->ps.weaponstate     = WEAPON_READY;
 	traceEnt->client->ps.classWeaponTime = oldclasstime;
 
@@ -3456,7 +3443,7 @@ gentity_t *Bullet_Fire(gentity_t *ent)
 	// skip corpses for bullet tracing (=non gibbing weapons)
 	G_TempTraceIgnoreBodies();
 
-    Bullet_Fire_Extended(ent, ent, muzzleTrace, end, forward, GetWeaponTableData(ent->s.weapon)->damage,
+	Bullet_Fire_Extended(ent, ent, muzzleTrace, end, forward, GetWeaponTableData(ent->s.weapon)->damage,
 	                     GetWeaponTableData(ent->s.weapon)->attributes & WEAPON_ATTRIBUT_FALL_OFF, GetWeaponTableData(ent->s.weapon)->mod);
 
 	// ok let the bodies be traced again


### PR DESCRIPTION
fix riflegrenade being equipped again if player shoots and dies right after
fix altweapon state not being properly restored when revived
fix riflegrenade grenade model disappearing if player dies and gets revived 
improve the flying nade effect fix when getting revived
improve weapon selection when player dies and upon revive has invalid weapon equipped
improve altweapon initialization on respawn (silenced pistols)