### PR TITLE
qcommon: fix pointer issues with Q_TrimStr

### DIFF
--- a/src/qcommon/q_shared.c
+++ b/src/qcommon/q_shared.c
@@ -1892,7 +1892,7 @@ char *Q_TrimStr(char *string)
 	char   *start = string;
 	size_t len    = 0;
 
-	while (*s <= 0x20 || *s >= 0x7F || (Q_IsColorString(s) && *(s + 2) == 0x20))
+	while (*s && (*s <= 0x20 || *s >= 0x7F || (Q_IsColorString(s) && *(s + 2) == 0x20)))
 	{
 		if (Q_IsColorString(s) && *(s + 2) == 0x20)
 		{
@@ -1912,11 +1912,14 @@ char *Q_TrimStr(char *string)
 			--p;
 		}
 
-		p[1] = '\0';
-		len  = (size_t) (p - s + 1);
+		if (*p)
+		{
+			p[1] = '\0';
+		}
+		len = (size_t) (p - s + 1);
 	}
 
-	return (s == start) ? s : memmove(start, s, len + 1);
+	return (s == start) ? s : memmove(start, s, len);
 }
 
 /**


### PR DESCRIPTION
Three separate problems fixed, at least one of which has caused clients to crash. I will use the server list's sorting functionality (by `sv_hostname`) as the example here since it's the only string with which this function is currently used.

* If a server's name only has white space/special characters, client's stack semi-randomly corrupted, likely causing a segfault or a stack smashing error. **This has happened already**
* Off-by-one `memmove` when server's name is exactly `MAX_SERVER_NAME_LENGTH` long
* Off-by-one buffer write when server's name is exactly `MAX_SERVER_NAME_LENGTH` long and does not have trailing whites space