### PR TITLE
mod: improve vsay commands, refs #2411

### DIFF
--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -2488,7 +2488,7 @@ void G_teamready_cmd(gentity_t *ent, unsigned int dwCommand, int fDump);
 void G_weaponRankings_cmd(gentity_t *ent, unsigned int dwCommand, int state);
 void G_weaponStats_cmd(gentity_t *ent, unsigned int dwCommand, int fDump);
 void G_weaponStatsLeaders_cmd(gentity_t *ent, qboolean doTop, qboolean doWindow);
-void G_VoiceTo(gentity_t *ent, gentity_t *other, int mode, const char *id, qboolean voiceonly, float randomNum);
+void G_VoiceTo(gentity_t *ent, gentity_t *other, int mode, const char *id, qboolean voiceonly, float randomNum, int vsayNum, const char *customChat);
 
 // g_config.c
 qboolean G_configSet(const char *configname);


### PR DESCRIPTION
Improved existing features:
 - Server passes custom vsay message to client instead of using `G_Say`, which helps with log clutter and gives the yellow `:` after the vsayer's name instead of the white one
 - Randomized on the server, so all clients hear the same variant of the vsay
 - Custom messages will work when sent through Lua as well, exact syntax below

Added feature:
 - Clients can choose which variant of the vsay they want to play. Everyone hears the chosen variant.

New syntax for clients:
- `vsay(_team) <vchatNum> <voiceLine> <customMessage>`
- e.g. `vsay 0 cheer ^1Oh YIIISS!` will always play the "Oh yes!" variant of the cheer on Axis, with that cringy custom message in red
- `vsay_buddy <whitelistClass> <numWhitelistClients> <whitelistCno 1> <whitelistCno2> ... <vchatNum> <voiceLine> <customMessage>`, works similarly as above, and the whitelist filters work the same as they did before
- e.g. `vsay_buddy 1 2 5 7 1 fthealme ^6HIIL MIIII` will play the hilarious variant (on Axis) of the `fthealme` vsay to medics in the fireteam if their client number is 5 or 7, with a stupid custom message

New Lua syntax:
- `vchat <voiceOnly> <chattingClient> <voiceLine> <randomNum> <vchatNum> \"<customMessage>\"`
- `vtchat/vbchat <voiceOnly> <chattingClient> <voiceLine> <X> <Y> <Z> <randomNum> <vchatNum> \"<customMessage>\"`
- replace `vchatNum` with -1 and generate a random number in [0,1) for `randomNum` to get a randomized vsay

Lua example snippet:

```lua
et.trap_SendServerCommand(0, "vtchat 0 0 IamMedic 1 1000 1 " .. math.random() .. " -1 \"^gI am medic test\"")
```