### PR TITLE
etmain: Server Browser - Easier to Understand Filters

### DIFF
--- a/etmain/locale/mod/af.po
+++ b/etmain/locale/mod/af.po
@@ -3650,18 +3650,68 @@ msgstr ""
 msgid "Filter Disabled"
 msgstr ""
 
-#: etmain/ui/playonline.menu:115 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
 msgid "Empty only..."
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
 msgstr ""
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648

--- a/etmain/locale/mod/af.po
+++ b/etmain/locale/mod/af.po
@@ -3639,10 +3639,14 @@ msgstr ""
 msgid "Filter affecting servers with map name"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr ""
 

--- a/etmain/locale/mod/af.po
+++ b/etmain/locale/mod/af.po
@@ -3646,11 +3646,11 @@ msgstr ""
 msgid "Filter Disabled"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
+#: etmain/ui/playonline.menu:115 etmain/ui/playonline.menu:125
 #: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
 #: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
 #: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
+msgid "Empty only..."
 msgstr ""
 
 #: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125

--- a/etmain/locale/mod/bg.po
+++ b/etmain/locale/mod/bg.po
@@ -3641,10 +3641,14 @@ msgstr "Показва или скрива от списъка сървъри с
 msgid "Filter affecting servers with map name"
 msgstr "Филтриране сървъри само по избраната карта"
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr "Изключен филтър"
 

--- a/etmain/locale/mod/bg.po
+++ b/etmain/locale/mod/bg.po
@@ -3652,19 +3652,69 @@ msgstr "Филтриране сървъри само по избраната к�
 msgid "Filter Disabled"
 msgstr "Изключен филтър"
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
-msgstr "Показвай само..."
+#: etmain/ui/playonline.menu:115
+msgid "Empty only..."
+msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
-msgstr "Не показвай..."
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
+msgstr ""
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648
 msgid "REFRESH LIST"

--- a/etmain/locale/mod/ca.po
+++ b/etmain/locale/mod/ca.po
@@ -3650,18 +3650,68 @@ msgstr ""
 msgid "Filter Disabled"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
+#: etmain/ui/playonline.menu:115
+msgid "Empty only..."
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
 msgstr ""
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648

--- a/etmain/locale/mod/ca.po
+++ b/etmain/locale/mod/ca.po
@@ -3639,10 +3639,14 @@ msgstr ""
 msgid "Filter affecting servers with map name"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr ""
 

--- a/etmain/locale/mod/cs.po
+++ b/etmain/locale/mod/cs.po
@@ -3656,19 +3656,69 @@ msgstr "Filtruje servery dle zvolené herní úrovně"
 msgid "Filter Disabled"
 msgstr "Filtr vypnut"
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
-msgstr "Zobraz jen..."
+#: etmain/ui/playonline.menu:115
+msgid "Empty only..."
+msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
-msgstr "Nezobrazuj..."
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
+msgstr ""
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648
 msgid "REFRESH LIST"

--- a/etmain/locale/mod/cs.po
+++ b/etmain/locale/mod/cs.po
@@ -3645,10 +3645,14 @@ msgstr "Na seznam zařazuje nebo vyřazuje servery se zvolenou herní úrovní"
 msgid "Filter affecting servers with map name"
 msgstr "Filtruje servery dle zvolené herní úrovně"
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr "Filtr vypnut"
 

--- a/etmain/locale/mod/da.po
+++ b/etmain/locale/mod/da.po
@@ -3650,18 +3650,68 @@ msgstr ""
 msgid "Filter Disabled"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
+#: etmain/ui/playonline.menu:115
+msgid "Empty only..."
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
 msgstr ""
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648

--- a/etmain/locale/mod/da.po
+++ b/etmain/locale/mod/da.po
@@ -3639,10 +3639,14 @@ msgstr ""
 msgid "Filter affecting servers with map name"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr ""
 

--- a/etmain/locale/mod/de.po
+++ b/etmain/locale/mod/de.po
@@ -3647,10 +3647,14 @@ msgstr ""
 msgid "Filter affecting servers with map name"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr "Filter aus"
 

--- a/etmain/locale/mod/de.po
+++ b/etmain/locale/mod/de.po
@@ -3658,19 +3658,69 @@ msgstr ""
 msgid "Filter Disabled"
 msgstr "Filter aus"
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
-msgstr "Zeige nur"
+#: etmain/ui/playonline.menu:115
+msgid "Empty only..."
+msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
-msgstr "Nicht zeigen"
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
+msgstr ""
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648
 msgid "REFRESH LIST"

--- a/etmain/locale/mod/el.po
+++ b/etmain/locale/mod/el.po
@@ -3653,19 +3653,69 @@ msgstr "Φίλτρο επηρεάζουν servers με το όνομά χάρτ�
 msgid "Filter Disabled"
 msgstr "φιλτράρετε με ειδικές ανάγκες"
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
-msgstr "Μόνο δείξει ..."
+#: etmain/ui/playonline.menu:115
+msgid "Empty only..."
+msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
-msgstr "Να μην εμφανίζονται ..."
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
+msgstr ""
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648
 msgid "REFRESH LIST"

--- a/etmain/locale/mod/el.po
+++ b/etmain/locale/mod/el.po
@@ -3642,10 +3642,14 @@ msgstr "Περιλαμβάνει ή εξαιρεί servers με το επιθυ�
 msgid "Filter affecting servers with map name"
 msgstr "Φίλτρο επηρεάζουν servers με το όνομά χάρτη"
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr "φιλτράρετε με ειδικές ανάγκες"
 

--- a/etmain/locale/mod/en.po
+++ b/etmain/locale/mod/en.po
@@ -3650,18 +3650,68 @@ msgstr ""
 msgid "Filter Disabled"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
+#: etmain/ui/playonline.menu:115
+msgid "Empty only..."
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
 msgstr ""
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648

--- a/etmain/locale/mod/en.po
+++ b/etmain/locale/mod/en.po
@@ -3639,10 +3639,14 @@ msgstr ""
 msgid "Filter affecting servers with map name"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr ""
 

--- a/etmain/locale/mod/eo.po
+++ b/etmain/locale/mod/eo.po
@@ -3636,18 +3636,68 @@ msgstr ""
 msgid "Filter Disabled"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
+#: etmain/ui/playonline.menu:115
+msgid "Empty only..."
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
 msgstr ""
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648

--- a/etmain/locale/mod/eo.po
+++ b/etmain/locale/mod/eo.po
@@ -3625,10 +3625,14 @@ msgstr ""
 msgid "Filter affecting servers with map name"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr ""
 

--- a/etmain/locale/mod/es.po
+++ b/etmain/locale/mod/es.po
@@ -3646,26 +3646,80 @@ msgstr "Incluye o excluye servidores con el mapa deseado de la lista de servidor
 msgid "Filter affecting servers with map name"
 msgstr "Filtrando servidores por el nombre del mapa"
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr "Filtro Desactivado"
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
-msgstr "Mostrar sólo..."
+#: etmain/ui/playonline.menu:115
+msgid "Empty only..."
+msgstr "Solo vacía..."
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
-msgstr "No mostrar..."
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr "No vacío..."
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr "Requiere contraseña..."
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr "Sin contraseña..."
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr "Fuego amigo..."
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr "Sin fuego amigo..."
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr "Con vidas máximas..."
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr "Sin vidas máximas..."
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr "Sin límites de armas..."
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr "Límites de armas..."
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr "Con antilag..."
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr "Sin antilag..."
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr "Solo equilibrada ..."
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr "Solo desequilibrada ..."
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr "Con humanos..."
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
+msgstr "Sin humanos..."
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648
 msgid "REFRESH LIST"

--- a/etmain/locale/mod/fi.po
+++ b/etmain/locale/mod/fi.po
@@ -3647,10 +3647,14 @@ msgstr "Näytä tai poista palvelimet joissa on tietty kartta pelissä"
 msgid "Filter affecting servers with map name"
 msgstr "Filtteröi palvelimet kartan nimellä"
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr "Suodatin poistettu käytöstä"
 

--- a/etmain/locale/mod/fi.po
+++ b/etmain/locale/mod/fi.po
@@ -3658,19 +3658,69 @@ msgstr "Filtteröi palvelimet kartan nimellä"
 msgid "Filter Disabled"
 msgstr "Suodatin poistettu käytöstä"
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
-msgstr "Näytä vain..."
+#: etmain/ui/playonline.menu:115
+msgid "Empty only..."
+msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
-msgstr "Älä näytä..."
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
+msgstr ""
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648
 msgid "REFRESH LIST"

--- a/etmain/locale/mod/fr.po
+++ b/etmain/locale/mod/fr.po
@@ -3647,10 +3647,14 @@ msgstr "Inclure ou exclure les serveurs de la liste de serveur avec le nom de la
 msgid "Filter affecting servers with map name"
 msgstr "Filtre affectant les serveurs avec le nom de carte"
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr "Filtre désactivé"
 

--- a/etmain/locale/mod/fr.po
+++ b/etmain/locale/mod/fr.po
@@ -3658,19 +3658,69 @@ msgstr "Filtre affectant les serveurs avec le nom de carte"
 msgid "Filter Disabled"
 msgstr "Filtre désactivé"
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
-msgstr "Montrer uniquement…"
+#: etmain/ui/playonline.menu:115
+msgid "Empty only..."
+msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
-msgstr "Ne pas montrer…"
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
+msgstr ""
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648
 msgid "REFRESH LIST"

--- a/etmain/locale/mod/ga.po
+++ b/etmain/locale/mod/ga.po
@@ -3651,18 +3651,68 @@ msgstr ""
 msgid "Filter Disabled"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
+#: etmain/ui/playonline.menu:115
+msgid "Empty only..."
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
 msgstr ""
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648

--- a/etmain/locale/mod/ga.po
+++ b/etmain/locale/mod/ga.po
@@ -3640,10 +3640,14 @@ msgstr ""
 msgid "Filter affecting servers with map name"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr ""
 

--- a/etmain/locale/mod/he.po
+++ b/etmain/locale/mod/he.po
@@ -3650,18 +3650,68 @@ msgstr ""
 msgid "Filter Disabled"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
+#: etmain/ui/playonline.menu:115
+msgid "Empty only..."
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
 msgstr ""
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648

--- a/etmain/locale/mod/he.po
+++ b/etmain/locale/mod/he.po
@@ -3639,10 +3639,14 @@ msgstr ""
 msgid "Filter affecting servers with map name"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr ""
 

--- a/etmain/locale/mod/hu.po
+++ b/etmain/locale/mod/hu.po
@@ -3652,19 +3652,69 @@ msgstr "Pályanév alapján a szerverekre hatással lévő szűrő"
 msgid "Filter Disabled"
 msgstr "Szűrő kikapcsolva"
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
-msgstr "Csak azokat mutasd..."
+#: etmain/ui/playonline.menu:115
+msgid "Empty only..."
+msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
-msgstr "Ne mutasd..."
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
+msgstr ""
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648
 msgid "REFRESH LIST"

--- a/etmain/locale/mod/hu.po
+++ b/etmain/locale/mod/hu.po
@@ -3641,10 +3641,14 @@ msgstr "Beteszi vagy kiveszi azokat a szervereket, amiken a kiválasztott pálya
 msgid "Filter affecting servers with map name"
 msgstr "Pályanév alapján a szerverekre hatással lévő szűrő"
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr "Szűrő kikapcsolva"
 

--- a/etmain/locale/mod/it.po
+++ b/etmain/locale/mod/it.po
@@ -3651,10 +3651,14 @@ msgstr "Include o esclude dalla lista i server con la mappa specificata"
 msgid "Filter affecting servers with map name"
 msgstr "Filtra i server con la mappa specificata"
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr "Filtro Disabilitato"
 

--- a/etmain/locale/mod/it.po
+++ b/etmain/locale/mod/it.po
@@ -3662,19 +3662,69 @@ msgstr "Filtra i server con la mappa specificata"
 msgid "Filter Disabled"
 msgstr "Filtro Disabilitato"
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
-msgstr "Mostra..."
+#: etmain/ui/playonline.menu:115
+msgid "Empty only..."
+msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
-msgstr "Non mostrare..."
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
+msgstr ""
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648
 msgid "REFRESH LIST"

--- a/etmain/locale/mod/ja.po
+++ b/etmain/locale/mod/ja.po
@@ -3650,18 +3650,68 @@ msgstr ""
 msgid "Filter Disabled"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
+#: etmain/ui/playonline.menu:115
+msgid "Empty only..."
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
 msgstr ""
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648

--- a/etmain/locale/mod/ja.po
+++ b/etmain/locale/mod/ja.po
@@ -3639,10 +3639,14 @@ msgstr ""
 msgid "Filter affecting servers with map name"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr ""
 

--- a/etmain/locale/mod/ko.po
+++ b/etmain/locale/mod/ko.po
@@ -3641,10 +3641,14 @@ msgstr "서버 목록에서 희망하는 맵이 포함된 서버를 포함하거
 msgid "Filter affecting servers with map name"
 msgstr "맵이 포함된 서버로 필터 적용"
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr "필터 끔"
 

--- a/etmain/locale/mod/ko.po
+++ b/etmain/locale/mod/ko.po
@@ -3652,19 +3652,69 @@ msgstr "맵이 포함된 서버로 필터 적용"
 msgid "Filter Disabled"
 msgstr "필터 끔"
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
-msgstr "보이기..."
+#: etmain/ui/playonline.menu:115
+msgid "Empty only..."
+msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
-msgstr "숨기기..."
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
+msgstr ""
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648
 msgid "REFRESH LIST"

--- a/etmain/locale/mod/nl.po
+++ b/etmain/locale/mod/nl.po
@@ -3659,19 +3659,69 @@ msgstr "Filter servers met mapnaam"
 msgid "Filter Disabled"
 msgstr "Filter uitgeschakeld"
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
-msgstr "Toon alleen..."
+#: etmain/ui/playonline.menu:115
+msgid "Empty only..."
+msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
-msgstr "Toon geen..."
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
+msgstr ""
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648
 msgid "REFRESH LIST"

--- a/etmain/locale/mod/nl.po
+++ b/etmain/locale/mod/nl.po
@@ -3648,10 +3648,14 @@ msgstr "Toon of verberg met of zonder deze map"
 msgid "Filter affecting servers with map name"
 msgstr "Filter servers met mapnaam"
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr "Filter uitgeschakeld"
 

--- a/etmain/locale/mod/no.po
+++ b/etmain/locale/mod/no.po
@@ -3651,18 +3651,68 @@ msgstr ""
 msgid "Filter Disabled"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
+#: etmain/ui/playonline.menu:115
+msgid "Empty only..."
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
 msgstr ""
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648

--- a/etmain/locale/mod/no.po
+++ b/etmain/locale/mod/no.po
@@ -3640,10 +3640,14 @@ msgstr ""
 msgid "Filter affecting servers with map name"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr ""
 

--- a/etmain/locale/mod/pa.po
+++ b/etmain/locale/mod/pa.po
@@ -3650,18 +3650,68 @@ msgstr ""
 msgid "Filter Disabled"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
+#: etmain/ui/playonline.menu:115
+msgid "Empty only..."
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
 msgstr ""
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648

--- a/etmain/locale/mod/pa.po
+++ b/etmain/locale/mod/pa.po
@@ -3639,10 +3639,14 @@ msgstr ""
 msgid "Filter affecting servers with map name"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr ""
 

--- a/etmain/locale/mod/pl.po
+++ b/etmain/locale/mod/pl.po
@@ -3657,19 +3657,69 @@ msgstr "Filtr wpływa na serwery z nazwą mapy"
 msgid "Filter Disabled"
 msgstr "Filtr Wyłączony"
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
-msgstr "Pokazuj tylko..."
+#: etmain/ui/playonline.menu:115
+msgid "Empty only..."
+msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
-msgstr "Nie pokazuj..."
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
+msgstr ""
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648
 msgid "REFRESH LIST"

--- a/etmain/locale/mod/pl.po
+++ b/etmain/locale/mod/pl.po
@@ -3646,10 +3646,14 @@ msgstr "Zawiera lub wyklucza serwery z pożądaną nazwą mapy z listy serwerów
 msgid "Filter affecting servers with map name"
 msgstr "Filtr wpływa na serwery z nazwą mapy"
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr "Filtr Wyłączony"
 

--- a/etmain/locale/mod/pt.po
+++ b/etmain/locale/mod/pt.po
@@ -3655,18 +3655,68 @@ msgstr ""
 msgid "Filter Disabled"
 msgstr "Filtro Desativado"
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
+#: etmain/ui/playonline.menu:115
+msgid "Empty only..."
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
 msgstr ""
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648

--- a/etmain/locale/mod/pt.po
+++ b/etmain/locale/mod/pt.po
@@ -3644,10 +3644,14 @@ msgstr ""
 msgid "Filter affecting servers with map name"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr "Filtro Desativado"
 

--- a/etmain/locale/mod/ro.po
+++ b/etmain/locale/mod/ro.po
@@ -3654,18 +3654,68 @@ msgstr ""
 msgid "Filter Disabled"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
+#: etmain/ui/playonline.menu:115
+msgid "Empty only..."
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
 msgstr ""
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648

--- a/etmain/locale/mod/ro.po
+++ b/etmain/locale/mod/ro.po
@@ -3643,10 +3643,14 @@ msgstr ""
 msgid "Filter affecting servers with map name"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr ""
 

--- a/etmain/locale/mod/ru.po
+++ b/etmain/locale/mod/ru.po
@@ -3655,19 +3655,69 @@ msgstr "Фильтр, влияющий на серверы именем карт
 msgid "Filter Disabled"
 msgstr "Фильтр выключен"
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
-msgstr "Только показывать"
+#: etmain/ui/playonline.menu:115
+msgid "Empty only..."
+msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
-msgstr "Не показывать"
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
+msgstr ""
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648
 msgid "REFRESH LIST"

--- a/etmain/locale/mod/ru.po
+++ b/etmain/locale/mod/ru.po
@@ -3644,10 +3644,14 @@ msgstr "Включает или исключает серверы с данны�
 msgid "Filter affecting servers with map name"
 msgstr "Фильтр, влияющий на серверы именем карты"
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr "Фильтр выключен"
 

--- a/etmain/locale/mod/sk.po
+++ b/etmain/locale/mod/sk.po
@@ -3650,18 +3650,68 @@ msgstr ""
 msgid "Filter Disabled"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
+#: etmain/ui/playonline.menu:115
+msgid "Empty only..."
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
 msgstr ""
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648

--- a/etmain/locale/mod/sk.po
+++ b/etmain/locale/mod/sk.po
@@ -3639,10 +3639,14 @@ msgstr ""
 msgid "Filter affecting servers with map name"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr ""
 

--- a/etmain/locale/mod/sl.po
+++ b/etmain/locale/mod/sl.po
@@ -3650,18 +3650,68 @@ msgstr ""
 msgid "Filter Disabled"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
+#: etmain/ui/playonline.menu:115
+msgid "Empty only..."
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
 msgstr ""
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648

--- a/etmain/locale/mod/sl.po
+++ b/etmain/locale/mod/sl.po
@@ -3639,10 +3639,14 @@ msgstr ""
 msgid "Filter affecting servers with map name"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr ""
 

--- a/etmain/locale/mod/sq.po
+++ b/etmain/locale/mod/sq.po
@@ -3650,18 +3650,68 @@ msgstr ""
 msgid "Filter Disabled"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
+#: etmain/ui/playonline.menu:115
+msgid "Empty only..."
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
 msgstr ""
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648

--- a/etmain/locale/mod/sq.po
+++ b/etmain/locale/mod/sq.po
@@ -3639,10 +3639,14 @@ msgstr ""
 msgid "Filter affecting servers with map name"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr ""
 

--- a/etmain/locale/mod/sr.po
+++ b/etmain/locale/mod/sr.po
@@ -3642,10 +3642,14 @@ msgstr "Показује или уклања сервере са датим им
 msgid "Filter affecting servers with map name"
 msgstr "Филтер који утиче на сервере са датим именом мапе"
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr "Филтер искључен"
 

--- a/etmain/locale/mod/sr.po
+++ b/etmain/locale/mod/sr.po
@@ -3653,19 +3653,69 @@ msgstr "Филтер који утиче на сервере са датим и�
 msgid "Filter Disabled"
 msgstr "Филтер искључен"
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
-msgstr "Показати само..."
+#: etmain/ui/playonline.menu:115
+msgid "Empty only..."
+msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
-msgstr "Не показати..."
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
+msgstr ""
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648
 msgid "REFRESH LIST"

--- a/etmain/locale/mod/sv.po
+++ b/etmain/locale/mod/sv.po
@@ -3652,18 +3652,68 @@ msgstr ""
 msgid "Filter Disabled"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
+#: etmain/ui/playonline.menu:115
+msgid "Empty only..."
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
 msgstr ""
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648

--- a/etmain/locale/mod/sv.po
+++ b/etmain/locale/mod/sv.po
@@ -3641,10 +3641,14 @@ msgstr ""
 msgid "Filter affecting servers with map name"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr ""
 

--- a/etmain/locale/mod/tr.po
+++ b/etmain/locale/mod/tr.po
@@ -3651,18 +3651,68 @@ msgstr ""
 msgid "Filter Disabled"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
+#: etmain/ui/playonline.menu:115
+msgid "Empty only..."
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
 msgstr ""
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648

--- a/etmain/locale/mod/tr.po
+++ b/etmain/locale/mod/tr.po
@@ -3640,10 +3640,14 @@ msgstr ""
 msgid "Filter affecting servers with map name"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr ""
 

--- a/etmain/locale/mod/uk.po
+++ b/etmain/locale/mod/uk.po
@@ -3650,18 +3650,68 @@ msgstr ""
 msgid "Filter Disabled"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
+#: etmain/ui/playonline.menu:115
+msgid "Empty only..."
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
 msgstr ""
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648

--- a/etmain/locale/mod/uk.po
+++ b/etmain/locale/mod/uk.po
@@ -3639,10 +3639,14 @@ msgstr ""
 msgid "Filter affecting servers with map name"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr ""
 

--- a/etmain/locale/mod/zh.po
+++ b/etmain/locale/mod/zh.po
@@ -3650,18 +3650,68 @@ msgstr ""
 msgid "Filter Disabled"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Only show..."
+#: etmain/ui/playonline.menu:115
+msgid "Empty only..."
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
-msgid "Don't show..."
+#: etmain/ui/playonline.menu:115
+msgid "Not empty..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "Requires password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:126
+msgid "No password..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "Friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:137
+msgid "No friendly fire..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "With max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:148
+msgid "Without max lives..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "No weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:159
+msgid "Weapon limits..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "With antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:170
+msgid "Without antilag..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Balanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:181
+msgid "Unbalanced only..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "With humans..."
+msgstr ""
+
+#: etmain/ui/playonline.menu:192
+msgid "Without humans..."
 msgstr ""
 
 #: etmain/ui/playonline.menu:194 etmain/ui/playonline.menu:648

--- a/etmain/locale/mod/zh.po
+++ b/etmain/locale/mod/zh.po
@@ -3639,10 +3639,14 @@ msgstr ""
 msgid "Filter affecting servers with map name"
 msgstr ""
 
-#: etmain/ui/playonline.menu:114 etmain/ui/playonline.menu:125
-#: etmain/ui/playonline.menu:136 etmain/ui/playonline.menu:147
-#: etmain/ui/playonline.menu:158 etmain/ui/playonline.menu:169
-#: etmain/ui/playonline.menu:180 etmain/ui/playonline.menu:191
+#: etmain/ui/playonline.menu:115
+#: etmain/ui/playonline.menu:126
+#: etmain/ui/playonline.menu:137
+#: etmain/ui/playonline.menu:148
+#: etmain/ui/playonline.menu:159
+#: etmain/ui/playonline.menu:170
+#: etmain/ui/playonline.menu:181
+#: etmain/ui/playonline.menu:192
 msgid "Filter Disabled"
 msgstr ""
 

--- a/etmain/ui/playonline.menu
+++ b/etmain/ui/playonline.menu
@@ -112,7 +112,7 @@ menuDef {
 		visible		1
 		decoration
 	}
-	TRICHECKBOXACTIONMULTI( 8+.33*(FILTERS_WIDTH-6)+2+2+12, 102, .34*(FILTERS_WIDTH-6)-18, 10, .2, 8, "ui_browserShowEmptyOrFull", cvarFloatList { "Filter Disabled" 0 "Only show..." 1 "Don't show..." 2 }, uiScript RefreshFilter ; setcvar ui_filterdescription "Filter affecting Empty and Full Servers", "Include or exclude empty and full servers from the server list"  )
+	TRICHECKBOXACTIONMULTI( 8+.33*(FILTERS_WIDTH-6)+2+2+12, 102, .34*(FILTERS_WIDTH-6)-18, 10, .2, 8, "ui_browserShowEmptyOrFull", cvarFloatList { "Filter Disabled" 0 "Empty only..." 1 "Not empty..." 2 }, uiScript RefreshFilter ; setcvar ui_filterdescription "Filter affecting Empty and Full Servers", "Include or exclude empty and full servers from the server list"  )
 
 	itemDef {
 		name		"filtericonPassword"
@@ -123,7 +123,7 @@ menuDef {
 		visible		1
 		decoration
 	}
-	TRICHECKBOXACTIONMULTI( 8+.33*(FILTERS_WIDTH-6)+2+2+12, 114, .34*(FILTERS_WIDTH-6)-18, 10, .2, 8, "ui_browserShowPasswordProtected", cvarFloatList { "Filter Disabled" 0 "Only show..." 1 "Don't show..." 2 }, uiScript RefreshFilter ; setcvar ui_filterdescription "Filter affecting Password Protected Servers", "Include or exclude password protected servers from the server list" )
+	TRICHECKBOXACTIONMULTI( 8+.33*(FILTERS_WIDTH-6)+2+2+12, 114, .34*(FILTERS_WIDTH-6)-18, 10, .2, 8, "ui_browserShowPasswordProtected", cvarFloatList { "Filter Disabled" 0 "Requires password..." 1 "No password..." 2 }, uiScript RefreshFilter ; setcvar ui_filterdescription "Filter affecting Password Protected Servers", "Include or exclude password protected servers from the server list" )
 
 	itemDef {
 		name		"filtericonFriendlyFire"
@@ -134,7 +134,7 @@ menuDef {
 		visible		1
 		decoration
 	}
-	TRICHECKBOXACTIONMULTI( 8+.33*(FILTERS_WIDTH-6)+2+2+12, 126, .34*(FILTERS_WIDTH-6)-18, 10, .2, 8, "ui_browserShowFriendlyFire", cvarFloatList { "Filter Disabled" 0 "Only show..." 1 "Don't show..." 2 }, uiScript RefreshFilter ; setcvar ui_filterdescription "Filter affecting Servers with Friendly Fire", "Include or exclude servers where team mates can damage each other from the server list"  )
+	TRICHECKBOXACTIONMULTI( 8+.33*(FILTERS_WIDTH-6)+2+2+12, 126, .34*(FILTERS_WIDTH-6)-18, 10, .2, 8, "ui_browserShowFriendlyFire", cvarFloatList { "Filter Disabled" 0 "Friendly fire..." 1 "No friendly fire..." 2 }, uiScript RefreshFilter ; setcvar ui_filterdescription "Filter affecting Servers with Friendly Fire", "Include or exclude servers where team mates can damage each other from the server list"  )
 
 	itemDef {
 		name		"filtericonMaxLives"
@@ -145,7 +145,7 @@ menuDef {
 		visible		1
 		decoration
 	}
-	TRICHECKBOXACTIONMULTI( 8+.33*(FILTERS_WIDTH-6)+2+2+12, 138, .34*(FILTERS_WIDTH-6)-18, 10, .2, 8, "ui_browserShowMaxlives", cvarFloatList { "Filter Disabled" 0 "Only show..." 1 "Don't show..." 2 }, uiScript RefreshFilter ; setcvar ui_filterdescription "Filter affecting Servers with Max Lives", "Include or exclude servers that limit the number of player lives per match from the server list" )
+	TRICHECKBOXACTIONMULTI( 8+.33*(FILTERS_WIDTH-6)+2+2+12, 138, .34*(FILTERS_WIDTH-6)-18, 10, .2, 8, "ui_browserShowMaxlives", cvarFloatList { "Filter Disabled" 0 "With max lives..." 1 "Without max lives..." 2 }, uiScript RefreshFilter ; setcvar ui_filterdescription "Filter affecting Servers with Max Lives", "Include or exclude servers that limit the number of player lives per match from the server list" )
 
 	itemDef {
 		name		"filtericonWeapRestrict"
@@ -156,7 +156,7 @@ menuDef {
 		visible		1
 		decoration
 	}
-	TRICHECKBOXACTIONMULTI( 8+.67*(FILTERS_WIDTH-6)+2+2+12, 102, .33*(FILTERS_WIDTH-6)-18, 10, .2, 8, "ui_browserShowWeaponsRestricted", cvarFloatList { "Filter Disabled" 0 "Only show..." 1 "Don't show..." 2 }, uiScript RefreshFilter ; setcvar ui_filterdescription "Filter affecting Servers with Weapon Restrictions", "Include or exclude servers that limit the number of\n available heavy weapons from the server list" )
+	TRICHECKBOXACTIONMULTI( 8+.67*(FILTERS_WIDTH-6)+2+2+12, 102, .33*(FILTERS_WIDTH-6)-18, 10, .2, 8, "ui_browserShowWeaponsRestricted", cvarFloatList { "Filter Disabled" 0 "No weapon limits..." 1 "Weapon limits..." 2 }, uiScript RefreshFilter ; setcvar ui_filterdescription "Filter affecting Servers with Weapon Restrictions", "Include or exclude servers that limit the number of\n available heavy weapons from the server list" )
 
 	itemDef {
 		name		"filtericonAntilag"
@@ -167,7 +167,7 @@ menuDef {
 		visible		1
 		decoration
 	}
-	TRICHECKBOXACTIONMULTI( 8+.67*(FILTERS_WIDTH-6)+2+2+12, 114, .33*(FILTERS_WIDTH-6)-18, 10, .2, 8, "ui_browserShowAntilag", cvarFloatList { "Filter Disabled" 0 "Only show..." 1 "Don't show..." 2 }, uiScript RefreshFilter ; setcvar ui_filterdescription "Filter affecting Anti-Lag Servers", "Include or exclude servers with anti-lag support from the server list" )
+	TRICHECKBOXACTIONMULTI( 8+.67*(FILTERS_WIDTH-6)+2+2+12, 114, .33*(FILTERS_WIDTH-6)-18, 10, .2, 8, "ui_browserShowAntilag", cvarFloatList { "Filter Disabled" 0 "With antilag..." 1 "Without antilag..." 2 }, uiScript RefreshFilter ; setcvar ui_filterdescription "Filter affecting Anti-Lag Servers", "Include or exclude servers with anti-lag support from the server list" )
 
 	itemDef {
 		name		"filtericonTeamBalance"
@@ -178,7 +178,7 @@ menuDef {
 		visible		1
 		decoration
 	}
-	TRICHECKBOXACTIONMULTI( 8+.67*(FILTERS_WIDTH-6)+2+2+12, 126, .33*(FILTERS_WIDTH-6)-18, 10, .2, 8, "ui_browserShowTeamBalanced", cvarFloatList { "Filter Disabled" 0 "Only show..." 1 "Don't show..." 2 }, uiScript RefreshFilter ; setcvar ui_filterdescription "Filter affecting Servers with Force Team Balance", "Include or exclude servers that enforce balanced teams from the server list" )
+	TRICHECKBOXACTIONMULTI( 8+.67*(FILTERS_WIDTH-6)+2+2+12, 126, .33*(FILTERS_WIDTH-6)-18, 10, .2, 8, "ui_browserShowTeamBalanced", cvarFloatList { "Filter Disabled" 0 "Balanced only..." 1 "Unbalanced only..." 2 }, uiScript RefreshFilter ; setcvar ui_filterdescription "Filter affecting Servers with Force Team Balance", "Include or exclude servers that enforce balanced teams from the server list" )
 
 	itemDef {
 		name		"filtericonBots"
@@ -189,7 +189,7 @@ menuDef {
 		visible		1
 		decoration
 	}
-	TRICHECKBOXACTIONMULTI( 8+.67*(FILTERS_WIDTH-6)+2+2+12, 138, .33*(FILTERS_WIDTH-6)-18, 10, .2, 8, "ui_browserShowHumans", cvarFloatList { "Filter Disabled" 0 "Only show..." 1 "Don't show..." 2 }, uiScript RefreshFilter ; setcvar ui_filterdescription "Filter affecting ET: Legacy Servers with Humans players", "Include or exclude ET: Legacy servers with humans from the server list" )
+	TRICHECKBOXACTIONMULTI( 8+.67*(FILTERS_WIDTH-6)+2+2+12, 138, .33*(FILTERS_WIDTH-6)-18, 10, .2, 8, "ui_browserShowHumans", cvarFloatList { "Filter Disabled" 0 "With humans..." 1 "Without humans..." 2 }, uiScript RefreshFilter ; setcvar ui_filterdescription "Filter affecting ET: Legacy Servers with Humans players", "Include or exclude ET: Legacy servers with humans from the server list" )
 
 	/*
 	itemDef {


### PR DESCRIPTION
Demo video:

https://www.youtube.com/watch?v=HErivAFFd_8

Instead of just showing "include only" or "exclude only", we can show much better short descriptions that still fit fine.

Refs https://github.com/etlegacy/etlegacy/issues/2381

Verified the filters against the vars from the servers for correctness.