### PR TITLE
Fixes vote abuse by joining server with one player, calling vote, and leaving.

### DIFF
--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -3497,6 +3497,17 @@ void ClientDisconnect(int clientNum)
 
 	CalculateRanks();
 
+    // disconnecting does not trigger vote cancel due to team switch in checkVote
+    // note: after CalculateRanks so level.numConnectedClients is up-to-date
+    if (level.voteInfo.voteTime && level.voteInfo.voteCaller == clientNum) {
+        AP(va("cpm \"^1Vote CANCELED! Caller disconnected\n\""));
+        G_LogPrintf("Vote canceled: %s (caller %s disconnected)\n",
+                    level.voteInfo.voteString, ent->client->pers.netname);
+        level.voteInfo.voteTime = 0;
+        level.voteInfo.voteCanceled = 1;
+        trap_SetConfigstring(CS_VOTE_TIME, ""); // so the counter goes away
+    }
+
 	G_verifyMatchState((team_t)i);
 #ifdef FEATURE_MULTIVIEW
 	G_smvAllRemoveSingleClient(ent - g_entities);

--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -3497,8 +3497,6 @@ void ClientDisconnect(int clientNum)
 
 	CalculateRanks();
 
-    // disconnecting does not trigger vote cancel due to team switch in checkVote
-    // note: after CalculateRanks so level.numConnectedClients is up-to-date
     if (level.voteInfo.voteTime && level.voteInfo.voteCaller == clientNum) {
         AP(va("cpm \"^1Vote CANCELED! Caller disconnected\n\""));
         G_LogPrintf("Vote canceled: %s (caller %s disconnected)\n",

--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -3300,6 +3300,17 @@ void ClientSpawn(gentity_t *ent, qboolean revived, qboolean teamChange, qboolean
 	{
 		G_ResetTeamMapData();
 	}
+
+    if (teamChange) {
+        if (level.voteInfo.voteTime && level.voteInfo.voteCaller == index) {
+            AP(va("cpm \"^1Vote CANCELED! Caller switched team\n\""));
+            G_LogPrintf("Vote canceled: %s (caller %s switched team)\n",
+                        level.voteInfo.voteString, ent->client->pers.netname);
+            level.voteInfo.voteTime = 0;
+            level.voteInfo.voteCanceled = 1;
+            trap_SetConfigstring(CS_VOTE_TIME, ""); // so the counter goes away
+        }
+    }
 }
 
 /**

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -4664,21 +4664,6 @@ void CheckVote(void)
 
 		if (level.voteInfo.voteYes > threshold || level.voteInfo.votePassed)
 		{
-            if (!level.voteInfo.votePassed && level.voteInfo.voteYes == 1) {
-                // Scenario: two players - one calls vote and then leaves.
-                // Check if they left, so that the vote does not get passed by calling a vote
-                // and then immediately leaving :)
-                gentity_t *ent = &g_entities[level.voteInfo.voteCaller];
-
-                // client will still be valid for one frame after disconnect, so we have to check inuse too.
-                if (!ent->client || !ent->inuse)
-                {
-                    // Important that we cancel the vote or else it will pass once someone joins, and we re-use
-                    // the g_entity object.
-                    level.voteInfo.voteCanceled = 1;
-                    return;
-                }
-            }
 			// execute the command, then remove the vote
 			if (level.voteInfo.voteYes > total + 1)
 			{

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -4670,6 +4670,7 @@ void CheckVote(void)
                 // and then immediately leaving :)
                 gentity_t *ent = &g_entities[level.voteInfo.voteCaller];
 
+                // client will still be valid for one frame after disconnect, so we have to check inuse too.
                 if (!ent->client || !ent->inuse)
                 {
                     // Important that we cancel the vote or else it will pass once someone joins, and we re-use

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -4664,6 +4664,20 @@ void CheckVote(void)
 
 		if (level.voteInfo.voteYes > threshold || level.voteInfo.votePassed)
 		{
+            if (!level.voteInfo.votePassed && level.voteInfo.voteYes == 1) {
+                // Scenario: two players - one calls vote and then leaves.
+                // Check if they left, so that the vote does not get passed by calling a vote
+                // and then immediately leaving :)
+                gentity_t *ent = &g_entities[level.voteInfo.voteCaller];
+
+                if (!ent->client || !ent->inuse)
+                {
+                    // Important that we cancel the vote or else it will pass once someone joins, and we re-use
+                    // the g_entity object.
+                    level.voteInfo.voteCanceled = 1;
+                    return;
+                }
+            }
 			// execute the command, then remove the vote
 			if (level.voteInfo.voteYes > total + 1)
 			{


### PR DESCRIPTION
Fixes #2454

![Screenshot from 2024-01-10 18-11-00](https://github.com/etlegacy/etlegacy/assets/1733933/6ebb8438-955b-4798-aa63-0e0be99762b2)
![Screenshot from 2024-01-10 19-29-04](https://github.com/etlegacy/etlegacy/assets/1733933/0d0a6a7d-1d50-44a1-a2f8-a0e2d224d43d)


Previously the vote would pass once you leave, if there is only one other player.
Now it will cancel.
