### PR TITLE
server: add possibility for etlded to act as a client (ettv), refs #229

### DIFF
--- a/src/game/g_public.h
+++ b/src/game/g_public.h
@@ -43,49 +43,6 @@
 typedef qboolean (*addToSnapshotCallback)(int entityNum, int clientNum);
 
 /**
-  * @struct entityShared_s
-  * @brief entityShared_t
-  *
-  * @warning Don't add or remove fields to keep 2.60 compatibility
-  */
-typedef struct
-{
-	qboolean linked;                ///< qfalse if not in any good cluster
-	int linkcount;
-
-	int svFlags;                    ///<  SVF_NOCLIENT, SVF_BROADCAST, etc
-	int singleClient;               ///<  only send to this client when SVF_SINGLECLIENT is set
-
-	qboolean bmodel;                ///<  if false, assume an explicit mins / maxs bounding box
-	///<  only set by trap_SetBrushModel
-	vec3_t mins, maxs;
-	int contents;                   ///<  CONTENTS_TRIGGER, CONTENTS_SOLID, CONTENTS_BODY, etc
-	///<  a non-solid entity should set to 0
-
-	vec3_t absmin, absmax;          ///<  derived from mins/maxs and origin + rotation
-
-	/// currentOrigin will be used for all collision detection and world linking.
-	/// it will not necessarily be the same as the trajectory evaluation for the current
-	/// time, because each entity must be moved one at a time after time is advanced
-	/// to avoid simultanious collision issues
-	///
-	vec3_t currentOrigin;
-	vec3_t currentAngles;
-
-	/// when a trace call is made and passEntityNum != ENTITYNUM_NONE,
-	/// an ent will be excluded from testing if:
-	/// ent->s.number == passEntityNum   (don't interact with self)
-	/// ent->s.ownerNum = passEntityNum  (don't interact with your own missiles)
-	/// entity[ent->s.ownerNum].ownerNum = passEntityNum (don't interact with other missiles from owner)
-	int ownerNum;
-	int eventTime;
-
-	int worldflags;
-
-	qboolean snapshotCallback;
-} entityShared_t;
-
-/**
   @struct sharedEntity_t
   @brief The server looks at a sharedEntity, which is the start of the game's gentity_t structure
   */
@@ -263,6 +220,8 @@ typedef enum
 
 	G_SENDMESSAGE = 585,
 	G_MESSAGESTATUS,
+
+	G_ETLTV_GETPLAYERSTATE = 600,
 
 	///< engine extensions padding
 	G_TRAP_GETVALUE = COM_TRAP_GETVALUE,

--- a/src/null/null_client.c
+++ b/src/null/null_client.c
@@ -78,14 +78,14 @@ void CL_Frame(int msec)
 {
 }
 
-/**
- * @brief CL_PacketEvent
- * @param from - unused
- * @param msg  - unused
- */
-void CL_PacketEvent(netadr_t from, msg_t *msg)
-{
-}
+///**
+// * @brief CL_PacketEvent
+// * @param from - unused
+// * @param msg  - unused
+// */
+//void CL_PacketEvent(netadr_t from, msg_t *msg)
+//{
+//}
 
 /**
  * @brief CL_CharEvent
@@ -189,12 +189,12 @@ qboolean CL_ConnectedToServer(void)
 	return qfalse;
 }
 
-/**
- * @brief CL_FlushMemory
- */
-void CL_FlushMemory(void)
-{
-}
+///**
+// * @brief CL_FlushMemory
+// */
+//void CL_FlushMemory(void)
+//{
+//}
 
 /**
  * @brief CL_StartHunkUsers

--- a/src/null/null_client.c
+++ b/src/null/null_client.c
@@ -78,15 +78,6 @@ void CL_Frame(int msec)
 {
 }
 
-///**
-// * @brief CL_PacketEvent
-// * @param from - unused
-// * @param msg  - unused
-// */
-//void CL_PacketEvent(netadr_t from, msg_t *msg)
-//{
-//}
-
 /**
  * @brief CL_CharEvent
  * @param key - unused
@@ -188,13 +179,6 @@ qboolean CL_ConnectedToServer(void)
 {
 	return qfalse;
 }
-
-///**
-// * @brief CL_FlushMemory
-// */
-//void CL_FlushMemory(void)
-//{
-//}
 
 /**
  * @brief CL_StartHunkUsers

--- a/src/qcommon/cmd.c
+++ b/src/qcommon/cmd.c
@@ -577,6 +577,22 @@ void Cmd_Args_Sanitize(void)
 }
 
 /**
+ * @brief Creates a single token string.
+ * @param[in] text_in
+ */
+void Cmd_SingleTokenString(const char *text_in)
+{
+	// clear previous args
+	cmd_argc = 0;
+	if (text_in)
+	{
+		Q_strncpyz(cmd_cmd, text_in, sizeof(cmd_cmd));
+		cmd_argv[0] = &cmd_cmd;
+	}
+	cmd_argc = text_in != NULL;
+}
+
+/**
  * @brief Parses the given string into command line tokens.
  *
  * @details The text is copied to a separate buffer and 0 characters

--- a/src/qcommon/cmd.c
+++ b/src/qcommon/cmd.c
@@ -587,7 +587,7 @@ void Cmd_SingleTokenString(const char *text_in)
 	if (text_in)
 	{
 		Q_strncpyz(cmd_cmd, text_in, sizeof(cmd_cmd));
-		cmd_argv[0] = &cmd_cmd;
+		cmd_argv[0] = cmd_cmd;
 	}
 	cmd_argc = text_in != NULL;
 }

--- a/src/qcommon/common.c
+++ b/src/qcommon/common.c
@@ -3538,7 +3538,7 @@ void Com_Frame(void)
 
 #ifdef DEDICATED
 	// watchdog
-	Com_WatchDog();
+	//Com_WatchDog();
 #endif
 
 	// report timing information

--- a/src/qcommon/common.c
+++ b/src/qcommon/common.c
@@ -3538,7 +3538,7 @@ void Com_Frame(void)
 
 #ifdef DEDICATED
 	// watchdog
-	//Com_WatchDog();
+	Com_WatchDog();
 #endif
 
 	// report timing information

--- a/src/qcommon/msg.c
+++ b/src/qcommon/msg.c
@@ -1649,7 +1649,7 @@ netField_t ettventitySharedFields[] =
 };
 
 /**
-* @brief MSG_ETTV_WriteDeltaSharedEntity
+* @brief MSG_ETTV_WriteDeltaEntityShared
 * @details Appends part of a packetentities message with entityShared_t, without the entity number.
 *          Can delta from either a baseline or a previous packet_entity.
 * @param[out] msg
@@ -1657,7 +1657,7 @@ netField_t ettventitySharedFields[] =
 * @param[in] to
 * @param[in] force
 */
-void MSG_ETTV_WriteDeltaSharedEntity(msg_t *msg, entityShared_t *from, entityShared_t *to, qboolean force)
+void MSG_ETTV_WriteDeltaEntityShared(msg_t *msg, entityShared_t *from, entityShared_t *to, qboolean force)
 {
 	int        i, lc;
 	int        numFields;
@@ -1817,7 +1817,7 @@ void MSG_ETTV_ReadDeltaEntityShared(msg_t *msg, entityShared_t *from, entityShar
 	}
 
 	numFields = sizeof(ettventitySharedFields) / sizeof(ettventitySharedFields[0]);
-	lc = MSG_ReadByte(msg);
+	lc        = MSG_ReadByte(msg);
 
 	if (lc > numFields || lc < 0)
 	{
@@ -1827,7 +1827,7 @@ void MSG_ETTV_ReadDeltaEntityShared(msg_t *msg, entityShared_t *from, entityShar
 	for (i = 0, field = ettventitySharedFields; i < lc; i++, field++)
 	{
 		fromF = (int *)((byte *)from + field->offset);
-		toF = (int *)((byte *)to + field->offset);
+		toF   = (int *)((byte *)to + field->offset);
 
 		if (!MSG_ReadBits(msg, 1))
 		{
@@ -1850,7 +1850,7 @@ void MSG_ETTV_ReadDeltaEntityShared(msg_t *msg, entityShared_t *from, entityShar
 						// integral float
 						trunc = MSG_ReadBits(msg, FLOAT_INT_BITS);
 						// bias to allow equal parts positive and negative
-						trunc -= FLOAT_INT_BIAS;
+						trunc        -= FLOAT_INT_BIAS;
 						*(float *)toF = trunc;
 					}
 					else
@@ -1878,7 +1878,7 @@ void MSG_ETTV_ReadDeltaEntityShared(msg_t *msg, entityShared_t *from, entityShar
 	for (i = lc, field = &ettventitySharedFields[lc]; i < numFields; i++, field++)
 	{
 		fromF = (int *)((byte *)from + field->offset);
-		toF = (int *)((byte *)to + field->offset);
+		toF   = (int *)((byte *)to + field->offset);
 		// no change
 		*toF = *fromF;
 	}

--- a/src/qcommon/msg.c
+++ b/src/qcommon/msg.c
@@ -1657,7 +1657,7 @@ netField_t ettventitySharedFields[] =
 * @param[in] to
 * @param[in] force
 */
-void MSG_ETTV_WriteDeltaSharedEntity(msg_t *msg, void *from, void *to, qboolean force)
+void MSG_ETTV_WriteDeltaSharedEntity(msg_t *msg, entityShared_t *from, entityShared_t *to, qboolean force)
 {
 	int        i, lc;
 	int        numFields;
@@ -1781,13 +1781,12 @@ void MSG_ETTV_WriteDeltaSharedEntity(msg_t *msg, void *from, void *to, qboolean 
 }
 
 /**
-* @brief MSG_ETTV_ReadDeltaSharedEntity unused
+* @brief MSG_ETTV_ReadDeltaEntityShared
 * @param[in] msg
 * @param[in] from
 * @param[in] to
 */
-/*
-void MSG_ETTV_ReadDeltaSharedEntity(msg_t *msg, void *from, void *to)
+void MSG_ETTV_ReadDeltaEntityShared(msg_t *msg, entityShared_t *from, entityShared_t *to)
 {
 	int        i, lc;
 	int        numFields;
@@ -1800,7 +1799,7 @@ void MSG_ETTV_ReadDeltaSharedEntity(msg_t *msg, void *from, void *to)
 	magic = MSG_ReadBits(msg, 8);
 	if (magic != 0x77)
 	{
-		Com_Error(ERR_DROP, "MSG_ETTV_ReadDeltaSharedEntity: wrong magic byte 0x%x", magic);
+		Com_Error(ERR_DROP, "MSG_ETTV_ReadDeltaEntityShared: wrong magic byte 0x%x", magic);
 	}
 
 	// check for a remove
@@ -1813,7 +1812,7 @@ void MSG_ETTV_ReadDeltaSharedEntity(msg_t *msg, void *from, void *to)
 	// check for no delta
 	if (MSG_ReadBits(msg, 1) == 0)
 	{
-		*(entityShared_t *)to = *(entityShared_t *)from;
+		*to = *from;
 		return;
 	}
 
@@ -1883,7 +1882,7 @@ void MSG_ETTV_ReadDeltaSharedEntity(msg_t *msg, void *from, void *to)
 		// no change
 		*toF = *fromF;
 	}
-}*/
+}
 
 /**
  * @brief MSG_WriteDeltaSharedEntity

--- a/src/qcommon/q_shared.h
+++ b/src/qcommon/q_shared.h
@@ -1716,6 +1716,49 @@ typedef struct entityState_s
 } entityState_t;
 
 /**
+  * @struct entityShared_s
+  * @brief entityShared_t
+  *
+  * @warning Don't add or remove fields to keep 2.60 compatibility
+  */
+typedef struct
+{
+	qboolean linked;                ///< qfalse if not in any good cluster
+	int linkcount;
+
+	int svFlags;                    ///<  SVF_NOCLIENT, SVF_BROADCAST, etc
+	int singleClient;               ///<  only send to this client when SVF_SINGLECLIENT is set
+
+	qboolean bmodel;                ///<  if false, assume an explicit mins / maxs bounding box
+	///<  only set by trap_SetBrushModel
+	vec3_t mins, maxs;
+	int contents;                   ///<  CONTENTS_TRIGGER, CONTENTS_SOLID, CONTENTS_BODY, etc
+	///<  a non-solid entity should set to 0
+
+	vec3_t absmin, absmax;          ///<  derived from mins/maxs and origin + rotation
+
+	/// currentOrigin will be used for all collision detection and world linking.
+	/// it will not necessarily be the same as the trajectory evaluation for the current
+	/// time, because each entity must be moved one at a time after time is advanced
+	/// to avoid simultanious collision issues
+	///
+	vec3_t currentOrigin;
+	vec3_t currentAngles;
+
+	/// when a trace call is made and passEntityNum != ENTITYNUM_NONE,
+	/// an ent will be excluded from testing if:
+	/// ent->s.number == passEntityNum   (don't interact with self)
+	/// ent->s.ownerNum = passEntityNum  (don't interact with your own missiles)
+	/// entity[ent->s.ownerNum].ownerNum = passEntityNum (don't interact with other missiles from owner)
+	int ownerNum;
+	int eventTime;
+
+	int worldflags;
+
+	qboolean snapshotCallback;
+} entityShared_t;
+
+/**
  * @enum connstate_t
  * @brief
  */
@@ -1956,7 +1999,7 @@ typedef struct userAgent_s
 */
 typedef struct ettvClientSnapshot_s
 {
-	qboolean valid;    ///< is the playerstate valid for delta compression
+	qboolean valid;    ///< is the playerstate valid
 	playerState_t ps;
 } ettvClientSnapshot_t;
 

--- a/src/qcommon/q_shared.h
+++ b/src/qcommon/q_shared.h
@@ -85,6 +85,7 @@
 
 #define DEMOEXT "dm_"          ///< standard demo extension
 #define SVDEMOEXT "sv_"        ///< standard server demo extension
+#define SVCLDEMOEXT "tv_"      ///< ettv server demo extension
 
 #define MAX_MASTER_SERVERS 5   ///< number of supported master servers
 

--- a/src/qcommon/qcommon.h
+++ b/src/qcommon/qcommon.h
@@ -435,7 +435,8 @@ enum svc_ops_e
 	svc_download,               ///< [short] size [size bytes]
 	svc_snapshot,
 	svc_EOF,
-	svc_ettv_playerstates
+	svc_ettv_playerstates,
+	svc_ettv_currentstate
 };
 
 /**

--- a/src/qcommon/qcommon.h
+++ b/src/qcommon/qcommon.h
@@ -122,8 +122,8 @@ void MSG_ReadDeltaPlayerstate(msg_t *msg, struct playerState_s *from, struct pla
 
 void MSG_ReportChangeVectors_f(void);
 
-void MSG_ETTV_WriteDeltaSharedEntity(msg_t *msg, void *from, void *to, qboolean force);
-//void MSG_ETTV_ReadDeltaSharedEntity(msg_t *msg, void *from, void *to);
+void MSG_ETTV_WriteDeltaSharedEntity(msg_t *msg, entityShared_t *from, entityShared_t *to, qboolean force);
+void MSG_ETTV_ReadDeltaEntityShared(msg_t *msg, entityShared_t *from, entityShared_t *to);
 
 /**
 ==============================================================
@@ -631,6 +631,8 @@ void Cmd_TokenizeStringIncludeComments(const char *text);
 /// Parses a single line of text into arguments and tries to execute it
 /// as if it was typed at the console
 void Cmd_ExecuteString(const char *text);
+
+void Cmd_SingleTokenString(const char *text_in);
 
 /*
 ==============================================================

--- a/src/qcommon/qcommon.h
+++ b/src/qcommon/qcommon.h
@@ -1296,6 +1296,7 @@ void SV_PacketEvent(netadr_t from, msg_t *msg);
 qboolean SV_GameCommand(void);
 int SV_FrameMsec();
 int SV_SendQueuedPackets();
+void SV_CheckTimeouts(void);
 
 // UI interface
 

--- a/src/qcommon/qcommon.h
+++ b/src/qcommon/qcommon.h
@@ -122,7 +122,7 @@ void MSG_ReadDeltaPlayerstate(msg_t *msg, struct playerState_s *from, struct pla
 
 void MSG_ReportChangeVectors_f(void);
 
-void MSG_ETTV_WriteDeltaSharedEntity(msg_t *msg, entityShared_t *from, entityShared_t *to, qboolean force);
+void MSG_ETTV_WriteDeltaEntityShared(msg_t *msg, entityShared_t *from, entityShared_t *to, qboolean force);
 void MSG_ETTV_ReadDeltaEntityShared(msg_t *msg, entityShared_t *from, entityShared_t *to);
 
 /**

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -699,4 +699,244 @@ qboolean SV_Netchan_Process(client_t *client, msg_t *msg);
 #define DLNOTIFY_BEGIN      0x00000002  ///< "clientDownload: 4 : beginning ..."
 #define DLNOTIFY_ALL        (DLNOTIFY_REDIRECT | DLNOTIFY_BEGIN)
 
+/**
+ * @struct clientStatic_t
+ * @brief the clientStatic_t structure is never wiped, and is used even when
+ * no client connection is active at all
+ *
+ * A connection can be to either a server through the network layer or a
+ * demo through a file.
+ */
+typedef struct
+{
+	connstate_t state;               ///< connection status
+	challengeState_t challengeState; ///< challenge status
+
+	char servername[MAX_OSPATH];     ///< name of server from original connect (used by reconnect)
+
+	int framecount;
+	int frametime;                  ///< msec since last frame
+
+	int realtime;                   ///< ignores pause
+
+	qboolean isTVGame;
+
+} svclientStatic_t;
+
+extern svclientStatic_t svcls;
+
+/**
+ * @struct clientConnection_t
+ * @brief The clientConnection_t structure is wiped when disconnecting from a server,
+ * either to go to a full screen console, play a demo, or connect to a different server
+ *
+ * A connection can be to either a server through the network layer or a
+ * demo through a file.
+ */
+typedef struct
+{
+	connstate_t state;                          ///< connection status
+
+	int clientNum;
+	int lastPacketSentTime;                     ///< for retransmits during connection
+	int lastPacketTime;                         ///< for timeouts
+
+	netadr_t serverAddress;
+	int connectTime;                            ///< for connection retransmits
+	int connectPacketCount;                     ///< for display on connection dialog
+	char serverMessage[MAX_STRING_TOKENS];      ///< for display on connection dialog
+
+	char serverMasterPassword[MAX_STRING_TOKENS];
+
+	int challenge;                              ///< from the server to use for connecting
+	int checksumFeed;                           ///< from the server for checksum calculations
+
+	int onlyVisibleClients;
+
+	// these are our reliable messages that go to the server
+	int reliableSequence;
+	int reliableAcknowledge;                    ///< the last one the server has executed
+	/// NOTE: incidentally, reliableCommands[0] is never used (always start at reliableAcknowledge+1)
+	char reliableCommands[MAX_RELIABLE_COMMANDS][MAX_TOKEN_CHARS];
+
+	// unreliable binary data to send to server
+	int binaryMessageLength;
+	char binaryMessage[MAX_BINARY_MESSAGE];
+	qboolean binaryMessageOverflowed;
+
+	/// server message (unreliable) and command (reliable) sequence
+	/// numbers are NOT cleared at level changes, but continue to
+	/// increase as long as the connection is valid
+
+	/// message sequence is used by both the network layer and the
+	/// delta compression layer
+	int serverMessageSequence;
+
+	// reliable messages received from server
+	int serverCommandSequence;
+	int lastExecutedServerCommand;              ///< last server command grabbed or executed with CL_GetServerCommand
+	char serverCommands[MAX_RELIABLE_COMMANDS][MAX_TOKEN_CHARS];
+
+	// demo information
+	//demo_t demo;
+
+	userAgent_t agent;                          ///< holds server engine information
+
+	/// big stuff at end of structure so most offsets are 15 bits or less
+	netchan_t netchan;
+
+} svclientConnection_t;
+
+extern svclientConnection_t svclc;
+
+/**
+ * @struct clSnapshot_t
+ * @brief Snapshots are a view of the server at a given time
+ */
+typedef struct
+{
+	qboolean valid;                     ///< cleared if delta parsing was invalid
+	int snapFlags;                      ///< rate delayed and dropped commands
+
+	int serverTime;                     ///< server time the message is valid for (in msec)
+
+	int messageNum;                     ///< copied from netchan->incoming_sequence
+	int deltaNum;                       ///< messageNum the delta is from
+	int ping;                           ///< time from when cmdNum-1 was sent to time packet was reeceived
+	byte areamask[MAX_MAP_AREA_BYTES];  ///< portalarea visibility bits
+
+	int cmdNum;                         ///< the next cmdNum the server is expecting
+	playerState_t ps;                   ///< complete information about the current player at this time
+
+	int numEntities;                    ///< all of the entities that need to be presented
+	int parseEntitiesNum;               ///< at the time of this snapshot
+
+	int serverCommandNum;               ///< execute all commands up to this before
+										///< making the snapshot current
+
+	ettvClientSnapshot_t playerstates[MAX_CLIENTS];
+
+} svclSnapshot_t;
+
+/**
+ * @struct outPacket_t
+ * @brief
+ */
+typedef struct
+{
+	int p_cmdNumber;            ///< cl.cmdNumber when packet was sent
+	int p_serverTime;           ///< usercmd->serverTime when packet was sent
+	int p_realtime;             ///< cls.realtime when packet was sent
+} svoutPacket_t;
+
+#define MAX_PARSE_ENTITIES  2048
+#define CMD_BACKUP          64
+#define CMD_MASK            (CMD_BACKUP - 1)
+
+/**
+ * @struct clientActive_t
+ * @brief The clientActive_t structure is wiped completely at every
+ * new gamestate_t, potentially several times during an established connection
+ */
+typedef struct
+{
+	int timeoutcount;                       ///< it requres several frames in a timeout condition
+											///< to disconnect, preventing debugging breaks from
+											///< causing immediate disconnects on continue
+	svclSnapshot_t snap;                      ///< latest received from server
+
+	int serverTime;                         ///< may be paused during play
+	int oldServerTime;                      ///< to prevent time from flowing bakcwards
+	int oldFrameServerTime;                 ///< to check tournament restarts
+	int serverTimeDelta;                    ///< cl.serverTime = cls.realtime + cl.serverTimeDelta
+											///  this value changes as net lag varies
+	int baselineDelta;                      ///< initial or reset value of serverTimeDelta w/o adjustments
+	qboolean extrapolatedSnapshot;          ///< set if any cgame frame has been forced to extrapolate
+											///< cleared when CL_AdjustTimeDelta looks at it
+	qboolean newSnapshots;                  ///< set on parse of any valid packet
+
+	gameState_t gameState;                  ///< configstrings
+	char mapname[MAX_QPATH];                ///< extracted from CS_SERVERINFO
+
+	int parseEntitiesNum;                   ///< index (not anded off) into cl_parse_entities[]
+
+	int mouseDx[2], mouseDy[2];             ///< added to by mouse events
+	int mouseIndex;
+	int joystickAxis[MAX_JOYSTICK_AXIS];    ///< set by joystick events
+
+	// cgame communicates a few values to the client system
+	int cgameUserCmdValue;                  ///< current weapon to add to usercmd_t
+	int cgameFlags;                         ///< flags that can be set by the gamecode
+	float cgameSensitivity;
+	int cgameMpIdentClient;
+	vec3_t cgameClientLerpOrigin;
+
+	/// cmds[cmdNumber] is the predicted command, [cmdNumber-1] is the last
+	/// properly generated command
+	usercmd_t cmds[CMD_BACKUP];             ///< each mesage will send several old cmds
+	int cmdNumber;                          ///< incremented each frame, because multiple
+											///< frames may need to be packed into a single packet
+
+	/// double tapping
+	//doubleTap_t doubleTap;
+
+	svoutPacket_t outPackets[PACKET_BACKUP];  ///< information about each packet we have sent out
+
+	/// the client maintains its own idea of view angles, which are
+	/// sent to the server each frame.  It is cleared to 0 upon entering each level.
+	/// the server sends a delta each frame which is added to the locally
+	/// tracked view angles to account for standing on rotating objects,
+	/// and teleport direction changes
+	vec3_t viewangles;
+
+	int serverId;                           ///< included in each client message so the server
+											///< can tell if it is for a prior map_restart
+											///< big stuff at end of structure so most offsets are 15 bits or less
+	svclSnapshot_t snapshots[PACKET_BACKUP];
+
+	entityState_t entityBaselines[MAX_GENTITIES];   ///< for delta compression when not in previous frame
+	entityShared_t entitySharedBaselines[MAX_GENTITIES];
+
+	entityState_t parseEntities[MAX_PARSE_ENTITIES];
+	entityShared_t parseEntitiesShared[MAX_PARSE_ENTITIES];
+
+} svclientActive_t;
+
+extern svclientActive_t svcl;
+
+// sv_cl_main.c
+void SV_CL_Commands_f(void);
+void SV_CL_CheckForResend(void);
+void SV_CL_Disconnect(void);
+void SV_CL_AddReliableCommand(const char *cmd);
+void SV_CL_WritePacket(void);
+void SV_CL_ClearState(void);
+void SV_CL_DownloadsComplete(void);
+void SV_CL_SendPureChecksums(void);
+void SV_CL_InitTVGame(void);
+qboolean SV_CL_GetServerCommand(int serverCommandNumber);
+void SV_CL_ConfigstringModified(void);
+
+int SV_CL_GetPlayerstate(int clientNum, playerState_t *ps);
+
+void SV_CL_ConnectionlessPacket(netadr_t from, msg_t *msg);
+void SV_CL_ServerInfoPacketCheck(netadr_t from, msg_t *msg);
+void SV_CL_ServerInfoPacket(netadr_t from, msg_t *msg);
+
+
+// sv_cl_net_chan.c
+void SV_CL_Netchan_Transmit(netchan_t *chan, msg_t *msg);
+void SV_CL_Netchan_TransmitNextFragment(netchan_t *chan);
+qboolean SV_CL_Netchan_Process(netchan_t *chan, msg_t *msg);
+
+// sv_cl_parse.c
+void SV_CL_ParseServerMessage(msg_t *msg);
+void SV_CL_ParseGamestate(msg_t *msg);
+void SV_CL_ParseCommandString(msg_t *msg);
+void SV_CL_ParseSnapshot(msg_t *msg);
+void SV_CL_ParsePacketEntities(msg_t *msg, svclSnapshot_t *oldframe, svclSnapshot_t *newframe);
+void SV_CL_DeltaEntity(msg_t *msg, svclSnapshot_t *frame, int newnum, entityState_t *old, entityShared_t *oldShared, qboolean unchanged);
+void SV_CL_ParsePlayerstates(msg_t *msg);
+void SV_CL_SystemInfoChanged(void);
+
 #endif // #ifndef INCLUDE_SERVER_H

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -704,8 +704,8 @@ qboolean SV_Netchan_Process(client_t *client, msg_t *msg);
 #define SV_CL_MAXPACKETS 40
 
 /**
- * @struct clientStatic_t
- * @brief the clientStatic_t structure is never wiped, and is used even when
+ * @struct svclientStatic_t
+ * @brief the svclientStatic_t structure is never wiped, and is used even when
  * no client connection is active at all
  *
  * A connection can be to either a server through the network layer or a
@@ -751,8 +751,8 @@ typedef struct
 } svcldemo_t;
 
 /**
- * @struct clientConnection_t
- * @brief The clientConnection_t structure is wiped when disconnecting from a server,
+ * @struct svclientConnection_t
+ * @brief The svclientConnection_t structure is wiped when disconnecting from a server,
  * either to go to a full screen console, play a demo, or connect to a different server
  *
  * A connection can be to either a server through the network layer or a
@@ -815,7 +815,7 @@ typedef struct
 extern svclientConnection_t svclc;
 
 /**
- * @struct clSnapshot_t
+ * @struct svclSnapshot_t
  * @brief Snapshots are a view of the server at a given time
  */
 typedef struct
@@ -844,7 +844,7 @@ typedef struct
 } svclSnapshot_t;
 
 /**
- * @struct outPacket_t
+ * @struct svoutPacket_t
  * @brief
  */
 typedef struct
@@ -859,8 +859,8 @@ typedef struct
 #define CMD_MASK            (CMD_BACKUP - 1)
 
 /**
- * @struct clientActive_t
- * @brief The clientActive_t structure is wiped completely at every
+ * @struct svclientActive_t
+ * @brief The svclientActive_t structure is wiped completely at every
  * new gamestate_t, potentially several times during an established connection
  */
 typedef struct
@@ -959,7 +959,6 @@ void SV_CL_SystemInfoChanged(void);
 
 // sv_cl_demo.c
 void SV_CL_DemoInit(void);
-
 void SV_CL_Record(const char *name);
 void SV_CL_StopRecord_f(void);
 void SV_CL_WriteDemoMessage(msg_t *msg, int headerBytes);

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -387,7 +387,7 @@ typedef struct
 	int numSnapshotEntities;                    ///< sv_maxclients->integer*PACKET_BACKUP*MAX_PACKET_ENTITIES
 	int nextSnapshotEntities;                   ///< next snapshotEntities to use
 	entityState_t *snapshotEntities;            ///< [numSnapshotEntities]
-	entityShared_t *snapshotSharedEntities;
+	entityShared_t *snapshotEntitiesShared;
 	int nextHeartbeatTime;
 	challenge_t challenges[MAX_CHALLENGES];     ///< to prevent invalid IPs from connecting
 	receipt_t infoReceipts[MAX_INFO_RECEIPTS];
@@ -703,6 +703,8 @@ qboolean SV_Netchan_Process(client_t *client, msg_t *msg);
 
 //============================ TV server client ============================
 
+#ifdef DEDICATED
+
 #define SV_CL_MAXPACKETS 40
 
 /**
@@ -896,9 +898,6 @@ typedef struct
 	int cmdNumber;                          ///< incremented each frame, because multiple
 	                                        ///< frames may need to be packed into a single packet
 
-	/// double tapping
-	//doubleTap_t doubleTap;
-
 	svoutPacket_t outPackets[PACKET_BACKUP];  ///< information about each packet we have sent out
 
 	/// the client maintains its own idea of view angles, which are
@@ -914,7 +913,7 @@ typedef struct
 	svclSnapshot_t snapshots[PACKET_BACKUP];
 
 	entityState_t entityBaselines[MAX_GENTITIES];   ///< for delta compression when not in previous frame
-	entityShared_t entitySharedBaselines[MAX_GENTITIES];
+	entityShared_t entityBaselinesShared[MAX_GENTITIES];
 
 	entityState_t currentStateEntities[MAX_GENTITIES];
 	entityShared_t currentStateEntitiesShared[MAX_GENTITIES];
@@ -974,6 +973,8 @@ void SV_CL_ReadDemoMessage(void);
 void SV_CL_DemoCompleted(void);
 void SV_CL_DemoCleanUp(void);
 void SV_CL_NextDemo(void);
+
+#endif // DEDICATED
 
 //============================================================
 

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -723,7 +723,8 @@ typedef struct
 
 	int realtime;                   ///< ignores pause
 
-	int lastFrameTime;
+	int lastRunFrameTime;
+	int lastRunFrameSysTime;
 
 	qboolean isTVGame;
 
@@ -910,6 +911,9 @@ typedef struct
 
 	entityState_t entityBaselines[MAX_GENTITIES];   ///< for delta compression when not in previous frame
 	entityShared_t entitySharedBaselines[MAX_GENTITIES];
+
+	entityState_t currentStateEntities[MAX_GENTITIES];
+	entityShared_t currentStateEntitiesShared[MAX_GENTITIES];
 
 	entityState_t parseEntities[MAX_PARSE_ENTITIES];
 	entityShared_t parseEntitiesShared[MAX_PARSE_ENTITIES];

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -502,6 +502,8 @@ extern cvar_t *sv_serverTimeReset;
 
 extern cvar_t *sv_etltv_maxslaves;
 extern cvar_t *sv_etltv_password;
+extern cvar_t *sv_etltv_autorecord;
+extern cvar_t *sv_etltv_autoplay;
 
 //===========================================================
 
@@ -749,6 +751,8 @@ typedef struct
 	int timeFrames;                         ///< counter of rendered frames
 	int timeStart;                          ///< cls.realtime before first frame
 	int timeBaseTime;                       ///< each frame will be at this time + frameNum * 50
+
+	int fastForwardTime;
 } svcldemo_t;
 
 /**

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -504,6 +504,7 @@ extern cvar_t *sv_etltv_maxslaves;
 extern cvar_t *sv_etltv_password;
 extern cvar_t *sv_etltv_autorecord;
 extern cvar_t *sv_etltv_autoplay;
+extern cvar_t *sv_etltv_clientname;
 
 //===========================================================
 

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -860,17 +860,6 @@ typedef struct
 
 	int parseEntitiesNum;                   ///< index (not anded off) into cl_parse_entities[]
 
-	int mouseDx[2], mouseDy[2];             ///< added to by mouse events
-	int mouseIndex;
-	int joystickAxis[MAX_JOYSTICK_AXIS];    ///< set by joystick events
-
-	// cgame communicates a few values to the client system
-	int cgameUserCmdValue;                  ///< current weapon to add to usercmd_t
-	int cgameFlags;                         ///< flags that can be set by the gamecode
-	float cgameSensitivity;
-	int cgameMpIdentClient;
-	vec3_t cgameClientLerpOrigin;
-
 	/// cmds[cmdNumber] is the predicted command, [cmdNumber-1] is the last
 	/// properly generated command
 	usercmd_t cmds[CMD_BACKUP];             ///< each mesage will send several old cmds
@@ -922,7 +911,6 @@ int SV_CL_GetPlayerstate(int clientNum, playerState_t *ps);
 void SV_CL_ConnectionlessPacket(netadr_t from, msg_t *msg);
 void SV_CL_ServerInfoPacketCheck(netadr_t from, msg_t *msg);
 void SV_CL_ServerInfoPacket(netadr_t from, msg_t *msg);
-
 
 // sv_cl_net_chan.c
 void SV_CL_Netchan_Transmit(netchan_t *chan, msg_t *msg);

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -699,6 +699,10 @@ qboolean SV_Netchan_Process(client_t *client, msg_t *msg);
 #define DLNOTIFY_BEGIN      0x00000002  ///< "clientDownload: 4 : beginning ..."
 #define DLNOTIFY_ALL        (DLNOTIFY_REDIRECT | DLNOTIFY_BEGIN)
 
+//============================ TV server client ============================
+
+#define SV_CL_MAXPACKETS 40
+
 /**
  * @struct clientStatic_t
  * @brief the clientStatic_t structure is never wiped, and is used even when
@@ -920,6 +924,7 @@ void SV_CL_CheckForResend(void);
 void SV_CL_Disconnect(void);
 void SV_CL_AddReliableCommand(const char *cmd);
 void SV_CL_WritePacket(void);
+qboolean SV_CL_ReadyToSendPacket(void);
 void SV_CL_ClearState(void);
 void SV_CL_DownloadsComplete(void);
 void SV_CL_SendPureChecksums(void);
@@ -929,7 +934,8 @@ void SV_CL_ConfigstringModified(void);
 char *SV_CL_Cvar_InfoString(char *cs, int index);
 
 int SV_CL_GetPlayerstate(int clientNum, playerState_t *ps);
-void SV_CL_Frame(void);
+void SV_CL_Frame(int frameMsec);
+void SV_CL_RunFrame(void);
 
 void SV_CL_ConnectionlessPacket(netadr_t from, msg_t *msg);
 void SV_CL_ServerInfoPacketCheck(netadr_t from, msg_t *msg);
@@ -961,5 +967,7 @@ void SV_CL_ReadDemoMessage(void);
 void SV_CL_DemoCompleted(void);
 void SV_CL_DemoCleanUp(void);
 void SV_CL_NextDemo(void);
+
+//============================================================
 
 #endif // #ifndef INCLUDE_SERVER_H

--- a/src/server/sv_ccmds.c
+++ b/src/server/sv_ccmds.c
@@ -745,6 +745,9 @@ void SV_AddOperatorCommands(void)
 	Cmd_AddCommand("devmap", SV_Map_f, "Loads a specific map in developer mode.", SV_CompleteMapName);
 	Cmd_AddCommand("killserver", SV_KillServer_f, "Kills the server.");
 	Cmd_AddCommand("cleartempbans", SV_TempBanClear_f, "Clears the temporary ban list.");
+	Cmd_AddCommand("tv", SV_CL_Commands_f, "Kills the server.");
+	//Cmd_AddCommand("tv", TV_Commands_f, "tv commands.");
+
 	if (com_dedicated->integer)
 	{
 		Cmd_AddCommand("say", SV_ConSay_f, "Prints console messages on dedicated servers.");

--- a/src/server/sv_ccmds.c
+++ b/src/server/sv_ccmds.c
@@ -745,8 +745,7 @@ void SV_AddOperatorCommands(void)
 	Cmd_AddCommand("devmap", SV_Map_f, "Loads a specific map in developer mode.", SV_CompleteMapName);
 	Cmd_AddCommand("killserver", SV_KillServer_f, "Kills the server.");
 	Cmd_AddCommand("cleartempbans", SV_TempBanClear_f, "Clears the temporary ban list.");
-	Cmd_AddCommand("tv", SV_CL_Commands_f, "Kills the server.");
-	//Cmd_AddCommand("tv", TV_Commands_f, "tv commands.");
+	Cmd_AddCommand("tv", SV_CL_Commands_f, "tv commands.");
 
 	if (com_dedicated->integer)
 	{

--- a/src/server/sv_ccmds.c
+++ b/src/server/sv_ccmds.c
@@ -267,6 +267,13 @@ static void SV_MapRestart_f(void)
 		return;
 	}
 
+#ifdef DEDICATED
+	if (svclc.demo.playing)
+	{
+		svclc.demo.fastForwardTime = 0;
+	}
+#endif // DEDICATED
+
 	if (Cmd_Argc() > 1)
 	{
 		delay = Q_atoi(Cmd_Argv(1));
@@ -429,7 +436,7 @@ void SV_TempBan(client_t *client, int length)
 			if (slot == -1 || oldesttime > svs.tempBans[i].endtime)
 			{
 				oldesttime = svs.tempBans[i].endtime;
-				slot     = i;
+				slot       = i;
 			}
 		}
 	}

--- a/src/server/sv_ccmds.c
+++ b/src/server/sv_ccmds.c
@@ -745,7 +745,10 @@ void SV_AddOperatorCommands(void)
 	Cmd_AddCommand("devmap", SV_Map_f, "Loads a specific map in developer mode.", SV_CompleteMapName);
 	Cmd_AddCommand("killserver", SV_KillServer_f, "Kills the server.");
 	Cmd_AddCommand("cleartempbans", SV_TempBanClear_f, "Clears the temporary ban list.");
+
+#ifdef DEDICATED
 	Cmd_AddCommand("tv", SV_CL_Commands_f, "tv commands.");
+#endif
 
 	if (com_dedicated->integer)
 	{
@@ -761,6 +764,10 @@ void SV_AddOperatorCommands(void)
 #endif
 
 	SV_DemoInit();
+
+#ifdef DEDICATED
+	SV_CL_DemoInit();
+#endif
 }
 
 /**

--- a/src/server/sv_cl_demo.c
+++ b/src/server/sv_cl_demo.c
@@ -34,6 +34,8 @@
 
 #include "server.h"
 
+#ifdef DEDICATED
+
 /**
   * @brief Dumps the current net message, prefixed by the length
   * @param[in] msg
@@ -184,14 +186,14 @@ void SV_CL_Record(const char *name)
 	for (i = 0; i < MAX_GENTITIES; i++)
 	{
 		ent       = &svcl.entityBaselines[i];
-		entShared = &svcl.entitySharedBaselines[i];
+		entShared = &svcl.entityBaselinesShared[i];
 		if (!ent->number)
 		{
 			continue;
 		}
 		MSG_WriteByte(&buf, svc_baseline);
 		MSG_WriteDeltaEntity(&buf, &nullstate, ent, qtrue);
-		MSG_ETTV_WriteDeltaSharedEntity(&buf, &nullstateShared, entShared, qtrue);
+		MSG_ETTV_WriteDeltaEntityShared(&buf, &nullstateShared, entShared, qtrue);
 	}
 
 	// current states
@@ -203,7 +205,7 @@ void SV_CL_Record(const char *name)
 		{
 			MSG_WriteByte(&buf, svc_ettv_currentstate);
 			MSG_WriteDeltaEntity(&buf, &svcl.entityBaselines[i], &svent->s, qtrue);
-			MSG_ETTV_WriteDeltaSharedEntity(&buf, &svcl.entitySharedBaselines[i], &svent->r, qtrue);
+			MSG_ETTV_WriteDeltaEntityShared(&buf, &svcl.entityBaselinesShared[i], &svent->r, qtrue);
 		}
 	}
 
@@ -481,3 +483,5 @@ void SV_CL_DemoInit(void)
 	Cmd_AddCommand("ff", SV_CL_FastForward_f);
 	Cmd_SetCommandCompletionFunc("demo", SV_CL_CompleteDemoName);
 }
+
+#endif // DEDICATED

--- a/src/server/sv_cl_demo.c
+++ b/src/server/sv_cl_demo.c
@@ -1,0 +1,555 @@
+/*
+ * Wolfenstein: Enemy Territory GPL Source Code
+ * Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company.
+ *
+ * ET: Legacy
+ * Copyright (C) 2012-2024 ET:Legacy team <mail@etlegacy.com>
+ *
+ * This file is part of ET: Legacy - http://www.etlegacy.com
+ *
+ * ET: Legacy is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ET: Legacy is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ET: Legacy. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * In addition, Wolfenstein: Enemy Territory GPL Source Code is also
+ * subject to certain additional terms. You should have received a copy
+ * of these additional terms immediately following the terms and conditions
+ * of the GNU General Public License which accompanied the source code.
+ * If not, please request a copy in writing from id Software at the address below.
+ *
+ * id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, Maryland 20850 USA.
+ */
+/**
+ * @file sv_cl_demo.c
+ */
+
+#include "server.h"
+
+/**
+  * @brief Dumps the current net message, prefixed by the length
+  * @param[in] msg
+  * @param[in] headerBytes
+  */
+void SV_CL_WriteDemoMessage(msg_t *msg, int headerBytes)
+{
+	int len, swlen;
+
+	// write the packet sequence
+	len   = svclc.serverMessageSequence;
+	swlen = LittleLong(len);
+	(void)FS_Write(&swlen, 4, svclc.demo.file);
+
+	// skip the packet sequencing information
+	len   = msg->cursize - headerBytes;
+	swlen = LittleLong(len);
+	(void)FS_Write(&swlen, 4, svclc.demo.file);
+	(void)FS_Write(msg->data + headerBytes, len, svclc.demo.file);
+}
+
+/**
+  * @brief SV_CL_DemoFilename
+  * @param[in] number
+  * @param[in] fileName
+  */
+void SV_CL_DemoFilename(int number, char *fileName)
+{
+	if (number < 0 || number > 9999)
+	{
+		Com_sprintf(fileName, MAX_OSPATH, "demo9999");
+		return;
+	}
+
+	Com_sprintf(fileName, MAX_OSPATH, "demo%04i", number);
+}
+
+static char demoName[MAX_OSPATH];        // compiler bug workaround
+
+void SV_CL_Record_f(void)
+{
+	char name[MAX_OSPATH];
+	char *s;
+
+	if (Cmd_Argc() > 2)
+	{
+		Com_Printf("record <demoname>\n");
+		return;
+	}
+
+	if (svclc.demo.recording)
+	{
+		Com_Printf("Already recording.\n");
+		return;
+	}
+
+	if (svcls.state != CA_ACTIVE)
+	{
+		Com_Printf("You must be in a level to record.\n");
+		return;
+	}
+
+	if (Cmd_Argc() == 2)
+	{
+		s = Cmd_Argv(1);
+		Q_strncpyz(demoName, s, sizeof(demoName));
+		Com_sprintf(name, sizeof(name), "svdemos/%s.%s%d", demoName, SVCLDEMOEXT, ETTV_PROTOCOL_VERSION);
+	}
+	else
+	{
+		int number, len;
+
+		// scan for a free demo name
+		for (number = 0; number <= 9999; number++)
+		{
+			SV_CL_DemoFilename(number, demoName);
+			Com_sprintf(name, sizeof(name), "svdemos/%s.%s%d", demoName, SVCLDEMOEXT, ETTV_PROTOCOL_VERSION);
+
+			len = FS_ReadFile(name, NULL);
+			if (len <= 0)
+			{
+				break;  // file doesn't exist
+			}
+		}
+	}
+
+	SV_CL_Record(name);
+}
+
+/**
+ * @brief SV_CL_Record
+ * @param[in] name
+ */
+void SV_CL_Record(const char *name)
+{
+	int            i;
+	msg_t          buf;
+	byte           bufData[MAX_MSGLEN];
+	entityState_t  *ent;
+	entityState_t  nullstate;
+	entityShared_t *entShared;
+	entityShared_t nullstateShared;
+	sharedEntity_t *svent;
+	char           *s;
+	int            len;
+
+	// open the demo file
+	Com_Printf("Recording to %s.\n", name);
+	svclc.demo.file = FS_FOpenFileWrite(name);
+	if (!svclc.demo.file)
+	{
+		Com_Printf("ERROR: couldn't open.\n");
+		return;
+	}
+
+	svclc.demo.recording = qtrue;
+	Q_strncpyz(svclc.demo.demoName, demoName, sizeof(svclc.demo.demoName));
+
+	// don't start saving messages until a non-delta compressed message is received
+	svclc.demo.waiting = qtrue;
+
+	// write out the gamestate message
+	MSG_Init(&buf, bufData, sizeof(bufData));
+	MSG_Bitstream(&buf);
+
+	// NOTE: all server->client messages now acknowledge
+	MSG_WriteLong(&buf, svclc.reliableSequence);
+
+	MSG_WriteByte(&buf, svc_gamestate);
+	MSG_WriteLong(&buf, svclc.serverCommandSequence);
+
+	// configstrings
+	for (i = 0; i < MAX_CONFIGSTRINGS; i++)
+	{
+		if (!svcl.gameState.stringOffsets[i])
+		{
+			continue;
+		}
+		s = svcl.gameState.stringData + svcl.gameState.stringOffsets[i];
+		MSG_WriteByte(&buf, svc_configstring);
+		MSG_WriteShort(&buf, i);
+		MSG_WriteBigString(&buf, s);
+	}
+
+	// baselines
+	Com_Memset(&nullstate, 0, sizeof(nullstate));
+	Com_Memset(&nullstateShared, 0, sizeof(nullstateShared));
+	for (i = 0; i < MAX_GENTITIES; i++)
+	{
+		ent       = &svcl.entityBaselines[i];
+		entShared = &svcl.entitySharedBaselines[i];
+		if (!ent->number)
+		{
+			continue;
+		}
+		MSG_WriteByte(&buf, svc_baseline);
+		MSG_WriteDeltaEntity(&buf, &nullstate, ent, qtrue);
+		MSG_ETTV_WriteDeltaSharedEntity(&buf, &nullstateShared, entShared, qtrue);
+	}
+
+	// current states
+	for (i = 0; i < MAX_GENTITIES; i++)
+	{
+		svent = SV_GentityNum(i);
+
+		if (svent->r.linked)
+		{
+			MSG_WriteByte(&buf, svc_ettv_currentstate);
+			MSG_WriteDeltaEntity(&buf, &svcl.entityBaselines[i], &svent->s, qtrue);
+			MSG_ETTV_WriteDeltaSharedEntity(&buf, &svcl.entitySharedBaselines[i], &svent->r, qtrue);
+		}
+	}
+
+	MSG_WriteByte(&buf, svc_EOF);
+
+	// finished writing the gamestate stuff
+
+	// write the client num
+	MSG_WriteLong(&buf, svclc.clientNum);
+	// write the checksum feed
+	MSG_WriteLong(&buf, svclc.checksumFeed);
+
+	// finished writing the client packet
+	MSG_WriteByte(&buf, svc_EOF);
+
+	// write it to the demo file
+	len = LittleLong(svclc.serverMessageSequence - 1);
+	(void)FS_Write(&len, 4, svclc.demo.file);
+
+	len = LittleLong(buf.cursize);
+	(void)FS_Write(&len, 4, svclc.demo.file);
+	(void)FS_Write(buf.data, buf.cursize, svclc.demo.file);
+
+	// the rest of the demo file will be copied from net messages
+}
+
+void SV_CL_StopRecord_f(void)
+{
+	int len;
+
+	if (!svclc.demo.recording)
+	{
+		Com_Printf("Not recording a demo.\n");
+		return;
+	}
+
+	// finish up
+	len = -1;
+	(void)FS_Write(&len, 4, svclc.demo.file);
+	(void)FS_Write(&len, 4, svclc.demo.file);
+	FS_FCloseFile(svclc.demo.file);
+	svclc.demo.file = 0;
+
+	svclc.demo.recording = qfalse;
+	Com_Printf("Stopped demo.\n");
+}
+
+/**
+ * @brief Called when a demo or cinematic finishes
+ * If the "nextdemo" cvar is set, that command will be issued
+ */
+void SV_CL_NextDemo(void)
+{
+	char v[MAX_STRING_CHARS];
+
+	Q_strncpyz(v, Cvar_VariableString("nextdemo"), sizeof(v));
+	v[MAX_STRING_CHARS - 1] = 0;
+	Com_Printf("SV_CL_NextDemo: %s\n", v);
+	if (!v[0])
+	{
+		return;
+	}
+
+	Cvar_Set("nextdemo", "");
+	Cbuf_AddText(v);
+	Cbuf_AddText("\n");
+	Cbuf_Execute();
+}
+
+/**
+ * @brief SV_CL_DemoCleanUp
+ */
+void SV_CL_DemoCleanUp(void)
+{
+	if (svclc.demo.file)
+	{
+		FS_FCloseFile(svclc.demo.file);
+		svclc.demo.file = 0;
+	}
+}
+
+/**
+ * @brief SV_CL_DemoCompleted
+ */
+void SV_CL_DemoCompleted(void)
+{
+	//if (cl_timedemo && cl_timedemo->integer)
+	//{
+	//	int time;
+
+	//	time = Sys_Milliseconds() - clc.demo.timeStart;
+	//	if (time > 0)
+	//	{
+	//		Com_FuncPrinf("%i frames, %3.1f seconds: %3.1f fps\n", clc.demo.timeFrames,
+	//			time / 1000.0, clc.demo.timeFrames * 1000.0 / time);
+	//	}
+	//}
+
+	Com_Printf("etltv: demo completed\n");
+
+	SV_CL_Disconnect();
+	SV_CL_NextDemo();
+}
+
+/**
+ * @brief SV_CL_ReadDemoMessage
+ */
+void SV_CL_ReadDemoMessage(void)
+{
+	int   r;
+	msg_t buf;
+	byte  bufData[MAX_MSGLEN];
+	int   s;
+
+	if (!svclc.demo.file)
+	{
+		SV_CL_DemoCompleted();
+		return;
+	}
+
+	// get the sequence number
+	r = FS_Read(&s, 4, svclc.demo.file);
+	if (r != 4)
+	{
+		SV_CL_DemoCompleted();
+		return;
+	}
+
+	svclc.serverMessageSequence = LittleLong(s);
+
+	// init the message
+	MSG_Init(&buf, bufData, sizeof(bufData));
+
+	// get the length
+	r = FS_Read(&buf.cursize, 4, svclc.demo.file);
+
+	if (r != 4)
+	{
+		SV_CL_DemoCompleted();
+		return;
+	}
+	buf.cursize = LittleLong(buf.cursize);
+	if (buf.cursize == -1)
+	{
+		SV_CL_DemoCompleted();
+		return;
+	}
+
+	if (buf.cursize > buf.maxsize)
+	{
+		Com_Error(ERR_DROP, "demoMsglen > MAX_MSGLEN");
+	}
+
+	r = FS_Read(buf.data, buf.cursize, svclc.demo.file);
+	if (r != buf.cursize)
+	{
+		Com_Printf("Demo file was truncated.\n");
+		SV_CL_DemoCompleted();
+		return;
+	}
+
+	svclc.lastPacketTime = svcls.realtime;
+	buf.readcount        = 0;
+	SV_CL_ParseServerMessage(&buf);
+}
+
+/**
+ * @brief SV_CL_WalkDemoExt
+ * @param[in] arg
+ * @param[in,out] name
+ * @param[in,out] demofile
+ * @return
+ */
+static int SV_CL_WalkDemoExt(const char *arg, char *name, fileHandle_t *demofile)
+{
+	int i = 0;
+	*demofile = 0;
+
+	Com_sprintf(name, MAX_OSPATH, "svdemos/%s.%s%d", arg, SVCLDEMOEXT, PROTOCOL_VERSION);
+	FS_FOpenFileRead(name, demofile, qtrue);
+
+	if (*demofile)
+	{
+		Com_Printf("Demo file: %s\n", name);
+		return PROTOCOL_VERSION;
+	}
+
+	Com_Printf("Not found: %s\n", name);
+
+	while (demo_protocols[i])
+	{
+		if (demo_protocols[i] == PROTOCOL_VERSION)
+		{
+			continue;
+		}
+
+		Com_sprintf(name, MAX_OSPATH, "svdemos/%s.%s%d", arg, SVCLDEMOEXT, demo_protocols[i]);
+		FS_FOpenFileRead(name, demofile, qtrue);
+		if (*demofile)
+		{
+			Com_Printf("Demo file: %s\n", name);
+			return demo_protocols[i];
+		}
+		else
+		{
+			Com_Printf("Not found: %s\n", name);
+		}
+		i++;
+	}
+
+	return -1;
+}
+
+void SV_CL_PlayDemo_f(void)
+{
+	char name[MAX_OSPATH], retry[MAX_OSPATH];
+	char *demoFile, *ext_test;
+	int  protocol, i;
+
+	if (Cmd_Argc() < 2)
+	{
+		Com_Printf("demo <demoname>\n");
+		return;
+	}
+
+	SV_CL_Disconnect();
+
+	// open the demo file (should be the last arg)
+	demoFile = Cmd_Argv(Cmd_Argc() - 1);
+	// check for an extension .DEMOEXT_?? (?? is protocol)
+	ext_test = strrchr(demoFile, '.');
+
+	if (ext_test && !Q_stricmpn(ext_test + 1, SVCLDEMOEXT, ARRAY_LEN(SVCLDEMOEXT) - 1))
+	{
+		protocol = Q_atoi(ext_test + ARRAY_LEN(SVCLDEMOEXT));
+
+		for (i = 0; demo_protocols[i]; i++)
+		{
+			if (demo_protocols[i] == protocol)
+			{
+				break;
+			}
+		}
+
+		if (demo_protocols[i] || protocol == PROTOCOL_VERSION)
+		{
+			if (Sys_PathAbsolute(demoFile))
+			{
+				char *nameOnly = strrchr(demoFile, '/');
+				FS_FOpenFileReadFullDir(demoFile, &svclc.demo.file);
+
+				if (nameOnly)
+				{
+					demoFile = nameOnly + 1;
+				}
+			}
+			else
+			{
+				Com_sprintf(name, sizeof(name), "svdemos/%s", demoFile);
+				FS_FOpenFileRead(name, &svclc.demo.file, qtrue);
+			}
+		}
+		else
+		{
+			size_t len;
+
+			Com_Printf("Protocol %d not supported for demos\n", protocol);
+			len = ext_test - demoFile;
+
+			if (len >= ARRAY_LEN(retry))
+			{
+				len = ARRAY_LEN(retry) - 1;
+			}
+
+			Q_strncpyz(retry, demoFile, len + 1);
+			retry[len] = '\0';
+			protocol   = SV_CL_WalkDemoExt(retry, name, &svclc.demo.file);
+		}
+	}
+	else
+	{
+		protocol = SV_CL_WalkDemoExt(demoFile, name, &svclc.demo.file);
+	}
+
+	if (!svclc.demo.file)
+	{
+		Com_Error(ERR_DROP, "couldn't open %s", name);
+	}
+	Q_strncpyz(svclc.demo.demoName, demoFile, sizeof(svclc.demo.demoName));
+
+	if (Cmd_Argc() == 3)
+	{
+		char *param = Cmd_Argv(1);
+
+		if (!Q_stricmp(param, "pure"))
+		{
+			svclc.demo.pure = qtrue;
+		}
+		else if (!Q_stricmp(param, "dirty"))
+		{
+			svclc.demo.pure = qfalse;
+		}
+	}
+	else
+	{
+		svclc.demo.pure = Cvar_VariableIntegerValue("sv_pure") != 0;
+	}
+
+	svcls.state        = CA_CONNECTED;
+	svclc.demo.playing = qtrue;
+
+	Q_strncpyz(svcls.servername, demoFile, sizeof(svcls.servername));
+
+	// read demo messages until connected
+	while (svcls.state >= CA_CONNECTED && svcls.state < CA_PRIMED)
+	{
+		SV_CL_ReadDemoMessage();
+	}
+	// don't get the first snapshot this frame, to prevent the long
+	// time from the gamestate load from messing causing a time skip
+	svclc.demo.firstFrameSkipped = qfalse;
+}
+
+/**
+ * @brief SV_CL_CompleteDemoName
+ * @param args - unused
+ * @param[in] argNum
+ */
+static void SV_CL_CompleteDemoName(char *args, int argNum)
+{
+	if (argNum == 2)
+	{
+		char demoExt[16];
+
+		Com_sprintf(demoExt, sizeof(demoExt), ".%s%d", SVCLDEMOEXT, PROTOCOL_VERSION);
+		Field_CompleteFilename("svdemos", demoExt, qtrue, qtrue);
+	}
+}
+
+/**
+  * @brief SV_CL_DemoInit
+  */
+void SV_CL_DemoInit(void)
+{
+	Cmd_AddCommand("record", SV_CL_Record_f);
+	Cmd_AddCommand("stoprecord", SV_CL_StopRecord_f);
+	Cmd_AddCommand("demo", SV_CL_PlayDemo_f);
+	Cmd_SetCommandCompletionFunc("demo", SV_CL_CompleteDemoName);
+}

--- a/src/server/sv_cl_demo.c
+++ b/src/server/sv_cl_demo.c
@@ -73,8 +73,11 @@ void SV_CL_DemoFilename(int number, char *fileName)
 	Com_sprintf(fileName, MAX_OSPATH, "demo%04i", number);
 }
 
-static char demoName[MAX_OSPATH];        // compiler bug workaround
+static char demoName[MAX_OSPATH];
 
+/**
+ * @brief SV_CL_Record_f
+ */
 void SV_CL_Record_f(void)
 {
 	char name[MAX_OSPATH];
@@ -232,6 +235,9 @@ void SV_CL_Record(const char *name)
 	// the rest of the demo file will be copied from net messages
 }
 
+/**
+ * @brief SV_CL_StopRecord_f
+ */
 void SV_CL_StopRecord_f(void)
 {
 	int len;
@@ -254,7 +260,7 @@ void SV_CL_StopRecord_f(void)
 }
 
 /**
- * @brief Called when a demo or cinematic finishes
+ * @brief Called when a demo finishes
  * If the "nextdemo" cvar is set, that command will be issued
  */
 void SV_CL_NextDemo(void)
@@ -443,17 +449,12 @@ void SV_CL_PlayDemo_f(void)
 
 	Q_strncpyz(svcls.servername, demoFile, sizeof(svcls.servername));
 
-	// read demo messages until connected
 	while (!svcl.snap.valid || !svcl.serverTime)
 	{
 		SV_CL_ReadDemoMessage();
 	}
 
 	sv.time = svcl.serverTime;
-
-	// don't get the first snapshot this frame, to prevent the long
-	// time from the gamestate load from messing causing a time skip
-	svclc.demo.firstFrameSkipped = qfalse;
 }
 
 /**

--- a/src/server/sv_cl_demo.c
+++ b/src/server/sv_cl_demo.c
@@ -100,7 +100,7 @@ void SV_CL_Record_f(void)
 	{
 		s = Cmd_Argv(1);
 		Q_strncpyz(demoName, s, sizeof(demoName));
-		Com_sprintf(name, sizeof(name), "svdemos/%s.%s%d", demoName, SVCLDEMOEXT, ETTV_PROTOCOL_VERSION);
+		Com_sprintf(name, sizeof(name), "svdemos/%s.%s%d", demoName, SVCLDEMOEXT, PROTOCOL_VERSION);
 	}
 	else
 	{
@@ -110,7 +110,7 @@ void SV_CL_Record_f(void)
 		for (number = 0; number <= 9999; number++)
 		{
 			SV_CL_DemoFilename(number, demoName);
-			Com_sprintf(name, sizeof(name), "svdemos/%s.%s%d", demoName, SVCLDEMOEXT, ETTV_PROTOCOL_VERSION);
+			Com_sprintf(name, sizeof(name), "svdemos/%s.%s%d", demoName, SVCLDEMOEXT, PROTOCOL_VERSION);
 
 			len = FS_ReadFile(name, NULL);
 			if (len <= 0)
@@ -399,34 +399,20 @@ void SV_CL_PlayDemo_f(void)
 
 	Q_strncpyz(svclc.demo.demoName, demoFile, sizeof(svclc.demo.demoName));
 
-	if (Cmd_Argc() == 3)
-	{
-		char *param = Cmd_Argv(1);
-
-		if (!Q_stricmp(param, "pure"))
-		{
-			svclc.demo.pure = qtrue;
-		}
-		else if (!Q_stricmp(param, "dirty"))
-		{
-			svclc.demo.pure = qfalse;
-		}
-	}
-	else
-	{
-		svclc.demo.pure = Cvar_VariableIntegerValue("sv_pure") != 0;
-	}
-
 	svcls.state        = CA_CONNECTED;
 	svclc.demo.playing = qtrue;
+	svclc.demo.pure    = sv_pure->integer != 0;
 
 	Q_strncpyz(svcls.servername, demoFile, sizeof(svcls.servername));
 
 	// read demo messages until connected
-	while (svcls.state >= CA_CONNECTED && svcls.state < CA_PRIMED)
+	while (!svcl.snap.valid || !svcl.serverTime)
 	{
 		SV_CL_ReadDemoMessage();
 	}
+
+	sv.time = svcl.serverTime;
+
 	// don't get the first snapshot this frame, to prevent the long
 	// time from the gamestate load from messing causing a time skip
 	svclc.demo.firstFrameSkipped = qfalse;

--- a/src/server/sv_cl_main.c
+++ b/src/server/sv_cl_main.c
@@ -223,7 +223,7 @@ void SV_CL_CheckForResend(void)
 			Info_SetValueForKey(info, "challenge", va("%i", svclc.challenge));
 			Info_SetValueForKey(info, "masterpassword", va("%s", svclc.serverMasterPassword));
 
-			Info_SetValueForKey(info, "name", "ETLTV_TEST");
+			Info_SetValueForKey(info, "name", sv_etltv_clientname->string);
 			Info_SetValueForKey(info, "rate", "90000");
 			Info_SetValueForKey(info, "snaps", "20");
 			Info_SetValueForKey(info, "cl_maxpackets", va("%i", SV_CL_MAXPACKETS));

--- a/src/server/sv_cl_main.c
+++ b/src/server/sv_cl_main.c
@@ -1,0 +1,1177 @@
+/*
+ * Wolfenstein: Enemy Territory GPL Source Code
+ * Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company.
+ *
+ * ET: Legacy
+ * Copyright (C) 2012-2023 ET:Legacy team <mail@etlegacy.com>
+ *
+ * This file is part of ET: Legacy - http://www.etlegacy.com
+ *
+ * ET: Legacy is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ET: Legacy is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ET: Legacy. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * In addition, Wolfenstein: Enemy Territory GPL Source Code is also
+ * subject to certain additional terms. You should have received a copy
+ * of these additional terms immediately following the terms and conditions
+ * of the GNU General Public License which accompanied the source code.
+ * If not, please request a copy in writing from id Software at the address below.
+ *
+ * id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, Maryland 20850 USA.
+ */
+/**
+ * @file sv_cl_main.c
+ */
+
+#include "server.h"
+
+/**
+* @brief SV_CL_Commands_f
+*/
+void SV_CL_Commands_f(void)
+{
+	char         *server;
+	char         *password;
+	const char   *ip_port;
+	int          argc = Cmd_Argc();
+	netadrtype_t family = NA_UNSPEC;
+
+	if (argc != 4)
+	{
+		Com_Printf("usage: tv connect [-4|-6] server masterpassword\n");
+		return;
+	}
+
+	//if (!strcmp(Cmd_Argv(2), "-4"))
+	//{
+	//	family = NA_IP;
+	//}
+	//else if (!strcmp(Cmd_Argv(2), "-6"))
+	//{
+	//	family = NA_IP6;
+	//}
+	//else
+	//{
+	//	Com_Printf(S_COLOR_YELLOW "WARNING: only -4 or -6 as address type understood\n");
+	//}
+
+	server   = Cmd_Argv(2);
+	password = Cmd_Argv(3);
+
+	//FS_ClearPureServerPacks();
+
+	// clear any previous "server full" type messages
+	svclc.serverMessage[0] = 0;
+
+	if (com_sv_running->integer && !strcmp(server, "localhost"))
+	{
+		// if running a local server, kill it
+		SV_Shutdown("Server quit");
+	}
+
+	// make sure a local server is killed
+	Cvar_Set("sv_killserver", "1");
+	SV_Frame(0);
+
+	SV_CL_Disconnect();
+
+	Q_strncpyz(svcls.servername, server, sizeof(svcls.servername));
+
+	if (!NET_StringToAdr(svcls.servername, &svclc.serverAddress, family))
+	{
+		Com_Printf("Bad server address\n");
+		svcls.state = CA_DISCONNECTED;
+		return;
+	}
+	if (svclc.serverAddress.port == 0)
+	{
+		svclc.serverAddress.port = BigShort(PORT_SERVER);
+	}
+
+	Q_strncpyz(svclc.serverMasterPassword, password, sizeof(svclc.serverMasterPassword));
+
+	ip_port = NET_AdrToString(svclc.serverAddress);
+
+	Com_Printf("%s resolved to %s\n", svcls.servername, ip_port);
+
+	// if we aren't playing on a lan, we need to request a challenge
+	if (NET_IsLocalAddress(svclc.serverAddress))
+	{
+		svcls.state = CA_CHALLENGING;
+		svcls.challengeState = CA_CHALLENGING_INFO;
+	}
+	else
+	{
+		svcls.state = CA_CONNECTING;
+	}
+
+	// prepare to catch a connection process that would turn bad
+	Cvar_Set("com_errorDiagnoseIP", NET_AdrToString(svclc.serverAddress));
+
+	// we need to setup a correct default for this, otherwise the first val we set might reappear
+	Cvar_Set("com_errorMessage", "");
+
+	svclc.connectTime = -99999; // CL_CheckForResend() will fire immediately
+	svclc.connectPacketCount = 0;
+
+	// server connection string
+	Cvar_Set("cl_currentServerAddress", server);
+	Cvar_Set("cl_currentServerIP", ip_port);
+}
+
+#define RETRANSMIT_TIMEOUT  3000
+
+/**
+ * @brief Resend a connect message if the last one has timed out
+ */
+void SV_CL_CheckForResend(void)
+{
+	char buffer[64];
+	// don't send anything if playing back a demo
+	//if (svclc.demo.playing)
+	//{
+	//	return;
+	//}
+
+	// resend if we haven't gotten a reply yet
+	if (svcls.state != CA_CONNECTING && svcls.state != CA_CHALLENGING)
+	{
+		return;
+	}
+
+	if (svcls.realtime - svclc.connectTime < RETRANSMIT_TIMEOUT)
+	{
+		return;
+	}
+
+	svclc.connectTime = svcls.realtime; // for retransmit requests
+	svclc.connectPacketCount++;
+
+	switch (svcls.state)
+	{
+	case CA_CONNECTING:
+	{
+		strcpy(buffer, "getchallenge");
+		NET_OutOfBandPrint(NS_CLIENT, svclc.serverAddress, buffer);
+	}
+	break;
+	case CA_CHALLENGING:
+	{
+		// first get the server information
+		if (svcls.challengeState == CA_CHALLENGING_INFO)
+		{
+			Com_sprintf(buffer, sizeof(buffer), "getinfo %i", svclc.challenge);
+			NET_OutOfBandPrint(NS_CLIENT, svclc.serverAddress, buffer);
+		}
+		// then attempt to connect
+		else
+		{
+			int  port;
+			char info[MAX_INFO_STRING];
+			char data[MAX_INFO_STRING + 10];
+
+			// received and confirmed the challenge, now responding with a 'connect' packet
+			port = (int)(Cvar_VariableValue("net_qport"));
+
+			Q_strncpyz(info, Cvar_InfoString(CVAR_USERINFO), sizeof(info));
+
+			// make sure nothing restricted can slip through
+			if (!Com_IsCompatible(&svclc.agent, 0x1))
+			{
+				Q_SafeNetString(info, MAX_INFO_STRING, qtrue);
+			}
+
+			Info_SetValueForKey(info, "protocol", va("%i", ETTV_PROTOCOL_VERSION));
+			Info_SetValueForKey(info, "qport", va("%i", port));
+			Info_SetValueForKey(info, "challenge", va("%i", svclc.challenge));
+			Info_SetValueForKey(info, "masterpassword", va("%s", svclc.serverMasterPassword));
+
+			Info_SetValueForKey(info, "name", "ETLTV_TEST");
+			Info_SetValueForKey(info, "rate", "90000");
+			Info_SetValueForKey(info, "snaps", "20");
+			Info_SetValueForKey(info, "cl_maxpackets", "40");
+			Info_SetValueForKey(info, "cg_uinfo", "0 0 40");
+
+			Com_sprintf(data, sizeof(data), "connect \"%s\"", info);
+			NET_OutOfBandData(NS_CLIENT, svclc.serverAddress, (const char *)data, strlen(data));
+
+			// the most current userinfo has been sent, so watch for any
+			// newer changes to userinfo variables
+			cvar_modifiedFlags &= ~CVAR_USERINFO;
+		}
+	}
+	break;
+	default:
+		Com_Error(ERR_FATAL, "CL_CheckForResend: bad cls.state");
+	}
+}
+
+/**
+* @brief SV_CL_Disconnect
+*/
+void SV_CL_Disconnect(void)
+{
+	// send a disconnect message to the server
+	// send it a few times in case one is dropped
+	if (svcls.state >= CA_CONNECTED)
+	{
+		SV_CL_AddReliableCommand("disconnect");
+		SV_CL_WritePacket();
+		SV_CL_WritePacket();
+		SV_CL_WritePacket();
+	}
+}
+
+/**
+ * @brief The given command will be transmitted to the server, and is guaranteed to
+ * not have future usercmd_t executed before it is executed.
+ *
+ * @param cmd
+ */
+void SV_CL_AddReliableCommand(const char *cmd)
+{
+	int index;
+
+	// if we would be losing an old command that hasn't been acknowledged,
+	// we must drop the connection
+	if (svclc.reliableSequence - svclc.reliableAcknowledge > MAX_RELIABLE_COMMANDS)
+	{
+		Com_Error(ERR_DROP, "Server Client command overflow");
+	}
+	svclc.reliableSequence++;
+	index = svclc.reliableSequence & (MAX_RELIABLE_COMMANDS - 1);
+	Q_strncpyz(svclc.reliableCommands[index], cmd, sizeof(svclc.reliableCommands[index]));
+}
+
+/**
+ * @brief Create and send the command packet to the server
+ * Including both the reliable commands and the usercmds
+ *
+ * @details During normal gameplay, a client packet will contain something like:
+ *
+ * 4   sequence number
+ * 2   qport
+ * 4   serverid
+ * 4   acknowledged sequence number
+ * 4   clc.serverCommandSequence
+ * \<optional reliable commands\>
+ * 1   clc_move or clc_moveNoDelta
+ * 1   command count
+ * \<count * usercmds\>
+ */
+void SV_CL_WritePacket(void)
+{
+	msg_t     buf;
+	byte      data[MAX_MSGLEN];
+	int       i, j;
+	usercmd_t *cmd, *oldcmd;
+	usercmd_t nullcmd;
+	int       packetNum;
+	int       oldPacketNum;
+	int       count, key;
+
+	// don't send anything if playing back a demo
+	//if (svclc.demo.playing || svcls.state == CA_CINEMATIC)
+	//{
+	//	return;
+	//}
+
+	Com_Memset(&nullcmd, 0, sizeof(nullcmd));
+	oldcmd = &nullcmd;
+
+	MSG_Init(&buf, data, sizeof(data));
+
+	MSG_Bitstream(&buf);
+	// write the current serverId so the server
+	// can tell if this is from the current gameState
+	MSG_WriteLong(&buf, svcl.serverId);
+
+	// write the last message we received, which can
+	// be used for delta compression, and is also used
+	// to tell if we dropped a gamestate
+	MSG_WriteLong(&buf, svclc.serverMessageSequence);
+
+	// write the last reliable message we received
+	MSG_WriteLong(&buf, svclc.serverCommandSequence);
+
+	// write any unacknowledged clientCommands
+	// NOTE: if you verbose this, you will see that there are quite a few duplicates
+	// typically several unacknowledged cp or userinfo commands stacked up
+	for (i = svclc.reliableAcknowledge + 1; i <= svclc.reliableSequence; i++)
+	{
+		MSG_WriteByte(&buf, clc_clientCommand);
+		MSG_WriteLong(&buf, i);
+		MSG_WriteString(&buf, svclc.reliableCommands[i & (MAX_RELIABLE_COMMANDS - 1)]);
+	}
+
+	svcl.cmdNumber++;
+	oldPacketNum = (svclc.netchan.outgoingSequence - 1) & PACKET_MASK;
+	count = svcl.cmdNumber - svcl.outPackets[oldPacketNum].p_cmdNumber;
+
+	if (count >= 1)
+	{
+		//if (cl_showSend->integer)
+		//{
+		//	Com_Printf("(%i)", count);
+		//}
+
+		// begin a client move command
+		if (/*cl_nodelta->integer || */!svcl.snap.valid /*|| clc.demo.waiting*/
+			|| svclc.serverMessageSequence != svcl.snap.messageNum)
+		{
+			MSG_WriteByte(&buf, clc_moveNoDelta);
+		}
+		else
+		{
+			MSG_WriteByte(&buf, clc_move);
+		}
+
+		// write the command count
+		MSG_WriteByte(&buf, count);
+
+		// use the checksum feed in the key
+		key = svclc.checksumFeed;
+		// also use the message acknowledge
+		key ^= svclc.serverMessageSequence;
+		// also use the last acknowledged server command in the key
+		key ^= MSG_HashKey(svclc.serverCommands[svclc.serverCommandSequence & (MAX_RELIABLE_COMMANDS - 1)], 32, 0);
+
+		// write all the commands, including the predicted command
+		for (i = 0; i < count; i++)
+		{
+			j = (svcl.cmdNumber - count + i + 1) & CMD_MASK;
+			cmd             = &svcl.cmds[j];
+			cmd->serverTime = sv.time;
+			MSG_WriteDeltaUsercmdKey(&buf, key, oldcmd, cmd);
+			oldcmd = cmd;
+		}
+	}
+
+	// deliver the message
+	packetNum = svclc.netchan.outgoingSequence & PACKET_MASK;
+	svcl.outPackets[packetNum].p_realtime = svcls.realtime;
+	svcl.outPackets[packetNum].p_serverTime = oldcmd->serverTime;
+	svcl.outPackets[packetNum].p_cmdNumber = svcl.cmdNumber;
+	svclc.lastPacketSentTime = svcls.realtime;
+
+	//if (cl_showSend->integer)
+	//{
+	//	Com_Printf("%i ", buf.cursize);
+	//}
+	SV_CL_Netchan_Transmit(&svclc.netchan, &buf);
+
+	// clients never really should have messages large enough
+	// to fragment, but in case they do, fire them all off
+	// at once
+	// - this causes a packet burst, which is bad karma for winsock
+	// added a WARNING message, we'll see if there are legit situations where this happens
+	while (svclc.netchan.unsentFragments)
+	{
+		//if (cl_showSend->integer)
+		//{
+		//	Com_Printf("WARNING: unsent fragments (not supposed to happen!)\n");
+		//}
+		SV_CL_Netchan_TransmitNextFragment(&svclc.netchan);
+	}
+}
+
+/**
+ * @brief SV_CL_InitTVGame
+ */
+void SV_CL_InitTVGame(void)
+{
+	const char *info;
+	const char *mapname;
+	int        i, t1, t2;
+
+	t1 = Sys_Milliseconds();
+
+	// find the current mapname
+	info = svcl.gameState.stringData + svcl.gameState.stringOffsets[CS_SERVERINFO];
+	mapname = Info_ValueForKey(info, "mapname");
+	Com_sprintf(svcl.mapname, sizeof(svcl.mapname), "maps/%s.bsp", mapname);
+
+	svcls.state = CA_LOADING;
+
+	SV_SpawnServer(mapname);
+
+	for (i = 0; i < MAX_CONFIGSTRINGS; i++)
+	{
+		SV_SetConfigstring(i, svcl.gameState.stringData + svcl.gameState.stringOffsets[i]);
+	}
+
+	Info_SetValueForKey_Big(sv.configstrings[CS_SYSTEMINFO], "sv_serverid", va("%d", sv.serverId));
+
+	// we will send a usercmd this frame, which
+	// will cause the server to send us the first snapshot
+	svcls.state = CA_PRIMED;
+
+	t2 = Sys_Milliseconds();
+
+	Com_Printf("CL_InitCGame: %5.2f seconds\n", (t2 - t1) / 1000.0);
+
+	// make sure everything is paged in
+	if (!Sys_LowPhysicalMemory())
+	{
+		Com_TouchMemory();
+	}
+}
+
+/**
+ * @brief SV_CL_ConfigstringModified
+ */
+void SV_CL_ConfigstringModified(void)
+{
+	char        *old, *s;
+	int         i, index;
+	char        *dup;
+	gameState_t oldGs;
+	int         len;
+
+	index = Q_atoi(Cmd_Argv(1));
+	if (index < 0 || index >= MAX_CONFIGSTRINGS)
+	{
+		Com_Error(ERR_DROP, "configstring < 0 or configstring >= MAX_CONFIGSTRINGS");
+	}
+	// get everything after "cs <num>"
+	s = Cmd_ArgsFrom(2);
+
+	old = svcl.gameState.stringData + svcl.gameState.stringOffsets[index];
+	if (!strcmp(old, s))
+	{
+		return;     // unchanged
+	}
+
+	// build the new gameState_t
+	oldGs = svcl.gameState;
+
+	Com_Memset(&svcl.gameState, 0, sizeof(svcl.gameState));
+
+	// leave the first 0 for uninitialized strings
+	svcl.gameState.dataCount = 1;
+
+	for (i = 0; i < MAX_CONFIGSTRINGS; i++)
+	{
+		if (i == index)
+		{
+			dup = s;
+		}
+		else
+		{
+			dup = oldGs.stringData + oldGs.stringOffsets[i];
+		}
+		if (!dup[0])
+		{
+			continue;       // leave with the default empty string
+		}
+
+		len = strlen(dup);
+
+		if (len + 1 + svcl.gameState.dataCount > MAX_GAMESTATE_CHARS)
+		{
+			Com_Error(ERR_DROP, "MAX_GAMESTATE_CHARS exceeded");
+		}
+
+		// append it to the gameState string buffer
+		svcl.gameState.stringOffsets[i] = svcl.gameState.dataCount;
+		Com_Memcpy(svcl.gameState.stringData + svcl.gameState.dataCount, dup, len + 1);
+		svcl.gameState.dataCount += len + 1;
+	}
+
+	if (index == CS_SYSTEMINFO)
+	{
+		// parse serverId and other cvars
+		SV_CL_SystemInfoChanged();
+	}
+	else
+	{
+		SV_SetConfigstring(index, s);
+	}
+}
+
+/**
+ * @brief Set up argc/argv for the given command
+ * @param[in] serverCommandNumber
+ * @return
+ */
+qboolean SV_CL_GetServerCommand(int serverCommandNumber)
+{
+	char        *s;
+	char        *cmd;
+	static char bigConfigString[BIG_INFO_STRING];
+	int         argc;
+
+	// if we have irretrievably lost a reliable command, drop the connection
+	if (serverCommandNumber <= svclc.serverCommandSequence - MAX_RELIABLE_COMMANDS)
+	{
+		// when a demo record was started after the client got a whole bunch of
+		// reliable commands then the client never got those first reliable commands
+		//if (svclc.demo.playing)
+		//{
+		//	return qfalse;
+		//}
+		Com_Error(ERR_DROP, "CL_GetServerCommand: a reliable command was cycled out");
+		return qfalse;
+	}
+
+	if (serverCommandNumber > svclc.serverCommandSequence)
+	{
+		Com_Error(ERR_DROP, "CL_GetServerCommand: requested a command not received");
+		return qfalse;
+	}
+
+	s = svclc.serverCommands[serverCommandNumber & (MAX_RELIABLE_COMMANDS - 1)];
+	svclc.lastExecutedServerCommand = serverCommandNumber;
+
+	//if (cl_showServerCommands->integer)
+	//{
+	//	Com_DPrintf("serverCommand: %i : %s\n", serverCommandNumber, s);
+	//}
+
+rescan:
+	Cmd_TokenizeString(s);
+	cmd = Cmd_Argv(0);
+	argc = Cmd_Argc();
+
+	if (!strcmp(cmd, "disconnect"))
+	{
+		// allow server to indicate why they were disconnected
+		if (argc >= 2)
+		{
+			Com_Error(ERR_SERVERDISCONNECT, "%s", va("Server Disconnected - %s", Cmd_Argv(1)));
+		}
+		else
+		{
+			Com_Error(ERR_SERVERDISCONNECT, "Server disconnected");
+		}
+	}
+
+	if (!strcmp(cmd, "bcs0"))
+	{
+		Com_sprintf(bigConfigString, BIG_INFO_STRING, "cs %s \"%s", Cmd_Argv(1), Cmd_Argv(2));
+		return qfalse;
+	}
+
+	if (!strcmp(cmd, "bcs1"))
+	{
+		s = Cmd_Argv(2);
+		if (strlen(bigConfigString) + strlen(s) >= BIG_INFO_STRING)
+		{
+			Com_Error(ERR_DROP, "bcs exceeded BIG_INFO_STRING");
+		}
+		strcat(bigConfigString, s);
+		return qfalse;
+	}
+
+	if (!strcmp(cmd, "bcs2"))
+	{
+		s = Cmd_Argv(2);
+		if (strlen(bigConfigString) + strlen(s) + 1 >= BIG_INFO_STRING)
+		{
+			Com_Error(ERR_DROP, "bcs exceeded BIG_INFO_STRING");
+		}
+		strcat(bigConfigString, s);
+		strcat(bigConfigString, "\"");
+		s = bigConfigString;
+		goto rescan;
+	}
+
+	if (!strcmp(cmd, "cs"))
+	{
+		SV_CL_ConfigstringModified();
+		// reparse the string, because CL_ConfigstringModified may have done another Cmd_TokenizeString()
+		Cmd_TokenizeString(s);
+		return qtrue;
+	}
+
+	if (!strcmp(cmd, "map_restart"))
+	{
+		// reparse the string, because Con_ClearNotify() may have done another Cmd_TokenizeString()
+		//Cmd_TokenizeString(s);
+		//// clear outgoing commands before passing
+		//Com_Memset(cl.cmds, 0, sizeof(cl.cmds));
+		return qtrue;
+	}
+
+	if (!strcmp(cmd, "popup"))       // direct server to client popup request, bypassing cgame
+	{
+		return qfalse;
+	}
+
+	// the clientLevelShot command is used during development
+	// to generate 128*128 screenshots from the intermission
+	// point of levels for the menu system to use
+	// we pass it along to the cgame to make apropriate adjustments,
+	// but we also clear the console and notify lines here
+	//if (!strcmp(cmd, "clientLevelShot"))
+	//{
+	//	// don't do it if we aren't running the server locally,
+	//	// otherwise malicious remote servers could overwrite
+	//	// the existing thumbnails
+	//	if (!com_sv_running->integer)
+	//	{
+	//		return qfalse;
+	//	}
+	//	// close the console
+	//	Con_Close();
+	//	// take a special screenshot next frame
+	//	Cbuf_AddText("wait ; wait ; wait ; wait ; screenshot levelshot\n");
+	//	return qtrue;
+	//}
+
+	Cmd_SingleTokenString(s);
+	return qtrue;
+}
+
+/**
+ * @brief SV_CL_SendPureChecksums
+ */
+void SV_CL_SendPureChecksums(void)
+{
+	//const char *pChecksums;
+	char       cMsg[MAX_INFO_VALUE];
+
+	// if we are pure we need to send back a command with our referenced pk3 checksums
+	//pChecksums = FS_ReferencedPakPureChecksums();
+
+	//Com_sprintf(cMsg, sizeof(cMsg), "cp %d %s", svcl.serverId, pChecksums);
+	Com_sprintf(cMsg, sizeof(cMsg), "cp %d SLAVE", svcl.serverId);
+
+	SV_CL_AddReliableCommand(cMsg);
+}
+
+/**
+ * @brief SV_CL_DownloadsComplete
+ */
+void SV_CL_DownloadsComplete(void)
+{
+	// let the client game init and load data
+	svcls.state = CA_LOADING;
+
+	// Pump the loop, this may change gamestate!
+	Com_EventLoop();
+
+	// if the gamestate was changed by calling Com_EventLoop
+	// then we loaded everything already and we don't want to do it again.
+	if (svcls.state != CA_LOADING)
+	{
+		return;
+	}
+
+	// flush client memory and start loading stuff
+	// this will also (re)load the UI
+	// if this is a local client then only the client part of the hunk
+	// will be cleared, note that this is done after the hunk mark has been set
+	CL_FlushMemory();
+
+	SV_CL_InitTVGame();
+
+	// set pure checksums
+	SV_CL_SendPureChecksums();
+
+	SV_CL_WritePacket();
+	SV_CL_WritePacket();
+	SV_CL_WritePacket();
+}
+
+/**
+ * @brief SV_CL_ServerInfoPacketCheck
+ * @param[in] from
+ * @param[in] msg
+ */
+void SV_CL_ServerInfoPacketCheck(netadr_t from, msg_t *msg)
+{
+	int  prot;
+	char *infoString;
+	char *gameName;
+
+	infoString = MSG_ReadString(msg);
+
+	// if this isn't the correct protocol version, ignore it
+	prot = Q_atoi(Info_ValueForKey(infoString, "protocol"));
+	if (prot != PROTOCOL_VERSION)
+	{
+		Com_DPrintf("Different protocol info packet: %s\n", infoString);
+		Com_Error(ERR_FATAL, "Game server uses unsupported protocol: %i, expected %i (%s)", prot, PROTOCOL_VERSION, GAMENAME_STRING);
+		return;
+	}
+
+	// if this isn't the correct game, ignore it
+	gameName = Info_ValueForKey(infoString, "gamename");
+	if (!gameName[0] || Q_stricmp(gameName, GAMENAME_STRING))
+	{
+		Com_DPrintf("Different game info packet: %s\n", infoString);
+		Com_Error(ERR_FATAL, "Unsupported game server: %s", gameName);
+		return;
+	}
+
+	// upon challenging we request server info to obtain user agent information
+	// btw, old clients dont store version in getinfoResponse body, however, all etl clients do
+	if (svcls.state == CA_CHALLENGING && svcls.challengeState == CA_CHALLENGING_INFO)
+	{
+		Com_ParseUA(&svclc.agent, Info_ValueForKey(infoString, "version"));
+	}
+}
+
+/**
+ * @brief SV_CL_ServerInfoPacket
+ * @param[in] from
+ * @param[in] msg
+ */
+void SV_CL_ServerInfoPacket(netadr_t from, msg_t *msg)
+{
+	int  i, type;
+	char info[MAX_INFO_STRING];
+	char *infoString;
+	int  prot;
+	char *gameName;
+
+	infoString = MSG_ReadString(msg);
+
+	// if this isn't the correct protocol version, ignore it
+	prot = Q_atoi(Info_ValueForKey(infoString, "protocol"));
+	if (prot != PROTOCOL_VERSION)
+	{
+		Com_DPrintf("Different protocol info packet: %s\n", infoString);
+		return;
+	}
+
+	// if this isn't the correct game, ignore it
+	gameName = Info_ValueForKey(infoString, "gamename");
+	if (!gameName[0] || Q_stricmp(gameName, GAMENAME_STRING))
+	{
+		Com_DPrintf("Different game info packet: %s\n", infoString);
+		return;
+	}
+
+	//// iterate servers waiting for ping response
+	//for (i = 0; i < MAX_PINGREQUESTS; i++)
+	//{
+	//	if (cl_pinglist[i].adr.port && !cl_pinglist[i].time && NET_CompareAdr(from, cl_pinglist[i].adr))
+	//	{
+	//		// calc ping time
+	//		cl_pinglist[i].time = svcls.realtime - cl_pinglist[i].start + 1;
+
+	//		if (com_developer->integer)
+	//		{
+	//			Com_Printf("ping time %dms from %s\n", cl_pinglist[i].time, NET_AdrToString(from));
+	//		}
+
+	//		// save of info
+	//		Q_strncpyz(cl_pinglist[i].info, infoString, sizeof(cl_pinglist[i].info));
+
+	//		// tack on the net type
+	//		// NOTE: make sure these types are in sync with the netnames strings in the UI
+	//		switch (from.type)
+	//		{
+	//		case NA_BROADCAST:
+	//		case NA_IP:
+	//			type = 1;
+	//			break;
+	//		case NA_IP6:
+	//			type = 2;
+	//			break;
+	//		default:
+	//			type = 0;
+	//			break;
+	//		}
+	//		Info_SetValueForKey(cl_pinglist[i].info, "nettype", va("%d", type));
+	//		CL_SetServerInfoByAddress(from, infoString, cl_pinglist[i].time);
+
+	//		return;
+	//	}
+	//}
+
+	//// if not just sent a local broadcast or pinging local servers
+	//if (svcls.pingUpdateSource != AS_LOCAL)
+	//{
+	//	return;
+	//}
+
+	//for (i = 0; i < MAX_OTHER_SERVERS; i++)
+	//{
+	//	// empty slot
+	//	if (cls.localServers[i].adr.port == 0)
+	//	{
+	//		break;
+	//	}
+
+	//	// avoid duplicate
+	//	if (NET_CompareAdr(from, cls.localServers[i].adr))
+	//	{
+	//		return;
+	//	}
+	//}
+
+	//if (svcls.numlocalservers == MAX_OTHER_SERVERS)
+	//{
+	//	Com_DPrintf("MAX_OTHER_SERVERS hit, dropping infoResponse\n");
+	//	return;
+	//}
+
+	//// add this to the list
+	//svcls.numlocalservers = i + 1;
+	//CL_InitServerInfo(&cls.localServers[i], &from);
+
+	//Q_strncpyz(info, MSG_ReadString(msg), MAX_INFO_STRING);
+	//if (strlen(info))
+	//{
+	//	if (info[strlen(info) - 1] != '\n')
+	//	{
+	//		Q_strcat(info, sizeof(info), "\n");
+	//	}
+	//	Com_Printf("%s: %s", NET_AdrToString(from), info);
+	//}
+}
+
+/**
+ * @brief Responses to broadcasts, etc
+ *
+ * Compare first n chars so it doesn’t bail if token is parsed incorrectly.
+ *
+ * @param[in] from
+ * @param[in] msg
+ */
+void SV_CL_ConnectionlessPacket(netadr_t from, msg_t *msg)
+{
+	char *s;
+	char *c;
+
+	MSG_BeginReadingOOB(msg);
+	MSG_ReadLong(msg);      // skip the -1
+
+	s = MSG_ReadStringLine(msg);
+
+	Cmd_TokenizeString(s);
+
+	c = Cmd_Argv(0);
+
+	if (com_developer->integer)
+	{
+		Com_Printf("CL packet %s: %s\n", NET_AdrToString(from), c);
+	}
+
+	// challenge from the server we are connecting to
+	if (!Q_stricmp(c, "challengeResponse"))
+	{
+		if (svcls.state != CA_CONNECTING)
+		{
+			Com_Printf("Unwanted challenge response received, '%s' ignored\n", c);
+		}
+		else
+		{
+			// start sending challenge response instead of challenge request packets
+			svclc.challenge = Q_atoi(Cmd_Argv(1));
+			if (Cmd_Argc() > 2)
+			{
+				svclc.onlyVisibleClients = Q_atoi(Cmd_Argv(2));
+			}
+			else
+			{
+				svclc.onlyVisibleClients = 0;
+			}
+			svcls.state = CA_CHALLENGING;
+			svcls.challengeState = CA_CHALLENGING_INFO;
+			svclc.connectPacketCount = 0;
+			svclc.connectTime = -99999;
+
+			// take this address as the new server address.  This allows
+			// a server proxy to hand off connections to multiple servers
+			svclc.serverAddress = from;
+			Com_DPrintf("challenge: %d\n", svclc.challenge);
+		}
+		return;
+	}
+
+	// server connection
+	if (!Q_stricmp(c, "connectResponse"))
+	{
+		if (svcls.state >= CA_CONNECTED)
+		{
+			Com_Printf("Dup connect received.  Ignored.\n");
+			return;
+		}
+		if (svcls.state != CA_CHALLENGING)
+		{
+			Com_Printf("connectResponse packet while not connecting.  Ignored.\n");
+			return;
+		}
+		if (!NET_CompareAdr(from, svclc.serverAddress))
+		{
+			Com_Printf("connectResponse from a different address.  Ignored.\n");
+			Com_Printf("%s should have been %s\n", NET_AdrToString(from),
+				NET_AdrToString(svclc.serverAddress));
+			return;
+		}
+
+		Com_CheckUpdateStarted();
+
+		Netchan_Setup(NS_CLIENT, &svclc.netchan, from, Cvar_VariableValue("net_qport"));
+		svcls.state = CA_CONNECTED;
+		svclc.lastPacketSentTime = -9999;     // send first packet immediately
+		return;
+	}
+
+	// server responding to an info broadcast
+	if (!Q_stricmp(c, "infoResponse"))
+	{
+		if (svcls.state == CA_CHALLENGING && svcls.challengeState == CA_CHALLENGING_INFO)
+		{
+			SV_CL_ServerInfoPacketCheck(from, msg);
+			svcls.challengeState = CA_CHALLENGING_REQUEST;
+			svclc.connectTime = -99999;    // CL_CheckForResend() will fire immediately
+			return;
+		}
+		SV_CL_ServerInfoPacket(from, msg);
+		return;
+	}
+
+	// server responding to a get playerlist
+	if (!Q_stricmp(c, "statusResponse"))
+	{
+		//CL_ServerStatusResponse(from, msg);
+		return;
+	}
+
+	// a disconnect message from the server, which will happen if the server
+	// dropped the connection but it is still getting packets from us
+	if (!Q_stricmp(c, "disconnect"))
+	{
+		//CL_DisconnectPacket(from);
+		return;
+	}
+
+	// echo request from server
+	//if (!Q_stricmp(c, "echo"))
+	//{
+	//	// FIXME: || NET_CompareAdr(from, clc.authorizeServer)
+	//	if (NET_CompareAdr(from, svclc.serverAddress) || NET_CompareAdr(from, rcon_address) || NET_CompareAdr(from, autoupdate.autoupdateServer))
+	//	{
+	//		NET_OutOfBandPrint(NS_CLIENT, from, "%s", Cmd_Argv(1));
+	//	}
+	//	return;
+	//}
+
+	// cd check
+	if (!Q_stricmp(c, "keyAuthorize"))
+	{
+		// we don't use these now, so dump them on the floor
+		return;
+	}
+
+	// global MOTD
+	if (!Q_stricmp(c, "motd"))
+	{
+		//CL_MotdPacket(from);
+		return;
+	}
+
+	//// echo request from server
+	//if (!Q_stricmp(c, "print"))
+	//{
+	//	// FIXME: || NET_CompareAdr(from, clc.authorizeServer)
+	//	if (NET_CompareAdr(from, clc.serverAddress) || NET_CompareAdr(from, rcon_address) || NET_CompareAdr(from, autoupdate.autoupdateServer))
+	//	{
+	//		CL_PrintPacket(msg);
+	//	}
+	//	return;
+	//}
+
+	// Update server response message
+	if (!Q_stricmp(c, "updateResponse"))
+	{
+		//Com_UpdateInfoPacket(from);
+		return;
+	}
+
+	// list of servers sent back by a master server
+	if (!Q_strncmp(c, "getserversResponse", 18))
+	{
+		//CL_ServersResponsePacket(&from, msg, qfalse);
+		return;
+	}
+
+	// list of servers sent back by a master server (extended)
+	if (!Q_strncmp(c, "getserversExtResponse", 21))
+	{
+		//CL_ServersResponsePacket(&from, msg, qtrue);
+		return;
+	}
+
+	// list of blocked servers sent back by a master server
+	if (!Q_strncmp(c, "getBlockedServersResponse", 25))
+	{
+		//CL_BlockedServersResponsePacket(&from, msg);
+		return;
+	}
+
+	Com_DPrintf("Unknown connectionless packet command.\n");
+}
+
+/**
+ * @brief A packet has arrived from the main event loop
+ *
+ * @param[in] from
+ * @param[in] msg
+ */
+static void SV_CL_PacketEvent(netadr_t from, msg_t *msg)
+{
+	int headerBytes;
+
+	if (!NET_CompareAdr(from, svclc.serverAddress))
+	{
+		SV_PacketEvent(from, msg);
+		return;
+	}
+
+	//if (Com_UpdatePacketEvent(from))
+	//{
+	//	return;
+	//}
+
+	if (msg->cursize >= 4 && *(int *)msg->data == -1)
+	{
+		SV_CL_ConnectionlessPacket(from, msg);
+		return;
+	}
+
+	svclc.lastPacketTime = svcls.realtime;
+
+	if (svcls.state < CA_CONNECTED)
+	{
+		return;     // can't be a valid sequenced packet
+	}
+
+	if (msg->cursize < 4)
+	{
+		Com_Printf("%s: Runt packet\n", NET_AdrToString(from));
+		return;
+	}
+
+	// packet from server
+	if (!NET_CompareAdr(from, svclc.netchan.remoteAddress))
+	{
+		if (com_developer->integer)
+		{
+			Com_Printf("%s:sequenced packet without connection\n", NET_AdrToString(from));
+		}
+		// client isn't connected - don't send disconnect
+		return;
+	}
+
+	if (!SV_CL_Netchan_Process(&svclc.netchan, msg))
+	{
+		return;     // out of order, duplicated, etc
+	}
+
+	// the header is different lengths for reliable and unreliable messages
+	headerBytes = msg->readcount;
+
+	// track the last message received so it can be returned in
+	// client messages, allowing the server to detect a dropped
+	// gamestate
+	svclc.serverMessageSequence = LittleLong(*(int *)msg->data);
+
+	svclc.lastPacketTime = svcls.realtime;
+	SV_CL_ParseServerMessage(msg);
+
+	// we don't know if it is ok to save a demo message until
+	// after we have parsed the frame
+	//if (svclc.demo.recording && !svclc.demo.waiting)
+	//{
+	//	CL_WriteDemoMessage(msg, headerBytes);
+	//}
+}
+
+#ifdef DEDICATED
+/**
+ * @brief A packet has arrived from the main event loop
+ *
+ * @param[in] from
+ * @param[in] msg
+ */
+void CL_PacketEvent(netadr_t from, msg_t *msg)
+{
+	if (svcls.state != CA_DISCONNECTED)
+	{
+		SV_CL_PacketEvent(from, msg);
+	}
+}
+
+/**
+ * @brief Called by CL_MapLoading, CL_Connect_f, CL_PlayDemo_f, and CL_ParseGamestate the only
+ * ways a client gets into a game
+ * Also called by Com_Error
+ */
+void CL_FlushMemory(void)
+{
+	// if not running a server clear the whole hunk
+	if (!com_sv_running->integer)
+	{
+		// clear the whole hunk
+		Hunk_Clear();
+		// clear collision map data
+		CM_ClearMap();
+	}
+	else
+	{
+		// clear all the client data on the hunk
+		Hunk_ClearToMark();
+	}
+}
+
+#endif // DEDICATED
+
+/**
+ * @brief Called before parsing a gamestate
+ */
+void SV_CL_ClearState(void)
+{
+	Com_Memset(&svcl, 0, sizeof(svcl));
+}
+
+/**
+ * @brief SV_CL_GetPlayerstate
+ */
+int SV_CL_GetPlayerstate(int clientNum, playerState_t *ps)
+{
+	if (!svcls.isTVGame)
+	{
+		Com_Error(ERR_FATAL, "TVGame not loaded");
+	}
+
+	if (clientNum >= MAX_CLIENTS)
+	{
+		Com_Error(ERR_FATAL, "TVGame invalid clientNum %d", clientNum);
+	}
+
+	if (ps == NULL)
+	{
+		Com_Error(ERR_FATAL, "TVGame clientNum %d NULL ps", clientNum);
+	}
+
+	if (clientNum == -1)
+	{
+		*ps = svcl.snap.ps;
+	}
+	else
+	{
+		if (!svcl.snap.playerstates[clientNum].valid)
+		{
+			return 0;
+		}
+
+		*ps = svcl.snap.playerstates[clientNum].ps;
+	}
+
+	return 1;
+}

--- a/src/server/sv_cl_main.c
+++ b/src/server/sv_cl_main.c
@@ -34,6 +34,8 @@
 
 #include "server.h"
 
+#ifdef DEDICATED
+
 /**
  * @brief SV_CL_Connect_f
  */
@@ -1332,7 +1334,6 @@ static void SV_CL_PacketEvent(netadr_t from, msg_t *msg)
 	}
 }
 
-#ifdef DEDICATED
 /**
  * @brief A packet has arrived from the main event loop
  *
@@ -1373,8 +1374,6 @@ void CL_FlushMemory(void)
 		Hunk_ClearToMark();
 	}
 }
-
-#endif // DEDICATED
 
 /**
  * @brief Called before parsing a gamestate
@@ -1572,3 +1571,5 @@ void SV_CL_Frame(int frameMsec)
 	// check user info buffer thingy
 	SV_CheckClientUserinfoTimer();
 }
+
+#endif // DEDICATED

--- a/src/server/sv_cl_net_chan.c
+++ b/src/server/sv_cl_net_chan.c
@@ -34,6 +34,8 @@
 
 #include "server.h"
 
+#ifdef DEDICATED
+
 /**
  * @brief SV_CL_Netchan_Encode
  * @details First 12 bytes of the data are always:
@@ -211,3 +213,5 @@ qboolean SV_CL_Netchan_Process(netchan_t *chan, msg_t *msg)
 	newsize2 += msg->cursize;
 	return qtrue;
 }
+
+#endif // DEDICATED

--- a/src/server/sv_cl_net_chan.c
+++ b/src/server/sv_cl_net_chan.c
@@ -1,0 +1,213 @@
+/*
+ * Wolfenstein: Enemy Territory GPL Source Code
+ * Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company.
+ *
+ * ET: Legacy
+ * Copyright (C) 2012-2023 ET:Legacy team <mail@etlegacy.com>
+ *
+ * This file is part of ET: Legacy - http://www.etlegacy.com
+ *
+ * ET: Legacy is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ET: Legacy is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ET: Legacy. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * In addition, Wolfenstein: Enemy Territory GPL Source Code is also
+ * subject to certain additional terms. You should have received a copy
+ * of these additional terms immediately following the terms and conditions
+ * of the GNU General Public License which accompanied the source code.
+ * If not, please request a copy in writing from id Software at the address below.
+ *
+ * id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, Maryland 20850 USA.
+ */
+/**
+ * @file sv_cl_net_chan.c
+ */
+
+#include "server.h"
+
+/**
+ * @brief SV_CL_Netchan_Encode
+ * @details First 12 bytes of the data are always:
+ * long serverId;
+ * long messageAcknowledge;
+ * long reliableAcknowledge;
+ * @param[in,out] msg
+ */
+static void SV_CL_Netchan_Encode(msg_t *msg)
+{
+	int      serverId, messageAcknowledge, reliableAcknowledge;
+	int      i, index, srdc, sbit;
+	qboolean soob;
+	byte     key, *string;
+
+	if (msg->cursize <= CL_ENCODE_START)
+	{
+		return;
+	}
+
+	srdc = msg->readcount;
+	sbit = msg->bit;
+	soob = msg->oob;
+
+	msg->bit = 0;
+	msg->readcount = 0;
+	msg->oob = qfalse;
+
+	serverId = MSG_ReadLong(msg);
+	messageAcknowledge = MSG_ReadLong(msg);
+	reliableAcknowledge = MSG_ReadLong(msg);
+
+	msg->oob = soob;
+	msg->bit = sbit;
+	msg->readcount = srdc;
+
+	string = (byte *)svclc.serverCommands[reliableAcknowledge & (MAX_RELIABLE_COMMANDS - 1)];
+	index = 0;
+
+	key = svclc.challenge ^ serverId ^ messageAcknowledge;
+	for (i = CL_ENCODE_START; i < msg->cursize; i++)
+	{
+		// modify the key with the last received now acknowledged server command
+		if (!string[index])
+		{
+			index = 0;
+		}
+
+		key ^= string[index] << (i & 1);
+
+		index++;
+		// encode the data with this key
+		*(msg->data + i) = (*(msg->data + i)) ^ key;
+	}
+}
+
+/**
+ * @brief SV_CL_WriteBinaryMessage
+ * @param[in] msg
+ */
+static void SV_CL_WriteBinaryMessage(msg_t *msg)
+{
+	if (!svclc.binaryMessageLength)
+	{
+		return;
+	}
+
+	MSG_Uncompressed(msg);
+
+	if ((msg->cursize + svclc.binaryMessageLength) >= msg->maxsize)
+	{
+		svclc.binaryMessageOverflowed = qtrue;
+		return;
+	}
+
+	MSG_WriteData(msg, svclc.binaryMessage, svclc.binaryMessageLength);
+	svclc.binaryMessageLength = 0;
+	svclc.binaryMessageOverflowed = qfalse;
+}
+
+/**
+ * @brief SV_CL_Netchan_Transmit
+ * @param[in] chan
+ * @param[in] msg
+ */
+void SV_CL_Netchan_Transmit(netchan_t *chan, msg_t *msg)
+{
+	MSG_WriteByte(msg, clc_EOF);
+	SV_CL_WriteBinaryMessage(msg);
+
+	SV_CL_Netchan_Encode(msg);
+
+	Netchan_Transmit(chan, msg->cursize, msg->data);
+}
+
+/**
+ * @brief SV_CL_Netchan_TransmitNextFragment
+ * @param[in] chan
+ */
+void SV_CL_Netchan_TransmitNextFragment(netchan_t *chan)
+{
+	Netchan_TransmitNextFragment(chan);
+}
+
+/**
+ * @brief SV_CL_Netchan_Decode
+ * @details First four bytes of the data are always:
+ * long reliableAcknowledge;
+ * @param[in,out] msg
+ */
+static void SV_CL_Netchan_Decode(msg_t *msg)
+{
+	long     reliableAcknowledge, i, index;
+	byte     key, *string;
+	int      srdc, sbit;
+	qboolean soob;
+
+	srdc = msg->readcount;
+	sbit = msg->bit;
+	soob = msg->oob;
+
+	msg->oob = qfalse;
+
+	reliableAcknowledge = MSG_ReadLong(msg);
+
+	msg->oob = soob;
+	msg->bit = sbit;
+	msg->readcount = srdc;
+
+	string = (byte *)svclc.reliableCommands[reliableAcknowledge & (MAX_RELIABLE_COMMANDS - 1)];
+	index = 0;
+	// xor the client challenge with the netchan sequence number (need something that changes every message)
+	key = svclc.challenge ^ LittleLong(*(unsigned *)msg->data);
+	for (i = msg->readcount + CL_DECODE_START; i < msg->cursize; i++)
+	{
+		// modify the key with the last sent and with this message acknowledged client command
+		if (!string[index])
+		{
+			index = 0;
+		}
+
+		if ((!Com_IsCompatible(&svclc.agent, 0x1) && (byte)string[index] > 127) || string[index] == '%')
+		{
+			string[index] = '.';
+		}
+
+		key ^= string[index] << (i & 1);
+
+		index++;
+		// decode the data with this key
+		*(msg->data + i) = *(msg->data + i) ^ key;
+	}
+}
+
+int newsize2 = 0;
+
+/**
+ * @brief SV_CL_Netchan_Process
+ * @param[in] chan
+ * @param[in] msg
+ * @return
+ */
+qboolean SV_CL_Netchan_Process(netchan_t *chan, msg_t *msg)
+{
+	int ret;
+
+	ret = Netchan_Process(chan, msg);
+	if (!ret)
+	{
+		return qfalse;
+	}
+
+	SV_CL_Netchan_Decode(msg);
+
+	newsize2 += msg->cursize;
+	return qtrue;
+}

--- a/src/server/sv_cl_net_chan.c
+++ b/src/server/sv_cl_net_chan.c
@@ -3,7 +3,7 @@
  * Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company.
  *
  * ET: Legacy
- * Copyright (C) 2012-2023 ET:Legacy team <mail@etlegacy.com>
+ * Copyright (C) 2012-2024 ET:Legacy team <mail@etlegacy.com>
  *
  * This file is part of ET: Legacy - http://www.etlegacy.com
  *
@@ -58,20 +58,20 @@ static void SV_CL_Netchan_Encode(msg_t *msg)
 	sbit = msg->bit;
 	soob = msg->oob;
 
-	msg->bit = 0;
+	msg->bit       = 0;
 	msg->readcount = 0;
-	msg->oob = qfalse;
+	msg->oob       = qfalse;
 
-	serverId = MSG_ReadLong(msg);
-	messageAcknowledge = MSG_ReadLong(msg);
+	serverId            = MSG_ReadLong(msg);
+	messageAcknowledge  = MSG_ReadLong(msg);
 	reliableAcknowledge = MSG_ReadLong(msg);
 
-	msg->oob = soob;
-	msg->bit = sbit;
+	msg->oob       = soob;
+	msg->bit       = sbit;
 	msg->readcount = srdc;
 
 	string = (byte *)svclc.serverCommands[reliableAcknowledge & (MAX_RELIABLE_COMMANDS - 1)];
-	index = 0;
+	index  = 0;
 
 	key = svclc.challenge ^ serverId ^ messageAcknowledge;
 	for (i = CL_ENCODE_START; i < msg->cursize; i++)
@@ -110,7 +110,7 @@ static void SV_CL_WriteBinaryMessage(msg_t *msg)
 	}
 
 	MSG_WriteData(msg, svclc.binaryMessage, svclc.binaryMessageLength);
-	svclc.binaryMessageLength = 0;
+	svclc.binaryMessageLength     = 0;
 	svclc.binaryMessageOverflowed = qfalse;
 }
 
@@ -159,12 +159,12 @@ static void SV_CL_Netchan_Decode(msg_t *msg)
 
 	reliableAcknowledge = MSG_ReadLong(msg);
 
-	msg->oob = soob;
-	msg->bit = sbit;
+	msg->oob       = soob;
+	msg->bit       = sbit;
 	msg->readcount = srdc;
 
 	string = (byte *)svclc.reliableCommands[reliableAcknowledge & (MAX_RELIABLE_COMMANDS - 1)];
-	index = 0;
+	index  = 0;
 	// xor the client challenge with the netchan sequence number (need something that changes every message)
 	key = svclc.challenge ^ LittleLong(*(unsigned *)msg->data);
 	for (i = msg->readcount + CL_DECODE_START; i < msg->cursize; i++)

--- a/src/server/sv_cl_parse.c
+++ b/src/server/sv_cl_parse.c
@@ -169,14 +169,14 @@ void SV_CL_SystemInfoChanged(void)
 /**
  * @brief SV_CL_ConfigstringInfoChanged update cvars based on configstring from master
  */
-static void SV_CL_ConfigstringInfoChanged(int num)
+static void SV_CL_ConfigstringInfoChanged(int csnum)
 {
 	char       *cs;
 	const char *s;
 	char       key[BIG_INFO_KEY];
 	char       value[BIG_INFO_VALUE];
 
-	cs = svcl.gameState.stringData + svcl.gameState.stringOffsets[num];
+	cs = svcl.gameState.stringData + svcl.gameState.stringOffsets[csnum];
 
 	s = cs;
 	while (s)
@@ -189,7 +189,7 @@ static void SV_CL_ConfigstringInfoChanged(int num)
 			break;
 		}
 
-		if (num == CS_SERVERINFO)
+		if (csnum == CS_SERVERINFO)
 		{
 			if (!Q_strncmp(key, "sv_", 3) || !Q_stricmp(key, "protocol") || !Q_stricmp(key, "version") ||
 			    !Q_stricmp(key, "gamename") || !Q_stricmp(key, "g_needpass") || !Q_stricmp(key, "g_password"))

--- a/src/server/sv_cl_parse.c
+++ b/src/server/sv_cl_parse.c
@@ -227,8 +227,7 @@ void SV_CL_ParseGamestate(msg_t *msg)
 		}
 	}
 
-	svclc.clientNum = MSG_ReadLong(msg);
-	// read the checksum feed
+	svclc.clientNum    = MSG_ReadLong(msg);
 	svclc.checksumFeed = MSG_ReadLong(msg);
 
 	// parse serverId and other cvars
@@ -262,9 +261,7 @@ void SV_CL_ParseGamestate(msg_t *msg)
 }
 
 /**
- * @brief Command strings are just saved off until cgame asks for them
- * when it transitions a snapshot
- *
+ * @brief Command strings are saved off and executed right away
  * @param[in] msg
  */
 void SV_CL_ParseCommandString(msg_t *msg)

--- a/src/server/sv_cl_parse.c
+++ b/src/server/sv_cl_parse.c
@@ -729,8 +729,10 @@ void SV_CL_ParseSnapshot(msg_t *msg)
 
 	svcl.newSnapshots = qtrue;
 
-
-	sv.time = svcl.snap.serverTime;
+	if (svcl.snap.deltaNum == -1)
+	{
+		sv.time = svcl.snap.serverTime;
+	}
 }
 
 /**

--- a/src/server/sv_cl_parse.c
+++ b/src/server/sv_cl_parse.c
@@ -1,0 +1,882 @@
+/*
+ * Wolfenstein: Enemy Territory GPL Source Code
+ * Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company.
+ *
+ * ET: Legacy
+ * Copyright (C) 2012-2023 ET:Legacy team <mail@etlegacy.com>
+ *
+ * This file is part of ET: Legacy - http://www.etlegacy.com
+ *
+ * ET: Legacy is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ET: Legacy is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ET: Legacy. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * In addition, Wolfenstein: Enemy Territory GPL Source Code is also
+ * subject to certain additional terms. You should have received a copy
+ * of these additional terms immediately following the terms and conditions
+ * of the GNU General Public License which accompanied the source code.
+ * If not, please request a copy in writing from id Software at the address below.
+ *
+ * id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, Maryland 20850 USA.
+ */
+/**
+ * @file sv_cl_parse.c
+ */
+
+#include "server.h"
+
+static void SV_CL_SetPurePaks(qboolean referencedOnly)
+{
+	const char *s, *t;
+	char       *systemInfo = svcl.gameState.stringData + svcl.gameState.stringOffsets[CS_SYSTEMINFO];
+
+	if (!referencedOnly)
+	{
+		// check pure server string
+		s = Info_ValueForKey(systemInfo, "sv_paks");
+		t = Info_ValueForKey(systemInfo, "sv_pakNames");
+		FS_PureServerSetLoadedPaks(s, t);
+	}
+	else
+	{
+		FS_PureServerSetLoadedPaks("", "");
+	}
+
+	s = Info_ValueForKey(systemInfo, "sv_referencedPaks");
+	t = Info_ValueForKey(systemInfo, "sv_referencedPakNames");
+	FS_PureServerSetReferencedPaks(s, t);
+}
+
+ /**
+  * @brief The systeminfo configstring has been changed, so parse new information out of it.
+  * This will happen at every gamestate, and possibly during gameplay.
+  */
+void SV_CL_SystemInfoChanged(void)
+{
+	char       *systemInfo = svcl.gameState.stringData + svcl.gameState.stringOffsets[CS_SYSTEMINFO];
+	const char *s;
+	char       key[BIG_INFO_KEY];
+	char       value[BIG_INFO_VALUE];
+	qboolean   gameSet;
+
+	// NOTE: when the serverId changes, any further messages we send to the server will use this new serverId
+	// in some cases, outdated cp commands might get sent with this news serverId
+	svcl.serverId = Q_atoi(Info_ValueForKey(systemInfo, "sv_serverid"));
+
+	//Com_Memset(&entLastVisible, 0, sizeof(entLastVisible));
+
+	// don't set any vars when playing a demo
+	//if (svclc.demo.playing)
+	//{
+	//	// allow running demo in pure mode to simulate server environment,
+	//	// but still setup the referenced packages for the container system to work
+	//	CL_SetPurePaks(!svclc.demo.pure);
+	//	return;
+	//}
+
+	//s = Info_ValueForKey(systemInfo, "sv_cheats");
+	//cl_connectedToCheatServer = Q_atoi(s);      //bani
+	//if (!cl_connectedToCheatServer)
+	//{
+	//	Cvar_SetCheatState();
+	//}
+
+	SV_CL_SetPurePaks(qfalse);
+
+	gameSet = qfalse;
+	// scan through all the variables in the systeminfo and locally set cvars to match
+	s = systemInfo;
+	while (s)
+	{
+		cvarFlags_t cvar_flags;
+
+		Info_NextPair(&s, key, value);
+		if (!key[0])
+		{
+			break;
+		}
+
+		// ehw!
+		if (!Q_stricmp(key, "fs_game"))
+		{
+			if (FS_InvalidGameDir(value))
+			{
+				Com_Printf(S_COLOR_YELLOW "WARNING: Server sent invalid fs_game value %s\n", value);
+				continue;
+			}
+
+			gameSet = qtrue;
+		}
+
+		if ((cvar_flags = Cvar_Flags(key)) & CVAR_NONEXISTENT)
+		{
+			Cvar_Get(key, value, CVAR_SERVER_CREATED | CVAR_ROM);
+		}
+		else
+		{
+			// If this cvar may not be modified by a server discard the value.
+			// "shared" is for ETJump compatibility, information shared between server & client
+			// TODO: see why CVAR_SERVER_CREATED flag gets dropped here
+			if (!(cvar_flags & (CVAR_SYSTEMINFO | CVAR_SERVER_CREATED | CVAR_USER_CREATED)))
+			{
+				if (Q_stricmp(key, "g_synchronousClients") && Q_stricmp(key, "pmove_fixed") &&
+					Q_stricmp(key, "pmove_msec") && Q_stricmp(key, "shared"))
+				{
+					Com_DPrintf(S_COLOR_YELLOW "WARNING: server is not allowed to set %s=%s\n", key, value);
+					continue;
+				}
+			}
+
+			Cvar_SetSafe(key, value);
+		}
+	}
+
+	// if game folder should not be set and it is set at the client side
+	if (!gameSet && *Cvar_VariableString("fs_game"))
+	{
+		Cvar_Set("fs_game", "");
+	}
+
+	// big hack to clear the image cache on a pure change
+	//cl_connectedToPureServer = Cvar_VariableValue( "sv_pure" );
+	//if (Cvar_VariableValue("sv_pure") != 0.f)
+	//{
+	//	if (!cl_connectedToPureServer && cls.state <= CA_CONNECTED)
+	//	{
+	//		CL_PurgeCache();
+	//	}
+	//	cl_connectedToPureServer = qtrue;
+	//}
+	//else
+	//{
+	//	if (cl_connectedToPureServer && cls.state <= CA_CONNECTED)
+	//	{
+	//		CL_PurgeCache();
+	//	}
+	//	cl_connectedToPureServer = qfalse;
+	//}
+}
+
+/**
+ * @brief SV_CL_ParseGamestate
+ * @param[in] msg
+ */
+void SV_CL_ParseGamestate(msg_t *msg)
+{
+	int            i;
+	entityState_t  *es;
+	entityShared_t *entShared;
+	int            newnum;
+	entityState_t  nullstate;
+	entityShared_t nullstateShared;
+	int            cmd;
+	char           *s;
+
+	svclc.connectPacketCount = 0;
+
+	// wipe local client state
+	SV_CL_ClearState();
+
+	// a gamestate always marks a server command sequence
+	svclc.serverCommandSequence = MSG_ReadLong(msg);
+
+	// parse all the configstrings and baselines
+	svcl.gameState.dataCount = 1; // leave a 0 at the beginning for uninitialized configstrings
+	while (1)
+	{
+		cmd = MSG_ReadByte(msg);
+
+		if (cmd == svc_EOF)
+		{
+			break;
+		}
+
+		if (cmd == svc_configstring)
+		{
+			int len;
+
+			i = MSG_ReadShort(msg);
+			if (i < 0 || i >= MAX_CONFIGSTRINGS)
+			{
+				Com_Error(ERR_DROP, "configstring < 0 or configstring >= MAX_CONFIGSTRINGS");
+			}
+			s = MSG_ReadBigString(msg);
+			len = strlen(s);
+
+			if (len + 1 + svcl.gameState.dataCount > MAX_GAMESTATE_CHARS)
+			{
+				Com_Error(ERR_DROP, "MAX_GAMESTATE_CHARS exceeded");
+			}
+
+			// append it to the gameState string buffer
+			svcl.gameState.stringOffsets[i] = svcl.gameState.dataCount;
+			Com_Memcpy(svcl.gameState.stringData + svcl.gameState.dataCount, s, len + 1);
+			svcl.gameState.dataCount += len + 1;
+		}
+		else if (cmd == svc_baseline)
+		{
+			newnum = MSG_ReadBits(msg, GENTITYNUM_BITS);
+			if (newnum < 0 || newnum >= MAX_GENTITIES)
+			{
+				Com_Error(ERR_DROP, "Baseline number out of range: %i", newnum);
+			}
+			Com_Memset(&nullstate, 0, sizeof(nullstate));
+			Com_Memset(&nullstateShared, 0, sizeof(nullstateShared));
+			es        = &svcl.entityBaselines[newnum];
+			entShared = &svcl.entitySharedBaselines[newnum];
+			MSG_ReadDeltaEntity(msg, &nullstate, es, newnum);
+			MSG_ETTV_ReadDeltaEntityShared(msg, &nullstateShared, entShared);
+		}
+		else
+		{
+			Com_Error(ERR_DROP, "CL_ParseGamestate: bad command byte");
+		}
+	}
+
+	svclc.clientNum = MSG_ReadLong(msg);
+	// read the checksum feed
+	svclc.checksumFeed = MSG_ReadLong(msg);
+
+	// parse serverId and other cvars
+	SV_CL_SystemInfoChanged();
+
+	// Verify if we have all official pakfiles. As we won't
+	// be downloading them, we should be kicked for not having them.
+	if (/*cl_connectedToPureServer && */!FS_VerifyOfficialPaks())
+	{
+		Com_Error(ERR_DROP, "Couldn't load an official pak file; verify your installation and make sure it has been updated to the latest version.");
+	}
+
+#if defined(FEATURE_PAKISOLATION) && !defined(DEDICATED)
+	Cvar_Set("fs_containerMount", "1");
+#endif
+
+	// reinitialize the filesystem if the game directory has changed
+	//FS_ConditionalRestart(svclc.checksumFeed);
+
+	// This used to call CL_StartHunkUsers, but now we enter the download state before loading the
+	// cgame
+	/*if (!clc.demo.playing)
+	{
+		Com_InitDownloads();
+	}
+	else*/
+	{
+		//char missingFiles[MAX_TOKEN_CHARS] = { '\0' };
+		/*if (clc.demo.pure && FS_ComparePaks(missingFiles, sizeof(missingFiles), qfalse))
+		{
+			Com_Error(ERR_DROP, "Missing required packages: %s", missingFiles);
+		}
+		else*/
+		{
+			SV_CL_DownloadsComplete();
+		}
+	}
+
+	// make sure the game starts
+	Cvar_Set("cl_paused", "0");
+}
+
+/**
+ * @brief Command strings are just saved off until cgame asks for them
+ * when it transitions a snapshot
+ *
+ * @param[in] msg
+ */
+void SV_CL_ParseCommandString(msg_t *msg)
+{
+	char *s;
+	int  seq;
+	int  index;
+
+	seq = MSG_ReadLong(msg);
+	s = MSG_ReadString(msg);
+
+	// see if we have already executed stored it off
+	if (svclc.serverCommandSequence >= seq)
+	{
+		return;
+	}
+
+	svclc.serverCommandSequence = seq;
+	index                       = seq & (MAX_RELIABLE_COMMANDS - 1);
+
+	Q_strncpyz(svclc.serverCommands[index], s, sizeof(svclc.serverCommands[index]));
+
+	if (!gvm)
+	{
+		return;
+	}
+
+	while (svclc.lastExecutedServerCommand < svclc.serverCommandSequence)
+	{
+		if (SV_CL_GetServerCommand(++svclc.lastExecutedServerCommand))
+		{
+			VM_CallFunc(gvm, GAME_CLIENT_COMMAND, -2);
+		}
+	}
+}
+
+/**
+ * @brief Parses deltas from the given base and adds the resulting entity to the current frame
+ *
+ * @param[in] msg
+ * @param[in,out] frame
+ * @param[in] newnum
+ * @param[in,out] old
+ * @param[in,out] oldShared
+ * @param[in] unchanged
+ */
+void SV_CL_DeltaEntity(msg_t *msg, svclSnapshot_t *frame, int newnum, entityState_t *old, entityShared_t *oldShared, qboolean unchanged)
+{
+	// save the parsed entity state into the big circular buffer so
+	// it can be used as the source for a later delta
+	entityState_t  *state       = &svcl.parseEntities[svcl.parseEntitiesNum & (MAX_PARSE_ENTITIES - 1)];
+	entityShared_t *stateShared = &svcl.parseEntitiesShared[svcl.parseEntitiesNum & (MAX_PARSE_ENTITIES - 1)];
+	sharedEntity_t *gEnt;
+
+	if (unchanged)
+	{
+		*state       = *old;
+		*stateShared = *oldShared;
+	}
+	else
+	{
+		MSG_ReadDeltaEntity(msg, old, state, newnum);
+		MSG_ETTV_ReadDeltaEntityShared(msg, oldShared, stateShared);
+	}
+
+	if (svcls.isTVGame && sv.gentities)
+	{
+		gEnt = SV_GentityNum(newnum);
+
+		if (state->number == (MAX_GENTITIES - 1))
+		{
+			SV_UnlinkEntity(gEnt);
+			return;     // entity was delta removed
+		}
+
+		gEnt->s = *state;
+		gEnt->r = *stateShared;
+
+		if (state->number < MAX_CLIENTS)
+		{
+			gEnt->r.contents = CONTENTS_SOLID;
+		}
+
+		gEnt->s.number = newnum;
+		SV_LinkEntity(gEnt);
+	}
+
+	if (state->number == (MAX_GENTITIES - 1))
+	{
+		return;     // entity was delta removed
+	}
+
+	svcl.parseEntitiesNum++;
+	frame->numEntities++;
+}
+
+/**
+ * @brief SV_CL_ParsePacketEntities
+ * @param[in] msg
+ * @param[in] oldframe
+ * @param[out] newframe
+ *
+ * @note oldnum is set to MAX_GENTITIES to ensure newnum
+ * will never be greater than oldnum in case of invalid oldframe or oldindex
+ */
+void SV_CL_ParsePacketEntities(msg_t *msg, svclSnapshot_t *oldframe, svclSnapshot_t *newframe)
+{
+	entityState_t  *oldstate;
+	entityShared_t *oldstateShared;
+	int            oldindex, newnum, oldnum;
+
+	oldstate       = NULL;
+	oldstateShared = NULL;
+	oldindex       = 0;
+
+	newframe->parseEntitiesNum = svcl.parseEntitiesNum;
+	newframe->numEntities = 0;
+
+	// delta from the entities present in oldframe
+
+	if (!oldframe)
+	{
+		oldnum = MAX_GENTITIES;
+	}
+	else
+	{
+		if (oldindex >= oldframe->numEntities)
+		{
+			oldnum = MAX_GENTITIES;
+		}
+		else
+		{
+			oldstate = &svcl.parseEntities[
+				(oldframe->parseEntitiesNum + oldindex) & (MAX_PARSE_ENTITIES - 1)];
+			oldstateShared = &svcl.parseEntitiesShared[
+				(oldframe->parseEntitiesNum + oldindex) & (MAX_PARSE_ENTITIES - 1)];
+			oldnum = oldstate->number;
+		}
+	}
+
+	while (1)
+	{
+		// read the entity index number
+		newnum = MSG_ReadBits(msg, GENTITYNUM_BITS);
+
+		if (newnum >= (MAX_GENTITIES - 1))
+		{
+			break;
+		}
+
+		if (msg->readcount > msg->cursize)
+		{
+			Com_Error(ERR_DROP, "CL_ParsePacketEntities: end of message");
+		}
+
+		while (oldnum < newnum)
+		{
+			// one or more entities from the old packet are unchanged
+			//if (cl_shownet->integer == 3)
+			//{
+			//	Com_Printf("%3i:  unchanged: %i\n", msg->readcount, oldnum);
+			//}
+			SV_CL_DeltaEntity(msg, newframe, oldnum, oldstate, oldstateShared, qtrue);
+
+			oldindex++;
+
+			if (!oldframe || oldindex >= oldframe->numEntities)
+			{
+				oldnum = MAX_GENTITIES;
+			}
+			else
+			{
+				oldstate = &svcl.parseEntities[
+					(oldframe->parseEntitiesNum + oldindex) & (MAX_PARSE_ENTITIES - 1)];
+				oldstateShared = &svcl.parseEntitiesShared[
+					(oldframe->parseEntitiesNum + oldindex) & (MAX_PARSE_ENTITIES - 1)];
+				oldnum = oldstate->number;
+			}
+		}
+
+		if (oldnum == newnum)
+		{
+			// delta from previous state
+			//if (cl_shownet->integer == 3)
+			//{
+			//	Com_Printf("%3i:  delta: %i\n", msg->readcount, newnum);
+			//}
+			SV_CL_DeltaEntity(msg, newframe, newnum, oldstate, oldstateShared, qfalse);
+
+			oldindex++;
+
+			if (oldindex >= oldframe->numEntities)
+			{
+				oldnum = MAX_GENTITIES;
+			}
+			else
+			{
+				oldstate = &svcl.parseEntities[
+					(oldframe->parseEntitiesNum + oldindex) & (MAX_PARSE_ENTITIES - 1)];
+				oldstateShared = &svcl.parseEntitiesShared[
+					(oldframe->parseEntitiesNum + oldindex) & (MAX_PARSE_ENTITIES - 1)];
+				oldnum = oldstate->number;
+			}
+		}
+		else if (oldnum > newnum)
+		{
+			// delta from baseline
+			//if (cl_shownet->integer == 3)
+			//{
+			//	Com_Printf("%3i:  baseline: %i\n", msg->readcount, newnum);
+			//}
+			SV_CL_DeltaEntity(msg, newframe, newnum, &svcl.entityBaselines[newnum], &svcl.entitySharedBaselines[newnum], qfalse);
+		}
+	}
+
+	// any remaining entities in the old frame are copied over
+	while (oldnum != MAX_GENTITIES)
+	{
+		// one or more entities from the old packet are unchanged
+		//if (cl_shownet->integer == 3)
+		//{
+		//	Com_Printf("%3i:  unchanged: %i\n", msg->readcount, oldnum);
+		//}
+		SV_CL_DeltaEntity(msg, newframe, oldnum, oldstate, oldstateShared, qtrue);
+
+		oldindex++;
+
+		if (oldindex >= oldframe->numEntities)
+		{
+			oldnum = MAX_GENTITIES;
+		}
+		else
+		{
+			oldstate       = &svcl.parseEntities[(oldframe->parseEntitiesNum + oldindex) & (MAX_PARSE_ENTITIES - 1)];
+			oldstateShared = &svcl.parseEntitiesShared[(oldframe->parseEntitiesNum + oldindex) & (MAX_PARSE_ENTITIES - 1)];
+			oldnum         = oldstate->number;
+		}
+	}
+
+	//if (cl_shownuments->integer)
+	{
+		//Com_Printf("Entities in packet: %i\n", newframe->numEntities);
+	}
+}
+
+/**
+ * @brief If the snapshot is parsed properly, it will be copied to
+ * cl.snap and saved in cl.snapshots[].  If the snapshot is invalid
+ * for any reason, no changes to the state will be made at all.
+ *
+ * @param[in] msg
+ */
+void SV_CL_ParseSnapshot(msg_t *msg)
+{
+	int            len;
+	svclSnapshot_t *old;
+	svclSnapshot_t newSnap;
+	int            deltaNum;
+	int            oldMessageNum;
+	int            i, packetNum;
+
+	// get the reliable sequence acknowledge number
+	// NOTE: now sent with all server to client messages
+	//clc.reliableAcknowledge = MSG_ReadLong( msg );
+
+	// read in the new snapshot to a temporary buffer
+	// we will only copy to cl.snap if it is valid
+	Com_Memset(&newSnap, 0, sizeof(newSnap));
+
+	// we will have read any new server commands in this
+	// message before we got to svc_snapshot
+	newSnap.serverCommandNum = svclc.serverCommandSequence;
+
+	newSnap.serverTime = MSG_ReadLong(msg);
+
+	newSnap.messageNum = svclc.serverMessageSequence;
+
+	deltaNum = MSG_ReadByte(msg);
+	if (!deltaNum)
+	{
+		newSnap.deltaNum = -1;
+	}
+	else
+	{
+		newSnap.deltaNum = newSnap.messageNum - deltaNum;
+	}
+	newSnap.snapFlags = MSG_ReadByte(msg);
+
+	// If the frame is delta compressed from data that we
+	// no longer have available, we must suck up the rest of
+	// the frame, but not use it, then ask for a non-compressed
+	// message
+	if (newSnap.deltaNum <= 0)
+	{
+		newSnap.valid = qtrue;      // uncompressed frame
+		old = NULL;
+		//if (svclc.demo.recording)
+		//{
+		//	svclc.demo.waiting = qfalse;   // we can start recording now
+		//	//if(cl_autorecord->integer) {
+		//	//  Cvar_Set( "g_synchronousClients", "0" );
+		//	//}
+		//}
+		//else
+		//{
+		//	if (cl_autorecord->integer /*&& Cvar_VariableValue( "g_synchronousClients")*/)
+		//	{
+		//		char    name[256];
+		//		char    mapname[MAX_QPATH];
+		//		char    *period;
+		//		qtime_t time;
+
+		//		Com_RealTime(&time);
+
+		//		Q_strncpyz(mapname, cl.mapname, MAX_QPATH);
+		//		for (period = mapname; *period; period++)
+		//		{
+		//			if (*period == '.')
+		//			{
+		//				*period = '\0';
+		//				break;
+		//			}
+		//		}
+
+		//		for (period = mapname; *period; period++)
+		//		{
+		//			if (*period == '/')
+		//			{
+		//				break;
+		//			}
+		//		}
+		//		if (*period)
+		//		{
+		//			period++;
+		//		}
+
+		//		Com_sprintf(name, sizeof(name), "demos/%d-%02d-%02d-%02d%02d%02d-%s.dm_%d", 1900 + time.tm_year,
+		//			time.tm_mon + 1, time.tm_mday, time.tm_hour, time.tm_min, time.tm_sec, period, PROTOCOL_VERSION);
+
+		//		CL_Record(name);
+		//	}
+		//}
+	}
+	else
+	{
+		old = &svcl.snapshots[newSnap.deltaNum & PACKET_MASK];
+		if (!old->valid)
+		{
+			// should never happen
+			Com_Printf("Delta from invalid frame (not supposed to happen!).\n");
+		}
+		else if (old->messageNum != newSnap.deltaNum)
+		{
+			// The frame that the server did the delta from
+			// is too old, so we can't reconstruct it properly.
+			Com_DPrintf("Delta frame too old.\n");
+		}
+		else if (svcl.parseEntitiesNum - old->parseEntitiesNum > MAX_PARSE_ENTITIES - 128)
+		{
+			Com_DPrintf("Delta parseEntitiesNum too old.\n");
+		}
+		else
+		{
+			newSnap.valid = qtrue;  // valid delta parse
+		}
+	}
+
+	// read areamask
+	len = MSG_ReadByte(msg);
+
+	if (len < 0 || len > sizeof(newSnap.areamask))
+	{
+		Com_Error(ERR_DROP, "SV_CL_ParseSnapshot: Invalid size %d for areamask.", len);
+		return;
+	}
+
+	MSG_ReadData(msg, &newSnap.areamask, len);
+
+	// read playerinfo
+	//SHOWNET(msg, "playerstate");
+	if (old)
+	{
+		MSG_ReadDeltaPlayerstate(msg, &old->ps, &newSnap.ps);
+	}
+	else
+	{
+		MSG_ReadDeltaPlayerstate(msg, NULL, &newSnap.ps);
+	}
+
+	// read packet entities
+	//SHOWNET(msg, "packet entities");
+	SV_CL_ParsePacketEntities(msg, old, &newSnap);
+
+	// if not valid, dump the entire thing now that it has
+	// been properly read
+	if (!newSnap.valid)
+	{
+		return;
+	}
+
+	// clear the valid flags of any snapshots between the last
+	// received and this one, so if there was a dropped packet
+	// it won't look like something valid to delta from next
+	// time we wrap around in the buffer
+	oldMessageNum = svcl.snap.messageNum + 1;
+
+	if (newSnap.messageNum - oldMessageNum >= PACKET_BACKUP)
+	{
+		oldMessageNum = newSnap.messageNum - (PACKET_BACKUP - 1);
+	}
+	for (; oldMessageNum < newSnap.messageNum; oldMessageNum++)
+	{
+		svcl.snapshots[oldMessageNum & PACKET_MASK].valid = qfalse;
+	}
+
+	// copy to the current good spot
+	svcl.snap = newSnap;
+	svcl.snap.ping = 999;
+	// calculate ping time
+	for (i = 0; i < PACKET_BACKUP; i++)
+	{
+		packetNum = (svclc.netchan.outgoingSequence - 1 - i) & PACKET_MASK;
+		if (svcl.snap.ps.commandTime >= svcl.outPackets[packetNum].p_serverTime)
+		{
+			svcl.snap.ping = svcls.realtime - svcl.outPackets[packetNum].p_realtime;
+			break;
+		}
+	}
+	// save the frame off in the backup array for later delta comparisons
+	svcl.snapshots[svcl.snap.messageNum & PACKET_MASK] = svcl.snap;
+
+	//if (cl_shownet->integer == 3)
+	//{
+	//	Com_Printf("   snapshot:%i  delta:%i  ping:%i\n", cl.snap.messageNum,
+	//		cl.snap.deltaNum, cl.snap.ping);
+	//}
+
+	svcl.newSnapshots = qtrue;
+
+
+	sv.time = svcl.snap.serverTime;
+}
+
+/**
+ * @brief SV_CL_ParsePlayerstates
+ * @param[in] msg
+ */
+void SV_CL_ParsePlayerstates(msg_t *msg)
+{
+	svclSnapshot_t *frame, *oldframe = NULL;
+	int            i, clientNum, oldMessageNum;
+
+	if (svcl.snap.deltaNum != -1)
+	{
+		oldframe = &svcl.snapshots[svcl.snap.deltaNum & PACKET_MASK];
+	}
+
+	frame = &svcl.snapshots[svcl.snap.messageNum & PACKET_MASK];
+
+	while (1)
+	{
+		// read the clientNum	
+		clientNum = MSG_ReadByte(msg);
+
+		if (clientNum == 255)
+		{
+			break;
+		}
+
+		if (!oldframe || !oldframe->playerstates[clientNum].valid)
+		{
+			MSG_ReadDeltaPlayerstate(msg, NULL, &frame->playerstates[clientNum].ps);
+		}
+		else
+		{
+			MSG_ReadDeltaPlayerstate(msg, &oldframe->playerstates[clientNum].ps, &frame->playerstates[clientNum].ps);
+		}
+
+		frame->playerstates[clientNum].valid = qtrue;
+	}
+
+	svcl.snap = *frame;
+
+	// clear the valid flags of any snapshots between the last
+	// received and this one, so if there was a dropped packet
+	// it won't look like something valid to delta from next
+	// time we wrap around in the buffer
+	oldMessageNum = svcl.snap.messageNum + 1;
+
+	if (svcl.snap.messageNum - oldMessageNum >= PACKET_BACKUP)
+	{
+		oldMessageNum = svcl.snap.messageNum - (PACKET_BACKUP - 1);
+	}
+	for (; oldMessageNum < svcl.snap.messageNum; oldMessageNum++)
+	{
+		for (i = 0; i < MAX_CLIENTS; i++)
+		{
+			svcl.snapshots[oldMessageNum & PACKET_MASK].playerstates[i].valid = qfalse;
+		}
+	}
+}
+
+/**
+ * @brief SV_CL_ParseServerMessage
+ * @param[in] msg
+ */
+void SV_CL_ParseServerMessage(msg_t *msg)
+{
+	int cmd;
+
+	//if (cl_shownet->integer == 1)
+	//{
+	//	Com_Printf("%i ", msg->cursize);
+	//}
+	//else if (cl_shownet->integer >= 2)
+	//{
+	//	Com_Printf("------------------\n");
+	//}
+
+	MSG_Bitstream(msg);
+
+	// get the reliable sequence acknowledge number
+	svclc.reliableAcknowledge = MSG_ReadLong(msg);
+
+	if (svclc.reliableAcknowledge < svclc.reliableSequence - MAX_RELIABLE_COMMANDS)
+	{
+		svclc.reliableAcknowledge = svclc.reliableSequence;
+	}
+
+	// parse the message
+	while (1)
+	{
+		if (msg->readcount > msg->cursize)
+		{
+			Com_Error(ERR_DROP, "CL_ParseServerMessage: read past end of server message");
+		}
+
+		cmd = MSG_ReadByte(msg);
+
+		if (cmd == svc_EOF)
+		{
+			//SHOWNET(msg, "END OF MESSAGE");
+			break;
+		}
+
+		//if (cl_shownet->integer >= 2)
+		//{
+		//	if (cmd < 0 || cmd > svc_EOF) // MSG_ReadByte might return -1 and we can't access our svc_strings array ...
+		//	{
+		//		Com_Printf("%3i:BAD BYTE %i\n", msg->readcount - 1, cmd); // -> ERR_DROP
+		//	}
+		//	else
+		//	{
+		//		if (!svc_strings[cmd])
+		//		{
+		//			Com_Printf("%3i:BAD CMD %i\n", msg->readcount - 1, cmd);
+		//		}
+		//		else
+		//		{
+		//			SHOWNET(msg, svc_strings[cmd]);
+		//		}
+		//	}
+		//}
+
+		// other commands
+		switch (cmd)
+		{
+		default:
+			Com_Error(ERR_DROP, "CL_ParseServerMessage: Illegible server message %d", cmd);
+		case svc_nop:
+			break;
+		case svc_serverCommand:
+			SV_CL_ParseCommandString(msg);
+			break;
+		case svc_gamestate:
+			SV_CL_ParseGamestate(msg);
+			break;
+		case svc_snapshot:
+			SV_CL_ParseSnapshot(msg);
+			break;
+		case svc_ettv_playerstates:
+			SV_CL_ParsePlayerstates(msg);
+		case svc_download:
+			//CL_ParseDownload(msg);
+			break;
+		}
+	}
+
+	//CL_ParseBinaryMessage(msg);
+}

--- a/src/server/sv_cl_parse.c
+++ b/src/server/sv_cl_parse.c
@@ -34,6 +34,8 @@
 
 #include "server.h"
 
+#ifdef DEDICATED
+
 /**
   * @brief SV_CL_SetPurePaks
  * @param[in] referencedOnly
@@ -202,7 +204,7 @@ void SV_CL_ParseGamestate(msg_t *msg)
 			Com_Memset(&nullstate, 0, sizeof(nullstate));
 			Com_Memset(&nullstateShared, 0, sizeof(nullstateShared));
 			es        = &svcl.entityBaselines[newnum];
-			entShared = &svcl.entitySharedBaselines[newnum];
+			entShared = &svcl.entityBaselinesShared[newnum];
 			MSG_ReadDeltaEntity(msg, &nullstate, es, newnum);
 			MSG_ETTV_ReadDeltaEntityShared(msg, &nullstateShared, entShared);
 		}
@@ -216,7 +218,7 @@ void SV_CL_ParseGamestate(msg_t *msg)
 			}
 
 			MSG_ReadDeltaEntity(msg, &svcl.entityBaselines[newnum], &svcl.currentStateEntities[newnum], newnum);
-			MSG_ETTV_ReadDeltaEntityShared(msg, &svcl.entitySharedBaselines[newnum], &svcl.currentStateEntitiesShared[newnum]);
+			MSG_ETTV_ReadDeltaEntityShared(msg, &svcl.entityBaselinesShared[newnum], &svcl.currentStateEntitiesShared[newnum]);
 			svcl.currentStateEntitiesShared[newnum].linked = qtrue;
 		}
 		else
@@ -493,7 +495,7 @@ void SV_CL_ParsePacketEntities(msg_t *msg, svclSnapshot_t *oldframe, svclSnapsho
 			//{
 			//	Com_Printf("%3i:  baseline: %i\n", msg->readcount, newnum);
 			//}
-			SV_CL_DeltaEntity(msg, newframe, newnum, &svcl.entityBaselines[newnum], &svcl.entitySharedBaselines[newnum], qfalse);
+			SV_CL_DeltaEntity(msg, newframe, newnum, &svcl.entityBaselines[newnum], &svcl.entityBaselinesShared[newnum], qfalse);
 		}
 	}
 
@@ -840,3 +842,5 @@ void SV_CL_ParseServerMessage(msg_t *msg)
 		SV_CL_RunFrame();
 	}
 }
+
+#endif // DEDICATED

--- a/src/server/sv_cl_parse.c
+++ b/src/server/sv_cl_parse.c
@@ -385,6 +385,25 @@ void SV_CL_ParseCommandString(msg_t *msg)
 }
 
 /**
+ * @brief SV_CL_ParseBinaryMessage
+ * @param[in] msg
+ */
+void SV_CL_ParseBinaryMessage(msg_t *msg)
+{
+	int size;
+
+	MSG_BeginReadingUncompressed(msg);
+
+	size = msg->cursize - msg->readcount;
+	if (size <= 0 || size > MAX_BINARY_MESSAGE)
+	{
+		return;
+	}
+
+	SV_GameBinaryMessageReceived(-1, (char *)&msg->data[msg->readcount], size, svcl.snap.serverTime);
+}
+
+/**
  * @brief Parses deltas from the given base and adds the resulting entity to the current frame
  *
  * @param[in] msg
@@ -934,7 +953,7 @@ void SV_CL_ParseServerMessage(msg_t *msg)
 		}
 	}
 
-	//CL_ParseBinaryMessage(msg);
+	SV_CL_ParseBinaryMessage(msg);
 
 	if (svcls.isTVGame)
 	{

--- a/src/server/sv_cl_parse.c
+++ b/src/server/sv_cl_parse.c
@@ -582,49 +582,14 @@ void SV_CL_ParseSnapshot(msg_t *msg)
 		if (svclc.demo.recording)
 		{
 			svclc.demo.waiting = qfalse;   // we can start recording now
-			//if(cl_autorecord->integer) {
-			//  Cvar_Set( "g_synchronousClients", "0" );
-			//}
 		}
-		//else
-		//{
-		//	if (cl_autorecord->integer /*&& Cvar_VariableValue( "g_synchronousClients")*/)
-		//	{
-		//		char    name[256];
-		//		char    mapname[MAX_QPATH];
-		//		char    *period;
-		//		qtime_t time;
-
-		//		Com_RealTime(&time);
-
-		//		Q_strncpyz(mapname, cl.mapname, MAX_QPATH);
-		//		for (period = mapname; *period; period++)
-		//		{
-		//			if (*period == '.')
-		//			{
-		//				*period = '\0';
-		//				break;
-		//			}
-		//		}
-
-		//		for (period = mapname; *period; period++)
-		//		{
-		//			if (*period == '/')
-		//			{
-		//				break;
-		//			}
-		//		}
-		//		if (*period)
-		//		{
-		//			period++;
-		//		}
-
-		//		Com_sprintf(name, sizeof(name), "demos/%d-%02d-%02d-%02d%02d%02d-%s.dm_%d", 1900 + time.tm_year,
-		//			time.tm_mon + 1, time.tm_mday, time.tm_hour, time.tm_min, time.tm_sec, period, PROTOCOL_VERSION);
-
-		//		CL_Record(name);
-		//	}
-		//}
+		else
+		{
+			if (sv_etltv_autorecord->integer && !svclc.demo.playing)
+			{
+				Cbuf_ExecuteText(EXEC_APPEND, "record\n");
+			}
+		}
 	}
 	else
 	{

--- a/src/server/sv_client.c
+++ b/src/server/sv_client.c
@@ -211,21 +211,21 @@ static qboolean SV_IsValidUserinfo(netadr_t from, const char *userinfo)
 
 		if (sv_etltv_maxslaves->integer <= 0)
 		{
-			NET_OutOfBandPrint(NS_SERVER, from, "print\nMaster must reserve slots with sv_etltv_maxslaves.\n");
+			NET_OutOfBandPrint(NS_SERVER, from, "print\n[err_dialog]Master must reserve slots with sv_etltv_maxslaves.\n");
 			Com_DPrintf("    rejected ettv slave connection from %s because sv_etltv_maxslaves is not set.\n", NET_AdrToString(from));
 			return qfalse;
 		}
 
 		if (!sv_etltv_password->string[0])
 		{
-			NET_OutOfBandPrint(NS_SERVER, from, "print\nMaster must set an sv_etltv_password.\n");
+			NET_OutOfBandPrint(NS_SERVER, from, "print\n[err_dialog]Master must set an sv_etltv_password.\n");
 			Com_DPrintf("    rejected ettv slave connection from %s because of empty sv_etltv_password.\n", NET_AdrToString(from));
 			return qfalse;
 		}
 
 		if (strcmp(Info_ValueForKey(userinfo, "masterpassword"), sv_etltv_password->string))
 		{
-			NET_OutOfBandPrint(NS_SERVER, from, "print\nInvalid master password.\n");
+			NET_OutOfBandPrint(NS_SERVER, from, "print\n[err_dialog]Invalid master password.\n");
 			Com_DPrintf("    rejected ettv slave connection from %s because password didn\'t match sv_etltv_password.\n", NET_AdrToString(from));
 			return qfalse;
 		}
@@ -562,16 +562,16 @@ gotnewcl:
 	// build a new connection
 	// accept the new client
 	// this is the only place a client_t is EVER initialized
-	*newcl         = temp;
-	clientNum      = newcl - svs.clients;
+	*newcl    = temp;
+	clientNum = newcl - svs.clients;
 
 	if (!svcls.isTVGame)
 	{
-		newcl->gentity = SV_GentityNum(clientNum);
+		newcl->gentity            = SV_GentityNum(clientNum);
 		newcl->gentity->r.svFlags = 0; // clear client flags on new connection.
 	}
 
-	newcl->challenge          = challenge; // save the challenge
+	newcl->challenge = challenge;          // save the challenge
 	Q_strncpyz(newcl->guid, Info_ValueForKey(userinfo, "cl_guid"), sizeof(newcl->guid)); // save guid
 
 	// save the address

--- a/src/server/sv_client.c
+++ b/src/server/sv_client.c
@@ -565,7 +565,9 @@ gotnewcl:
 	*newcl    = temp;
 	clientNum = newcl - svs.clients;
 
+#ifdef DEDICATED
 	if (!svcls.isTVGame)
+#endif // DEDICATED
 	{
 		newcl->gentity            = SV_GentityNum(clientNum);
 		newcl->gentity->r.svFlags = 0; // clear client flags on new connection.
@@ -867,7 +869,7 @@ void SV_SendClientGameState(client_t *client)
 		MSG_WriteDeltaEntity(&msg, &nullstate, base, qtrue);
 		if (client->ettvClient)
 		{
-			MSG_ETTV_WriteDeltaSharedEntity(&msg, &nullstateShared, baseShared, qtrue);
+			MSG_ETTV_WriteDeltaEntityShared(&msg, &nullstateShared, baseShared, qtrue);
 		}
 	}
 

--- a/src/server/sv_client.c
+++ b/src/server/sv_client.c
@@ -564,9 +564,13 @@ gotnewcl:
 	// this is the only place a client_t is EVER initialized
 	*newcl         = temp;
 	clientNum      = newcl - svs.clients;
-	newcl->gentity = SV_GentityNum(clientNum);
 
-	newcl->gentity->r.svFlags = 0; // clear client flags on new connection.
+	if (!svcls.isTVGame)
+	{
+		newcl->gentity = SV_GentityNum(clientNum);
+		newcl->gentity->r.svFlags = 0; // clear client flags on new connection.
+	}
+
 	newcl->challenge          = challenge; // save the challenge
 	Q_strncpyz(newcl->guid, Info_ValueForKey(userinfo, "cl_guid"), sizeof(newcl->guid)); // save guid
 

--- a/src/server/sv_client.c
+++ b/src/server/sv_client.c
@@ -873,7 +873,16 @@ void SV_SendClientGameState(client_t *client)
 
 	MSG_WriteByte(&msg, svc_EOF);
 
-	MSG_WriteLong(&msg, client - svs.clients);
+#ifdef DEDICATED
+	if (svcls.isTVGame)
+	{
+		MSG_WriteLong(&msg, svclc.clientNum);
+	}
+	else
+#endif // DEDICATED
+	{
+		MSG_WriteLong(&msg, client - svs.clients);
+	}
 
 	// write the checksum feed
 	MSG_WriteLong(&msg, sv.checksumFeed);

--- a/src/server/sv_game.c
+++ b/src/server/sv_game.c
@@ -133,6 +133,12 @@ void SV_GameSendServerCommand(int clientNum, const char *text)
 		SV_DemoWriteGameCommand(clientNum, text);
 	}
 
+	if (clientNum == -2)
+	{
+		SV_CL_AddReliableCommand(text);
+		return;
+	}
+
 	if (clientNum == -1)
 	{
 		SV_SendServerCommand(NULL, "%s", text);

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -300,6 +300,21 @@ void SV_CreateBaseline(void)
 	sharedEntity_t *svent;
 	int            entnum;
 
+	if (svcls.isTVGame)
+	{
+		for (entnum = 0; entnum < MAX_GENTITIES; entnum++)
+		{
+			if (svcl.entitySharedBaselines[entnum].linked)
+			{
+				svent           = SV_GentityNum(entnum);
+				svent->s        = svcl.entityBaselines[entnum];
+				svent->r        = svcl.entitySharedBaselines[entnum];
+				sv.num_entities = entnum + 1;
+				SV_LinkEntity(svent);
+			}
+		}
+	}
+
 	for (entnum = 1; entnum < sv.num_entities ; entnum++)
 	{
 		svent = SV_GentityNum(entnum);
@@ -842,9 +857,13 @@ void SV_SpawnServer(const char *server)
 
 					client          = &svs.clients[i];
 					client->state   = CS_ACTIVE;
-					ent             = SV_GentityNum(i);
-					ent->s.number   = i;
-					client->gentity = ent;
+
+					if (!svcls.isTVGame)
+					{
+						ent = SV_GentityNum(i);
+						ent->s.number = i;
+						client->gentity = ent;
+					}
 
 					client->deltaMessage     = -1;
 					client->lastSnapshotTime = 0;   // generate a snapshot immediately

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -300,6 +300,7 @@ void SV_CreateBaseline(void)
 	sharedEntity_t *svent;
 	int            entnum;
 
+#ifdef DEDICATED
 	if (svcls.isTVGame)
 	{
 		for (entnum = 0; entnum < MAX_GENTITIES; entnum++)
@@ -314,6 +315,7 @@ void SV_CreateBaseline(void)
 			}
 		}
 	}
+#endif // DEDICATED
 
 	for (entnum = 1; entnum < sv.num_entities ; entnum++)
 	{
@@ -754,7 +756,7 @@ void SV_SpawnServer(const char *server)
 
 	// allocate the snapshot entities on the hunk
 	svs.snapshotEntities       = Hunk_Alloc(sizeof(entityState_t) * svs.numSnapshotEntities, h_high);
-	svs.snapshotSharedEntities = Hunk_Alloc(sizeof(entityShared_t) * svs.numSnapshotEntities, h_high);
+	svs.snapshotEntitiesShared = Hunk_Alloc(sizeof(entityShared_t) * svs.numSnapshotEntities, h_high);
 	svs.nextSnapshotEntities   = 0;
 
 	// toggle the server bit so clients can detect that a
@@ -857,8 +859,9 @@ void SV_SpawnServer(const char *server)
 
 					client        = &svs.clients[i];
 					client->state = CS_ACTIVE;
-
+#ifdef DEDICATED
 					if (!svcls.isTVGame)
+#endif // DEDICATED
 					{
 						ent             = SV_GentityNum(i);
 						ent->s.number   = i;

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -855,13 +855,13 @@ void SV_SpawnServer(const char *server)
 					client_t       *client;
 					sharedEntity_t *ent;
 
-					client          = &svs.clients[i];
-					client->state   = CS_ACTIVE;
+					client        = &svs.clients[i];
+					client->state = CS_ACTIVE;
 
 					if (!svcls.isTVGame)
 					{
-						ent = SV_GentityNum(i);
-						ent->s.number = i;
+						ent             = SV_GentityNum(i);
+						ent->s.number   = i;
 						client->gentity = ent;
 					}
 
@@ -1289,6 +1289,13 @@ void SV_Shutdown(const char *finalmsg)
 	{
 		return;
 	}
+
+#ifdef DEDICATED
+	if (!svclc.demo.playing)
+	{
+		SV_CL_Disconnect();
+	}
+#endif
 
 #if defined(FEATURE_IRC_SERVER) && defined(DEDICATED)
 	Cmd_RemoveCommand("irc_connect");

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -304,11 +304,11 @@ void SV_CreateBaseline(void)
 	{
 		for (entnum = 0; entnum < MAX_GENTITIES; entnum++)
 		{
-			if (svcl.entitySharedBaselines[entnum].linked)
+			if (svcl.currentStateEntitiesShared[entnum].linked)
 			{
 				svent           = SV_GentityNum(entnum);
-				svent->s        = svcl.entityBaselines[entnum];
-				svent->r        = svcl.entitySharedBaselines[entnum];
+				svent->s        = svcl.currentStateEntities[entnum];
+				svent->r        = svcl.currentStateEntitiesShared[entnum];
 				sv.num_entities = entnum + 1;
 				SV_LinkEntity(svent);
 			}

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -1223,8 +1223,10 @@ void SV_Init(void)
 
 	sv_serverTimeReset = Cvar_GetAndDescribe("sv_serverTimeReset", "0", CVAR_ARCHIVE_ND, "Reset server time on map change.");
 
-	sv_etltv_maxslaves = Cvar_GetAndDescribe("sv_etltv_maxslaves", "0", CVAR_ARCHIVE_ND, "Number of ettv slaves allowed to connect.");
-	sv_etltv_password  = Cvar_GetAndDescribe("sv_etltv_password", "", CVAR_ARCHIVE_ND, "Password for ettv slaves. Must be set, or no slaves will be able to connect.");
+	sv_etltv_maxslaves  = Cvar_GetAndDescribe("sv_etltv_maxslaves", "0", CVAR_ARCHIVE_ND, "Number of ettv slaves allowed to connect.");
+	sv_etltv_password   = Cvar_GetAndDescribe("sv_etltv_password", "", CVAR_ARCHIVE_ND, "Password for ettv slaves. Must be set, or no slaves will be able to connect.");
+	sv_etltv_autorecord = Cvar_Get("sv_etltv_autorecord", "0", CVAR_ARCHIVE_ND);
+	sv_etltv_autoplay   = Cvar_Get("sv_etltv_autoplay", "0", CVAR_ARCHIVE_ND);
 
 #if defined(FEATURE_IRC_SERVER) && defined(DEDICATED)
 	IRC_Init();

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -1230,6 +1230,7 @@ void SV_Init(void)
 	sv_etltv_password   = Cvar_GetAndDescribe("sv_etltv_password", "", CVAR_ARCHIVE_ND, "Password for ettv slaves. Must be set, or no slaves will be able to connect.");
 	sv_etltv_autorecord = Cvar_Get("sv_etltv_autorecord", "0", CVAR_ARCHIVE_ND);
 	sv_etltv_autoplay   = Cvar_Get("sv_etltv_autoplay", "0", CVAR_ARCHIVE_ND);
+	sv_etltv_clientname = Cvar_GetAndDescribe("sv_etltv_clientname", "ETLTV", CVAR_ARCHIVE_ND, "Name of the ETLTV client.");
 
 #if defined(FEATURE_IRC_SERVER) && defined(DEDICATED)
 	IRC_Init();

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -1604,6 +1604,8 @@ int SV_FrameMsec()
  */
 static void SV_Frame_Ext(int frameMsec)
 {
+	int startTime;
+
 	if (cvar_modifiedFlags & CVAR_SERVERINFO)
 	{
 		SV_SetConfigstring(CS_SERVERINFO, Cvar_InfoString(CVAR_SERVERINFO | CVAR_SERVERINFO_NOUPDATE));
@@ -1623,6 +1625,15 @@ static void SV_Frame_Ext(int frameMsec)
 	{
 		SV_SetConfigstring(CS_WOLFINFO, Cvar_InfoString(CVAR_WOLFINFO));
 		cvar_modifiedFlags &= ~CVAR_WOLFINFO;
+	}
+
+	if (com_speeds->integer)
+	{
+		startTime = Sys_Milliseconds();
+	}
+	else
+	{
+		startTime = 0;  // quite a compiler warning
 	}
 
 	// start recording a demo
@@ -1657,6 +1668,11 @@ static void SV_Frame_Ext(int frameMsec)
 		{
 			SV_DemoReadFrame();
 		}
+	}
+
+	if (com_speeds->integer)
+	{
+		time_game = Sys_Milliseconds() - startTime;
 	}
 
 	// check timeouts

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -38,12 +38,14 @@
 #include "sv_tracker.h"
 #endif
 
-serverStatic_t       svs;             // persistant server info
-server_t             sv;              // local server
+serverStatic_t svs;                   // persistant server info
+server_t       sv;                    // local server
+#ifdef DEDICATED
 svclientActive_t     svcl;
 svclientConnection_t svclc;
 svclientStatic_t     svcls;
-vm_t                 *gvm = NULL;     // game virtual machine
+#endif // DEDICATED
+vm_t *gvm = NULL;                     // game virtual machine
 
 cvar_t *sv_fps = NULL;          // time rate for running non-clients
 cvar_t *sv_timeout;             // seconds without any message
@@ -1299,6 +1301,7 @@ void SV_PacketEvent(netadr_t from, msg_t *msg)
 	client_t *cl;
 	int      qport;
 
+#ifdef DEDICATED
 	if (NET_CompareAdr(from, svclc.serverAddress))
 	{
 		CL_PacketEvent(from, msg);
@@ -1309,6 +1312,7 @@ void SV_PacketEvent(netadr_t from, msg_t *msg)
 	{
 		return;
 	}
+#endif // DEDICATED
 
 	// check for connectionless packet (0xffffffff) first
 	if (msg->cursize >= 4 && *(int *)msg->data == -1)
@@ -1717,7 +1721,9 @@ void SV_Frame(int msec)
 	start           = Sys_Milliseconds();
 	svs.stats.idle += ( double )(start - end) / 1000;
 
+#ifdef DEDICATED
 	svcls.realtime += msec;
+#endif // DEDICATED
 
 	// the menu kills the server with this cvar
 	if (sv_killserver->integer)
@@ -1804,11 +1810,13 @@ void SV_Frame(int msec)
 		return;
 	}
 
+#ifdef DEDICATED
 	if (svcls.isTVGame)
 	{
 		SV_CL_Frame(frameMsec);
 	}
 	else
+#endif // DEDICATED
 	{
 		SV_Frame_Ext(frameMsec);
 	}

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -134,6 +134,7 @@ cvar_t *sv_etltv_maxslaves;
 cvar_t *sv_etltv_password;
 cvar_t *sv_etltv_autorecord;
 cvar_t *sv_etltv_autoplay;
+cvar_t *sv_etltv_clientname;
 
 static void SVC_Status(netadr_t from, qboolean force);
 

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -130,6 +130,8 @@ cvar_t *sv_serverTimeReset;
 
 cvar_t *sv_etltv_maxslaves;
 cvar_t *sv_etltv_password;
+cvar_t *sv_etltv_autorecord;
+cvar_t *sv_etltv_autoplay;
 
 static void SVC_Status(netadr_t from, qboolean force);
 
@@ -1579,6 +1581,13 @@ static qboolean SV_CheckPaused(void)
  */
 int SV_FrameMsec()
 {
+#ifdef DEDICATED
+	if (svcls.isTVGame)
+	{
+		return 8;
+	}
+#endif // DEDICATED
+
 	if (sv_fps)
 	{
 		int frameMsec = (int)(1000.0f / sv_fps->value);

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -1579,7 +1579,7 @@ static qboolean SV_CheckPaused(void)
  */
 int SV_FrameMsec()
 {
-	if (sv_fps && !svcls.isTVGame)
+	if (sv_fps)
 	{
 		int frameMsec = (int)(1000.0f / sv_fps->value);
 
@@ -1759,7 +1759,7 @@ void SV_Frame(int msec)
 	{
 		Cvar_Set("sv_fps", "10");
 	}
-	frameMsec = 1000 / sv_fps->integer ;
+	frameMsec = 1000 / sv_fps->integer;
 
 	sv.timeResidual += msec;
 

--- a/src/server/sv_snapshot.c
+++ b/src/server/sv_snapshot.c
@@ -90,7 +90,7 @@ static void SV_EmitPacketEntities(client_t *client, clientSnapshot_t *from, clie
 		else
 		{
 			newent       = &svs.snapshotEntities[(to->first_entity + newindex) % svs.numSnapshotEntities];
-			newSharedent = &svs.snapshotSharedEntities[(to->first_entity + newindex) % svs.numSnapshotEntities];
+			newSharedent = &svs.snapshotEntitiesShared[(to->first_entity + newindex) % svs.numSnapshotEntities];
 			newnum       = newent->number;
 		}
 
@@ -101,7 +101,7 @@ static void SV_EmitPacketEntities(client_t *client, clientSnapshot_t *from, clie
 		else
 		{
 			oldent       = &svs.snapshotEntities[(from->first_entity + oldindex) % svs.numSnapshotEntities];
-			oldSharedent = &svs.snapshotSharedEntities[(from->first_entity + oldindex) % svs.numSnapshotEntities];
+			oldSharedent = &svs.snapshotEntitiesShared[(from->first_entity + oldindex) % svs.numSnapshotEntities];
 			oldnum       = oldent->number;
 		}
 
@@ -115,7 +115,7 @@ static void SV_EmitPacketEntities(client_t *client, clientSnapshot_t *from, clie
 			MSG_WriteDeltaEntity(msg, oldent, newent, qfalse);
 			if (client->ettvClient && messageSize != msg->cursize)
 			{
-				MSG_ETTV_WriteDeltaSharedEntity(msg, oldSharedent, newSharedent, qtrue);
+				MSG_ETTV_WriteDeltaEntityShared(msg, oldSharedent, newSharedent, qtrue);
 			}
 
 			oldindex++;
@@ -134,7 +134,7 @@ static void SV_EmitPacketEntities(client_t *client, clientSnapshot_t *from, clie
 			MSG_WriteDeltaEntity(msg, &sv.svEntities[newnum].baseline, newent, qtrue);
 			if (client->ettvClient)
 			{
-				MSG_ETTV_WriteDeltaSharedEntity(msg, &sv.svEntities[newnum].baselineShared, newSharedent, qtrue);
+				MSG_ETTV_WriteDeltaEntityShared(msg, &sv.svEntities[newnum].baselineShared, newSharedent, qtrue);
 			}
 			newindex++;
 			continue;
@@ -146,7 +146,7 @@ static void SV_EmitPacketEntities(client_t *client, clientSnapshot_t *from, clie
 			MSG_WriteDeltaEntity(msg, oldent, NULL, qtrue);
 			if (client->ettvClient)
 			{
-				MSG_ETTV_WriteDeltaSharedEntity(msg, oldSharedent, NULL, qtrue);
+				MSG_ETTV_WriteDeltaEntityShared(msg, oldSharedent, NULL, qtrue);
 			}
 			oldindex++;
 			continue;
@@ -826,7 +826,7 @@ static void SV_BuildClientSnapshot(client_t *client)
 
 		if (client->ettvClient)
 		{
-			stateShared  = &svs.snapshotSharedEntities[svs.nextSnapshotEntities % svs.numSnapshotEntities];
+			stateShared  = &svs.snapshotEntitiesShared[svs.nextSnapshotEntities % svs.numSnapshotEntities];
 			*stateShared = ent->r;
 		}
 
@@ -1063,6 +1063,7 @@ void SV_SendClientMessages(void)
 	// update any changed configstrings from this frame
 	SV_UpdateConfigStrings();
 
+#ifdef DEDICATED
 	if (svcls.isTVGame)
 	{
 		sharedEntity_t *gEnt;
@@ -1077,6 +1078,7 @@ void SV_SendClientMessages(void)
 			}
 		}
 	}
+#endif // DEDICATED
 
 	// send a message to each connected client
 	for (i = 0; i < sv_maxclients->integer; i++)

--- a/src/server/sv_snapshot.c
+++ b/src/server/sv_snapshot.c
@@ -1063,6 +1063,21 @@ void SV_SendClientMessages(void)
 	// update any changed configstrings from this frame
 	SV_UpdateConfigStrings();
 
+	if (svcls.isTVGame)
+	{
+		sharedEntity_t *gEnt;
+		sv.num_entities = 0;
+		for (i = 0; i < MAX_GENTITIES; i++)
+		{
+			gEnt = SV_GentityNum(i);
+
+			if (gEnt->r.linked)
+			{
+				sv.num_entities = i + 1;
+			}
+		}
+	}
+
 	// send a message to each connected client
 	for (i = 0; i < sv_maxclients->integer; i++)
 	{

--- a/src/server/sv_world.c
+++ b/src/server/sv_world.c
@@ -231,13 +231,19 @@ void SV_LinkEntity(sharedEntity_t *gEnt)
 
 	ent = SV_SvEntityForGentity(gEnt);
 
+#ifdef DEDICATED
 	if (svcls.isTVGame && gEnt->s.solid == SOLID_BMODEL)
 	{
 		gEnt->r.bmodel = qtrue;
 	}
+#endif // DEDICATED
 
 	// sanity check for possible currentOrigin being reset bug
-	if (!gEnt->r.bmodel && vec3_compare(gEnt->r.currentOrigin, vec3_origin))
+	if (!gEnt->r.bmodel && vec3_compare(gEnt->r.currentOrigin, vec3_origin)
+#ifdef DEDICATED
+	    && !svcls.isTVGame
+#endif // DEDICATED
+	    )
 	{
 		// I've seen this warning a lot - let map makers know which entity is affected.
 		// FIXME: - Clarify if this warning is false positive for some ents

--- a/src/server/sv_world.c
+++ b/src/server/sv_world.c
@@ -231,6 +231,11 @@ void SV_LinkEntity(sharedEntity_t *gEnt)
 
 	ent = SV_SvEntityForGentity(gEnt);
 
+	if (svcls.isTVGame && gEnt->s.solid == SOLID_BMODEL)
+	{
+		gEnt->r.bmodel = qtrue;
+	}
+
 	// sanity check for possible currentOrigin being reset bug
 	if (!gEnt->r.bmodel && vec3_compare(gEnt->r.currentOrigin, vec3_origin))
 	{

--- a/src/tvgame/tvg_active.c
+++ b/src/tvgame/tvg_active.c
@@ -312,10 +312,10 @@ qboolean TVG_ClientInactivityTimer(gclient_t *client)
 }
 
 /**
- * @brief ClientIntermissionThink
+ * @brief TVG_ClientIntermissionThink
  * @param[in,out] client Client
  */
-void ClientIntermissionThink(gclient_t *client)
+void TVG_ClientIntermissionThink(gclient_t *client)
 {
 	client->ps.eFlags &= ~EF_TALK;
 	client->ps.eFlags &= ~EF_FIRING;
@@ -389,12 +389,11 @@ void TVG_ClientThink_real(gclient_t *client)
 		                    client->pers.pmoveMsec) * client->pers.pmoveMsec;
 	}
 
-	// check for exiting intermission
-	//if (level.intermissiontime)
-	//{
-	//	ClientIntermissionThink(client);
-	//	return;
-	//}
+	if (level.intermission)
+	{
+		TVG_ClientIntermissionThink(client);
+		return;
+	}
 
 	// check for inactivity timer, but never drop the local client of a non-dedicated server
 	// moved here to allow for spec inactivity checks as well

--- a/src/tvgame/tvg_active.c
+++ b/src/tvgame/tvg_active.c
@@ -389,12 +389,6 @@ void TVG_ClientThink_real(gclient_t *client)
 		                    client->pers.pmoveMsec) * client->pers.pmoveMsec;
 	}
 
-	if (level.intermission)
-	{
-		TVG_ClientIntermissionThink(client);
-		return;
-	}
-
 	// check for inactivity timer, but never drop the local client of a non-dedicated server
 	// moved here to allow for spec inactivity checks as well
 	//if (!TVG_ClientInactivityTimer(client))
@@ -409,6 +403,12 @@ void TVG_ClientThink_real(gclient_t *client)
 			trap_SendServerCommand(client - level.clients, level.cmds.infoStats[i].data[client->wantsInfoStats[i].requestedClientNum]);
 			client->wantsInfoStats[i].requested = qfalse;
 		}
+	}
+
+	if (level.intermission)
+	{
+		TVG_ClientIntermissionThink(client);
+		return;
 	}
 
 	// spectators don't do much

--- a/src/tvgame/tvg_cmds.c
+++ b/src/tvgame/tvg_cmds.c
@@ -1432,6 +1432,7 @@ qboolean TVG_Cmd_UnIgnore_f(gclient_t *client, tvcmd_reference_t *self)
 #define ROCKANDROLL_HASH    146207
 #define BP_HASH             25102
 #define XPGAIN_HASH         78572
+#define DISCONNECT_HASH     131683
 
 /**
 * @brief TVG_ClientCommandPassThrough This handles server commands (server responses to client commands)
@@ -1662,6 +1663,9 @@ static void TVG_ClientCommandPassThrough(char *cmd)
 		return;
 	//case XPGAIN_HASH:                                    // "xpgain"
 	//	return;
+	case DISCONNECT_HASH:                                  // "disconnect"
+		trap_SendServerCommand(-1, cmd);
+		return;
 	default:
 		G_Printf("TVGAME: Unknown client game command: %s [%lu]\n", cmd, BG_StringHashValue(token));
 		break;

--- a/src/tvgame/tvg_public.h
+++ b/src/tvgame/tvg_public.h
@@ -43,49 +43,6 @@
 typedef qboolean (*addToSnapshotCallback)(int entityNum, int clientNum);
 
 /**
-  * @struct entityShared_s
-  * @brief entityShared_t
-  *
-  * @warning Don't add or remove fields to keep 2.60 compatibility
-  */
-typedef struct
-{
-	qboolean linked;                ///< qfalse if not in any good cluster
-	int linkcount;
-
-	int svFlags;                    ///<  SVF_NOCLIENT, SVF_BROADCAST, etc
-	int singleClient;               ///<  only send to this client when SVF_SINGLECLIENT is set
-
-	qboolean bmodel;                ///<  if false, assume an explicit mins / maxs bounding box
-	///<  only set by trap_SetBrushModel
-	vec3_t mins, maxs;
-	int contents;                   ///<  CONTENTS_TRIGGER, CONTENTS_SOLID, CONTENTS_BODY, etc
-	///<  a non-solid entity should set to 0
-
-	vec3_t absmin, absmax;          ///<  derived from mins/maxs and origin + rotation
-
-	/// currentOrigin will be used for all collision detection and world linking.
-	/// it will not necessarily be the same as the trajectory evaluation for the current
-	/// time, because each entity must be moved one at a time after time is advanced
-	/// to avoid simultanious collision issues
-	///
-	vec3_t currentOrigin;
-	vec3_t currentAngles;
-
-	/// when a trace call is made and passEntityNum != ENTITYNUM_NONE,
-	/// an ent will be excluded from testing if:
-	/// ent->s.number == passEntityNum   (don't interact with self)
-	/// ent->s.ownerNum = passEntityNum  (don't interact with your own missiles)
-	/// entity[ent->s.ownerNum].ownerNum = passEntityNum (don't interact with other missiles from owner)
-	int ownerNum;
-	int eventTime;
-
-	int worldflags;
-
-	qboolean snapshotCallback;
-} entityShared_t;
-
-/**
   @struct sharedEntity_t
   @brief The server looks at a sharedEntity, which is the start of the game's gentity_t structure
   */


### PR DESCRIPTION
- add possibility for etlded to act as a client
- add command `tv connect <ip> <masterpassword>` (sv_etltv_maxslaves and sv_etltv_password must be set on master server)
- add command `tv disconnect`
- add command `record <name> (optional)` for recording tv demos
- add command `stoprecord` for stopping recording
- add command `demo <name>` for demo playback
- add command `ff <seconds>` command - fastforwarding demo (works similiar to timescale) stops on map_restart or can stop it with ff 0
- add `cvar sv_etltv_autorecord <0/1>` automatically record tv demos
- add `cvar sv_etltv_autoplay <0/1>` automatically play demos (only on specifically named demos from autorecording, fe. demo0001->demo0002 etc.)
- add `cvar sv_etltv_clientname` etltv client name
- demos are recorded into tvdemos folder with extension tv_84
- etpro tv demos are playable, best is to use ettv tvgame and start etlded with +fs_game etpro (put etpro tvgame into etpro mod folder). Need 2.6b client in order to watch
- slave server will not download missing files from master server, so need to make sure it has every pk3 it needs
- only available for dedicated server

Missing ettv features:

- more than 64 client servers
- chaining slave server still not tested
- delayed feed (ettv_delay), everything is live, old like ettv solution of delay by playing back demo might work (not tested)

refs #229