### PR TITLE
cmake: add toolchain file for Mingw x86-64

### DIFF
--- a/cmake/Toolchain-cross-mingw-x64-linux.cmake
+++ b/cmake/Toolchain-cross-mingw-x64-linux.cmake
@@ -1,0 +1,31 @@
+#-----------------------------------------------------------------
+# Toolchain Cross MingW
+#-----------------------------------------------------------------
+
+# the name of the target operating system
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_VERSION 1)
+set(CMAKE_SYSTEM_PROCESSOR "x86_64")
+set(CMAKE_SIZEOF_VOID_P 8)
+
+# Choose an appropriate compiler prefix
+# see http://mingw-w64.sourceforge.net/
+set(COMPILER_PREFIX "x86_64-w64-mingw32")
+
+# which compilers to use for C and C++
+find_program(CMAKE_C_COMPILER NAMES ${COMPILER_PREFIX}-gcc)
+set(CMAKE_C_COMPILER ${COMPILER_PREFIX}-gcc)
+find_program(CMAKE_CXX_COMPILER NAMES ${COMPILER_PREFIX}-g++)
+set(CMAKE_CXX_COMPILER ${COMPILER_PREFIX}-g++)
+find_program(CMAKE_RC_COMPILER NAMES ${COMPILER_PREFIX}-windres)
+set(CMAKE_RC_COMPILER ${COMPILER_PREFIX}-windres)
+
+# here is the target environment located
+set(CMAKE_FIND_ROOT_PATH  /usr/${COMPILER_PREFIX})
+
+# adjust the default behaviour of the FIND_XXX() commands:
+# search headers and libraries in the target environment, search
+# programs in the host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)


### PR DESCRIPTION
While MSVC is the supported way to build ET Legacy for Windows, it is useful to be able to build the mod using Mingw on Linux. I made this toolchain file to support the x86-64 architecture on Windows.

I have not tested that the mod really loads with the ET Legacy Windows client, but I don't think there will be any issue, or it shouldn't be related to the toolchain.

I saw the addition of `CMAKE_SIZEOF_VOID_P`, so I adapted the toolchain for this new code.

It was tested with mingw-w64 13.1.0 packaged by Arch Linux.

```diff
--- a/cmake/Toolchain-cross-mingw-linux.cmake
+++ b/cmake/Toolchain-cross-mingw-x64-linux.cmake
@@ -5,12 +5,12 @@
 # the name of the target operating system
 set(CMAKE_SYSTEM_NAME Windows)
 set(CMAKE_SYSTEM_VERSION 1)
-set(CMAKE_SYSTEM_PROCESSOR x86)
-set(CMAKE_SIZEOF_VOID_P 4)
+set(CMAKE_SYSTEM_PROCESSOR "x86_64")
+set(CMAKE_SIZEOF_VOID_P 8)
 
 # Choose an appropriate compiler prefix
 # see http://mingw-w64.sourceforge.net/
-set(COMPILER_PREFIX "i686-w64-mingw32")
+set(COMPILER_PREFIX "x86_64-w64-mingw32")
 
 # which compilers to use for C and C++
 find_program(CMAKE_C_COMPILER NAMES ${COMPILER_PREFIX}-gcc)
```

Sample test code:

```bash
./easybuild.sh clean
./easybuild.sh build -64 -mod -no-ssl -noextra -nopk3 --toolchain=cmake/Toolchain-cross-mingw-x64-linux.cmake
```

```bash
$ file build/legacy/*
build/legacy/cgame_mp_x64.dll:  PE32+ executable (DLL) (console) x86-64, for MS Windows, 21 sections
build/legacy/qagame_mp_x64.dll: PE32+ executable (DLL) (console) x86-64, for MS Windows, 21 sections
build/legacy/tvgame_mp_x64.dll: PE32+ executable (DLL) (console) x86-64, for MS Windows, 21 sections
build/legacy/ui_mp_x64.dll:     PE32+ executable (DLL) (console) x86-64, for MS Windows, 21 sections
```