### PR TITLE
mod: construction sound no longer loops, fixes #2429

### DIFF
--- a/src/game/g_weapon.c
+++ b/src/game/g_weapon.c
@@ -1006,8 +1006,12 @@ static qboolean TryConstructing(gentity_t *ent, gentity_t *trigger)
 
 		if (!ent->client->constructSoundTime || level.time > ent->client->constructSoundTime)
 		{
-			// construction sound sent as event (was temp entity)
-			G_AddEvent(ent, EV_GENERAL_SOUND, GAMESOUND_WORLD_BUILD);
+			if (constructible->s.angles2[0] == 0.f)
+			{
+				// construction sound sent as event (was temp entity)
+				G_AddEvent(ent, EV_GENERAL_SOUND, GAMESOUND_WORLD_BUILD);
+			}
+
 			ent->client->constructSoundTime = level.time + 4000; // duration of sound
 		}
 


### PR DESCRIPTION
Solved the issue where construction sound looped every 4s. Construction sound is now only triggered when starting to build.