### PR TITLE
server: add automatic feed delay to etltv, refs #229

### DIFF
--- a/src/server/server.h
+++ b/src/server/server.h
@@ -509,6 +509,7 @@ extern cvar_t *sv_etltv_autoplay;
 extern cvar_t *sv_etltv_clientname;
 extern cvar_t *sv_etltv_delay;
 extern cvar_t *sv_etltv_shownet;
+extern cvar_t *sv_etltv_queue_ms;
 
 //===========================================================
 

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -171,6 +171,7 @@ typedef struct
 	int messageSent;                    ///< time the message was transmitted
 	int messageAcked;                   ///< time the message was acked
 	int messageSize;                    ///< used to rate drop packets
+	qboolean parseEntities;             ///< does the frame contains parse entities?
 } clientSnapshot_t;
 
 /**
@@ -277,11 +278,12 @@ typedef struct client_s
 
 	int downloadnotify;
 
-	int protocol; ///< We can access clients protocol any time
+	int protocol;                           ///< We can access clients protocol any time
 
-	qboolean demoClient; ///< is this a demoClient?
-	qboolean ettvClient;
-	ettvClientSnapshot_t **ettvClientFrame;
+	qboolean demoClient;                    ///< is this a demoClient?
+	qboolean ettvClient;                    ///< is this a tv client
+	ettvClientSnapshot_t **ettvClientFrame; ///< playerstates for tv client
+	int parseEntitiesNum;                   ///< keep track how many parse entities we sent
 
 	userAgent_t agent;
 
@@ -505,6 +507,8 @@ extern cvar_t *sv_etltv_password;
 extern cvar_t *sv_etltv_autorecord;
 extern cvar_t *sv_etltv_autoplay;
 extern cvar_t *sv_etltv_clientname;
+extern cvar_t *sv_etltv_delay;
+extern cvar_t *sv_etltv_shownet;
 
 //===========================================================
 
@@ -607,7 +611,7 @@ void SV_UptimeReset(void);
 // sv_snapshot.c
 void SV_AddServerCommand(client_t *client, const char *cmd);
 void SV_UpdateServerCommandsToClient(client_t *client, msg_t *msg);
-void SV_SendMessageToClient(msg_t *msg, client_t *client);
+void SV_SendMessageToClient(msg_t *msg, client_t *client, qboolean parseEntities);
 void SV_SendClientMessages(void);
 void SV_SendClientSnapshot(client_t *client);
 void SV_CheckClientUserinfoTimer(void);
@@ -704,6 +708,8 @@ qboolean SV_Netchan_Process(client_t *client, msg_t *msg);
 
 //============================ TV server client ============================
 
+#define MAX_PARSE_ENTITIES  2048
+
 #ifdef DEDICATED
 
 #define SV_CL_MAXPACKETS 40
@@ -726,12 +732,16 @@ typedef struct
 	int framecount;
 	int frametime;                  ///< msec since last frame
 
-	int realtime;                   ///< ignores pause
+	int realtime;                   ///<
 
-	int lastRunFrameTime;
-	int lastRunFrameSysTime;
+	int lastRunFrameTime;           ///< last server GAME_RUN_FRAME time
+	int lastRunFrameSysTime;        ///< last server GAME_RUN_FRAME system time
 
-	qboolean isTVGame;
+	qboolean isTVGame;              ///< is it tv server
+	qboolean isDelayed;             ///< is the master server feed delayed
+	qboolean isGamestateParsed;     ///< was the first gamestate server message parsed when the master server feed is delayed
+	qboolean firstSnap;             ///< did we parse first snapshot after new gamestate
+	qboolean queueDemoWaiting;      ///< with autorecord on after new gamestate send moveNoDelta usercmds
 
 } svclientStatic_t;
 
@@ -780,9 +790,14 @@ typedef struct
 	char serverMessage[MAX_STRING_TOKENS];      ///< for display on connection dialog
 
 	char serverMasterPassword[MAX_STRING_TOKENS];
+	char serverPassword[MAX_STRING_TOKENS];
 
 	int challenge;                              ///< from the server to use for connecting
-	int checksumFeed;                           ///< from the server for checksum calculations
+	int checksumFeed;                           ///< from the server for checksum calculations may be delayed
+	int checksumFeedLatest;                     ///< from the server for checksum calculations always latest
+	int serverIdLatest;
+
+	qboolean moveDelta;                         ///< should we send moveDelta or moveNoDelta usercmd
 
 	int onlyVisibleClients;
 
@@ -803,12 +818,15 @@ typedef struct
 
 	/// message sequence is used by both the network layer and the
 	/// delta compression layer
-	int serverMessageSequence;
+	int serverMessageSequence;         ///< may be delayed or latest sequence number
+	int serverMessageSequenceLatest;   ///< always latest sequence number
 
 	// reliable messages received from server
-	int serverCommandSequence;
-	int lastExecutedServerCommand;              ///< last server command grabbed or executed with CL_GetServerCommand
+	int serverCommandSequence;         ///< may be delayed or latest sequence number
+	int serverCommandSequenceLatest;   ///< always latest sequence number
+	int lastExecutedServerCommand;     ///< last server command grabbed or executed with SV_CL_GetServerCommand
 	char serverCommands[MAX_RELIABLE_COMMANDS][MAX_TOKEN_CHARS];
+	char serverCommandsLatest[MAX_RELIABLE_COMMANDS][MAX_TOKEN_CHARS];
 
 	// demo information
 	svcldemo_t demo;
@@ -862,7 +880,6 @@ typedef struct
 	int p_realtime;             ///< cls.realtime when packet was sent
 } svoutPacket_t;
 
-#define MAX_PARSE_ENTITIES  2048
 #define CMD_BACKUP          64
 #define CMD_MASK            (CMD_BACKUP - 1)
 
@@ -878,8 +895,8 @@ typedef struct
 	                                        ///< causing immediate disconnects on continue
 	svclSnapshot_t snap;                      ///< latest received from server
 
-	int serverTime;                         ///< may be paused during play
-	int oldServerTime;                      ///< to prevent time from flowing bakcwards
+	int serverTime;                         ///< may be delayed or latest serverTime
+	int serverTimeLatest;                   ///< always latest serverTime
 	int oldFrameServerTime;                 ///< to check tournament restarts
 	int serverTimeDelta;                    ///< cl.serverTime = cls.realtime + cl.serverTimeDelta
 	                                        ///  this value changes as net lag varies
@@ -926,6 +943,28 @@ typedef struct
 
 extern svclientActive_t svcl;
 
+/**
+ * @struct messageQueue_t
+ */
+typedef struct serverMessageQueue_s
+{
+	struct serverMessageQueue_s *next, *prev;
+
+	int serverMessageSequence;
+	int serverCommandSequence;
+	int numServerCommand;
+	char *serverCommands[MAX_RELIABLE_COMMANDS];
+
+	int serverTime;
+	int systime;
+	int deltaNum;
+
+	int headerBytes;
+	msg_t msg;
+} serverMessageQueue_t;
+
+extern serverMessageQueue_t *svMsgQueueHead, *svMsgQueueTail;
+
 // sv_cl_main.c
 void SV_CL_Commands_f(void);
 void SV_CL_CheckForResend(void);
@@ -935,7 +974,7 @@ void SV_CL_WritePacket(void);
 qboolean SV_CL_ReadyToSendPacket(void);
 void SV_CL_ClearState(void);
 void SV_CL_DownloadsComplete(void);
-void SV_CL_SendPureChecksums(void);
+void SV_CL_SendPureChecksums(int serverId);
 void SV_CL_InitTVGame(void);
 qboolean SV_CL_GetServerCommand(int serverCommandNumber);
 void SV_CL_ConfigstringModified(void);
@@ -956,7 +995,8 @@ void SV_CL_Netchan_TransmitNextFragment(netchan_t *chan);
 qboolean SV_CL_Netchan_Process(netchan_t *chan, msg_t *msg);
 
 // sv_cl_parse.c
-void SV_CL_ParseServerMessage(msg_t *msg);
+void SV_CL_ParseServerMessage(msg_t *msg, int headerBytes);
+void SV_CL_ParseServerMessage_Ext(msg_t *msg, int headerBytes);
 void SV_CL_ParseGamestate(msg_t *msg);
 void SV_CL_ParseCommandString(msg_t *msg);
 void SV_CL_ParseSnapshot(msg_t *msg);
@@ -964,6 +1004,11 @@ void SV_CL_ParsePacketEntities(msg_t *msg, svclSnapshot_t *oldframe, svclSnapsho
 void SV_CL_DeltaEntity(msg_t *msg, svclSnapshot_t *frame, int newnum, entityState_t *old, entityShared_t *oldShared, qboolean unchanged);
 void SV_CL_ParsePlayerstates(msg_t *msg);
 void SV_CL_SystemInfoChanged(void);
+
+int SV_CL_GetQueueTime(void);
+void SV_CL_ParseMessageQueue(void);
+void SV_CL_ParseServerMessageIntoQueue(msg_t *msg, int headerBytes);
+void SV_CL_ParseGamestateQueue(msg_t *msg);
 
 // sv_cl_demo.c
 void SV_CL_DemoInit(void);

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -742,6 +742,7 @@ typedef struct
 	qboolean isGamestateParsed;     ///< was the first gamestate server message parsed when the master server feed is delayed
 	qboolean firstSnap;             ///< did we parse first snapshot after new gamestate
 	qboolean queueDemoWaiting;      ///< with autorecord on after new gamestate send moveNoDelta usercmds
+	qboolean fixHitch;              ///< fix map change hitch when feed is delayed
 
 } svclientStatic_t;
 

--- a/src/server/sv_cl_demo.c
+++ b/src/server/sv_cl_demo.c
@@ -253,8 +253,8 @@ void SV_CL_StopRecord_f(void)
 	(void)FS_Write(&len, 4, svclc.demo.file);
 	(void)FS_Write(&len, 4, svclc.demo.file);
 	FS_FCloseFile(svclc.demo.file);
-	svclc.demo.file = 0;
 
+	svclc.demo.file      = 0;
 	svclc.demo.recording = qfalse;
 	Com_Printf("Stopped demo.\n");
 }
@@ -340,7 +340,7 @@ void SV_CL_ReadDemoMessage(void)
 		return;
 	}
 
-	svclc.serverMessageSequence = LittleLong(s);
+	svclc.serverMessageSequenceLatest = LittleLong(s);
 
 	// init the message
 	MSG_Init(&buf, bufData, sizeof(bufData));
@@ -375,7 +375,7 @@ void SV_CL_ReadDemoMessage(void)
 
 	svclc.lastPacketTime = svcls.realtime;
 	buf.readcount        = 0;
-	SV_CL_ParseServerMessage(&buf);
+	SV_CL_ParseServerMessage_Ext(&buf, 0);
 }
 
 /**
@@ -449,7 +449,7 @@ void SV_CL_PlayDemo_f(void)
 
 	Q_strncpyz(svcls.servername, demoFile, sizeof(svcls.servername));
 
-	while (!svcl.snap.valid || !svcl.serverTime)
+	while (!svcls.firstSnap || !svcl.serverTime)
 	{
 		SV_CL_ReadDemoMessage();
 	}

--- a/src/server/sv_cl_demo.c
+++ b/src/server/sv_cl_demo.c
@@ -417,6 +417,12 @@ void SV_CL_PlayDemo_f(void)
 		return;
 	}
 
+	if (sv_etltv_delay->integer)
+	{
+		Com_Printf("sv_etltv_delay must be set to 0 to play demo (current value %d).\n", sv_etltv_delay->integer);
+		return;
+	}
+
 	SV_CL_Disconnect();
 
 	// open the demo file (should be the last arg)

--- a/src/server/sv_cl_main.c
+++ b/src/server/sv_cl_main.c
@@ -139,7 +139,7 @@ void SV_CL_Commands_f(void)
 
 	if (argc < 2)
 	{
-		Com_Printf("usage: tv <connect|disconnect> [-4|-6] server masterpassword\n");
+		Com_Printf("usage: tv <connect|disconnect> [-4|-6] server masterpassword privatepassword\n");
 		return;
 	}
 
@@ -155,7 +155,7 @@ void SV_CL_Commands_f(void)
 	}
 	else
 	{
-		Com_Printf("usage: tv <connect|disconnect> [-4|-6] server masterpassword\n");
+		Com_Printf("usage: tv <connect|disconnect> [-4|-6] server masterpassword privatepassword\n");
 	}
 }
 

--- a/src/server/sv_cl_main.c
+++ b/src/server/sv_cl_main.c
@@ -1445,7 +1445,7 @@ void SV_CL_RunFrame(void)
 	{
 		if (svcls.firstSnap)
 		{
-			Com_Printf("Server went backwards in time: %d > %d\n", svcls.lastRunFrameTime, svcl.serverTime);
+			Com_DPrintf("Server went backwards in time: %d > %d\n", svcls.lastRunFrameTime, svcl.serverTime);
 		}
 		else
 		{

--- a/src/server/sv_cl_main.c
+++ b/src/server/sv_cl_main.c
@@ -42,14 +42,13 @@
 void SV_CL_Connect_f(void)
 {
 	char         *server;
-	char         *password;
 	const char   *ip_port;
 	int          argc   = Cmd_Argc();
 	netadrtype_t family = NA_UNSPEC;
 
-	if (argc != 4)
+	if (argc != 4 && argc != 5)
 	{
-		Com_Printf("usage: tv connect [-4|-6] server masterpassword\n");
+		Com_Printf("usage: tv connect [-4|-6] server masterpassword privatepassword\n");
 		return;
 	}
 
@@ -66,8 +65,7 @@ void SV_CL_Connect_f(void)
 	//	Com_Printf(S_COLOR_YELLOW "WARNING: only -4 or -6 as address type understood\n");
 	//}
 
-	server   = Cmd_Argv(2);
-	password = Cmd_Argv(3);
+	server = Cmd_Argv(2);
 
 	FS_ClearPureServerPacks();
 
@@ -99,7 +97,12 @@ void SV_CL_Connect_f(void)
 		svclc.serverAddress.port = BigShort(PORT_SERVER);
 	}
 
-	Q_strncpyz(svclc.serverMasterPassword, password, sizeof(svclc.serverMasterPassword));
+	Q_strncpyz(svclc.serverMasterPassword, Cmd_Argv(3), sizeof(svclc.serverMasterPassword));
+
+	if (argc == 5)
+	{
+		Q_strncpyz(svclc.serverPassword, Cmd_Argv(4), sizeof(svclc.serverPassword));
+	}
 
 	ip_port = NET_AdrToString(svclc.serverAddress);
 
@@ -221,7 +224,8 @@ void SV_CL_CheckForResend(void)
 			Info_SetValueForKey(info, "protocol", va("%i", ETTV_PROTOCOL_VERSION));
 			Info_SetValueForKey(info, "qport", va("%i", port));
 			Info_SetValueForKey(info, "challenge", va("%i", svclc.challenge));
-			Info_SetValueForKey(info, "masterpassword", va("%s", svclc.serverMasterPassword));
+			Info_SetValueForKey(info, "masterpassword", svclc.serverMasterPassword);
+			Info_SetValueForKey(info, "password", svclc.serverPassword);
 
 			Info_SetValueForKey(info, "name", sv_etltv_clientname->string);
 			Info_SetValueForKey(info, "rate", "90000");
@@ -276,6 +280,8 @@ void SV_CL_Disconnect(void)
 	svcls.state               = CA_DISCONNECTED;
 	svcls.lastRunFrameTime    = 0;
 	svcls.lastRunFrameSysTime = Sys_Milliseconds();
+	svcls.isGamestateParsed   = qfalse;
+	svcls.isDelayed           = sv_etltv_delay->integer != 0;
 }
 
 /**
@@ -287,6 +293,11 @@ void SV_CL_Disconnect(void)
 void SV_CL_AddReliableCommand(const char *cmd)
 {
 	int index;
+
+	if (svclc.demo.playing)
+	{
+		return;
+	}
 
 	// if we would be losing an old command that hasn't been acknowledged,
 	// we must drop the connection
@@ -339,16 +350,16 @@ qboolean SV_CL_ReadyToSendPacket(void)
 	}
 
 	// send every frame for loopbacks
-	//if (clc.netchan.remoteAddress.type == NA_LOOPBACK)
-	//{
-	//	return qtrue;
-	//}
+	if (svclc.netchan.remoteAddress.type == NA_LOOPBACK)
+	{
+		return qtrue;
+	}
 
 	// send every frame for LAN
-	//if (Sys_IsLANAddress(clc.netchan.remoteAddress))
-	//{
-	//	return qtrue;
-	//}
+	if (Sys_IsLANAddress(svclc.netchan.remoteAddress))
+	{
+		return qtrue;
+	}
 
 	oldPacketNum = (svclc.netchan.outgoingSequence - 1) & PACKET_MASK;
 	delta        = svcls.realtime - svcl.outPackets[oldPacketNum].p_realtime;
@@ -381,12 +392,11 @@ void SV_CL_WritePacket(void)
 {
 	msg_t     buf;
 	byte      data[MAX_MSGLEN];
-	int       i, j;
-	usercmd_t *cmd, *oldcmd;
+	int       i;
+	usercmd_t *cmd;
 	usercmd_t nullcmd;
 	int       packetNum;
-	int       oldPacketNum;
-	int       count, key;
+	int       key;
 
 	// don't send anything if playing back a demo
 	if (svclc.demo.playing)
@@ -395,22 +405,21 @@ void SV_CL_WritePacket(void)
 	}
 
 	Com_Memset(&nullcmd, 0, sizeof(nullcmd));
-	oldcmd = &nullcmd;
 
 	MSG_Init(&buf, data, sizeof(data));
 
 	MSG_Bitstream(&buf);
 	// write the current serverId so the server
 	// can tell if this is from the current gameState
-	MSG_WriteLong(&buf, svcl.serverId);
+	MSG_WriteLong(&buf, svclc.serverIdLatest);
 
 	// write the last message we received, which can
 	// be used for delta compression, and is also used
 	// to tell if we dropped a gamestate
-	MSG_WriteLong(&buf, svclc.serverMessageSequence);
+	MSG_WriteLong(&buf, svclc.serverMessageSequenceLatest);
 
 	// write the last reliable message we received
-	MSG_WriteLong(&buf, svclc.serverCommandSequence);
+	MSG_WriteLong(&buf, svclc.serverCommandSequenceLatest);
 
 	// write any unacknowledged clientCommands
 	// NOTE: if you verbose this, you will see that there are quite a few duplicates
@@ -423,72 +432,47 @@ void SV_CL_WritePacket(void)
 	}
 
 	svcl.cmdNumber++;
-	oldPacketNum = (svclc.netchan.outgoingSequence - 1) & PACKET_MASK;
-	count        = svcl.cmdNumber - svcl.outPackets[oldPacketNum].p_cmdNumber;
 
-	if (count >= 1)
+	// FIXME: there has to be a way to simplify this
+	// begin a client move command
+	if ((!svcls.isGamestateParsed && (!svcl.snap.valid || svclc.demo.waiting || svclc.serverMessageSequence != svcl.snap.messageNum)) // live game
+	    || (svcls.isGamestateParsed && (!svclc.moveDelta || svclc.demo.waiting || !svcls.queueDemoWaiting)))                         // delayed game
 	{
-		//if (cl_showSend->integer)
-		//{
-		//	Com_Printf("(%i)", count);
-		//}
-
-		// begin a client move command
-		if (/*cl_nodelta->integer || */ !svcl.snap.valid || svclc.demo.waiting
-		    || svclc.serverMessageSequence != svcl.snap.messageNum)
-		{
-			MSG_WriteByte(&buf, clc_moveNoDelta);
-		}
-		else
-		{
-			MSG_WriteByte(&buf, clc_move);
-		}
-
-		// write the command count
-		MSG_WriteByte(&buf, count);
-
-		// use the checksum feed in the key
-		key = svclc.checksumFeed;
-		// also use the message acknowledge
-		key ^= svclc.serverMessageSequence;
-		// also use the last acknowledged server command in the key
-		key ^= MSG_HashKey(svclc.serverCommands[svclc.serverCommandSequence & (MAX_RELIABLE_COMMANDS - 1)], 32, 0);
-
-		// write all the commands, including the predicted command
-		for (i = 0; i < count; i++)
-		{
-			j               = (svcl.cmdNumber - count + i + 1) & CMD_MASK;
-			cmd             = &svcl.cmds[j];
-			cmd->serverTime = sv.time;
-			MSG_WriteDeltaUsercmdKey(&buf, key, oldcmd, cmd);
-			oldcmd = cmd;
-		}
+		MSG_WriteByte(&buf, clc_moveNoDelta);
+	}
+	else
+	{
+		MSG_WriteByte(&buf, clc_move);
 	}
 
-	// deliver the message
-	packetNum                               = svclc.netchan.outgoingSequence & PACKET_MASK;
-	svcl.outPackets[packetNum].p_realtime   = svcls.realtime;
-	svcl.outPackets[packetNum].p_serverTime = oldcmd->serverTime;
-	svcl.outPackets[packetNum].p_cmdNumber  = svcl.cmdNumber;
-	svclc.lastPacketSentTime                = svcls.realtime;
+	// write the command count
+	MSG_WriteByte(&buf, 1);
 
-	//if (cl_showSend->integer)
-	//{
-	//	Com_Printf("%i ", buf.cursize);
-	//}
+	// use the checksum feed in the key
+	key = svclc.checksumFeedLatest;
+	// also use the message acknowledge
+	key ^= svclc.serverMessageSequenceLatest;
+	// also use the last acknowledged server command in the key
+	key ^= MSG_HashKey(svclc.serverCommandsLatest[svclc.serverCommandSequenceLatest & (MAX_RELIABLE_COMMANDS - 1)], 32, 0);
+
+	// write all the commands, including the predicted command
+	cmd                = &svcl.cmds[svcl.cmdNumber & CMD_MASK];
+	cmd->serverTime    = svcl.serverTimeLatest;
+	nullcmd.serverTime = svcl.cmds[svcl.cmdNumber - 1 & CMD_MASK].serverTime;
+	MSG_WriteDeltaUsercmdKey(&buf, key, &nullcmd, cmd);
+
+	// deliver the message
+	packetNum                             = svclc.netchan.outgoingSequence & PACKET_MASK;
+	svcl.outPackets[packetNum].p_realtime = svcls.realtime;
+	//svcl.outPackets[packetNum].p_serverTime = cmd->serverTime;
+	svcl.outPackets[packetNum].p_cmdNumber = svcl.cmdNumber;
+	svclc.lastPacketSentTime               = svcls.realtime;
+
 	SV_CL_Netchan_Transmit(&svclc.netchan, &buf);
 
-	// clients never really should have messages large enough
-	// to fragment, but in case they do, fire them all off
-	// at once
-	// - this causes a packet burst, which is bad karma for winsock
-	// added a WARNING message, we'll see if there are legit situations where this happens
+	// tv clients never really should have messages large enough
 	while (svclc.netchan.unsentFragments)
 	{
-		//if (cl_showSend->integer)
-		//{
-		//	Com_Printf("WARNING: unsent fragments (not supposed to happen!)\n");
-		//}
 		SV_CL_Netchan_TransmitNextFragment(&svclc.netchan);
 	}
 }
@@ -529,7 +513,7 @@ void SV_CL_InitTVGame(void)
 
 	t2 = Sys_Milliseconds();
 
-	Com_Printf("CL_InitCGame: %5.2f seconds\n", (t2 - t1) / 1000.0);
+	Com_Printf("SV_CL_InitTVGame: %5.2f seconds\n", (t2 - t1) / 1000.0);
 
 	// make sure everything is paged in
 	if (!Sys_LowPhysicalMemory())
@@ -624,7 +608,7 @@ char *SV_CL_Cvar_InfoString(char *cs, int index)
 
 	if (svcls.state != CA_DISCONNECTED)
 	{
-		if (index == 0)
+		if (index == CS_SERVERINFO)
 		{
 			Info_SetValueForKey_Big(newcs, "sv_maxPing", sv_maxPing->string);
 			Info_SetValueForKey_Big(newcs, "sv_minPing", sv_minPing->string);
@@ -635,7 +619,7 @@ char *SV_CL_Cvar_InfoString(char *cs, int index)
 			Info_SetValueForKey_Big(newcs, "sv_privateClients", sv_privateClients->string);
 			Info_SetValueForKey_Big(newcs, "version", Cvar_VariableString("version"));
 		}
-		else if (index == 1)
+		else if (index == CS_SYSTEMINFO)
 		{
 			Info_SetValueForKey_Big(newcs, "sv_serverid", va("%d", sv.serverId));
 			Info_SetValueForKey_Big(newcs, "sv_pure", sv_pure->string);
@@ -666,13 +650,13 @@ qboolean SV_CL_GetServerCommand(int serverCommandNumber)
 		{
 			return qfalse;
 		}
-		Com_Error(ERR_DROP, "CL_GetServerCommand: a reliable command was cycled out");
+		Com_Error(ERR_DROP, "SV_CL_GetServerCommand: a reliable command was cycled out");
 		return qfalse;
 	}
 
 	if (serverCommandNumber > svclc.serverCommandSequence)
 	{
-		Com_Error(ERR_DROP, "CL_GetServerCommand: requested a command not received");
+		Com_Error(ERR_DROP, "SV_CL_GetServerCommand: requested a command not received");
 		return qfalse;
 	}
 
@@ -729,7 +713,7 @@ rescan:
 	if (!strcmp(cmd, "cs"))
 	{
 		SV_CL_ConfigstringModified();
-		// reparse the string, because CL_ConfigstringModified may have done another Cmd_TokenizeString()
+		// reparse the string, because SV_CL_ConfigstringModified may have done another Cmd_TokenizeString()
 		Cmd_TokenizeString(s);
 		return qtrue;
 	}
@@ -777,7 +761,7 @@ rescan:
 /**
  * @brief SV_CL_SendPureChecksums
  */
-void SV_CL_SendPureChecksums(void)
+void SV_CL_SendPureChecksums(int serverId)
 {
 	//const char *pChecksums;
 	char cMsg[MAX_INFO_VALUE];
@@ -786,7 +770,7 @@ void SV_CL_SendPureChecksums(void)
 	//pChecksums = FS_ReferencedPakPureChecksums();
 
 	//Com_sprintf(cMsg, sizeof(cMsg), "cp %d %s", svcl.serverId, pChecksums);
-	Com_sprintf(cMsg, sizeof(cMsg), "cp %d SLAVE", svcl.serverId);
+	Com_sprintf(cMsg, sizeof(cMsg), "cp %d SLAVE", serverId);
 
 	SV_CL_AddReliableCommand(cMsg);
 }
@@ -817,8 +801,10 @@ void SV_CL_DownloadsComplete(void)
 
 	SV_CL_InitTVGame();
 
-	// set pure checksums
-	SV_CL_SendPureChecksums();
+	if (!svcls.isGamestateParsed)
+	{
+		SV_CL_SendPureChecksums(svcl.serverId);
+	}
 
 	SV_CL_WritePacket();
 	SV_CL_WritePacket();
@@ -1097,7 +1083,7 @@ void SV_CL_ConnectionlessPacket(netadr_t from, msg_t *msg)
 
 	if (com_developer->integer)
 	{
-		Com_Printf("CL packet %s: %s\n", NET_AdrToString(from), c);
+		Com_Printf("SV_CL packet %s: %s\n", NET_AdrToString(from), c);
 	}
 
 	// challenge from the server we are connecting to
@@ -1323,15 +1309,10 @@ static void SV_CL_PacketEvent(netadr_t from, msg_t *msg)
 	// track the last message received so it can be returned in
 	// client messages, allowing the server to detect a dropped
 	// gamestate
-	svclc.serverMessageSequence = LittleLong(*(int *)msg->data);
+	svclc.serverMessageSequenceLatest = LittleLong(*(int *)msg->data);
+	svclc.lastPacketTime              = svcls.realtime;
 
-	svclc.lastPacketTime = svcls.realtime;
-	SV_CL_ParseServerMessage(msg);
-
-	if (svclc.demo.recording && !svclc.demo.waiting)
-	{
-		SV_CL_WriteDemoMessage(msg, headerBytes);
-	}
+	SV_CL_ParseServerMessage_Ext(msg, headerBytes);
 }
 
 /**
@@ -1385,6 +1366,7 @@ void SV_CL_ClearState(void)
 
 /**
  * @brief SV_CL_GetPlayerstate
+ * @return
  */
 int SV_CL_GetPlayerstate(int clientNum, playerState_t *ps)
 {
@@ -1434,14 +1416,28 @@ void SV_CL_RunFrame(void)
 		return;
 	}
 
+	if (svcls.isDelayed)
+	{
+		int queueTime = SV_CL_GetQueueTime() - sv_etltv_delay->integer * 1000;
+
+		if (queueTime < 0)
+		{
+			queueTime = queueTime - frameMsec + 1;
+		}
+
+		svcl.serverTime = (queueTime / frameMsec) * frameMsec;
+	}
+
 	if (svcl.serverTime < svcls.lastRunFrameTime)
 	{
-		if (svcl.snap.valid)
+		if (svcls.firstSnap)
 		{
 			Com_Printf("Server went backwards in time: %d > %d\n", svcls.lastRunFrameTime, svcl.serverTime);
 		}
 		else
 		{
+			Com_Printf("Rewinding server time\n");
+
 			sv.time                   = svcl.serverTime;
 			svcls.lastRunFrameTime    = svcl.serverTime;
 			svcls.lastRunFrameSysTime = systime;
@@ -1465,15 +1461,13 @@ void SV_CL_RunFrame(void)
 		}
 	}
 
-	if (sv.time < svcl.serverTime && svcl.snap.valid)
+	Cbuf_Execute();
+
+	if (sv.time < svcl.serverTime && (svcls.firstSnap || svcls.isDelayed))
 	{
 		if (!svclc.demo.playing || svcl.serverTime - sv.time <= frameMsec)
 		{
-			if (svclc.demo.playing && svclc.demo.fastForwardTime > sv.time)
-			{
-				svs.time += frameMsec;
-			}
-
+			svs.time                 += frameMsec;
 			sv.time                   = svcl.serverTime;
 			svcls.lastRunFrameTime    = sv.time;
 			svcls.lastRunFrameSysTime = systime;
@@ -1489,7 +1483,8 @@ void SV_CL_RunFrame(void)
 			Com_Printf("Dropped frame: sv.time [%d] svcl.serverTime [%d] frameMsec [%d]\n", sv.time, svcl.serverTime, frameMsec);
 		}
 
-		sv.time                   = sv.time + frameMsec;
+		svs.time                 += frameMsec;
+		sv.time                  += frameMsec;
 		svcls.lastRunFrameTime    = sv.time;
 		svcls.lastRunFrameSysTime = systime;
 
@@ -1534,6 +1529,8 @@ void SV_CL_Frame(int frameMsec)
 		startTime = 0;  // quite a compiler warning
 	}
 
+	SV_CL_ParseMessageQueue();
+
 	if (svclc.demo.fastForwardTime <= sv.time)
 	{
 		// run the game simulation in chunks
@@ -1553,6 +1550,10 @@ void SV_CL_Frame(int frameMsec)
 	else if (svclc.demo.playing && svcl.serverTime <= sv.time)
 	{
 		SV_CL_ReadDemoMessage();
+	}
+	else
+	{
+		SV_CL_RunFrame();
 	}
 
 	if (com_speeds->integer)

--- a/src/server/sv_cl_main.c
+++ b/src/server/sv_cl_main.c
@@ -1409,7 +1409,7 @@ void SV_CL_RunFrame(void)
 {
 	int frameMsec = 1000 / sv_fps->integer;
 	int systime   = Sys_Milliseconds();
-	int frameDelta;
+	int frameDelta, queueMs;
 
 	if (svcls.state <= CA_DISCONNECTED)
 	{
@@ -1426,6 +1426,23 @@ void SV_CL_RunFrame(void)
 		}
 
 		svcl.serverTime = (queueTime / frameMsec) * frameMsec;
+
+		if (svMsgQueueHead)
+		{
+			queueMs = svMsgQueueHead->serverTime - svcl.serverTime;
+
+			if (sv_etltv_queue_ms->integer != queueMs)
+			{
+				Cvar_Set("ettv_queue_ms", va("%i", queueMs));
+			}
+		}
+	}
+	else
+	{
+		if (sv_etltv_queue_ms->integer != -1)
+		{
+			Cvar_Set("ettv_queue_ms", "-1");
+		}
 	}
 
 	if (svcl.serverTime < svcls.lastRunFrameTime)

--- a/src/server/sv_cl_main.c
+++ b/src/server/sv_cl_main.c
@@ -456,15 +456,13 @@ void SV_CL_WritePacket(void)
 	key ^= MSG_HashKey(svclc.serverCommandsLatest[svclc.serverCommandSequenceLatest & (MAX_RELIABLE_COMMANDS - 1)], 32, 0);
 
 	// write all the commands, including the predicted command
-	cmd                = &svcl.cmds[svcl.cmdNumber & CMD_MASK];
-	cmd->serverTime    = svcl.serverTimeLatest;
-	nullcmd.serverTime = svcl.cmds[svcl.cmdNumber - 1 & CMD_MASK].serverTime;
+	cmd             = &svcl.cmds[svcl.cmdNumber & CMD_MASK];
+	cmd->serverTime = svcl.serverTimeLatest;
 	MSG_WriteDeltaUsercmdKey(&buf, key, &nullcmd, cmd);
 
 	// deliver the message
-	packetNum                             = svclc.netchan.outgoingSequence & PACKET_MASK;
-	svcl.outPackets[packetNum].p_realtime = svcls.realtime;
-	//svcl.outPackets[packetNum].p_serverTime = cmd->serverTime;
+	packetNum                              = svclc.netchan.outgoingSequence & PACKET_MASK;
+	svcl.outPackets[packetNum].p_realtime  = svcls.realtime;
 	svcl.outPackets[packetNum].p_cmdNumber = svcl.cmdNumber;
 	svclc.lastPacketSentTime               = svcls.realtime;
 
@@ -720,8 +718,6 @@ rescan:
 
 	if (!strcmp(cmd, "map_restart"))
 	{
-		// reparse the string, because Con_ClearNotify() may have done another Cmd_TokenizeString()
-		Cmd_TokenizeString(s);
 		// clear outgoing commands before passing
 		Com_Memset(svcl.cmds, 0, sizeof(svcl.cmds));
 		Cbuf_AddText("map_restart 0\n");
@@ -1470,7 +1466,8 @@ void SV_CL_RunFrame(void)
 			{
 				if (sv.time != 0)
 				{
-					Com_Printf("Dropped server frame: systimeDelta [%d] sv.time [%d] svcl.serverTime [%d] frameDelta [%d]\n", systime - svcls.lastRunFrameSysTime, sv.time, svcl.serverTime, frameDelta);
+					Com_Printf("Dropped server frame: systimeDelta [%d] sv.time [%d] svcl.serverTime [%d] frameDelta [%d]\n",
+					           systime - svcls.lastRunFrameSysTime, sv.time, svcl.serverTime, frameDelta);
 				}
 
 				svcl.serverTime = frameDelta;

--- a/src/server/sv_cl_net_chan.c
+++ b/src/server/sv_cl_net_chan.c
@@ -72,7 +72,7 @@ static void SV_CL_Netchan_Encode(msg_t *msg)
 	msg->bit       = sbit;
 	msg->readcount = srdc;
 
-	string = (byte *)svclc.serverCommands[reliableAcknowledge & (MAX_RELIABLE_COMMANDS - 1)];
+	string = (byte *)svclc.serverCommandsLatest[reliableAcknowledge & (MAX_RELIABLE_COMMANDS - 1)];
 	index  = 0;
 
 	key = svclc.challenge ^ serverId ^ messageAcknowledge;

--- a/src/server/sv_cl_parse.c
+++ b/src/server/sv_cl_parse.c
@@ -367,7 +367,7 @@ void SV_CL_ParseGamestateQueue(msg_t *msg)
 	SV_CL_WritePacket();
 	SV_CL_WritePacket();
 
-	svcls.queueDemoWaiting = qfalse;
+	svcls.queueDemoWaiting = !sv_etltv_autorecord->integer;
 }
 
 /**

--- a/src/server/sv_cl_parse.c
+++ b/src/server/sv_cl_parse.c
@@ -300,7 +300,7 @@ void SV_CL_ParseGamestate(msg_t *msg)
 
 	svcls.isGamestateParsed = svcls.isDelayed;
 	svcls.firstSnap         = qfalse;
-	svcls.queueDemoWaiting  = qfalse;
+	svcls.queueDemoWaiting  = !sv_etltv_autorecord->integer;
 	svcls.fixHitch          = qtrue;
 }
 

--- a/src/server/sv_cl_parse.c
+++ b/src/server/sv_cl_parse.c
@@ -36,6 +36,35 @@
 
 #ifdef DEDICATED
 
+const char *svc_strings[32] =
+{
+	"svc_bad",
+
+	"svc_nop",
+	"svc_gamestate",
+	"svc_configstring",
+	"svc_baseline",
+	"svc_serverCommand",
+	"svc_download",
+	"svc_snapshot",
+	"svc_EOF",
+	"svc_ettv_playerstates",
+	"svc_ettv_currentstate"
+};
+
+/**
+ * @brief SV_CL_SHOWNET
+ * @param[in] msg
+ * @param[in] s
+ */
+void SV_CL_SHOWNET(msg_t *msg, const char *s)
+{
+	if (sv_etltv_shownet->integer >= 2)
+	{
+		Com_Printf("%3i:%s\n", msg->readcount - 1, s);
+	}
+}
+
 /**
   * @brief SV_CL_SetPurePaks
  * @param[in] referencedOnly
@@ -179,14 +208,14 @@ void SV_CL_ParseGamestate(msg_t *msg)
 			i = MSG_ReadShort(msg);
 			if (i < 0 || i >= MAX_CONFIGSTRINGS)
 			{
-				Com_Error(ERR_DROP, "configstring < 0 or configstring >= MAX_CONFIGSTRINGS");
+				Com_Error(ERR_DROP, "SV_CL_ParseGamestate: configstring < 0 or configstring >= MAX_CONFIGSTRINGS");
 			}
 			s   = MSG_ReadBigString(msg);
 			len = strlen(s);
 
 			if (len + 1 + svcl.gameState.dataCount > MAX_GAMESTATE_CHARS)
 			{
-				Com_Error(ERR_DROP, "MAX_GAMESTATE_CHARS exceeded");
+				Com_Error(ERR_DROP, "SV_CL_ParseGamestate: MAX_GAMESTATE_CHARS exceeded");
 			}
 
 			// append it to the gameState string buffer
@@ -199,7 +228,7 @@ void SV_CL_ParseGamestate(msg_t *msg)
 			newnum = MSG_ReadBits(msg, GENTITYNUM_BITS);
 			if (newnum < 0 || newnum >= MAX_GENTITIES)
 			{
-				Com_Error(ERR_DROP, "Baseline number out of range: %i", newnum);
+				Com_Error(ERR_DROP, "SV_CL_ParseGamestate: Baseline number out of range: %i", newnum);
 			}
 			Com_Memset(&nullstate, 0, sizeof(nullstate));
 			Com_Memset(&nullstateShared, 0, sizeof(nullstateShared));
@@ -214,7 +243,7 @@ void SV_CL_ParseGamestate(msg_t *msg)
 
 			if (newnum < 0 || newnum >= MAX_GENTITIES)
 			{
-				Com_Error(ERR_DROP, "Currentstate number out of range : %i", newnum);
+				Com_Error(ERR_DROP, "SV_CL_ParseGamestate: Currentstate number out of range : %i", newnum);
 			}
 
 			MSG_ReadDeltaEntity(msg, &svcl.entityBaselines[newnum], &svcl.currentStateEntities[newnum], newnum);
@@ -223,7 +252,7 @@ void SV_CL_ParseGamestate(msg_t *msg)
 		}
 		else
 		{
-			Com_Error(ERR_DROP, "CL_ParseGamestate: bad command byte");
+			Com_Error(ERR_DROP, "SV_CL_ParseGamestate: bad command byte");
 		}
 	}
 
@@ -235,6 +264,12 @@ void SV_CL_ParseGamestate(msg_t *msg)
 	SV_CL_ConfigstringInfoChanged(CS_SERVERINFO);
 	SV_CL_ConfigstringInfoChanged(CS_WOLFINFO);
 
+	if (!svcls.isGamestateParsed)
+	{
+		svclc.serverIdLatest     = svcl.serverId;
+		svclc.checksumFeedLatest = svclc.checksumFeed;
+	}
+
 	// Verify if we have all official pakfiles. As we won't
 	// be downloading them, we should be kicked for not having them.
 	if (sv_pure->integer && !FS_VerifyOfficialPaks())
@@ -245,6 +280,8 @@ void SV_CL_ParseGamestate(msg_t *msg)
 	// reinitialize the filesystem if the game directory has changed
 	FS_ConditionalRestart(svclc.checksumFeed);
 
+	// Verify if we have all non-official pakfiles. As we won't
+	// be downloading them, we should be kicked for not having them.
 	if (FS_ComparePaks(missingFiles, sizeof(missingFiles), qfalse))
 	{
 		Com_Printf("Missing paks: %s\n", missingFiles);
@@ -254,10 +291,82 @@ void SV_CL_ParseGamestate(msg_t *msg)
 		return;
 	}
 
+	svclc.moveDelta = svcls.isGamestateParsed;
+
 	SV_CL_DownloadsComplete();
 
 	// make sure the game starts
 	Cvar_Set("cl_paused", "0");
+
+	svcls.isGamestateParsed = svcls.isDelayed;
+	svcls.firstSnap         = qfalse;
+	svcls.queueDemoWaiting  = qfalse;
+}
+
+/**
+ * @brief SV_CL_ParseGamestateQueue
+ * @param[in] msg
+ */
+void SV_CL_ParseGamestateQueue(msg_t *msg)
+{
+	int            i;
+	entityState_t  nullstate;
+	entityShared_t nullstateShared;
+	int            cmd;
+	char           *s;
+
+	// a gamestate always marks a server command sequence
+	svclc.serverCommandSequenceLatest = MSG_ReadLong(msg);
+
+	while (1)
+	{
+		cmd = MSG_ReadByte(msg);
+
+		if (cmd == svc_EOF)
+		{
+			break;
+		}
+
+		if (cmd == svc_configstring)
+		{
+			i = MSG_ReadShort(msg);
+
+			if (i < 0 || i >= MAX_CONFIGSTRINGS)
+			{
+				Com_Error(ERR_DROP, "SV_CL_ParseGamestateQueue: configstring < 0 or configstring >= MAX_CONFIGSTRINGS");
+			}
+
+			s = MSG_ReadBigString(msg);
+
+			if (i == CS_SYSTEMINFO)
+			{
+				svclc.serverIdLatest = Q_atoi(Info_ValueForKey(s, "sv_serverid"));
+			}
+		}
+		else if (cmd == svc_baseline || cmd == svc_ettv_currentstate)
+		{
+			MSG_ReadBits(msg, GENTITYNUM_BITS);
+			MSG_ReadDeltaEntity(msg, &nullstate, &nullstate, 0);
+			MSG_ETTV_ReadDeltaEntityShared(msg, &nullstateShared, &nullstateShared);
+		}
+		else
+		{
+			Com_Error(ERR_DROP, "SV_CL_ParseGamestateQueue: bad command byte");
+		}
+	}
+
+	MSG_ReadLong(msg); // clientNum
+	svclc.checksumFeedLatest = MSG_ReadLong(msg);
+
+	SV_CL_SendPureChecksums(svclc.serverIdLatest);
+
+	svclc.moveDelta = qfalse;
+
+	SV_CL_WritePacket();
+	SV_CL_WritePacket();
+	SV_CL_WritePacket();
+
+	svcls.queueDemoWaiting = qfalse;
 }
 
 /**
@@ -279,10 +388,12 @@ void SV_CL_ParseCommandString(msg_t *msg)
 		return;
 	}
 
-	svclc.serverCommandSequence = seq;
-	index                       = seq & (MAX_RELIABLE_COMMANDS - 1);
+	svclc.serverCommandSequence       = seq;
+	svclc.serverCommandSequenceLatest = seq;
+	index                             = seq & (MAX_RELIABLE_COMMANDS - 1);
 
 	Q_strncpyz(svclc.serverCommands[index], s, sizeof(svclc.serverCommands[index]));
+	Q_strncpyz(svclc.serverCommandsLatest[index], s, sizeof(svclc.serverCommands[index]));
 
 	if (!gvm)
 	{
@@ -353,6 +464,12 @@ void SV_CL_DeltaEntity(msg_t *msg, svclSnapshot_t *frame, int newnum, entityStat
 		if (state->number == (MAX_GENTITIES - 1))
 		{
 			SV_UnlinkEntity(gEnt);
+
+			if (sv_etltv_shownet->integer == 4)
+			{
+				Com_Printf("%d- ", newnum);
+			}
+
 			return;     // entity was delta removed
 		}
 
@@ -366,6 +483,11 @@ void SV_CL_DeltaEntity(msg_t *msg, svclSnapshot_t *frame, int newnum, entityStat
 
 		gEnt->s.number = newnum;
 		SV_LinkEntity(gEnt);
+
+		if (sv_etltv_shownet->integer == 4)
+		{
+			Com_Printf("%d+ ", newnum);
+		}
 	}
 
 	if (state->number == (MAX_GENTITIES - 1))
@@ -439,10 +561,10 @@ void SV_CL_ParsePacketEntities(msg_t *msg, svclSnapshot_t *oldframe, svclSnapsho
 		while (oldnum < newnum)
 		{
 			// one or more entities from the old packet are unchanged
-			//if (cl_shownet->integer == 3)
-			//{
-			//	Com_Printf("%3i:  unchanged: %i\n", msg->readcount, oldnum);
-			//}
+			if (sv_etltv_shownet->integer == 3)
+			{
+				Com_Printf("%3i:  unchanged: %i\n", msg->readcount, oldnum);
+			}
 			SV_CL_DeltaEntity(msg, newframe, oldnum, oldstate, oldstateShared, qtrue);
 
 			oldindex++;
@@ -464,10 +586,10 @@ void SV_CL_ParsePacketEntities(msg_t *msg, svclSnapshot_t *oldframe, svclSnapsho
 		if (oldnum == newnum)
 		{
 			// delta from previous state
-			//if (cl_shownet->integer == 3)
-			//{
-			//	Com_Printf("%3i:  delta: %i\n", msg->readcount, newnum);
-			//}
+			if (sv_etltv_shownet->integer == 3)
+			{
+				Com_Printf("%3i:  delta: %i\n", msg->readcount, newnum);
+			}
 			SV_CL_DeltaEntity(msg, newframe, newnum, oldstate, oldstateShared, qfalse);
 
 			oldindex++;
@@ -488,10 +610,10 @@ void SV_CL_ParsePacketEntities(msg_t *msg, svclSnapshot_t *oldframe, svclSnapsho
 		else if (oldnum > newnum)
 		{
 			// delta from baseline
-			//if (cl_shownet->integer == 3)
-			//{
-			//	Com_Printf("%3i:  baseline: %i\n", msg->readcount, newnum);
-			//}
+			if (sv_etltv_shownet->integer == 3)
+			{
+				Com_Printf("%3i:  baseline: %i\n", msg->readcount, newnum);
+			}
 			SV_CL_DeltaEntity(msg, newframe, newnum, &svcl.entityBaselines[newnum], &svcl.entityBaselinesShared[newnum], qfalse);
 		}
 	}
@@ -500,10 +622,10 @@ void SV_CL_ParsePacketEntities(msg_t *msg, svclSnapshot_t *oldframe, svclSnapsho
 	while (oldnum != MAX_GENTITIES)
 	{
 		// one or more entities from the old packet are unchanged
-		//if (cl_shownet->integer == 3)
-		//{
-		//	Com_Printf("%3i:  unchanged: %i\n", msg->readcount, oldnum);
-		//}
+		if (sv_etltv_shownet->integer == 3)
+		{
+			Com_Printf("%3i:  unchanged: %i\n", msg->readcount, oldnum);
+		}
 		SV_CL_DeltaEntity(msg, newframe, oldnum, oldstate, oldstateShared, qtrue);
 
 		oldindex++;
@@ -570,24 +692,26 @@ void SV_CL_ParseSnapshot(msg_t *msg)
 	}
 	newSnap.snapFlags = MSG_ReadByte(msg);
 
+	svclc.moveDelta = qfalse;
+
 	// If the frame is delta compressed from data that we
 	// no longer have available, we must suck up the rest of
 	// the frame, but not use it, then ask for a non-compressed
 	// message
 	if (newSnap.deltaNum <= 0)
 	{
-		newSnap.valid = qtrue;      // uncompressed frame
-		old           = NULL;
+		svclc.moveDelta = qtrue;
+		svcls.firstSnap = qtrue;
+		newSnap.valid   = qtrue;      // uncompressed frame
+		old             = NULL;
+
 		if (svclc.demo.recording)
 		{
 			svclc.demo.waiting = qfalse;   // we can start recording now
 		}
-		else
+		else if (sv_etltv_autorecord->integer && !svclc.demo.playing)
 		{
-			if (sv_etltv_autorecord->integer && !svclc.demo.playing)
-			{
-				Cbuf_ExecuteText(EXEC_APPEND, "record\n");
-			}
+			Cbuf_ExecuteText(EXEC_APPEND, "record\n");
 		}
 	}
 	else
@@ -596,21 +720,28 @@ void SV_CL_ParseSnapshot(msg_t *msg)
 		if (!old->valid)
 		{
 			// should never happen
-			Com_Printf("Delta from invalid frame (not supposed to happen!).\n");
+			Com_Printf("SV_CL_ParseSnapshot: Delta from invalid frame (not supposed to happen!).\n");
 		}
 		else if (old->messageNum != newSnap.deltaNum)
 		{
 			// The frame that the server did the delta from
 			// is too old, so we can't reconstruct it properly.
-			Com_DPrintf("Delta frame too old.\n");
+			Com_DPrintf("SV_CL_ParseSnapshot: Delta frame too old.\n");
 		}
 		else if (svcl.parseEntitiesNum - old->parseEntitiesNum > MAX_PARSE_ENTITIES - 128)
 		{
-			Com_DPrintf("Delta parseEntitiesNum too old.\n");
+			Com_Error(ERR_DROP, "SV_CL_ParseSnapshot: Delta parseEntitiesNum too old.\n");
 		}
 		else
 		{
-			newSnap.valid = qtrue;  // valid delta parse
+			if (!svclc.demo.recording && sv_etltv_autorecord->integer && !svclc.demo.playing)
+			{
+				Cbuf_ExecuteText(EXEC_APPEND, "record\n");
+			}
+
+			svclc.moveDelta = qtrue;
+			newSnap.valid   = qtrue;  // valid delta parse
+			svcls.firstSnap = qtrue;
 		}
 	}
 
@@ -626,7 +757,7 @@ void SV_CL_ParseSnapshot(msg_t *msg)
 	MSG_ReadData(msg, &newSnap.areamask, len);
 
 	// read playerinfo
-	//SHOWNET(msg, "playerstate");
+	SV_CL_SHOWNET(msg, "playerstate");
 	if (old)
 	{
 		MSG_ReadDeltaPlayerstate(msg, &old->ps, &newSnap.ps);
@@ -637,7 +768,7 @@ void SV_CL_ParseSnapshot(msg_t *msg)
 	}
 
 	// read packet entities
-	//SHOWNET(msg, "packet entities");
+	SV_CL_SHOWNET(msg, "packet entities");
 	SV_CL_ParsePacketEntities(msg, old, &newSnap);
 
 	// if not valid, dump the entire thing now that it has
@@ -678,11 +809,11 @@ void SV_CL_ParseSnapshot(msg_t *msg)
 	// save the frame off in the backup array for later delta comparisons
 	svcl.snapshots[svcl.snap.messageNum & PACKET_MASK] = svcl.snap;
 
-	//if (cl_shownet->integer == 3)
-	//{
-	//	Com_Printf("   snapshot:%i  delta:%i  ping:%i\n", cl.snap.messageNum,
-	//		cl.snap.deltaNum, cl.snap.ping);
-	//}
+	if (sv_etltv_shownet->integer == 3)
+	{
+		Com_Printf("   snapshot:%i  delta:%i  ping:%i\n", svcl.snap.messageNum,
+		           svcl.snap.deltaNum, svcl.snap.ping);
+	}
 
 	svcl.newSnapshots = qtrue;
 }
@@ -716,10 +847,20 @@ void SV_CL_ParsePlayerstates(msg_t *msg)
 		if (!oldframe || !oldframe->playerstates[clientNum].valid)
 		{
 			MSG_ReadDeltaPlayerstate(msg, NULL, &frame->playerstates[clientNum].ps);
+
+			if (sv_etltv_shownet->integer >= 2)
+			{
+				Com_Printf("%3i:playerstate baseline (client %d)\n", msg->readcount - 1, clientNum);
+			}
 		}
 		else
 		{
 			MSG_ReadDeltaPlayerstate(msg, &oldframe->playerstates[clientNum].ps, &frame->playerstates[clientNum].ps);
+
+			if (sv_etltv_shownet->integer >= 2)
+			{
+				Com_Printf("%3i:playerstate delta (client %d)\n", msg->readcount - 1, clientNum);
+			}
 		}
 
 		frame->playerstates[clientNum].valid = qtrue;
@@ -744,26 +885,109 @@ void SV_CL_ParsePlayerstates(msg_t *msg)
 			svcl.snapshots[oldMessageNum & PACKET_MASK].playerstates[i].valid = qfalse;
 		}
 	}
+
+	if (sv_etltv_shownet->integer >= 2)
+	{
+		Com_Printf("%3i:end of playerstates\n", msg->readcount - 1);
+	}
 }
 
 /**
- * @brief SV_CL_ParseServerMessage
- * @param[in] msg
+ * @brief SV_CL_GetQueueTime
+ * @return
  */
-void SV_CL_ParseServerMessage(msg_t *msg)
+int SV_CL_GetQueueTime(void)
 {
-	int cmd;
+	if (svMsgQueueHead)
+	{
+		return Sys_Milliseconds() - svMsgQueueHead->systime + svMsgQueueHead->serverTime;
+	}
 
-	//if (cl_shownet->integer == 1)
-	//{
-	//	Com_Printf("%i ", msg->cursize);
-	//}
-	//else if (cl_shownet->integer >= 2)
-	//{
-	//	Com_Printf("------------------\n");
-	//}
+	return 0;
+}
 
+/**
+ * @brief SV_CL_ParseMessageQueue
+ */
+void SV_CL_ParseMessageQueue(void)
+{
+	int i, index;
+
+	if (!svcls.isGamestateParsed)
+	{
+		return;
+	}
+
+	while (1)
+	{
+		if (!svMsgQueueHead || (svMsgQueueHead->serverTime && SV_CL_GetQueueTime() - sv_etltv_delay->integer * 1000 < svMsgQueueHead->serverTime))
+		{
+			break;
+		}
+
+		svclc.serverMessageSequence = svMsgQueueHead->serverMessageSequence;
+
+		if (svMsgQueueHead->serverTime)
+		{
+			svcls.isDelayed = qfalse;
+		}
+		else
+		{
+			svcls.isDelayed = qtrue;
+		}
+
+		for (i = 0; i < svMsgQueueHead->numServerCommand; i++)
+		{
+			index = (i + svMsgQueueHead->serverCommandSequence) & (MAX_RELIABLE_COMMANDS - 1);
+			Q_strncpyz(svclc.serverCommands[index], svMsgQueueHead->serverCommands[i], sizeof(svclc.serverCommands[index]));
+			free(svMsgQueueHead->serverCommands[i]);
+		}
+
+		svclc.serverCommandSequence = svMsgQueueHead->numServerCommand + svMsgQueueHead->serverCommandSequence - 1;
+
+		while (svclc.lastExecutedServerCommand < svclc.serverCommandSequence)
+		{
+			if (SV_CL_GetServerCommand(++svclc.lastExecutedServerCommand))
+			{
+				VM_CallFunc(gvm, GAME_CLIENT_COMMAND, -2);
+			}
+		}
+
+		SV_CL_ParseServerMessage(&svMsgQueueHead->msg, svMsgQueueHead->headerBytes);
+
+		if (svMsgQueueHead->next)
+		{
+			svMsgQueueHead = svMsgQueueHead->next;
+			free(svMsgQueueHead->prev->msg.data);
+			free(svMsgQueueHead->prev);
+			svMsgQueueHead->prev = NULL;
+		}
+		else
+		{
+			free(svMsgQueueHead->msg.data);
+			free(svMsgQueueHead);
+			svMsgQueueHead = NULL;
+		}
+	}
+}
+
+/**
+ * @brief SV_CL_ParseServerMessage_Ext
+ * @param[in] msg
+ * @param[in] headerBytes
+ */
+void SV_CL_ParseServerMessage_Ext(msg_t *msg, int headerBytes)
+{
 	MSG_Bitstream(msg);
+
+	if (sv_etltv_shownet->integer == 1)
+	{
+		Com_Printf("%i ", msg->cursize);
+	}
+	else if (sv_etltv_shownet->integer >= 2)
+	{
+		Com_Printf("------------------\n");
+	}
 
 	// get the reliable sequence acknowledge number
 	svclc.reliableAcknowledge = MSG_ReadLong(msg);
@@ -773,46 +997,71 @@ void SV_CL_ParseServerMessage(msg_t *msg)
 		svclc.reliableAcknowledge = svclc.reliableSequence;
 	}
 
+	if (!svcls.isGamestateParsed)
+	{
+		svclc.serverMessageSequence = svclc.serverMessageSequenceLatest;
+		svclc.serverCommandSequence = svclc.serverCommandSequenceLatest;
+		SV_CL_ParseServerMessage(msg, headerBytes);
+		// FIXME: not needed?
+		svcl.serverTimeLatest = svcl.serverTime;
+		svclc.serverIdLatest  = svcl.serverId;
+	}
+	else
+	{
+		SV_CL_ParseServerMessageIntoQueue(msg, headerBytes);
+		SV_CL_ParseMessageQueue();
+	}
+}
+
+/**
+ * @brief SV_CL_ParseServerMessage
+ * @param[in] msg
+ * @param[in] headerBytes
+ */
+void SV_CL_ParseServerMessage(msg_t *msg, int headerBytes)
+{
+	int cmd;
+
 	// parse the message
 	while (1)
 	{
 		if (msg->readcount > msg->cursize)
 		{
-			Com_Error(ERR_DROP, "CL_ParseServerMessage: read past end of server message");
+			Com_Error(ERR_DROP, "SV_CL_ParseServerMessage: read past end of server message");
 		}
 
 		cmd = MSG_ReadByte(msg);
 
 		if (cmd == svc_EOF)
 		{
-			//SHOWNET(msg, "END OF MESSAGE");
+			SV_CL_SHOWNET(msg, "END OF MESSAGE");
 			break;
 		}
 
-		//if (cl_shownet->integer >= 2)
-		//{
-		//	if (cmd < 0 || cmd > svc_EOF) // MSG_ReadByte might return -1 and we can't access our svc_strings array ...
-		//	{
-		//		Com_Printf("%3i:BAD BYTE %i\n", msg->readcount - 1, cmd); // -> ERR_DROP
-		//	}
-		//	else
-		//	{
-		//		if (!svc_strings[cmd])
-		//		{
-		//			Com_Printf("%3i:BAD CMD %i\n", msg->readcount - 1, cmd);
-		//		}
-		//		else
-		//		{
-		//			SHOWNET(msg, svc_strings[cmd]);
-		//		}
-		//	}
-		//}
+		if (sv_etltv_shownet->integer >= 2)
+		{
+			if (cmd < 0 || cmd > svc_ettv_currentstate) // MSG_ReadByte might return -1 and we can't access our svc_strings array ...
+			{
+				Com_Printf("%3i:BAD BYTE %i\n", msg->readcount - 1, cmd); // -> ERR_DROP
+			}
+			else
+			{
+				if (!svc_strings[cmd])
+				{
+					Com_Printf("%3i:BAD CMD %i\n", msg->readcount - 1, cmd);
+				}
+				else
+				{
+					SV_CL_SHOWNET(msg, svc_strings[cmd]);
+				}
+			}
+		}
 
 		// other commands
 		switch (cmd)
 		{
 		default:
-			Com_Error(ERR_DROP, "CL_ParseServerMessage: Illegible server message %d", cmd);
+			Com_Error(ERR_DROP, "SV_CL_ParseServerMessage: Illegible server message %d", cmd);
 		case svc_nop:
 			break;
 		case svc_serverCommand:
@@ -826,6 +1075,7 @@ void SV_CL_ParseServerMessage(msg_t *msg)
 			break;
 		case svc_ettv_playerstates:
 			SV_CL_ParsePlayerstates(msg);
+			break;
 		case svc_download:
 			//CL_ParseDownload(msg);
 			break;
@@ -838,6 +1088,248 @@ void SV_CL_ParseServerMessage(msg_t *msg)
 	{
 		SV_CL_RunFrame();
 	}
+
+	if (svclc.demo.recording && !svclc.demo.waiting)
+	{
+		SV_CL_WriteDemoMessage(msg, headerBytes);
+	}
+}
+
+/**
+ * @brief SV_CL_Allocate
+ */
+static void *SV_CL_Allocate(int size)
+{
+	void *data;
+
+	if (size > MAX_MSGLEN)
+	{
+		Com_Error(ERR_FATAL, "SV_CL_Allocate: Oversized allocation of [%d].", size);
+	}
+
+	data = Com_Allocate(size);
+
+	if (!data)
+	{
+		Com_Error(ERR_FATAL, "SV_CL_Allocate: Couldn't allocate size [%d].", size);
+	}
+
+	return data;
+}
+
+/**
+ * @brief SV_CL_NewMessage
+ */
+static serverMessageQueue_t *SV_CL_NewMessage(void)
+{
+	serverMessageQueue_t *newMessage = Com_Allocate(sizeof(serverMessageQueue_t));
+
+	if (!newMessage)
+	{
+		Com_Error(ERR_FATAL, "SV_CL_NewMessage: Couldn't allocate new message.");
+	}
+
+	Com_Memset(newMessage, 0, sizeof(serverMessageQueue_t));
+
+	if (svMsgQueueHead == NULL)
+	{
+		svMsgQueueHead = svMsgQueueTail = newMessage;
+	}
+	else
+	{
+		svMsgQueueTail->next       = newMessage;
+		svMsgQueueTail->next->prev = svMsgQueueTail;
+		svMsgQueueTail             = newMessage;
+	}
+
+	return newMessage;
+}
+
+/**
+ * @brief SV_CL_CheckNewQueuedCommand for change in serverId
+ * @param[in] cmd
+ */
+static void SV_CL_CheckNewQueuedCommand(char *queuedCmd)
+{
+	char        *s = queuedCmd;
+	char        *cmd;
+	static char bigConfigString[BIG_INFO_STRING];
+	int         argc;
+
+rescan:
+	Cmd_TokenizeString(s);
+	cmd  = Cmd_Argv(0);
+	argc = Cmd_Argc();
+
+	if (!strcmp(cmd, "bcs0"))
+	{
+		Com_sprintf(bigConfigString, BIG_INFO_STRING, "cs %s \"%s", Cmd_Argv(1), Cmd_Argv(2));
+		return;
+	}
+
+	if (!strcmp(cmd, "bcs1"))
+	{
+		s = Cmd_Argv(2);
+		if (strlen(bigConfigString) + strlen(s) >= BIG_INFO_STRING)
+		{
+			Com_Error(ERR_DROP, "bcs exceeded BIG_INFO_STRING");
+		}
+		strcat(bigConfigString, s);
+		return;
+	}
+
+	if (!strcmp(cmd, "bcs2"))
+	{
+		s = Cmd_Argv(2);
+		if (strlen(bigConfigString) + strlen(s) + 1 >= BIG_INFO_STRING)
+		{
+			Com_Error(ERR_DROP, "bcs exceeded BIG_INFO_STRING");
+		}
+		strcat(bigConfigString, s);
+		strcat(bigConfigString, "\"");
+		s = bigConfigString;
+		goto rescan;
+	}
+
+	if (!strcmp(cmd, "cs"))
+	{
+		if (Q_atoi(Cmd_Argv(1)) == CS_SYSTEMINFO)
+		{
+			s                    = Cmd_ArgsFrom(2);
+			svclc.serverIdLatest = Q_atoi(Info_ValueForKey(s, "sv_serverid"));
+		}
+	}
+}
+
+/**
+ * @brief SV_CL_CopyMsg
+ * @param[in,out] dest
+ * @param[in,out] src
+ * @param[in] readCount
+ * @param[in] bit
+ */
+void SV_CL_CopyMsg(msg_t *dest, msg_t *src, int readCount, int bit)
+{
+	byte *data;
+
+	src->readcount = readCount;
+	src->bit       = bit;
+	data           = SV_CL_Allocate(src->cursize);
+	MSG_Copy(dest, data, src->cursize, src);
+}
+
+/**
+ * @brief SV_CL_ParseServerMessageIntoQueue
+ * @param[in] msg
+ */
+void SV_CL_ParseServerMessageIntoQueue(msg_t *msg, int headerBytes)
+{
+	serverMessageQueue_t *currentMessage;
+	char                 *s;
+	int                  cmd, lastReadBit, lastReadCount, index, seq, size;
+
+	currentMessage                        = SV_CL_NewMessage();
+	currentMessage->headerBytes           = headerBytes;
+	currentMessage->serverMessageSequence = svclc.serverMessageSequenceLatest;
+	currentMessage->serverCommandSequence = svclc.serverCommandSequenceLatest;
+	currentMessage->deltaNum              = -1;
+
+	lastReadCount = msg->readcount;
+
+	// parse the message
+	while (1)
+	{
+		if (msg->readcount > msg->cursize)
+		{
+			Com_Error(ERR_DROP, "SV_CL_ParseServerMessageIntoQueue: read past end of server message");
+		}
+
+		lastReadBit = msg->bit;
+		cmd         = MSG_ReadByte(msg);
+
+		if (cmd == svc_EOF)
+		{
+			break;
+		}
+
+		// other commands
+		switch (cmd)
+		{
+		default:
+			Com_Error(ERR_DROP, "SV_CL_ParseServerMessageIntoQueue: Illegible server message %d", cmd);
+		case svc_nop:
+			break;
+		case svc_serverCommand:
+			if (currentMessage->numServerCommand >= MAX_RELIABLE_COMMANDS)
+			{
+				Com_Error(ERR_DROP, "SV_CL_ParseServerMessageIntoQueue: too many commands");
+			}
+
+			seq = MSG_ReadLong(msg);
+			s   = MSG_ReadString(msg);
+
+			lastReadCount = msg->readcount;
+
+			if (!currentMessage->numServerCommand)
+			{
+				currentMessage->serverCommandSequence = seq;
+			}
+			else if (currentMessage->numServerCommand + currentMessage->serverCommandSequence != seq)
+			{
+				Com_Error(ERR_DROP, "SV_CL_ParseServerMessageIntoQueue: command out of order");
+			}
+
+			// see if we have already executed stored it off
+			if (svclc.serverCommandSequenceLatest >= seq)
+			{
+				break;
+			}
+
+			svclc.serverCommandSequenceLatest = seq;
+			index                             = seq & (MAX_RELIABLE_COMMANDS - 1);
+			Q_strncpyz(svclc.serverCommandsLatest[index], s, sizeof(svclc.serverCommandsLatest[index]));
+
+			size                                                             = strlen(s) + 1;
+			currentMessage->serverCommands[currentMessage->numServerCommand] = SV_CL_Allocate(size);
+			Q_strncpyz(currentMessage->serverCommands[currentMessage->numServerCommand], s, size);
+
+			// check for new serverId
+			SV_CL_CheckNewQueuedCommand(currentMessage->serverCommands[currentMessage->numServerCommand]);
+
+			currentMessage->numServerCommand++;
+			break;
+		case svc_gamestate:
+			SV_CL_ParseGamestateQueue(msg);
+			SV_CL_CopyMsg(&currentMessage->msg, msg, lastReadCount, lastReadBit);
+			return;
+		case svc_snapshot:
+			svcl.serverTimeLatest      = MSG_ReadLong(msg);
+			currentMessage->serverTime = svcl.serverTimeLatest;
+			currentMessage->systime    = Sys_Milliseconds();
+			currentMessage->deltaNum   = MSG_ReadByte(msg);
+
+			// try and predict if we should send moveNoDelta command
+			// reduces the amount of unnecessary moveNoDelta commands caused by delay
+			if (!currentMessage->deltaNum || svclc.serverMessageSequenceLatest == currentMessage->deltaNum ||
+			    svclc.serverMessageSequenceLatest - currentMessage->deltaNum <= 0)
+			{
+				if (sv_etltv_autorecord->integer && !svcls.queueDemoWaiting &&
+				    currentMessage->prev && !currentMessage->prev->deltaNum)
+				{
+					svcls.queueDemoWaiting = qtrue;
+				}
+				else
+				{
+					svclc.moveDelta = qtrue;
+				}
+			}
+
+			SV_CL_CopyMsg(&currentMessage->msg, msg, lastReadCount, lastReadBit);
+			return;
+		}
+	}
+
+	SV_CL_CopyMsg(&currentMessage->msg, msg, lastReadCount, lastReadBit);
 }
 
 #endif // DEDICATED

--- a/src/server/sv_client.c
+++ b/src/server/sv_client.c
@@ -2300,7 +2300,7 @@ static void SV_UserMove(client_t *cl, msg_t *msg, qboolean delta)
 	*/
 	if (cl->frames[cl->messageAcknowledge & PACKET_MASK].messageSent < 1)
 	{
-		Com_Printf("client %d: Message from old map\n", cl - svs.clients);
+		Com_DPrintf("client %d: Message from old map\n", cl - svs.clients);
 		cl->parseEntitiesNum = 0;
 	}
 	else

--- a/src/server/sv_client.c
+++ b/src/server/sv_client.c
@@ -644,7 +644,7 @@ gotnewcl:
 
 	if (newcl->ettvClient)
 	{
-		newcl->ettvClientFrame = Com_Allocate(sizeof(ettvClientSnapshot_t*) * PACKET_BACKUP);
+		newcl->ettvClientFrame = Com_Allocate(sizeof(ettvClientSnapshot_t *) * PACKET_BACKUP);
 
 		for (i = 0; i < PACKET_BACKUP; i++)
 		{
@@ -898,7 +898,7 @@ void SV_SendClientGameState(client_t *client)
 	Com_DPrintf("Sending %i bytes in gamestate to client: %i\n", msg.cursize, (int) (client - svs.clients));
 
 	// deliver this to the client
-	SV_SendMessageToClient(&msg, client);
+	SV_SendMessageToClient(&msg, client, qfalse);
 }
 
 /**
@@ -938,6 +938,7 @@ void SV_ClientEnterWorld(client_t *client, usercmd_t *cmd)
 	client->gentity = ent;
 
 	client->deltaMessage     = -1;
+	client->parseEntitiesNum = 0;
 	client->lastSnapshotTime = 0;   // generate a snapshot immediately
 
 	if (cmd)
@@ -2244,8 +2245,15 @@ static void SV_UserMove(client_t *cl, msg_t *msg, qboolean delta)
 	usercmd_t cmds[MAX_PACKET_USERCMDS];
 	usercmd_t *cmd, *oldcmd;
 
+	cl->parseEntitiesNum = 0;
+
 	if (delta)
 	{
+		for (i = cl->messageAcknowledge; i < cl->netchan.outgoingSequence; i++)
+		{
+			cl->parseEntitiesNum += cl->frames[i & PACKET_MASK].num_entities;
+		}
+
 		cl->deltaMessage = cl->messageAcknowledge;
 	}
 	else
@@ -2290,9 +2298,22 @@ static void SV_UserMove(client_t *cl, msg_t *msg, qboolean delta)
 	    SV_DemoWriteClientUsercmd(cl, delta, cmdCount, cmds, key);
 	}
 	*/
+	if (cl->frames[cl->messageAcknowledge & PACKET_MASK].messageSent < 1)
+	{
+		Com_Printf("client %d: Message from old map\n", cl - svs.clients);
+		cl->parseEntitiesNum = 0;
+	}
+	else
+	{
+		// save time for ping calculation
+		cl->frames[cl->messageAcknowledge & PACKET_MASK].messageAcked = svs.time;
 
-	// save time for ping calculation
-	cl->frames[cl->messageAcknowledge & PACKET_MASK].messageAcked = svs.time;
+		if (!cl->frames[cl->messageAcknowledge & PACKET_MASK].parseEntities)
+		{
+			cl->deltaMessage     = -1;
+			cl->parseEntitiesNum = 0;
+		}
+	}
 
 	// if this is the first usercmd we have received
 	// this gamestate, put the client into the world

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -1233,6 +1233,7 @@ void SV_Init(void)
 	sv_etltv_clientname = Cvar_GetAndDescribe("sv_etltv_clientname", "ETLTV", CVAR_ARCHIVE_ND, "Name of the ETLTV client.");
 	sv_etltv_delay      = Cvar_GetAndDescribe("sv_etltv_delay", "0", CVAR_INIT, "Delay feed by number of seconds.");
 	sv_etltv_shownet    = Cvar_Get("sv_etltv_shownet", "0", CVAR_ARCHIVE_ND);
+	sv_etltv_queue_ms   = Cvar_Get("ettv_queue_ms", "-1", CVAR_ROM); // ettv_queue_ms for ettv backward compatibility
 
 #if defined(FEATURE_IRC_SERVER) && defined(DEDICATED)
 	IRC_Init();

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -1231,6 +1231,8 @@ void SV_Init(void)
 	sv_etltv_autorecord = Cvar_Get("sv_etltv_autorecord", "0", CVAR_ARCHIVE_ND);
 	sv_etltv_autoplay   = Cvar_Get("sv_etltv_autoplay", "0", CVAR_ARCHIVE_ND);
 	sv_etltv_clientname = Cvar_GetAndDescribe("sv_etltv_clientname", "ETLTV", CVAR_ARCHIVE_ND, "Name of the ETLTV client.");
+	sv_etltv_delay      = Cvar_GetAndDescribe("sv_etltv_delay", "0", CVAR_INIT, "Delay feed by number of seconds.");
+	sv_etltv_shownet    = Cvar_Get("sv_etltv_shownet", "0", CVAR_ARCHIVE_ND);
 
 #if defined(FEATURE_IRC_SERVER) && defined(DEDICATED)
 	IRC_Init();

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -138,6 +138,7 @@ cvar_t *sv_etltv_autoplay;
 cvar_t *sv_etltv_clientname;
 cvar_t *sv_etltv_delay;
 cvar_t *sv_etltv_shownet;
+cvar_t *sv_etltv_queue_ms;
 
 static void SVC_Status(netadr_t from, qboolean force);
 

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -44,6 +44,7 @@ server_t       sv;                    // local server
 svclientActive_t     svcl;
 svclientConnection_t svclc;
 svclientStatic_t     svcls;
+serverMessageQueue_t *svMsgQueueHead, *svMsgQueueTail;
 #endif // DEDICATED
 vm_t *gvm = NULL;                     // game virtual machine
 
@@ -135,6 +136,8 @@ cvar_t *sv_etltv_password;
 cvar_t *sv_etltv_autorecord;
 cvar_t *sv_etltv_autoplay;
 cvar_t *sv_etltv_clientname;
+cvar_t *sv_etltv_delay;
+cvar_t *sv_etltv_shownet;
 
 static void SVC_Status(netadr_t from, qboolean force);
 

--- a/src/server/sv_snapshot.c
+++ b/src/server/sv_snapshot.c
@@ -224,6 +224,14 @@ static void SV_WriteSnapshotToClient(client_t *client, msg_t *msg)
 	// this is the snapshot we are creating
 	frame = &client->frames[client->netchan.outgoingSequence & PACKET_MASK];
 
+	// if we are about to got over MAX_PARSE_ENTITIES send uncompressed snapshot
+	if (client->parseEntitiesNum > MAX_PARSE_ENTITIES - 128)
+	{
+		Com_DPrintf("%s: Too many parse entities.\n", client->name);
+		client->deltaMessage     = -1;
+		client->parseEntitiesNum = 0;
+	}
+
 	// try to use a previous frame as the source for delta compressing the snapshot
 	if (client->deltaMessage <= 0 || client->state != CS_ACTIVE)
 	{
@@ -306,6 +314,8 @@ static void SV_WriteSnapshotToClient(client_t *client, msg_t *msg)
 	{
 		SV_ETTV_EmitPlayerstates(client, msg);
 	}
+
+	client->parseEntitiesNum += frame->num_entities;
 
 	// padding for rate debugging
 	if (sv_padPackets->integer)
@@ -930,12 +940,13 @@ int SV_RateMsec(client_t *client)
  * @param[in] msg
  * @param[in,out] client
  */
-void SV_SendMessageToClient(msg_t *msg, client_t *client)
+void SV_SendMessageToClient(msg_t *msg, client_t *client, qboolean parseEntities)
 {
 	// record information about the message
-	client->frames[client->netchan.outgoingSequence & PACKET_MASK].messageSize  = msg->cursize;
-	client->frames[client->netchan.outgoingSequence & PACKET_MASK].messageSent  = svs.time;
-	client->frames[client->netchan.outgoingSequence & PACKET_MASK].messageAcked = -1;
+	client->frames[client->netchan.outgoingSequence & PACKET_MASK].messageSize   = msg->cursize;
+	client->frames[client->netchan.outgoingSequence & PACKET_MASK].messageSent   = svs.time;
+	client->frames[client->netchan.outgoingSequence & PACKET_MASK].messageAcked  = -1;
+	client->frames[client->netchan.outgoingSequence & PACKET_MASK].parseEntities = parseEntities;
 
 	// send the datagram
 	SV_Netchan_Transmit(client, msg);
@@ -979,7 +990,7 @@ void SV_SendClientIdle(client_t *client)
 		return;
 	}
 
-	SV_SendMessageToClient(&msg, client);
+	SV_SendMessageToClient(&msg, client, qfalse);
 
 	sv.bpsTotalBytes  += msg.cursize;           // net debugging
 	sv.ubpsTotalBytes += msg.uncompsize / 8;    // net debugging
@@ -1042,7 +1053,7 @@ void SV_SendClientSnapshot(client_t *client)
 		return;
 	}
 
-	SV_SendMessageToClient(&msg, client);
+	SV_SendMessageToClient(&msg, client, qtrue);
 
 	sv.bpsTotalBytes  += msg.cursize;           // net debugging
 	sv.ubpsTotalBytes += msg.uncompsize / 8;    // net debugging

--- a/src/tvgame/tvg_cmds_ext.c
+++ b/src/tvgame/tvg_cmds_ext.c
@@ -51,12 +51,12 @@ const char *lock_status[2] = { "unlock", "lock" };
 static tvcmd_reference_t tvCommandInfo[] =
 {
 	// keep "say" command on top for optimisation purpose, they are the most used command
-	{ "say",          CMD_USAGE_ANY_TIME,                        0,           NOCD,       0, qtrue,  TVG_say_cmd,                             " <msg>:^7 Sends a chat message"                                                             },
-	{ "say_team",     CMD_USAGE_ANY_TIME,                        0,           NOCD,       0, qtrue,  TVG_say_cmd,                             " <msg>:^7 Sends a chat message"                                                             },
-	{ "say_buddy",    CMD_USAGE_ANY_TIME,                        0,           NOCD,       0, qtrue,  TVG_say_cmd,                             " <msg>:^7 Sends a buddy chat message"                                                       },
-	{ "say_teamnl",   CMD_USAGE_ANY_TIME,                        0,           NOCD,       0, qtrue,  TVG_say_cmd,                             " <msg>:^7 Sends a team chat message without location info"                                  },
+	{ "say",          CMD_USAGE_ANY_TIME,                        0,          NOCD,       0, qtrue,  TVG_say_cmd,                             " <msg>:^7 Sends a chat message"                                                             },
+	{ "say_team",     CMD_USAGE_ANY_TIME,                        0,          NOCD,       0, qtrue,  TVG_say_cmd,                             " <msg>:^7 Sends a chat message"                                                             },
+	{ "say_buddy",    CMD_USAGE_ANY_TIME,                        0,          NOCD,       0, qtrue,  TVG_say_cmd,                             " <msg>:^7 Sends a buddy chat message"                                                       },
+	{ "say_teamnl",   CMD_USAGE_ANY_TIME,                        0,          NOCD,       0, qtrue,  TVG_say_cmd,                             " <msg>:^7 Sends a team chat message without location info"                                  },
 
-	{ "tvchat",       CMD_USAGE_ANY_TIME,                        0,           NOCD,       0, qtrue,  TVG_tvchat_cmd,                          ":^7 Turns tvchat on/off"                                                                    },
+	{ "tvchat",       CMD_USAGE_ANY_TIME,                        0,          NOCD,       0, qtrue,  TVG_tvchat_cmd,                          ":^7 Turns tvchat on/off"                                                                    },
 	//{ "ignore",         CMD_USAGE_ANY_TIME,          qtrue,       qfalse, TVCmd_Ignore_f,                      " <clientname>:^7 Ignore a player from chat"                                                 },
 	//{ "unignore",       CMD_USAGE_ANY_TIME,          qtrue,       qfalse, TVCmd_UnIgnore_f,                    " <clientname>:^7 Unignore a player from chat"                                               },
 
@@ -65,47 +65,47 @@ static tvcmd_reference_t tvCommandInfo[] =
 	//{ "commands",       CMD_USAGE_ANY_TIME,          qtrue,       qtrue,  G_commands_cmd,                      ":^7 Gives a list of commands"                                                               },
 	//{ "help",           CMD_USAGE_ANY_TIME,          qtrue,       qtrue,  G_commands_cmd,                      ":^7 Gives a list of commands"                                                               },
 
-	{ "bottomshots",  CMD_USAGE_ANY_TIME | CMD_USAGE_AUTOUPDATE, 0,           MEDIUMCD,   0, qfalse, TVG_weaponRankings_cmd,                  ":^7 Shows WORST player for each weapon. Add ^3<weapon_ID>^7 to show all stats for a weapon" },
-	{ "callvote",     CMD_USAGE_NO_INTERMISSION,                 0,           NOCD,       0, qtrue,  TVG_Cmd_CallVote_f,                      " <params>:^7 Calls a vote"                                                                  },
+	{ "bottomshots",  CMD_USAGE_ANY_TIME | CMD_USAGE_AUTOUPDATE, 0,          MEDIUMCD,   0, qfalse, TVG_weaponRankings_cmd,                  ":^7 Shows WORST player for each weapon. Add ^3<weapon_ID>^7 to show all stats for a weapon" },
+	{ "callvote",     CMD_USAGE_NO_INTERMISSION,                 0,          NOCD,       0, qtrue,  TVG_Cmd_CallVote_f,                      " <params>:^7 Calls a vote"                                                                  },
 
-	{ "follow",       CMD_USAGE_NO_INTERMISSION,                 0,           NOCD,       0, qfalse, TVG_Cmd_Follow_f,                        " <player_ID|allies|axis>:^7 Spectates a particular player or team"                          },
-	{ "follownext",   CMD_USAGE_NO_INTERMISSION,                 0,           NOCD,       0, qfalse, TVG_Cmd_FollowNext_f,                    ":^7 Follow next player in list"                                                             },
-	{ "followprev",   CMD_USAGE_NO_INTERMISSION,                 0,           NOCD,       0, qfalse, TVG_Cmd_FollowPrevious_f,                ":^7 Follow previous player in list"                                                         },
+	{ "follow",       CMD_USAGE_NO_INTERMISSION,                 0,          NOCD,       0, qfalse, TVG_Cmd_Follow_f,                        " <player_ID|allies|axis>:^7 Spectates a particular player or team"                          },
+	{ "follownext",   CMD_USAGE_NO_INTERMISSION,                 0,          NOCD,       0, qfalse, TVG_Cmd_FollowNext_f,                    ":^7 Follow next player in list"                                                             },
+	{ "followprev",   CMD_USAGE_NO_INTERMISSION,                 0,          NOCD,       0, qfalse, TVG_Cmd_FollowPrevious_f,                ":^7 Follow previous player in list"                                                         },
 
-	{ "imvotetally",  CMD_USAGE_INTERMISSION_ONLY,               0,           NOCD,       0, qfalse, TVG_IntermissionVoteTally,               ""                                                                                           },
-	{ "immaplist",    CMD_USAGE_INTERMISSION_ONLY,               0,           NOCD,       0, qfalse, TVG_IntermissionMapList,                 ""                                                                                           },
-	{ "immaphistory", CMD_USAGE_INTERMISSION_ONLY,               0,           NOCD,       0, qfalse, TVG_IntermissionMapHistory,              ""                                                                                           },
+	{ "imvotetally",  CMD_USAGE_INTERMISSION_ONLY,               0,          NOCD,       0, qfalse, TVG_IntermissionVoteTally,               ""                                                                                           },
+	{ "immaplist",    CMD_USAGE_INTERMISSION_ONLY,               0,          NOCD,       0, qfalse, TVG_IntermissionMapList,                 ""                                                                                           },
+	{ "immaphistory", CMD_USAGE_INTERMISSION_ONLY,               0,          NOCD,       0, qfalse, TVG_IntermissionMapHistory,              ""                                                                                           },
 
-	{ "impkd",        CMD_USAGE_INTERMISSION_ONLY,               0,           NOCD,       0, qfalse, TVG_Cmd_IntermissionPlayerKillsDeaths_f, ""                                                                                           },
-	{ "impr",         CMD_USAGE_INTERMISSION_ONLY,               0,           NOCD,       0, qfalse, TVG_Cmd_IntermissionPrestige_f,          ""                                                                                           },
-	{ "impt",         CMD_USAGE_INTERMISSION_ONLY,               0,           NOCD,       0, qfalse, TVG_Cmd_IntermissionPlayerTime_f,        ""                                                                                           },
-	{ "imsr",         CMD_USAGE_INTERMISSION_ONLY,               0,           NOCD,       0, qfalse, TVG_Cmd_IntermissionSkillRating_f,       ""                                                                                           },
-	{ "imwa",         CMD_USAGE_INTERMISSION_ONLY,               0,           NOCD,       0, qfalse, TVG_Cmd_IntermissionWeaponAccuracies_f,  ""                                                                                           },
-	{ "imws",         CMD_USAGE_INTERMISSION_ONLY,               0,           NOCD,       0, qfalse, TVG_Cmd_IntermissionWeaponStats_f,       ""                                                                                           },
+	{ "impkd",        CMD_USAGE_INTERMISSION_ONLY,               0,          NOCD,       0, qfalse, TVG_Cmd_IntermissionPlayerKillsDeaths_f, ""                                                                                           },
+	{ "impr",         CMD_USAGE_INTERMISSION_ONLY,               0,          NOCD,       0, qfalse, TVG_Cmd_IntermissionPrestige_f,          ""                                                                                           },
+	{ "impt",         CMD_USAGE_INTERMISSION_ONLY,               0,          NOCD,       0, qfalse, TVG_Cmd_IntermissionPlayerTime_f,        ""                                                                                           },
+	{ "imsr",         CMD_USAGE_INTERMISSION_ONLY,               0,          NOCD,       0, qfalse, TVG_Cmd_IntermissionSkillRating_f,       ""                                                                                           },
+	{ "imwa",         CMD_USAGE_INTERMISSION_ONLY,               0,          NOCD,       0, qfalse, TVG_Cmd_IntermissionWeaponAccuracies_f,  ""                                                                                           },
+	{ "imws",         CMD_USAGE_INTERMISSION_ONLY,               0,          NOCD,       0, qfalse, TVG_Cmd_IntermissionWeaponStats_f,       ""                                                                                           },
 
-	{ "players",      CMD_USAGE_ANY_TIME,                        0,           SHORTCD,    0, qtrue,  TVG_players_cmd,                         ":^7 Lists all active players and their IDs"                                                 },
-	{ "viewers",      CMD_USAGE_ANY_TIME,                        0,           SHORTCD,    0, qtrue,  TVG_viewers_cmd,                         ":^7 Lists all viewers and their IDs"                                                        },
-	{ "rconAuth",     CMD_USAGE_ANY_TIME,                        0,           SHORTCD,    0, qfalse, TVG_Cmd_AuthRcon_f,                      ":^7 Client authentication"                                                                  },
+	{ "players",      CMD_USAGE_ANY_TIME,                        0,          SHORTCD,    0, qtrue,  TVG_players_cmd,                         ":^7 Lists all active players and their IDs"                                                 },
+	{ "viewers",      CMD_USAGE_ANY_TIME,                        0,          SHORTCD,    0, qtrue,  TVG_viewers_cmd,                         ":^7 Lists all viewers and their IDs"                                                        },
+	{ "rconAuth",     CMD_USAGE_ANY_TIME,                        0,          SHORTCD,    0, qfalse, TVG_Cmd_AuthRcon_f,                      ":^7 Client authentication"                                                                  },
 
-	{ "ref",          CMD_USAGE_ANY_TIME,                        0,           SHORTCD,    0, qtrue,  TVG_ref_cmd,                             " <password>:^7 Become a referee (admin access)"                                             },
+	{ "ref",          CMD_USAGE_ANY_TIME,                        0,          SHORTCD,    0, qtrue,  TVG_ref_cmd,                             " <password>:^7 Become a referee (admin access)"                                             },
 
-	{ "score",        CMD_USAGE_ANY_TIME | CMD_USAGE_AUTOUPDATE, qtrue,       SHORTCD,    0, qfalse, TVG_Cmd_Score_f,                         ":^7 Request current scoreboard information"                                                 },
-	{ "scores",       CMD_USAGE_ANY_TIME | CMD_USAGE_AUTOUPDATE, qtrue,       MEDIUMCD,   0, qfalse, TVG_scores_cmd,                          ":^7 Displays current match stat info"                                                       },
+	{ "score",        CMD_USAGE_ANY_TIME | CMD_USAGE_AUTOUPDATE, qtrue,      SHORTCD,    0, qfalse, TVG_Cmd_Score_f,                         ":^7 Request current scoreboard information"                                                 },
+	{ "scores",       CMD_USAGE_ANY_TIME | CMD_USAGE_AUTOUPDATE, qtrue,      MEDIUMCD,   0, qfalse, TVG_scores_cmd,                          ":^7 Displays current match stat info"                                                       },
 
-	{ "sgstats",      CMD_USAGE_ANY_TIME,                        SHORTCD,     NOCD,       0, qtrue,  TVG_Cmd_sgStats_f,                       ""                                                                                           },
-	{ "wstats",       CMD_USAGE_ANY_TIME,                        SHORTCD,     NOCD,       0, qtrue,  TVG_Cmd_wStats_f,                        ""                                                                                           },
-	{ "weaponstats",  CMD_USAGE_ANY_TIME,                        SHORTCD,     NOCD,       0, qtrue,  TVG_weaponStats_cmd,                     " [player_ID]:^7 Shows weapon accuracy stats for a player"                                   },
+	{ "sgstats",      CMD_USAGE_ANY_TIME,                        SHORTCD,    NOCD,       0, qtrue,  TVG_Cmd_sgStats_f,                       ""                                                                                           },
+	{ "wstats",       CMD_USAGE_ANY_TIME,                        SHORTCD,    NOCD,       0, qtrue,  TVG_Cmd_wStats_f,                        ""                                                                                           },
+	{ "weaponstats",  CMD_USAGE_ANY_TIME,                        SHORTCD,    NOCD,       0, qtrue,  TVG_weaponStats_cmd,                     " [player_ID]:^7 Shows weapon accuracy stats for a player"                                   },
 
-	{ "statsall",     CMD_USAGE_ANY_TIME | CMD_USAGE_AUTOUPDATE, VERYLONGCD,  NOCD,       0, qtrue,  TVG_statsall_cmd,                        ":^7 Shows weapon accuracy stats for all players"                                            },
-	{ "stshots",      CMD_USAGE_ANY_TIME | CMD_USAGE_AUTOUPDATE, MEDIUMCD,    VERYLONGCD, 0, qfalse, TVG_Cmd_WeaponStatsLeaders_f,            ""                                                                                           },
-	{ "topshots",     CMD_USAGE_ANY_TIME | CMD_USAGE_AUTOUPDATE, qtrue,       MEDIUMCD,   0, qfalse, TVG_weaponRankings_cmd,                  ":^7 Shows BEST player for each weapon. Add ^3<weapon_ID>^7 to show all stats for a weapon"  },
-	{ "ws",           CMD_USAGE_ANY_TIME,                        qtrue,       MEDIUMCD,   0, qtrue,  TVG_Cmd_WeaponStat_f,                    ":^7 Shows weapon stats"                                                                     },
+	{ "statsall",     CMD_USAGE_ANY_TIME | CMD_USAGE_AUTOUPDATE, VERYLONGCD, NOCD,       0, qtrue,  TVG_statsall_cmd,                        ":^7 Shows weapon accuracy stats for all players"                                            },
+	{ "stshots",      CMD_USAGE_ANY_TIME | CMD_USAGE_AUTOUPDATE, MEDIUMCD,   VERYLONGCD, 0, qfalse, TVG_Cmd_WeaponStatsLeaders_f,            ""                                                                                           },
+	{ "topshots",     CMD_USAGE_ANY_TIME | CMD_USAGE_AUTOUPDATE, qtrue,      MEDIUMCD,   0, qfalse, TVG_weaponRankings_cmd,                  ":^7 Shows BEST player for each weapon. Add ^3<weapon_ID>^7 to show all stats for a weapon"  },
+	{ "ws",           CMD_USAGE_ANY_TIME,                        qtrue,      MEDIUMCD,   0, qtrue,  TVG_Cmd_WeaponStat_f,                    ":^7 Shows weapon stats"                                                                     },
 
-	{ "setviewpos",   CMD_USAGE_NO_INTERMISSION,                 qtrue,       MEDIUMCD,   0, qfalse, TVG_Cmd_SetViewpos_f,                    " x y z pitch yaw roll useViewHeight(0/1):^7 Set the current player position and view angle" },
-	{ "noclip",       CMD_USAGE_NO_INTERMISSION,                 qtrue,       NOCD,       0, qfalse, TVG_Cmd_Noclip_f,                        ":^7 No clip"                                                                                },
+	{ "setviewpos",   CMD_USAGE_NO_INTERMISSION,                 qtrue,      MEDIUMCD,   0, qfalse, TVG_Cmd_SetViewpos_f,                    " x y z pitch yaw roll useViewHeight(0/1):^7 Set the current player position and view angle" },
+	{ "noclip",       CMD_USAGE_NO_INTERMISSION,                 qtrue,      NOCD,       0, qfalse, TVG_Cmd_Noclip_f,                        ":^7 No clip"                                                                                },
 
-	{ "obj",          CMD_USAGE_NO_INTERMISSION,                 qtrue,       NOCD,       0, qfalse, TVG_Cmd_SelectedObjective_f,             " <val>:^7 Selected Objective"                                                               },
-	{ NULL,           CMD_USAGE_ANY_TIME,                        qtrue,       NOCD,       0, qfalse, NULL,                                    ""                                                                                           }
+	{ "obj",          CMD_USAGE_NO_INTERMISSION,                 qtrue,      NOCD,       0, qfalse, TVG_Cmd_SelectedObjective_f,             " <val>:^7 Selected Objective"                                                               },
+	{ NULL,           CMD_USAGE_ANY_TIME,                        qtrue,      NOCD,       0, qfalse, NULL,                                    ""                                                                                           }
 };
 
 /**
@@ -500,19 +500,27 @@ qboolean TVG_tvchat_cmd(gclient_t *client, tvcmd_reference_t *self)
  */
 qboolean TVG_scores_cmd(gclient_t *client, tvcmd_reference_t *self)
 {
-	int i;
+	//int i;
 
-	if (!client)
-	{
-		return TVG_CommandsAutoUpdate(self);
-	}
+	return qfalse;
 
-	for (i = 0; i < level.cmds.scoresEndIndex; i++)
-	{
-		trap_SendServerCommand(client - level.clients, level.cmds.scores[i]);
-	}
+	//if (!client)
+	//{
+	//	if (TVG_CommandsAutoUpdate(self))
+	//	{
+	//		Com_Printf("TVG_scores_cmd update [%d]\n", level.time);
+	//		return qtrue;
+	//	}
+	//
+	//	return qfalse;
+	//}
 
-	return qtrue;
+	//for (i = 0; i < level.cmds.scoresEndIndex; i++)
+	//{
+	//	trap_SendServerCommand(client - level.clients, level.cmds.scores[i]);
+	//}
+
+	//return qtrue;
 }
 
 /**

--- a/src/tvgame/tvg_cmds_ext.c
+++ b/src/tvgame/tvg_cmds_ext.c
@@ -500,15 +500,14 @@ qboolean TVG_tvchat_cmd(gclient_t *client, tvcmd_reference_t *self)
  */
 qboolean TVG_scores_cmd(gclient_t *client, tvcmd_reference_t *self)
 {
-	//int i;
-
 	return qfalse;
+
+	//int i;
 
 	//if (!client)
 	//{
 	//	if (TVG_CommandsAutoUpdate(self))
 	//	{
-	//		Com_Printf("TVG_scores_cmd update [%d]\n", level.time);
 	//		return qtrue;
 	//	}
 	//

--- a/src/tvgame/tvg_local.h
+++ b/src/tvgame/tvg_local.h
@@ -529,6 +529,7 @@ typedef struct level_locals_s
 
 	int numValidMasterClients;
 	int validMasterClients[MAX_CLIENTS];
+	int queueSeconds;
 
 } level_locals_t;
 
@@ -1007,6 +1008,8 @@ extern vmCvar_t g_skipCorrection;
 extern vmCvar_t g_extendedNames;
 
 extern vmCvar_t g_debugForSingleClient;
+
+extern vmCvar_t tvg_queue_ms;
 
 #define G_InactivityValue (g_inactivity.integer ? g_inactivity.integer : 60)
 #define G_SpectatorInactivityValue (g_spectatorInactivity.integer ? g_spectatorInactivity.integer : 60)

--- a/src/tvgame/tvg_main.c
+++ b/src/tvgame/tvg_main.c
@@ -1307,7 +1307,13 @@ void TVG_RunFrame(int levelTime)
 			queueMsg = va("cp \"t-%d second%s\n\"", level.queueSeconds, s);
 		}
 
-		trap_SendServerCommand(-1, queueMsg);
+		for (i = 0; i < level.numConnectedClients; i++)
+		{
+			if (level.clients[level.sortedClients[i]].pers.connected == CON_CONNECTED)
+			{
+				trap_SendServerCommand(level.sortedClients[i], queueMsg);
+			}
+		}
 	}
 
 	// if we are waiting for the level to restart, do nothing

--- a/src/tvgame/tvg_spawn.c
+++ b/src/tvgame/tvg_spawn.c
@@ -220,10 +220,10 @@ qboolean TVG_CallSpawn(gentity_t *ent)
 
 	// hack: this avoids spammy prints on start, bsp uses obsolete classnames!
 	// bot_sniper_spot (railgun)
-	if (Q_stricmp(ent->classname, "bot_sniper_spot"))
-	{
-		G_Printf("%s doesn't have a spawn function\n", ent->classname);
-	}
+	//if (Q_stricmp(ent->classname, "bot_sniper_spot"))
+	//{
+	//	G_Printf("%s doesn't have a spawn function\n", ent->classname);
+	//}
 
 	return qfalse;
 }


### PR DESCRIPTION
- add cvar `sv_etltv_delay <seconds>` - setable only on etlded init, delays feed from master server
- add cvar `sv_etltv_shownet` - for network debugging
- disabled `/scores` command in tvgame because it can easily lag the server
- add `parseEntitiesNum` check to etlded for snapshot generation - current check doesn't seem to work at all (`svs.nextSnapshotEntities`), server will send on its own uncompressed snapshot if it detects that client will go over `MAX_PARSE_ENTITIES`
- add optional privatepassword argument to `tv connect` command. `tv connect server masterpassword privatepassword`
- add cvar `sv_etltv_queue_ms` (read only) for storing the amount of time till the game will start (backward compatible with etpro)
- various other general improvments to etltv
- players can connect to delayed slave server even before the game starts just like on ettv

refs #229