### PR TITLE
Fix PowerPC build where SDL_HasAltiVec is undefined

### DIFF
--- a/src/qcommon/common.c
+++ b/src/qcommon/common.c
@@ -39,6 +39,7 @@
 
 #ifndef DEDICATED
 #include "../sys/sys_local.h"
+#include "../sdl/sdl_defs.h"
 #include "../client/client.h"
 #endif
 #include "../server/server.h"


### PR DESCRIPTION
Use proper includes for SDL definitions, which are needed for PPC specific initialization of altivec variable.

Should fix failure to build on powerpc, as seen on https://koji.rpmfusion.org/kojifiles/work/tasks/8108/628108/build.log
Not yet tested.

```
CMakeFiles/etl.dir/src/qcommon/common.c.o -c /builddir/build/BUILD/etlegacy-2.81.1/src/qcommon/common.c
/builddir/build/BUILD/etlegacy-2.81.1/src/qcommon/common.c: In function ‘Com_DetectAltivec’:
/builddir/build/BUILD/etlegacy-2.81.1/src/qcommon/common.c:2770:35: error: implicit declaration of function ‘SDL_HasAltiVec’ [-Wimplicit-function-declaration]
 2770 |                         altivec = SDL_HasAltiVec();
      |                                   ^~~~~~~~~~~~~~
gmake[2]: *** [CMakeFiles/etl.dir/build.make:163: CMakeFiles/etl.dir/src/qcommon/common.c.o] Error 1
```