### PR TITLE
client: increase CMD_BACKUP to 128 via extension

### DIFF
--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -3302,7 +3302,7 @@ void CG_DrawLagometer(hudComponent_t *comp)
 				{
 					w = range;
 				}
-				trap_R_DrawStretchPic(ax + aw - a, ay + ah - w - 2, 1, w, 0, 0, 0, 0, cgs.media.whiteShader);
+				trap_R_DrawStretchPic(ax + aw - a, ay + ah - w, 1, w, 0, 0, 0, 0, cgs.media.whiteShader);
 			}
 
 			if (lagometer.snapshotFlags[i] & SNAPFLAG_RATE_DELAYED)

--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -3143,7 +3143,7 @@ void CG_DrawDisconnect(hudComponent_t *comp)
 	}
 
 	// draw the phone jack if we are completely past our buffers
-	cmdNum = trap_GetCurrentCmdNumber() - CMD_BACKUP + 1;
+	cmdNum = trap_GetCurrentCmdNumber() - cg.cmdBackup + 1;
 	trap_GetUserCmd(cmdNum, &cmd);
 	if (cmd.serverTime <= cg.snap->ps.commandTime
 	    || cmd.serverTime > cg.time)        // special check for map_restart

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1564,6 +1564,9 @@ typedef struct
 
 	int lastKeyCatcher;
 
+	int cmdBackup;                                    ///< CMD_BACKUP
+	int cmdMask;                                      ///< CMD_MASK
+
 	qboolean updateOldestValidCmd;                    ///< whenever snapshot transition happens save oldest valid command
 	int oldestValidCmd;                               ///< that will be used as a next starting point for prediction
 	                                                  ///< instead of iterating through whole CMD_BACKUP array every frame

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1563,6 +1563,10 @@ typedef struct
 	char bannerPrint[1024];
 
 	int lastKeyCatcher;
+
+	qboolean updateOldestValidCmd;                    ///< whenever snapshot transition happens save oldest valid command
+	int oldestValidCmd;                               ///< that will be used as a next starting point for prediction
+	                                                  ///< instead of iterating through whole CMD_BACKUP array every frame
 } cg_t;
 
 #define MAX_LOCKER_DEBRIS 5
@@ -3755,9 +3759,11 @@ void trap_R_Finish(void);
 qboolean trap_GetValue(char *value, int valueSize, const char *key);
 void trap_SysFlashWindow(int state);
 void trap_CommandComplete(const char *value);
+void trap_CmdBackup_Ext(void);
 extern int dll_com_trapGetValue;
 extern int dll_trap_SysFlashWindow;
 extern int dll_trap_CommandComplete;
+extern int dll_trap_CmdBackup_Ext;
 
 bg_playerclass_t *CG_PlayerClassForClientinfo(clientInfo_t *ci, centity_t *cent);
 

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -46,6 +46,7 @@ extern qboolean  g_waitingForKey;
 int dll_com_trapGetValue;
 int dll_trap_SysFlashWindow;
 int dll_trap_CommandComplete;
+int dll_trap_CmdBackup_Ext;
 
 /**
  * @brief This is the only way control passes into the module.
@@ -2708,6 +2709,7 @@ static ID_INLINE void CG_SetupExtensions(void)
 
 		CG_SetupExtensionTrap(value, MAX_CVAR_VALUE_STRING, &dll_trap_SysFlashWindow, "trap_SysFlashWindow_Legacy");
 		CG_SetupExtensionTrap(value, MAX_CVAR_VALUE_STRING, &dll_trap_CommandComplete, "trap_CommandComplete_Legacy");
+		CG_SetupExtensionTrap(value, MAX_CVAR_VALUE_STRING, &dll_trap_CmdBackup_Ext, "trap_CmdBackup_Ext_Legacy");
 	}
 }
 
@@ -2801,6 +2803,7 @@ void CG_Init(int serverMessageNum, int serverCommandSequence, int clientNum, qbo
 	cgs.ccCurrentCamObjective = -2;
 
 	CG_SetupExtensions();
+	trap_CmdBackup_Ext();
 
 	// Background images on the loading screen were not visible on the first call
 	trap_R_SetColor(NULL);

--- a/src/cgame/cg_predict.c
+++ b/src/cgame/cg_predict.c
@@ -1113,12 +1113,12 @@ void CG_PredictPlayerState(void)
 
 	// fill in the current cmd with the latest prediction from
 	// cg.pmext (#166)
-	Com_Memcpy(&oldpmext[current & CMD_MASK], &cg.pmext, sizeof(pmoveExt_t));
+	Com_Memcpy(&oldpmext[current & cg.cmdMask], &cg.pmext, sizeof(pmoveExt_t));
 
 	// if we don't have the commands right after the snapshot, we
 	// can't accurately predict a current position, so just freeze at
 	// the last good position we had
-	cmdNum = current - CMD_BACKUP + 1;
+	cmdNum = current - cg.cmdBackup + 1;
 	trap_GetUserCmd(cmdNum, &oldestCmd);
 	if (oldestCmd.serverTime > cg.snap->ps.commandTime
 	    && oldestCmd.serverTime < cg.time)         // special check for map_restart
@@ -1190,7 +1190,7 @@ void CG_PredictPlayerState(void)
 			// do a full predict
 			cg.lastPredictedCommand = 0;
 			cg.backupStateTail      = cg.backupStateTop;
-			predictCmd              = current - CMD_BACKUP + 1;
+			predictCmd              = current - cg.cmdBackup + 1;
 		}
 		// cg.physicsTime is the current snapshot's serverTime
 		// if it's the same as the last one
@@ -1246,7 +1246,7 @@ void CG_PredictPlayerState(void)
 				// do a full predict
 				cg.lastPredictedCommand = 0;
 				cg.backupStateTail      = cg.backupStateTop;
-				predictCmd              = current - CMD_BACKUP + 1;
+				predictCmd              = current - cg.cmdBackup + 1;
 			}
 		}
 
@@ -1257,13 +1257,13 @@ void CG_PredictPlayerState(void)
 	}
 	// unlagged - optimized prediction
 
-	if (cg.oldestValidCmd && cg.oldestValidCmd >= current - CMD_BACKUP + 1)
+	if (cg.oldestValidCmd && cg.oldestValidCmd >= current - cg.cmdBackup + 1)
 	{
 		cmdNum = cg.oldestValidCmd;
 	}
 	else
 	{
-		cmdNum = current - CMD_BACKUP + 1;
+		cmdNum = current - cg.cmdBackup + 1;
 	}
 
 	// run cmds
@@ -1370,7 +1370,7 @@ void CG_PredictPlayerState(void)
 		// don't do anything if the time is before the snapshot player time
 		if (cg_pmove.cmd.serverTime <= cg.predictedPlayerState.commandTime)
 		{
-			Com_Memcpy(&pmext, &oldpmext[cmdNum & CMD_MASK], sizeof(pmoveExt_t));
+			Com_Memcpy(&pmext, &oldpmext[cmdNum & cg.cmdMask], sizeof(pmoveExt_t));
 			continue;
 		}
 
@@ -1417,7 +1417,7 @@ void CG_PredictPlayerState(void)
 		// copy the pmext as it was just before we
 		// previously ran this cmd (or, this will be the
 		// current predicted data if this is the current cmd)  (#166)
-		Com_Memcpy(&pmext, &oldpmext[cmdNum & CMD_MASK], sizeof(pmoveExt_t));
+		Com_Memcpy(&pmext, &oldpmext[cmdNum & cg.cmdMask], sizeof(pmoveExt_t));
 
 		fflush(stdout);
 

--- a/src/cgame/cg_predict.c
+++ b/src/cgame/cg_predict.c
@@ -1257,10 +1257,19 @@ void CG_PredictPlayerState(void)
 	}
 	// unlagged - optimized prediction
 
+	if (cg.oldestValidCmd && cg.oldestValidCmd >= current - CMD_BACKUP + 1)
+	{
+		cmdNum = cg.oldestValidCmd;
+	}
+	else
+	{
+		cmdNum = current - CMD_BACKUP + 1;
+	}
+
 	// run cmds
 	moved        = qfalse;
 	predictError = qtrue;
-	for (cmdNum = current - CMD_BACKUP + 1 ; cmdNum <= current ; cmdNum++)
+	for (; cmdNum <= current ; cmdNum++)
 	{
 		// get the command
 		trap_GetUserCmd(cmdNum, &cg_pmove.cmd);
@@ -1369,6 +1378,13 @@ void CG_PredictPlayerState(void)
 		if (cg_pmove.cmd.serverTime > latestCmd.serverTime)
 		{
 			continue;
+		}
+
+		// update the oldest valid command
+		if (cg.updateOldestValidCmd)
+		{
+			cg.oldestValidCmd       = cmdNum;
+			cg.updateOldestValidCmd = qfalse;
 		}
 
 		if (cg_pmove.pmove_fixed)

--- a/src/cgame/cg_public.h
+++ b/src/cgame/cg_public.h
@@ -38,8 +38,11 @@
 /// Allow a lot of command backups for very fast systems
 /// multiple commands may be combined into a single packet, so this
 /// needs to be larger than PACKET_BACKUP
-#define CMD_BACKUP          64
+#define CMD_BACKUP          128
 #define CMD_MASK            (CMD_BACKUP - 1)
+
+#define CMD_BACKUP_VET      64
+#define CMD_MASK_VET       (CMD_BACKUP_VET - 1)
 
 #define MAX_ENTITIES_IN_SNAPSHOT    512
 
@@ -281,6 +284,8 @@ typedef enum
 	CG_SYS_FLASH_WINDOW,
 
 	CG_COMMAND_COMPLETE,
+
+	CG_CMDBACKUP_EXT,
 
 } cgameImport_t;
 

--- a/src/cgame/cg_snapshot.c
+++ b/src/cgame/cg_snapshot.c
@@ -359,6 +359,8 @@ static void CG_TransitionSnapshot(void)
 			CG_TransitionPlayerState(ps, ops);
 		}
 	}
+
+	cg.updateOldestValidCmd = qtrue;
 }
 
 /**

--- a/src/cgame/cg_syscalls.c
+++ b/src/cgame/cg_syscalls.c
@@ -1954,3 +1954,14 @@ void trap_CommandComplete(const char *value)
 		SystemCall(dll_trap_CommandComplete, value);
 	}
 }
+
+/**
+ * @brief Extension for letting engine know to use extended user command backup
+ */
+void trap_CmdBackup_Ext(void)
+{
+	if (dll_trap_CmdBackup_Ext)
+	{
+		SystemCall(dll_trap_CmdBackup_Ext);
+	}
+}

--- a/src/cgame/cg_syscalls.c
+++ b/src/cgame/cg_syscalls.c
@@ -1962,6 +1962,13 @@ void trap_CmdBackup_Ext(void)
 {
 	if (dll_trap_CmdBackup_Ext)
 	{
+		cg.cmdBackup = CMD_BACKUP;
+		cg.cmdMask   = CMD_MASK;
 		SystemCall(dll_trap_CmdBackup_Ext);
+	}
+	else
+	{
+		cg.cmdBackup = CMD_BACKUP_VET;
+		cg.cmdMask   = CMD_MASK_VET;
 	}
 }

--- a/src/client/cl_cgame.c
+++ b/src/client/cl_cgame.c
@@ -44,6 +44,7 @@ static ext_trap_keys_t cg_extensionTraps[] =
 {
 	{ "trap_SysFlashWindow_Legacy",  CG_SYS_FLASH_WINDOW, qfalse },
 	{ "trap_CommandComplete_Legacy", CG_COMMAND_COMPLETE, qfalse },
+	{ "trap_CmdBackup_Ext_Legacy",   CG_CMDBACKUP_EXT,    qfalse },
 	{ NULL,                          -1,                  qfalse }
 };
 
@@ -89,12 +90,12 @@ qboolean CL_GetUserCmd(int cmdNumber, usercmd_t *ucmd)
 
 	// the usercmd has been overwritten in the wrapping
 	// buffer because it is too far out of date
-	if (cmdNumber <= cl.cmdNumber - CMD_BACKUP)
+	if (cmdNumber <= cl.cmdNumber - cl.cmdBackup)
 	{
 		return qfalse;
 	}
 
-	*ucmd = cl.cmds[cmdNumber & CMD_MASK];
+	*ucmd = cl.cmds[cmdNumber & cl.cmdMask];
 
 	return qtrue;
 }
@@ -1066,6 +1067,11 @@ intptr_t CL_CgameSystemCalls(intptr_t *args)
 
 	case CG_COMMAND_COMPLETE:
 		Field_CompleteModSuggestion(VMA(1));
+		return 0;
+
+	case CG_CMDBACKUP_EXT:
+		cl.cmdBackup = CMD_BACKUP;
+		cl.cmdMask   = CMD_MASK;
 		return 0;
 
 	default:

--- a/src/client/cl_input.c
+++ b/src/client/cl_input.c
@@ -1186,7 +1186,7 @@ void CL_CreateNewCommands(void)
 
 	// generate a command for this frame
 	cl.cmdNumber++;
-	cmdNum          = cl.cmdNumber & CMD_MASK;
+	cmdNum          = cl.cmdNumber & cl.cmdMask;
 	cl.cmds[cmdNum] = CL_CreateCmd();
 }
 
@@ -1376,7 +1376,7 @@ void CL_WritePacket(void)
 		// write all the commands, including the predicted command
 		for (i = 0 ; i < count ; i++)
 		{
-			j   = (cl.cmdNumber - count + i + 1) & CMD_MASK;
+			j   = (cl.cmdNumber - count + i + 1) & cl.cmdMask;
 			cmd = &cl.cmds[j];
 			MSG_WriteDeltaUsercmdKey(&buf, key, oldcmd, cmd);
 			oldcmd = cmd;

--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -608,6 +608,9 @@ static void CL_GenerateETKey(void)
 void CL_ClearState(void)
 {
 	Com_Memset(&cl, 0, sizeof(cl));
+
+	cl.cmdBackup = CMD_BACKUP_VET;
+	cl.cmdMask   = CMD_MASK_VET;
 }
 
 /**

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -157,6 +157,8 @@ typedef struct
 	usercmd_t cmds[CMD_BACKUP];             ///< each mesage will send several old cmds
 	int cmdNumber;                          ///< incremented each frame, because multiple
 	                                        ///< frames may need to be packed into a single packet
+	int cmdBackup;                          ///< CMD_BACKUP
+	int cmdMask;                            ///< CMD_MASK
 
 	/// double tapping
 	doubleTap_t doubleTap;

--- a/src/qcommon/common.c
+++ b/src/qcommon/common.c
@@ -2946,6 +2946,7 @@ void Com_Init(char *commandLine)
 	//
 	// no need to latch this in ET, our recoil is framerate independant
 	com_maxfps = Cvar_Get("com_maxfps", "125", CVAR_ARCHIVE /*|CVAR_LATCH*/);
+	Cvar_CheckRange(com_maxfps, 20, 500, qtrue);
 
 	com_developer = Cvar_Get("developer", "0", CVAR_TEMP);
 	com_logfile   = Cvar_Get("logfile", "0", CVAR_TEMP);
@@ -3371,11 +3372,6 @@ void Com_Frame(void)
 	if (com_speeds->integer)
 	{
 		timeBeforeFirstEvents = Sys_Milliseconds();
-	}
-
-	if (!com_dedicated->integer && !com_timedemo->integer && !com_developer->integer)
-	{
-		Cvar_CheckRange(com_maxfps, 20, 333, qtrue);
 	}
 
 	// we may want to spin here if things are going too fast


### PR DESCRIPTION
- increase `CMD_BACKUP` to 128 via extension
- fix antiwarp lagometer
- unlock `com_maxfps` up to `500`
- add client prediction optimization - instead of iterating over whole `CMD_BACKUP` array every frame oldest valid cmd will be saved during snapshot transition frame as future starting point 

Some notes:
- on `500` fps client side ping calculation breaks around 80 ping because `PACKET_BACKUP` is too low. Because `PACKET_BACKUP` is also used server side for various things I refrained from increasing it at this time.
- included client prediction optimization should basically mean it could be possible to increase `CMD_BACKUP` to a much higher value without many downsides and getting rid of the fps<->ping problem forever.