### PR TITLE
game: fix omni-bot mg42 goal names

### DIFF
--- a/src/game/g_etbot_interface.cpp
+++ b/src/game/g_etbot_interface.cpp
@@ -234,7 +234,7 @@ void GetMG42s()
 		name = (char *)_GetEntityName(trav);
 		if (name)
 		{
-			Q_strncpyz(mg42s[0].name, name, sizeof(mg42s[0].name));
+			Q_strncpyz(mg42.name, name, sizeof(mg42.name));
 		}
 		else
 		{


### PR DESCRIPTION
Broke in c66a4cf77f0fc80306dce0b0cab60eb2f8728dfd

Should use the local variable rather than the first index of the array.

fixes #2495 