### PR TITLE
game: enable spawning when changing entity classname with "set" scriptaction

### DIFF
--- a/src/game/g_script_actions.c
+++ b/src/game/g_script_actions.c
@@ -4946,7 +4946,9 @@ qboolean etpro_ScriptAction_SetValues(gentity_t *ent, char *params)
 	{
 		if (!nospawn)
 		{
+			level.spawning = qtrue;
 			G_CallSpawn(ent);
+			level.spawning = qfalse;
 		}
 
 		trap_LinkEntity(ent);


### PR DESCRIPTION
Server would crash if changing `classname` to an entity that calls string, int etc. spawn functions on the entity spawn.