### PR TITLE
cgame: fix dlights not updating if spawned after initial map load

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -3051,6 +3051,8 @@ void CG_Letterbox(float xsize, float ysize, qboolean center);
 
 void CG_DrawLine(const vec3_t start, const vec3_t end, float width, const vec4_t color, qhandle_t shader);
 
+void CG_SetupDlightstyles(void);
+
 // cg_drawtools.c
 
 qboolean Ccg_Is43Screen(void);      // does this game-window have a 4:3 aspectratio. note: this is also true for a 800x600 windowed game on a widescreen monitor

--- a/src/cgame/cg_servercmds.c
+++ b/src/cgame/cg_servercmds.c
@@ -1099,7 +1099,7 @@ static void CG_ConfigStringModified(void)
 		}
 		else if (num >= CS_DLIGHTS && num < CS_DLIGHTS + MAX_DLIGHT_CONFIGSTRINGS)
 		{
-			// FIXME - dlight changes ignored!
+			CG_SetupDlightstyles();
 		}
 		else if (num >= CS_FIRETEAMS && num < CS_FIRETEAMS + MAX_FIRETEAMS)
 		{

--- a/src/cgame/cg_view.c
+++ b/src/cgame/cg_view.c
@@ -2038,8 +2038,6 @@ extern int snapshotDelayTime;
 #endif // FAKELAG
 #endif // ETLEGACY_DEBUG
 
-extern void CG_SetupDlightstyles(void);
-
 static void CG_DrawSpawnpoints(void)
 {
 	vec3_t start, end;


### PR DESCRIPTION
dlight configstrings were not updated if a dlight was spawned after initial map load (such as when changing an existing entity to dlight with `set` script action).