### PR TITLE
client: fix client being stuck on loading screen after kick

### DIFF
--- a/src/client/cl_cgame.c
+++ b/src/client/cl_cgame.c
@@ -380,7 +380,7 @@ rescan:
 		// allow server to indicate why they were disconnected
 		if (argc >= 2)
 		{
-			Com_Error(ERR_SERVERDISCONNECT, "%s", va("Server Disconnected - %s", Cmd_Argv(1)));
+			Com_Error(ERR_SERVERDISCONNECT, "Server Disconnected - %s", Cmd_Argv(1));
 		}
 		else
 		{

--- a/src/client/cl_parse.c
+++ b/src/client/cl_parse.c
@@ -1056,6 +1056,26 @@ void CL_ParseCommandString(msg_t *msg)
 
 	index = seq & (MAX_RELIABLE_COMMANDS - 1);
 	Q_strncpyz(clc.serverCommands[index], s, sizeof(clc.serverCommands[index]));
+
+	// etlded no longer sends connectionless disconnect packet
+	// client only runs reliable server commands in cgame when CA_ACTIVE
+	// but server can send disconnect command before, which leads to client being stuck on connection screen
+	if (cls.state == CA_PRIMED)
+	{
+		Cmd_TokenizeString(s);
+
+		if (!Q_stricmp(Cmd_Argv(0), "disconnect"))
+		{
+			if (Cmd_Argc() >= 2)
+			{
+				Com_Error(ERR_SERVERDISCONNECT, "Server Disconnected - %s", Cmd_Argv(1));
+			}
+			else
+			{
+				Com_Error(ERR_SERVERDISCONNECT, "Server disconnected");
+			}
+		}
+	}
 }
 
 /**


### PR DESCRIPTION
etlded no longer sends connectionless disconnect packet and client only runs reliable server commands in cgame when `CA_ACTIVE` but server can send disconnect server command before, which leads to client being stuck on connection screen.

#refs https://github.com/etlegacy/etlegacy/commit/4d22dc9ba7c740da85a997a4e300b2a801a81bf6