### PR TITLE
cgame: fix blood flash alpha value overflowing normalized range

### DIFF
--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -3575,7 +3575,7 @@ static void CG_DrawFlashDamage(void)
 
 		width = Ccg_WideX(SCREEN_WIDTH);
 
-		col[3] = (1 - (cg.time - cg.v_dmg_time) / cg_bloodFlashTime.value) * Com_Clamp(0.f, 1.f, cg_bloodFlash.value);
+		col[3] = Q_fabs((cg.v_dmg_time - cg.time) / cg_bloodFlashTime.value) * Com_Clamp(0.f, 1.f, cg_bloodFlash.value);
 
 		if (cg.v_dmg_angle == -1.f) // all borders
 		{


### PR DESCRIPTION
The math was originally done by subtracting `cg.time` from `cg.v_dmg_time`, but this was probably accidentally flipped as a part of 0df88a2c7db5b270bd3404dd0e8653a20a9affdb. This caused `col[3]` to be in the range of 1-2 instead of 0-1, which would then cause overflow in renderer on `RB_SetColor`.

refs #1413 