### PR TITLE
ui: fix numericfield keyhandler ignoring maxChars data

### DIFF
--- a/src/ui/ui_parse.c
+++ b/src/ui/ui_parse.c
@@ -83,7 +83,7 @@ void Item_ValidateTypeData(itemDef_t *item)
 	{
 		item->typeData = UI_Alloc(sizeof(editFieldDef_t));
 		Com_Memset(item->typeData, 0, sizeof(editFieldDef_t));
-		if (item->type == ITEM_TYPE_EDITFIELD)
+		if (TEXTFIELD(item->type))
 		{
 			if (!((editFieldDef_t *)item->typeData)->maxPaintChars)
 			{


### PR DESCRIPTION
`maxPaintChars` was only set for `ITEM_TYPE_EDITFIELD` and not for `ITEM_TYPE_NUMERICFIELD`, which messed up home/end keyhandling when trying to jump to start/end of the field, as the keyhandler wasn't aware of the field limit and could not calculate cursor position correctly.