### PR TITLE
mod: fix reload behaviour on revive

### DIFF
--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -5061,6 +5061,7 @@ void PmoveSingle(pmove_t *pmove)
 		// clear the respawned flag if attack button are cleared
 		// don't clear if a weapon change is needed to prevent early weapon change
 		if (pm->ps->stats[STAT_HEALTH] > 0 &&
+		    !(pm->cmd.wbuttons & WBUTTON_RELOAD) &&
 		    !(pm->cmd.buttons & BUTTON_ATTACK) &&  // & (BUTTON_ATTACK /*| BUTTON_USE_HOLDABLE
 		    (pm->ps->weapon == pm->cmd.weapon))       // bit hacky, stop the slight lag from client -> server even on locahost, switching back to the weapon you were holding
 		                                              // and then back to what weapon you should have, became VERY noticible for the kar98/carbine + gpg40, esp now i've added the


### PR DESCRIPTION
Fixes reload getting out of sync between client<->server when client is holding `+reload` before revived. This change means that issuing `reload` before revive will have no effect just like `+attack` and client will have to release it first and issue it again for the reload to start.

#refs https://github.com/etlegacy/etlegacy/commit/1ea52623bd6c6c8d93bedd2455dbd685e6045936