### PR TITLE
game: fix combatState type in gclient_s struct

### DIFF
--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -993,7 +993,7 @@ struct gclient_s
 
 	int speedScale;
 
-	combatstate_t combatState;
+	unsigned int combatState;
 
 	int topMarker;
 	clientMarker_t clientMarkers[MAX_CLIENT_MARKERS];


### PR DESCRIPTION
The value is manipulated by bitwise operations using the values from the combatState_t enum, but it doesn't make sense for the actual data type to be the enum, it should just be an unsigned int.