### PR TITLE
server: add 64+ players server support to etltv, refs #229

### DIFF
--- a/src/server/server.h
+++ b/src/server/server.h
@@ -283,7 +283,7 @@ typedef struct client_s
 	qboolean demoClient;                    ///< is this a demoClient?
 	qboolean ettvClient;                    ///< is this a tv client
 	ettvClientSnapshot_t **ettvClientFrame; ///< playerstates for tv client
-	int parseEntitiesNum;                   ///< keep track how many parse entities we sent
+	int parseEntitiesNum;                   ///< keep track how many parse entities we've sent
 
 	userAgent_t agent;
 

--- a/src/server/sv_cl_main.c
+++ b/src/server/sv_cl_main.c
@@ -125,7 +125,7 @@ void SV_CL_Connect_f(void)
 	// we need to setup a correct default for this, otherwise the first val we set might reappear
 	Cvar_Set("com_errorMessage", "");
 
-	svclc.connectTime        = -99999; // CL_CheckForResend() will fire immediately
+	svclc.connectTime        = -99999; // SV_CL_CheckForResend() will fire immediately
 	svclc.connectPacketCount = 0;
 }
 
@@ -243,7 +243,7 @@ void SV_CL_CheckForResend(void)
 	}
 	break;
 	default:
-		Com_Error(ERR_FATAL, "CL_CheckForResend: bad cls.state");
+		Com_Error(ERR_FATAL, "SV_CL_CheckForResend: bad svcls.state");
 	}
 }
 
@@ -608,13 +608,23 @@ char *SV_CL_Cvar_InfoString(char *cs, int index)
 	{
 		if (index == CS_SERVERINFO)
 		{
+			// FIXME: sv_maxclients can't go over 64 for legacy cgame
+			// and possibly other mods, which would be good to support too
+			if (sv_maxclients->integer > MAX_CLIENTS)
+			{
+				Info_SetValueForKey_Big(newcs, "sv_maxclients", "64");
+			}
+			else
+			{
+				Info_SetValueForKey_Big(newcs, "sv_maxclients", sv_maxclients->string);
+			}
+
+			Info_SetValueForKey_Big(newcs, "sv_privateClients", sv_privateClients->string);
 			Info_SetValueForKey_Big(newcs, "sv_maxPing", sv_maxPing->string);
 			Info_SetValueForKey_Big(newcs, "sv_minPing", sv_minPing->string);
 			Info_SetValueForKey_Big(newcs, "sv_maxRate", sv_maxRate->string);
 			Info_SetValueForKey_Big(newcs, "sv_dlRate", sv_dlRate->string);
 			Info_SetValueForKey_Big(newcs, "sv_hostname", sv_hostname->string);
-			Info_SetValueForKey_Big(newcs, "sv_maxclients", sv_maxclients->string);
-			Info_SetValueForKey_Big(newcs, "sv_privateClients", sv_privateClients->string);
 			Info_SetValueForKey_Big(newcs, "version", Cvar_VariableString("version"));
 		}
 		else if (index == CS_SYSTEMINFO)
@@ -1362,6 +1372,8 @@ void SV_CL_ClearState(void)
 
 /**
  * @brief SV_CL_GetPlayerstate
+ * @param[in] clientNum
+ * @param[in,out] ps
  * @return
  */
 int SV_CL_GetPlayerstate(int clientNum, playerState_t *ps)

--- a/src/server/sv_cl_parse.c
+++ b/src/server/sv_cl_parse.c
@@ -485,6 +485,8 @@ void SV_CL_DeltaEntity(msg_t *msg, svclSnapshot_t *frame, int newnum, entityStat
 		gEnt->s.number = newnum;
 		SV_LinkEntity(gEnt);
 
+		sv.num_entities = newnum + 1;
+
 		if (sv_etltv_shownet->integer == 4)
 		{
 			Com_Printf("%d+ ", newnum);
@@ -515,6 +517,8 @@ void SV_CL_ParsePacketEntities(msg_t *msg, svclSnapshot_t *oldframe, svclSnapsho
 	entityShared_t *oldstateShared;
 	int            oldindex, newnum, oldnum;
 
+	sv.num_entities = 0;
+
 	oldstate       = NULL;
 	oldstateShared = NULL;
 	oldindex       = 0;
@@ -523,7 +527,6 @@ void SV_CL_ParsePacketEntities(msg_t *msg, svclSnapshot_t *oldframe, svclSnapsho
 	newframe->numEntities      = 0;
 
 	// delta from the entities present in oldframe
-
 	if (!oldframe)
 	{
 		oldnum = MAX_GENTITIES;
@@ -556,7 +559,7 @@ void SV_CL_ParsePacketEntities(msg_t *msg, svclSnapshot_t *oldframe, svclSnapsho
 
 		if (msg->readcount > msg->cursize)
 		{
-			Com_Error(ERR_DROP, "CL_ParsePacketEntities: end of message");
+			Com_Error(ERR_DROP, "SV_CL_ParsePacketEntities: end of message");
 		}
 
 		while (oldnum < newnum)

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -350,7 +350,13 @@ void SV_BoundMaxClients(int minimum)
 	}
 	else if (sv_maxclients->integer > MAX_CLIENTS)
 	{
-		Cvar_Set("sv_maxclients", va("%i", MAX_CLIENTS));
+#ifdef DEDICATED
+		// no limit for etltv slave server
+		if (svcls.state <= CA_DISCONNECTED)
+#endif // DEDICATED
+		{
+			Cvar_Set("sv_maxclients", va("%i", MAX_CLIENTS));
+		}
 	}
 }
 

--- a/src/server/sv_snapshot.c
+++ b/src/server/sv_snapshot.c
@@ -224,7 +224,7 @@ static void SV_WriteSnapshotToClient(client_t *client, msg_t *msg)
 	// this is the snapshot we are creating
 	frame = &client->frames[client->netchan.outgoingSequence & PACKET_MASK];
 
-	// if we are about to got over MAX_PARSE_ENTITIES send uncompressed snapshot
+	// if we are about to go over MAX_PARSE_ENTITIES send uncompressed snapshot
 	if (client->parseEntitiesNum > MAX_PARSE_ENTITIES - 128)
 	{
 		Com_DPrintf("%s: Too many parse entities.\n", client->name);
@@ -1073,23 +1073,6 @@ void SV_SendClientMessages(void)
 
 	// update any changed configstrings from this frame
 	SV_UpdateConfigStrings();
-
-#ifdef DEDICATED
-	if (svcls.isTVGame)
-	{
-		sharedEntity_t *gEnt;
-		sv.num_entities = 0;
-		for (i = 0; i < MAX_GENTITIES; i++)
-		{
-			gEnt = SV_GentityNum(i);
-
-			if (gEnt->r.linked)
-			{
-				sv.num_entities = i + 1;
-			}
-		}
-	}
-#endif // DEDICATED
 
 	// send a message to each connected client
 	for (i = 0; i < sv_maxclients->integer; i++)

--- a/src/tvgame/tvg_active.c
+++ b/src/tvgame/tvg_active.c
@@ -433,7 +433,7 @@ void TVG_ClientThink_cmd(gclient_t *client, usercmd_t *cmd)
 
 /**
  * @brief A new command has arrived from the client
- * @param[in] clientNum Client Number from 0 to MAX_CLIENTS
+ * @param[in] clientNum Client Number from 0 to g_maxclients
  */
 void TVG_ClientThink(int clientNum)
 {

--- a/src/tvgame/tvg_client.c
+++ b/src/tvgame/tvg_client.c
@@ -1025,10 +1025,7 @@ char *TVG_ClientConnect(int clientNum, qboolean firstTime, qboolean isBot)
 	// disabled for bots - see join message ... make cvar ?
 	if (firstTime)
 	{
-
-		{
-			trap_SendServerCommand(-1, va("cpm \"" S_COLOR_WHITE "%s" S_COLOR_WHITE " connected\n\"", client->pers.netname));
-		}
+		trap_SendServerCommand(-1, va("cpm \"" S_COLOR_WHITE "%s" S_COLOR_WHITE " connected\n\"", client->pers.netname));
 	}
 
 	// count current clients and rank for scoreboard
@@ -1292,10 +1289,10 @@ void ClientStoreSurfaceFlags(int clientNum, int surfaceFlags)
 */
 void TVG_RemoveFromAllIgnoreLists(int clientNum)
 {
-	int i;
+	//int i;
 
-	for (i = 0; i < MAX_CLIENTS; i++)
-	{
-		COM_BitClear(level.clients[i].sess.ignoreClients, clientNum);
-	}
+	//for (i = 0; i < MAX_CLIENTS; i++)
+	//{
+	//	COM_BitClear(level.clients[i].sess.ignoreClients, clientNum);
+	//}
 }

--- a/src/tvgame/tvg_cmds.c
+++ b/src/tvgame/tvg_cmds.c
@@ -41,6 +41,8 @@
 const char *aTeams[TEAM_NUM_TEAMS] = { "FFA", "^1Axis^7", "^$Allies^7", "^2Spectators^7" };
 team_info  teamInfo[TEAM_NUM_TEAMS];
 
+#define MAX_MATCHES 10 + 1
+
 /**
 * @brief G_MatchOnePlayer
 * @param[in] plist
@@ -149,6 +151,11 @@ int TVG_ClientNumbersFromString(char *s, int *plist)
 		{
 			*plist++ = i;
 			found++;
+
+			if (found == MAX_MATCHES - 1)
+			{
+				break;
+			}
 		}
 	}
 	*plist = -1;
@@ -163,7 +170,7 @@ int TVG_ClientNumbersFromString(char *s, int *plist)
 */
 int TVG_ClientNumberFromString(gclient_t *to, char *s)
 {
-	int pids[MAX_CLIENTS];
+	int pids[MAX_MATCHES];
 
 	// no match or more than 1 player matchs, out error
 	if (TVG_ClientNumbersFromString(s, pids) != 1)
@@ -909,7 +916,7 @@ void TVG_Say(gclient_t *client, gclient_t *target, int mode, const char *chatTex
 
 	if (target)
 	{
-		if (!COM_BitCheck(target->sess.ignoreClients, client - level.clients))
+		//if (!COM_BitCheck(target->sess.ignoreClients, client - level.clients))
 		{
 			TVG_SayTo(client, target, mode, color, name, text, qfalse);
 		}
@@ -926,7 +933,7 @@ void TVG_Say(gclient_t *client, gclient_t *target, int mode, const char *chatTex
 	for (j = 0; j < level.numConnectedClients; j++)
 	{
 		other = &level.clients[level.sortedClients[j]];
-		if (!COM_BitCheck(other->sess.ignoreClients, client - level.clients) && other->sess.tvchat)
+		if (/*!COM_BitCheck(other->sess.ignoreClients, client - level.clients) && */ other->sess.tvchat)
 		{
 			TVG_SayTo(client, other, mode, color, name, text, qfalse);
 		}

--- a/src/tvgame/tvg_local.h
+++ b/src/tvgame/tvg_local.h
@@ -257,7 +257,7 @@ typedef struct
 	int latchPlayerType;                                ///< latched class
 	weapon_t latchPlayerWeapon;                         ///< latched primary weapon
 	weapon_t latchPlayerWeapon2;                        ///< latched secondary weapon
-	int ignoreClients[MAX_CLIENTS / (sizeof(int) * 8)];
+	//int ignoreClients[MAX_CLIENTS / (sizeof(int) * 8)];
 	qboolean muted;
 	int skill[SK_NUM_SKILLS];                           ///< skill
 
@@ -483,7 +483,7 @@ typedef struct level_locals_s
 	qboolean restarted;                         ///< waiting for a map_restart to fire
 
 	int numConnectedClients;
-	int sortedClients[MAX_CLIENTS];             ///< sorted by score
+	int *sortedClients;
 
 	// spawn variables
 	qboolean spawning;                          ///< the G_Spawn*() functions are valid

--- a/src/tvgame/tvg_lua.c
+++ b/src/tvgame/tvg_lua.c
@@ -575,7 +575,7 @@ static int _et_trap_FS_GetFileList(lua_State *L)
 	for (i = 0; i < numfiles; i++, filenameptr += filelen + 1)
 	{
 		filelen = strlen(filenameptr);
-        Q_strncpyz(filename, filenameptr, sizeof(filename));
+		Q_strncpyz(filename, filenameptr, sizeof(filename));
 
 		lua_pushstring(L, filename);
 		lua_rawseti(L, newTable, index++);
@@ -968,7 +968,7 @@ static const gentity_field_t gclient_fields[] =
 	_et_gclient_addfield(sess.latchPlayerType,          FIELD_INT,         0),
 	_et_gclient_addfield(sess.latchPlayerWeapon,        FIELD_INT,         0),
 	_et_gclient_addfield(sess.latchPlayerWeapon2,       FIELD_INT,         0),
-	_et_gclient_addfield(sess.ignoreClients,            FIELD_INT_ARRAY,   0),
+	//_et_gclient_addfield(sess.ignoreClients,            FIELD_INT_ARRAY,   0),
 	_et_gclient_addfield(sess.muted,                    FIELD_INT,         0),
 	_et_gclient_addfield(sess.referee,                  FIELD_INT,         0),
 	_et_gclient_addfield(sess.shoutcaster,              FIELD_INT,         0),

--- a/src/tvgame/tvg_main.c
+++ b/src/tvgame/tvg_main.c
@@ -1017,12 +1017,15 @@ void TVG_InitGame(int levelTime, int randomSeed, int restart, int etLegacyServer
 		Q_sscanf(gclients, "%p", &g_clients);
 	}
 
+	level.sortedClients = Com_Allocate(g_maxclients.integer * sizeof(int));
+	Com_Memset(level.sortedClients, 0, g_maxclients.integer * sizeof(int));
+
 	level.clients = g_clients;
 
 	// always leave room for the max number of clients,
 	// even if they aren't all used, so numbers inside that
 	// range are NEVER anything but clients
-	level.num_entities = MAX_CLIENTS;
+	//level.num_entities = MAX_CLIENTS;
 
 	// let the server system know where the entities are
 	trap_LocateGameData(level.gentities, level.num_entities, sizeof(gentity_t),
@@ -1108,6 +1111,8 @@ void TVG_ShutdownGame(int restart)
 
 	// write all the client session data so we can get it back
 	TVG_WriteSessionData(restart);
+
+	free(level.sortedClients);
 }
 
 //===================================================================

--- a/src/tvgame/tvg_main.c
+++ b/src/tvgame/tvg_main.c
@@ -57,7 +57,7 @@ typedef struct
 } cvarTable_t;
 
 gentity_t g_entities[MAX_GENTITIES];
-gclient_t g_clients[MAX_CLIENTS];
+gclient_t *g_clients;
 
 const char *gameNames[] =
 {
@@ -927,9 +927,11 @@ extern void G_InitMemory(void);
  */
 void TVG_InitGame(int levelTime, int randomSeed, int restart, int etLegacyServer, int serverVersion)
 {
+	char   gclients[MAX_CVAR_VALUE_STRING];
 	char   cs[MAX_INFO_STRING];
 	time_t aclock;
 	char   timeFt[32];
+	int    i;
 
 	// mod version check
 	MOD_CHECK_ETLEGACY(etLegacyServer, serverVersion, level.etLegacyServer);
@@ -939,11 +941,6 @@ void TVG_InitGame(int levelTime, int randomSeed, int restart, int etLegacyServer
 	G_Printf("gamedate: %s\n", __DATE__);
 
 	srand(randomSeed);
-
-	if (g_maxclients.integer > MAX_CLIENTS)
-	{
-		G_Error("Error: tvgame does not support %d client slots.\n", g_maxclients.integer);
-	}
 
 	TVG_RegisterCvars();
 
@@ -1005,7 +1002,21 @@ void TVG_InitGame(int levelTime, int randomSeed, int restart, int etLegacyServer
 
 	// initialize all clients for this game
 	level.maxclients = g_maxclients.integer;
-	Com_Memset(g_clients, 0, MAX_CLIENTS * sizeof(g_clients[0]));
+
+	trap_Cvar_VariableStringBuffer("gclients", gclients, sizeof(gclients));
+
+	if (!Q_stricmp(gclients, ""))
+	{
+		g_clients = Com_Allocate(g_maxclients.integer * sizeof(gclient_t));
+		Com_Memset(g_clients, 0, g_maxclients.integer * sizeof(gclient_t));
+
+		trap_Cvar_Set("gclients", va("%p", g_clients));
+	}
+	else
+	{
+		Q_sscanf(gclients, "%p", &g_clients);
+	}
+
 	level.clients = g_clients;
 
 	// always leave room for the max number of clients,
@@ -1039,6 +1050,15 @@ void TVG_InitGame(int levelTime, int randomSeed, int restart, int etLegacyServer
 	TVG_SpawnEntitiesFromString();
 
 	TVG_FindIntermissionPoint();
+
+	for (i = 0; i < level.num_entities; i++)
+	{
+		G_FreeEntity(g_entities + i);
+	}
+
+	level.num_entities = 0;
+	trap_LocateGameData(level.gentities, level.num_entities, sizeof(gentity_t),
+	                    &level.clients[0].ps, sizeof(level.clients[0]));
 
 	BG_ClearScriptSpeakerPool();
 

--- a/src/tvgame/tvg_session.c
+++ b/src/tvgame/tvg_session.c
@@ -78,8 +78,8 @@ void TVG_WriteClientSessionData(gclient_t *client, qboolean restart)
 	cJSON_AddNumberToObject(root, "shoutcaster", client->sess.shoutcaster);
 
 	cJSON_AddNumberToObject(root, "muted", client->sess.muted);
-	cJSON_AddNumberToObject(root, "ignoreClients1", client->sess.ignoreClients[0]);
-	cJSON_AddNumberToObject(root, "ignoreClients2", client->sess.ignoreClients[1]);
+	//cJSON_AddNumberToObject(root, "ignoreClients1", client->sess.ignoreClients[0]);
+	//cJSON_AddNumberToObject(root, "ignoreClients2", client->sess.ignoreClients[1]);
 	cJSON_AddNumberToObject(root, "enterTime", client->pers.enterTime);
 	cJSON_AddNumberToObject(root, "userSpawnPointValue", restart ? client->sess.userSpawnPointValue : 0);
 
@@ -119,9 +119,9 @@ void TVG_ReadSessionData(gclient_t *client)
 	client->sess.referee            = Q_ReadIntValueJson(root, "referee");
 	client->sess.shoutcaster        = Q_ReadIntValueJson(root, "shoutcaster");
 
-	client->sess.muted               = Q_ReadIntValueJson(root, "muted");
-	client->sess.ignoreClients[0]    = Q_ReadIntValueJson(root, "ignoreClients1");
-	client->sess.ignoreClients[1]    = Q_ReadIntValueJson(root, "ignoreClients2");
+	client->sess.muted = Q_ReadIntValueJson(root, "muted");
+	//client->sess.ignoreClients[0]    = Q_ReadIntValueJson(root, "ignoreClients1");
+	//client->sess.ignoreClients[1]    = Q_ReadIntValueJson(root, "ignoreClients2");
 	client->pers.enterTime           = Q_ReadIntValueJson(root, "enterTime");
 	client->sess.userSpawnPointValue = Q_ReadIntValueJson(root, "userSpawnPointValue");
 
@@ -152,7 +152,7 @@ void TVG_InitSessionData(gclient_t *client, const char *userinfo)
 
 	sess->userSpawnPointValue = 0;
 
-	Com_Memset(sess->ignoreClients, 0, sizeof(sess->ignoreClients));
+	//Com_Memset(sess->ignoreClients, 0, sizeof(sess->ignoreClients));
 
 	sess->muted = qfalse;
 

--- a/src/tvgame/tvg_utils.c
+++ b/src/tvgame/tvg_utils.c
@@ -653,8 +653,8 @@ gentity_t *G_Spawn(void)
 	{
 		// if we go through all entities and can't find one to free,
 		// override the normal minimum times before use
-		e = &g_entities[MAX_CLIENTS];
-		for (i = MAX_CLIENTS ; i < level.num_entities ; i++, e++)
+		e = &g_entities[0];
+		for (i = 0; i < level.num_entities ; i++, e++)
 		{
 			if (e->inuse)
 			{
@@ -935,7 +935,7 @@ void TVG_globalSound(const char *sound)
 	te = G_TempEntityNotLinked(EV_GLOBAL_SOUND);
 
 	te->s.eventParm = G_SoundIndex(sound);
-	te->r.svFlags |= SVF_BROADCAST;
+	te->r.svFlags  |= SVF_BROADCAST;
 }
 
 /**
@@ -986,7 +986,7 @@ void TVG_TempTraceIgnoreEntity(gentity_t *ent)
 	}
 
 	level.tempTraceIgnoreEnts[ent - g_entities] = qtrue;
-	ent->r.linked = qfalse;
+	ent->r.linked                               = qfalse;
 }
 
 /**
@@ -1081,7 +1081,7 @@ void TVG_TempTraceIgnoreEntities(gentity_t *ent)
 		hit = &g_entities[list[i]];
 
 		if (hit->s.eType == ET_OID_TRIGGER || hit->s.eType == ET_TRIGGER_MULTIPLE
-			|| hit->s.eType == ET_TRIGGER_FLAGONLY || hit->s.eType == ET_TRIGGER_FLAGONLY_MULTIPLE)
+		    || hit->s.eType == ET_TRIGGER_FLAGONLY || hit->s.eType == ET_TRIGGER_FLAGONLY_MULTIPLE)
 		{
 			TVG_TempTraceIgnoreEntity(hit);
 		}
@@ -1092,7 +1092,7 @@ void TVG_TempTraceIgnoreEntities(gentity_t *ent)
 		}
 
 		if (hit->client && (!(ent->client->ps.stats[STAT_PLAYER_CLASS] == PC_MEDIC) || (ent->client->ps.stats[STAT_PLAYER_CLASS] == PC_MEDIC && ent->client->sess.sessionTeam != hit->client->sess.sessionTeam))
-			&& hit->client->ps.pm_type == PM_DEAD && !(hit->client->ps.pm_flags & PMF_LIMBO))
+		    && hit->client->ps.pm_type == PM_DEAD && !(hit->client->ps.pm_flags & PMF_LIMBO))
 		{
 			TVG_TempTraceIgnoreEntity(hit);
 		}


### PR DESCRIPTION
- add 64+ players server support
- optimize sv.num_entities
- fix comments

Notes: 
- setting `sv_maxclients` higher than 64 might require setting higher `com_hunkMegs`.
- legacy cgame doesn't support higher than 64 `sv_maxclients`, notably `CG_ParseFireteams` uses `cgs.maxclients` which will break the game if it goes over 64.
- legacy ui doesn't support showing higher than 64 `sv_maxclients` servers in the browser, unless `ui_serverBrowserSettings 4` is set on game init.

refs #229