### PR TITLE
cgame: use correct fov for corona frustum culling

### DIFF
--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -4533,7 +4533,8 @@ void CG_Coronas(void)
 				toofar = qtrue;
 			}
 			// dot = DotProduct(dir, cg.refdef_current->viewaxis[0]);
-			if (DotProduct(dir, cg.refdef_current->viewaxis[0]) >= -0.6f)
+			const float fov = cosf((cg.refdef_current->fov_x / 2) * (float)(M_PI / 180));
+			if (DotProduct(dir, cg.refdef_current->viewaxis[0]) >= -fov)
 			{
 				behind = qtrue;
 			}


### PR DESCRIPTION
Takes account players current FOV rather than using a hardcoded value, which culled coronas at the sides of the screen too early on > 4:3 aspect ratio.