### PR TITLE
sdl: force depthbits range to 0-24

### DIFF
--- a/etmain/configs/legacy1.config
+++ b/etmain/configs/legacy1.config
@@ -164,7 +164,7 @@ init
 	command "sv_cvar r_ati_truform_tess EQ 0" // vanilla clients only
 	command "sv_cvar r_clamptoedge EQ 1" // vanilla clients only
 	command "sv_cvar r_colorMipLevels EQ 0"
-	command "sv_cvar r_depthbits IN 24 32"
+	command "sv_cvar r_depthbits OUT 1 23"
 	command "sv_cvar r_detailtextures EQ 0"
 	command "sv_cvar r_flares IN 0 1"
 	command "sv_cvar r_ext_ATI_pntriangles EQ 0" // vanilla clients only

--- a/etmain/configs/legacy3.config
+++ b/etmain/configs/legacy3.config
@@ -165,7 +165,7 @@ init
 	command "sv_cvar r_ati_truform_tess EQ 0" // vanilla clients only
 	command "sv_cvar r_clamptoedge EQ 1" // vanilla clients only
 	command "sv_cvar r_colorMipLevels EQ 0"
-	command "sv_cvar r_depthbits IN 24 32"
+	command "sv_cvar r_depthbits OUT 1 23"
 	command "sv_cvar r_detailtextures EQ 0"
 	command "sv_cvar r_flares IN 0 1"
 	command "sv_cvar r_ext_ATI_pntriangles EQ 0" // vanilla clients only

--- a/etmain/configs/legacy5.config
+++ b/etmain/configs/legacy5.config
@@ -164,7 +164,7 @@ init
 	command "sv_cvar r_ati_truform_tess EQ 0" // vanilla clients only
 	command "sv_cvar r_clamptoedge EQ 1" // vanilla clients only
 	command "sv_cvar r_colorMipLevels EQ 0"
-	command "sv_cvar r_depthbits IN 24 32"
+	command "sv_cvar r_depthbits OUT 1 23"
 	command "sv_cvar r_detailtextures EQ 0"
 	command "sv_cvar r_flares IN 0 1"
 	command "sv_cvar r_ext_ATI_pntriangles EQ 0" // vanilla clients only

--- a/etmain/configs/legacy6.config
+++ b/etmain/configs/legacy6.config
@@ -164,7 +164,7 @@ init
 	command "sv_cvar r_ati_truform_tess EQ 0" // vanilla clients only
 	command "sv_cvar r_clamptoedge EQ 1" // vanilla clients only
 	command "sv_cvar r_colorMipLevels EQ 0"
-	command "sv_cvar r_depthbits IN 24 32"
+	command "sv_cvar r_depthbits OUT 1 23"
 	command "sv_cvar r_detailtextures EQ 0"
 	command "sv_cvar r_flares IN 0 1"
 	command "sv_cvar r_ext_ATI_pntriangles EQ 0" // vanilla clients only

--- a/src/sdl/sdl_glimp.c
+++ b/src/sdl/sdl_glimp.c
@@ -372,8 +372,9 @@ static void GLimp_InitCvars(void)
 	r_windowLocation = Cvar_Get("r_windowLocation", "0,-1,-1", CVAR_ARCHIVE | CVAR_PROTECTED);
 
 	// Window render surface cvars
-	r_stencilbits   = Cvar_Get("r_stencilbits", "0", CVAR_ARCHIVE_ND | CVAR_LATCH | CVAR_UNSAFE);
-	r_depthbits     = Cvar_Get("r_depthbits", "0", CVAR_ARCHIVE_ND | CVAR_LATCH | CVAR_UNSAFE);
+	r_stencilbits = Cvar_Get("r_stencilbits", "0", CVAR_ARCHIVE_ND | CVAR_LATCH | CVAR_UNSAFE);
+	r_depthbits   = Cvar_Get("r_depthbits", "0", CVAR_ARCHIVE_ND | CVAR_LATCH | CVAR_UNSAFE);
+	Cvar_CheckRange(r_depthbits, 0, 24, qtrue);
 	r_colorbits     = Cvar_Get("r_colorbits", "0", CVAR_ARCHIVE_ND | CVAR_LATCH | CVAR_UNSAFE);
 	r_ignorehwgamma = Cvar_Get("r_ignorehwgamma", "0", CVAR_ARCHIVE_ND | CVAR_LATCH | CVAR_UNSAFE);
 


### PR DESCRIPTION
There's no such thing as 32-bit depth and it tends to cause massive framedrops and/or crashes in ETL anyway.

`r_depthbits` is now also allowed to be 0 on competitive configs as that is the default, and will turn into 24 depth bits in the code anyway.

https://github.com/etlegacy/etlegacy/blob/2ae1f90dc50a68a49a475f9d11743b10cdac7b89/src/sdl/sdl_glimp.c#L799-L802