### PR TITLE
renderer: Allow setting multisample to 16x for supersample antialiasing

### DIFF
--- a/etmain/ui/options_system.menu
+++ b/etmain/ui/options_system.menu
@@ -74,7 +74,7 @@ menuDef {
 	// "GL_NEAREST" "GL_LINEAR" "GL_NEAREST_MIPMAP_NEAREST" "GL_LINEAR_MIPMAP_NEAREST" "GL_NEAREST_MIPMAP_LINEAR" "GL_LINEAR_MIPMAP_LINEAR"
 	MULTIACTION(8, GRAPHICSADVANCED_Y + 88, (SUBWINDOW_WIDTH_L)-4, 10, _("Texture Filtering:"), .2, 8, "ui_r_texturemode", cvarStrList { "Bilinear"; "GL_LINEAR_MIPMAP_NEAREST"; "Trilinear"; "GL_LINEAR_MIPMAP_LINEAR" }, uiScript glPreset, _("Set texture filtering mode"))
 	MULTIACTION(8, GRAPHICSADVANCED_Y + 100, (SUBWINDOW_WIDTH_L)-4, 10, _("Anisotropic Filtering:"), .2, 8, "ui_r_ext_texture_filter_anisotropic", cvarFloatList { "Disabled" 0 "Medium (4)" 4 "High (8)" 8 "Very High (16)" 16 }, uiScript glPreset, _("Set anisotropic filtering level"))
-	MULTIACTION(8, GRAPHICSADVANCED_Y + 112, (SUBWINDOW_WIDTH_L)-4, 10, _("Anti-Aliasing:"), .2, 8, "ui_r_ext_multisample", cvarFloatList { "Off" 0 "x2" 2 "x4" 4 "x8" 8 }, uiScript glPreset, _("Set MSAA level"))
+	MULTIACTION(8, GRAPHICSADVANCED_Y + 112, (SUBWINDOW_WIDTH_L)-4, 10, _("Anti-Aliasing:"), .2, 8, "ui_r_ext_multisample", cvarFloatList { "Off" 0 "x2" 2 "x4" 4 "x8" 8 "x16" 16 }, uiScript glPreset, _("Set MSAA level"))
 	MULTIACTION(8, GRAPHICSADVANCED_Y + 124, (SUBWINDOW_WIDTH_L)-4, 10, _("Color Depth:"), .2, 8, "ui_r_colorbits", cvarFloatList { "Desktop Default" 0 "16-bit" 16 "32-bit" 32 }, uiScript glPreset, _("Set color depth"))
 	YESNOACTION(8, GRAPHICSADVANCED_Y + 136, (SUBWINDOW_WIDTH_L)-4, 10, _("Detail Textures:"), .2, 8, "ui_r_detailtextures", uiScript glPreset, _("Enable use of detail textures"))
 	MULTIACTION(8, GRAPHICSADVANCED_Y + 148, (SUBWINDOW_WIDTH_L)-4, 10, _("Depth Buffer:"), .2, 8, "ui_r_depthbits", cvarFloatList { "Default" 0 "16-bit" 16 "24-bit" 24 }, uiScript glPreset, _("Set the number of desired depth bits"))

--- a/src/renderercommon/tr_common.c
+++ b/src/renderercommon/tr_common.c
@@ -77,7 +77,7 @@ void R_PrintLongString(const char *string)
 void R_RegisterCommon(void)
 {
 	r_ext_multisample = ri.Cvar_Get("r_ext_multisample", "0", CVAR_ARCHIVE_ND | CVAR_LATCH | CVAR_UNSAFE);
-	ri.Cvar_CheckRange(r_ext_multisample, 0, 8, qtrue);
+	ri.Cvar_CheckRange(r_ext_multisample, 0, 16, qtrue);
 }
 
 #ifdef USE_RENDERER_DLOPEN


### PR DESCRIPTION
- Follow-up to https://github.com/etlegacy/etlegacy/pull/1483.

Most graphics drivers implement 16x MSAA in OpenGL as 4x MSAA + 4x SSAA. This provides high-quality antialiasing for alpha-tested surfaces such as foliage and barbed wires. Compared to a post-processing-based antialiasing solution, this is slower but higher quality. It also does *not* make the image blurrier like FXAA or SMAA would.

Note that I haven't tested this. I've used 16x MSAA in a lot of other games now (including id Tech-based ones) and it works OK, so I don't expect major issues from this.

See the issue linked below for details on how this compares to `r_scale` values above `1.0`.

- This closes https://github.com/etlegacy/etlegacy/issues/2340.