### PR TITLE
omnibot: use .aarch64 suffix for loading omni-bot on aarch64

### DIFF
--- a/src/Omnibot/Common/BotLoadLibrary.cpp
+++ b/src/Omnibot/Common/BotLoadLibrary.cpp
@@ -317,6 +317,8 @@ eomnibot_error Omnibot_LoadLibrary(int version, const char *lib, const char *pat
 #define POSTFIX ".so"
 #ifdef __x86_64__
 #define SUFFIX ".x86_64"
+#elif defined __aarch64__
+#define SUFFIX ".aarch64"
 #else
 #define SUFFIX
 #endif


### PR DESCRIPTION
Relates to #2539 

With this patch, `omnibot_et.aarch64.so` is used on Linux aarch64 instead of `omnibot_et.so`, the latter being already used for the Linux i386 architecture.

I tested it on my [etbloat server](https://et.trackbase.net/server/48766):

```
Omni-bot: Looking for etbloat/omni-bot/omnibot_et.aarch64.so, found.
Omni-bot: Found Omni-bot: etbloat/omni-bot/omnibot_et.aarch64.so, Attempting to Initialize
```

It should work the same on `legacy`.

This is not a breaking change since aarch64 is not supported by omni-bot in the first place. But it may break the very few RPI setups that used `omnibot_et.so`.