### PR TITLE
game: fix WolfRevivePushEnt framerate dependency

### DIFF
--- a/src/game/g_active.c
+++ b/src/game/g_active.c
@@ -1948,6 +1948,13 @@ void WolfRevivePushEnt(gentity_t *self, gentity_t *other)
 {
 	vec3_t dir, push;
 
+	// apply push effect only every 50ms to match sv_fps 20 behavior
+	// scaling the speed to match higher framerates results in smaller push overall as friction has more effect on lower speeds
+	if ((self->client && self->client->lastRevivePushTime + 50 > level.time) || other->client->lastRevivePushTime + 50 > level.time)
+	{
+		return;
+	}
+
 	VectorSubtract(self->r.currentOrigin, other->r.currentOrigin, dir);
 	dir[2] = 0;
 	VectorNormalizeFast(dir);
@@ -1958,6 +1965,7 @@ void WolfRevivePushEnt(gentity_t *self, gentity_t *other)
 	{
 		VectorAdd(self->s.pos.trDelta, push, self->s.pos.trDelta);
 		VectorAdd(self->client->ps.velocity, push, self->client->ps.velocity);
+		self->client->lastRevivePushTime = level.time - (level.time % 50);
 	}
 
 	VectorScale(dir, -WR_PUSHAMOUNT, push);
@@ -1965,6 +1973,7 @@ void WolfRevivePushEnt(gentity_t *self, gentity_t *other)
 
 	VectorAdd(other->s.pos.trDelta, push, other->s.pos.trDelta);
 	VectorAdd(other->client->ps.velocity, push, other->client->ps.velocity);
+	other->client->lastRevivePushTime = level.time - (level.time % 50);
 }
 
 /**

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1045,6 +1045,8 @@ struct gclient_s
 	int constructSoundTime;                 ///< construction sound time
 
 	qboolean activateHeld;                  ///< client is holding down +activate
+
+	int lastRevivePushTime;
 };
 
 /**


### PR DESCRIPTION
Apply push at 50ms intervals instead of every frame to match `sv_fps 20` behavior. Scaling the push speed to match higher framerates results in different push speeds as friction has more impact on lower speeds, so this ensures that the push speed is consistent between different framerates.

refs #1637 