### PR TITLE
cgame: lerp lean angles in spec/demo playback

### DIFF
--- a/src/cgame/cg_predict.c
+++ b/src/cgame/cg_predict.c
@@ -594,6 +594,8 @@ static void CG_InterpolatePlayerState(qboolean grabAngles)
 		out->velocity[i] = prev->ps.velocity[i] +
 		                   f * (next->ps.velocity[i] - prev->ps.velocity[i]);
 	}
+
+	out->leanf = prev->ps.leanf + f * (next->ps.leanf - prev->ps.leanf);
 }
 
 /**


### PR DESCRIPTION
Lean angles were not interpolated while spectating/demo playback, which caused the angle transitions to be choppy since there was no lerp performed between snapshots.