### PR TITLE
Add a cvar with a list of Lua modules and increase the number of maximum Lua modules

### DIFF
--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -2115,6 +2115,7 @@ extern vmCvar_t g_maxWarp;
 #ifdef FEATURE_LUA
 extern vmCvar_t lua_modules;
 extern vmCvar_t lua_allowedModules;
+extern vmCvar_t g_luaModuleList;
 #endif
 
 extern vmCvar_t g_guidCheck;

--- a/src/game/g_lua.h
+++ b/src/game/g_lua.h
@@ -32,7 +32,7 @@
 #    include <lualib.h>
 #endif
 
-#define LUA_NUM_VM 18
+#define LUA_NUM_VM 64
 #define LUA_MAX_FSIZE 1024 * 1024 ///< 1MB
 
 #define FIELD_INT           0

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -268,6 +268,7 @@ vmCvar_t g_maxWarp;
 #ifdef FEATURE_LUA
 vmCvar_t lua_modules;
 vmCvar_t lua_allowedModules;
+vmCvar_t g_luaModuleList;
 #endif
 
 vmCvar_t g_guidCheck;
@@ -597,6 +598,7 @@ cvarTable_t gameCvarTable[] =
 #ifdef FEATURE_LUA
 	{ &lua_modules,                       "lua_modules",                       "",                           0,                                               0, qfalse, qfalse },
 	{ &lua_allowedModules,                "lua_allowedModules",                "",                           0,                                               0, qfalse, qfalse },
+	{ &g_luaModuleList,                   "g_luaModuleList",                   "",                           0,                                               0, qfalse, qfalse },
 #endif
 
 	{ &g_guidCheck,                       "g_guidCheck",                       "1",                          CVAR_ARCHIVE,                                    0, qfalse, qfalse },


### PR DESCRIPTION
When the new `g_luaModuleList` cvar is set, the older `lua_modules` cvar is intentionally ignored and a warning message is printed if it was set. This behavior can be changed.

I can rename the `g_luaModuleList` cvar if you have a better idea.

I increased the number of maximum Lua modules to `64` because I think this new value is big enough. The current maximum of `18` is a bit low.