### PR TITLE
ui: fix potential out of bounds read with uiInfo.map/campaignList

### DIFF
--- a/src/ui/ui_gameinfo.c
+++ b/src/ui/ui_gameinfo.c
@@ -283,6 +283,15 @@ void UI_LoadArenas(void)
 		trap_Print(va(S_COLOR_YELLOW "WARNING: Too many pk3 files in path - %i files found.\nWe strongly do recommend to reduce the number of map/pk3 files to max. 30 in path\nif you want to start a listen server with connected players.\n", uiInfo.mapCount));
 	}
 
+	// UI_LoadArenasFromFile will happily keep increasing this beyond the limits, cap it here instead of the function itself
+	// (or the parsing loop condition like in campaign loading), so we can still display the correct amount above.
+	// this is unlikely to happen with buffer size of 8192, but it could happen in theory with short map names
+	if (uiInfo.mapCount >= MAX_MAPS)
+	{
+		trap_Print(va(S_COLOR_YELLOW "WARNING: Reached MAX_MAPS (%i) for UI display, not all maps are displayed.\n", MAX_MAPS));
+		uiInfo.mapCount = MAX_MAPS - 1;
+	}
+
 	// sorting the maplist
 	qsort(uiInfo.mapList, uiInfo.mapCount, sizeof(uiInfo.mapList[0]), UI_SortArenas);
 }


### PR DESCRIPTION
Since `UI_LoadArenasFromFile` increases the mapcount before it checks for the limits, it will happily increase the count beyond `MAX_MAPS` limit. While this is sort of stupid by design, it's more convenient to cap it here so the warning about large amount of pk3 files can be displayed easily. This way the user also knows that they have too many maps.

Since this wasn't capped before, it caused potential out of bounds reads in several places, where looping was performed against `< uiInfo.mapCount` and then array access for arrays with the size of `MAX_MAPS` was performed with the iterator.

The buffer size of `8192` that is used to store arena files is unlikely to ever actually hold > 512 maps, I noticed this bug in ETJump initially since we have a bigger buffer, but smaller `MAX_MAPS` (500). The same setup that caused an oob read for me on ETJump actually only held ~430 maps in legacy.