### PR TITLE
show actual filename in warning when platforms.manifest is not found

### DIFF
--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -5707,7 +5707,7 @@ void G_ParsePlatformManifest(void)
 	len = trap_FS_FOpenFile("platforms.manifest", &fileHandle, FS_READ);
 	if (len <= 0)
 	{
-		G_Printf(S_COLOR_RED "[G_OSS] platforms.manifest file found\n");
+		G_Printf(S_COLOR_RED "[G_OSS] platforms.manifest file not found\n");
 		trap_FS_FCloseFile(fileHandle);
 		return;
 	}

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -5707,7 +5707,7 @@ void G_ParsePlatformManifest(void)
 	len = trap_FS_FOpenFile("platforms.manifest", &fileHandle, FS_READ);
 	if (len <= 0)
 	{
-		G_Printf(S_COLOR_RED "[G_OSS] no file found\n");
+		G_Printf(S_COLOR_RED "[G_OSS] platforms.manifest file found\n");
 		trap_FS_FCloseFile(fileHandle);
 		return;
 	}


### PR DESCRIPTION
This is a minor thing. It took me a while to figure out why was local server on arm64 being filtered in the server browser and how `g_oss` works. Might help someone else.