### PR TITLE
game: Prevent callvote when warmup/game is about to end

### DIFF
--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -3191,6 +3191,11 @@ qboolean Cmd_CallVote_f(gentity_t *ent, unsigned int dwCommand, int fRefCommand)
 				CP("cp \"You cannot call a vote as a spectator.\"");
 				return qfalse;
 			}
+			else if (g_gamestate.integer == GS_WARMUP_COUNTDOWN && (level.warmupTime - level.time) < VOTE_TIME)
+			{
+				CP("cp \"You cannot call a vote when warmup is about to end.\"");
+				return qfalse;
+			}
 		}
 	}
 
@@ -3273,12 +3278,9 @@ qboolean Cmd_CallVote_f(gentity_t *ent, unsigned int dwCommand, int fRefCommand)
 		G_globalSoundEnum(GAMESOUND_MISC_VOTE);
 	}
 
-	// shorter the vote timeout when warmup countdown or map time are going to end
-	if (g_gamestate.integer == GS_WARMUP_COUNTDOWN && (level.warmupTime - level.time) < VOTE_TIME)
-	{
-		level.voteInfo.voteTime = level.warmupTime - VOTE_TIME;
-	}
-	else if (g_gamestate.integer == GS_PLAYING && (level.startTime + (g_timelimit.value * 60000) - level.time < VOTE_TIME))
+	// shorter the vote timeout when map time is going to end
+	// (e.g. surrendering a match in stopwatch)
+	if (g_gamestate.integer == GS_PLAYING && (level.startTime + (g_timelimit.value * 60000) - level.time < VOTE_TIME))
 	{
 		level.voteInfo.voteTime = level.startTime + (g_timelimit.value * 60000) - VOTE_TIME;
 	}


### PR DESCRIPTION
Currently callvote'ing during warmup shortens the vote time (e.g. if callvote happens with 10s of warmup remaining, instead of 30s vote time it will be reduced to 10s as well), this often leads to failed callvotes, as there's not enough time for participation as players are often AFK, especially during warmup, or simply don't have enough time to notice and react.

A common observation on pub servers with 30+ players is that once the initial vote (e.g. shuffleteams) fails during warmup due to missing participation and then the vote is called again at the start of the game right after, enough people switch their voting behavior from 'yes' to 'no', presumably as the erroneously assume that the first vote failed not due to lack of participation but due to lack of approval, that the second vote consequently fails, even tho the first vote looked likely to succeed.

Preventing callvotes when warmup is about to end was already the behavior in dc4828e6ef16bb1249775c34c6f09dfaa9f266e6 and then was changed to reducing the votetime instead in
bacade7892a1a2c1563c6897897e2854e17b6a6e.