### PR TITLE
game: snap bullet impact ent number to max uint8

### DIFF
--- a/src/game/g_weapon.c
+++ b/src/game/g_weapon.c
@@ -3572,7 +3572,11 @@ void Bullet_Fire_Extended(gentity_t *source, gentity_t *attacker, vec3_t start, 
 
 	// send bullet impact
 	tent                   = G_TempEntity(impactPos, EV_BULLET);
-	tent->s.eventParm      = traceEnt->s.number;
+	if (traceEnt->s.number > 255) {  // snap to max uint8_t (wire size)
+		tent->s.eventParm  = 255;
+	} else {
+		tent->s.eventParm  = traceEnt->s.number;
+	}
 	tent->s.weapon         = GetMODTableData(mod)->weaponIcon;
 	tent->s.otherEntityNum = attacker->s.number;
 	tent->s.modelindex     = hitType;   // send the hit sound info in the flesh hit event


### PR DESCRIPTION
`eventParm` is transmitted as 8-bit integer over the wire, so to sidestep an overflow that can cause bullet impacts to wrongly appear as flesh (as the assumption is that bullet impacts on entites with number 1..MAX_CLIENTS hit player bodies) we always snap to 255 (max uint8 value)

fixes https://github.com/etlegacy/etlegacy/issues/2571