### PR TITLE
game: split EV_BULLET event again

### DIFF
--- a/src/cgame/cg_event.c
+++ b/src/cgame/cg_event.c
@@ -2457,10 +2457,15 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 		trap_S_StartSoundVControl(NULL, es->number, CHAN_AUTO, cgs.media.shoveSound, 255);
 		//}
 		break;
-	case EV_BULLET:
-		CG_PlayHitSound(es->otherEntityNum, es->modelindex);
-		CG_Bullet(es->weapon, es->pos.trBase, es->otherEntityNum, es->modelindex, es->eventParm);
-		break;
+    case EV_BULLET_HIT_WALL:
+    case EV_MG42BULLET_HIT_WALL:
+		CG_Bullet(es->weapon, es->pos.trBase, es->otherEntityNum, qfalse, 0);
+    	break;
+    case EV_BULLET_HIT_FLESH:
+    case EV_MG42BULLET_HIT_FLESH:
+    	CG_PlayHitSound(es->otherEntityNum, es->modelindex);
+		CG_Bullet(es->weapon, es->pos.trBase, es->otherEntityNum, qtrue, es->eventParm);
+    	break;
 	case EV_GENERAL_SOUND:
 	{
 		sfxHandle_t sound = CG_GetGameSound(es->eventParm);

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -3257,7 +3257,7 @@ void CG_MortarEFX(centity_t *cent);
 
 void CG_MissileHitPlayer(int entityNum, int weapon, vec3_t origin, vec3_t dir, int fleshEntityNum);
 qboolean CG_CalcMuzzlePoint(int entityNum, vec3_t muzzle);
-void CG_Bullet(int weapon, vec3_t end, int sourceEntityNum, qboolean isHeadShot, int fleshEntityNum);
+void CG_Bullet(int weapon, vec3_t end, int sourceEntityNum, qboolean isFlesh, int fleshEntityNum);
 
 void CG_RailTrail(vec3_t color, vec3_t start, vec3_t end, int type, int index);
 void CG_RailTrail2(vec3_t color, vec3_t start, vec3_t end, int index, int sideNum);

--- a/src/cgame/cg_weapons.c
+++ b/src/cgame/cg_weapons.c
@@ -6978,20 +6978,17 @@ void CG_DrawBulletTracer(vec3_t pstart, vec3_t pend, int sourceEntityNum)
 
 /**
  * @brief Renders bullet effects.
+ * @param[in] weapon
  * @param[in] end
  * @param[in] sourceEntityNum
- * @param[in] flesh
+ * @param[in] isFlesh
  * @param[in] fleshEntityNum
- * @param[in] otherEntNum2
- * @param[in] waterfraction
- * @param[in] seed
  */
-void CG_Bullet(int weapon, vec3_t end, int sourceEntityNum, qboolean isHeadShot, int fleshEntityNum)
+void CG_Bullet(int weapon, vec3_t end, int sourceEntityNum, qboolean isFlesh, int fleshEntityNum)
 {
 	trace_t  trace, trace2;
 	vec3_t   dir;
 	vec3_t   start = { 0, 0, 0 };
-	qboolean flesh = ISVALIDCLIENTNUM(fleshEntityNum);
 
 	if (sourceEntityNum < 0 || sourceEntityNum >= MAX_GENTITIES)
 	{
@@ -7048,7 +7045,7 @@ void CG_Bullet(int weapon, vec3_t end, int sourceEntityNum, qboolean isHeadShot,
 				CG_RailTrail(color, start, end, 0, 0);
 #endif
 				// if not flesh, then do a moving tracer
-				if (flesh)
+				if (isFlesh)
 				{
 					// draw a tracer
 					if (random() < cg_tracerChance.value)
@@ -7068,7 +7065,7 @@ void CG_Bullet(int weapon, vec3_t end, int sourceEntityNum, qboolean isHeadShot,
 	VectorNormalizeFast(dir);
 
 	// impact splash and mark
-	if (flesh)
+	if (isFlesh)
 	{
 		// play the bullet hit flesh sound
 		CG_MissileHitWall(weapon, PS_FX_FLESH, end, dir, 0, fleshEntityNum);

--- a/src/game/bg_misc.c
+++ b/src/game/bg_misc.c
@@ -3504,8 +3504,8 @@ const char *eventnames[EV_MAX_EVENTS] =
 	"EV_GLOBAL_CLIENT_SOUND",
 	"EV_GLOBAL_TEAM_SOUND",
 	"EV_FX_SOUND",
-	"unused event",              // EV_BULLET_HIT_FLESH
-	"unused event",              // EV_BULLET_HIT_WALL
+	"EV_BULLET_HIT_FLESH",
+	"EV_BULLET_HIT_WALL",
 	"EV_MISSILE_HIT",
 	"EV_MISSILE_MISS",
 	"EV_RAILTRAIL",
@@ -3564,8 +3564,8 @@ const char *eventnames[EV_MAX_EVENTS] =
 	"unused event",              // EV_POPUP,
 	"unused event",              // EV_POPUPBOOK,
 	"unused event",              // EV_GIVEPAGE,
-	"unused event",              // EV_MG42BULLET_HIT_FLESH
-	"unused event",              // EV_MG42BULLET_HIT_WALL
+	"EV_MG42BULLET_HIT_FLESH",
+	"EV_MG42BULLET_HIT_WALL",
 	"EV_SHAKE",
 	"EV_DISGUISE_SOUND",
 	"EV_BUILDDECAYED_SOUND",

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -1423,9 +1423,9 @@ typedef enum
 	EV_GLOBAL_CLIENT_SOUND,///< no attenuation, only plays for specified client
 	EV_GLOBAL_TEAM_SOUND,  ///< no attenuation, team only
 	EV_FX_SOUND,
-	//EV_BULLET_HIT_FLESH,
-	//EV_BULLET_HIT_WALL,
-	EV_MISSILE_HIT = 58,
+	EV_BULLET_HIT_FLESH,
+	EV_BULLET_HIT_WALL,
+	EV_MISSILE_HIT,
 	EV_MISSILE_MISS,
 	EV_RAILTRAIL,
 	EV_BULLET,             ///< otherEntity is the shooter
@@ -1483,9 +1483,9 @@ typedef enum
 	//EV_POPUP,
 	//EV_POPUPBOOK,
 	//EV_GIVEPAGE,
-	//EV_MG42BULLET_HIT_FLESH, ///< these two send the seed as well
-	//EV_MG42BULLET_HIT_WALL,
-	EV_SHAKE = 118,
+	EV_MG42BULLET_HIT_FLESH = 116,  ///< = identical to 'EV_BULLET_HIT_FLESH', but also sends 'seed' in 2.60b
+	EV_MG42BULLET_HIT_WALL,         ///< = identical to 'EV_BULLET_HIT_WALL',  but also sends 'seed' in 2.60b
+	EV_SHAKE,
 	EV_DISGUISE_SOUND,
 	EV_BUILDDECAYED_SOUND,
 	EV_FIRE_WEAPON_AAGUN,

--- a/src/game/g_weapon.c
+++ b/src/game/g_weapon.c
@@ -3517,18 +3517,6 @@ void Bullet_Fire_Extended(gentity_t *source, gentity_t *attacker, vec3_t start, 
 		}
 	*/
 
-	// TODO: we don't reflect bullet, for now
-	/* bullet impact should reflect off surface
-		vec3_t reflect;
-		float  dot;
-
-	dot = DotProduct(forward, tr.plane.normal);
-	VectorMA(forward, -2 * dot, tr.plane.normal, reflect);
-	VectorNormalize(reflect);
-
-	tent->s.eventParm = DirToByte(reflect);
-	*/
-
 	if ((g_debugBullets.integer >= 2 && traceEnt->takedamage && traceEnt->client)   // show hit player
 	    || g_debugBullets.integer <= -2)        // show hit thing bb
 	{
@@ -3570,12 +3558,34 @@ void Bullet_Fire_Extended(gentity_t *source, gentity_t *attacker, vec3_t start, 
 		}
 	}
 
+
 	// send bullet impact
-	tent                   = G_TempEntity(impactPos, EV_BULLET);
-	tent->s.eventParm      = traceEnt->s.number;
+	if (traceEnt->takedamage && hitType != HIT_NONE)  // hit player
+	{
+		tent			   = G_TempEntity(impactPos, EV_BULLET_HIT_FLESH);
+		tent->s.eventParm  = traceEnt->s.number;
+		tent->s.modelindex = hitType;  // send the hit sound info in the flesh hit event
+	} else {  // otherwise, i.e. hit wall/surface or nothing/sky
+		tent = G_TempEntity(impactPos, EV_BULLET_HIT_WALL);
+	}
+
+	if (traceEnt->takedamage && hitType == HIT_NONE)  // hit wall/surface
+	{
+		// TODO: we don't reflect bullet, for now
+		/* bullet impact should reflect off surface
+			vec3_t reflect;
+			float  dot;
+
+		dot = DotProduct(forward, tr.plane.normal);
+		VectorMA(forward, -2 * dot, tr.plane.normal, reflect);
+		VectorNormalize(reflect);
+
+		tent->s.eventParm = DirToByte(reflect);
+		*/
+	}
+
 	tent->s.weapon         = GetMODTableData(mod)->weaponIcon;
 	tent->s.otherEntityNum = attacker->s.number;
-	tent->s.modelindex     = hitType;   // send the hit sound info in the flesh hit event
 
 	/*return hitClient;*/
 }


### PR DESCRIPTION
The commit d8bba8e5f43551612df3707f47115376bc1c905d tried to unify the 2 separate EV_BULLET_HIT_WALL/EV_BULLET_HIT_FLESH events into just EV_BULLET.

This however caused bugs on the client due to an overflow of the `eventParm` field, which was attempted to be repurposed to separate between wall/flesh events.
(https://github.com/etlegacy/etlegacy/issues/2571)

This commit leaves the majority of code refactoring from d8bba8e5f43551612df3707f47115376bc1c905d and splits EV_BULLET into EV_BULLET_HIT_WALL and EV_BULLET_HIT_FLESH again.

fixes https://github.com/etlegacy/etlegacy/issues/2571