### PR TITLE
game: Fix erroneous error handling in g_lua.c

### DIFF
--- a/src/game/g_lua.c
+++ b/src/game/g_lua.c
@@ -879,12 +879,14 @@ static int _et_GetCurrentWeapon(lua_State *L)
 	if (clientNum < 0 || clientNum >= MAX_CLIENTS)
 	{
 		luaL_error(L, "\"clientNum\" is out of bounds: %d", clientNum);
+		return 0;
 	}
 
 	ent = g_entities + clientNum;
 	if (!ent->client)
 	{
 		luaL_error(L, "\"clientNum\" \"%d\" is not a client entity", clientNum);
+		return 0;
 	}
 
 	client   = ent->client;


### PR DESCRIPTION
Without returning at least in the second branch `ent->client` could be NULL which could cause a NULL dereference in the `ammo =` assignment.