### PR TITLE
cmake: Remove superfluous '-s' CFLAGS

### DIFF
--- a/cmake/ETLPlatform.cmake
+++ b/cmake/ETLPlatform.cmake
@@ -32,7 +32,6 @@ if(UNIX)
 	# optimization/debug flags
 	set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -ffast-math")
 	if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-		set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -s")
 		set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -ggdb")
 	elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__extern_always_inline=inline")


### PR DESCRIPTION
Resolves the clang warning:
    warning: argument unused during compilation: '-s' [clang-diagnostic-unused-command-line-argument]