### PR TITLE
ui: Allow disconnecting/exiting via 'Enter'

### DIFF
--- a/etmain/ui/credits_quit.menu
+++ b/etmain/ui/credits_quit.menu
@@ -20,6 +20,9 @@ menuDef {
 		uiScript Quit
 	}
 
+	onEnter {
+		uiScript Quit
+	}
 
 // Window //
 	itemDef {

--- a/etmain/ui/ingame_disconnect.menu
+++ b/etmain/ui/ingame_disconnect.menu
@@ -25,6 +25,12 @@ menuDef {
 		fadein background
 	}
 
+	onEnter {
+		close ingame_disconnect ;
+		close main ;
+		uiScript leave
+	}
+
 	onESC {
 		close ingame_disconnect ;
 		open ingame_main

--- a/etmain/ui/quit.menu
+++ b/etmain/ui/quit.menu
@@ -34,6 +34,16 @@ menuDef {
 #endif // FUI
 	}
 
+	onEnter {
+		close quit ;
+#ifdef FUI
+		close main
+#else
+		close ingame_main
+#endif // FUI
+		open credits_quit
+	}
+
 // Background //
 	itemDef {
 		name		"background"


### PR DESCRIPTION
'Escape' always worked to go back, however 'Enter' so far did nothing to confirm disconnnect/exit dialogues, or progress down the 'credits_quit' screen.