### PR TITLE
UI accelerators

### DIFF
--- a/etmain/ui/credits_etlegacy.menu
+++ b/etmain/ui/credits_etlegacy.menu
@@ -239,9 +239,9 @@ menuDef {
 
 // Buttons //
 #ifdef FUI
-	BUTTON( 6, WINDOW_HEIGHT - 24, .33 * (WINDOW_WIDTH - 24), 18, _("BACK"), .3, 14, close credits_etlegacy ; open main )
+	BUTTON( 6, WINDOW_HEIGHT - 24, .33 * (WINDOW_WIDTH - 24), 18, _("^_BACK"), .3, 14, close credits_etlegacy ; open main )
 #else
-	BUTTON( 6, WINDOW_HEIGHT - 24, .33 * (WINDOW_WIDTH - 24), 18, _("BACK"), .3, 14, close credits_etlegacy ; open ingame_main )
+	BUTTON( 6, WINDOW_HEIGHT - 24, .33 * (WINDOW_WIDTH - 24), 18, _("^_BACK"), .3, 14, close credits_etlegacy ; open ingame_main )
 #endif
 	BUTTON( 6 + .33 * (WINDOW_WIDTH - 24) + 6, WINDOW_HEIGHT - 24, .34 * (WINDOW_WIDTH - 24), 18, _("HALL OF FAME"), .3, 14, clearFocus ; open etlegacy_halloffame )
 	BUTTON( 6 + .33 * (WINDOW_WIDTH - 24) + 6 + .34 * (WINDOW_WIDTH - 24) + 6, WINDOW_HEIGHT - 24, .33 * (WINDOW_WIDTH - 24), 18, "SPLASH DAMAGE", .3, 14, close credits_etlegacy ; open credits_splashdamage )

--- a/etmain/ui/credits_splashdamage.menu
+++ b/etmain/ui/credits_splashdamage.menu
@@ -187,9 +187,9 @@ menuDef {
 
 // Buttons //
 #ifdef FUI
-	BUTTON( 6, WINDOW_HEIGHT - 24, .33 * (WINDOW_WIDTH - 24), 18, _("BACK"), .3, 14, close credits_splashdamage ; open main )
+	BUTTON( 6, WINDOW_HEIGHT - 24, .33 * (WINDOW_WIDTH - 24), 18, _("^_BACK"), .3, 14, close credits_splashdamage ; open main )
 #else
-	BUTTON( 6, WINDOW_HEIGHT - 24, .33 * (WINDOW_WIDTH - 24), 18, _("BACK"), .3, 14, close credits_splashdamage ; open ingame_main )
+	BUTTON( 6, WINDOW_HEIGHT - 24, .33 * (WINDOW_WIDTH - 24), 18, _("^_BACK"), .3, 14, close credits_splashdamage ; open ingame_main )
 #endif
 	BUTTON( 6 + .33 * (WINDOW_WIDTH - 24) + 6, WINDOW_HEIGHT - 24, .34 * (WINDOW_WIDTH - 24), 18, "ET LEGACY", .3, 14, close credits_splashdamage ; open credits_etlegacy )
 	BUTTON( 6 + .33 * (WINDOW_WIDTH - 24) + 6 + .34 * (WINDOW_WIDTH - 24) + 6, WINDOW_HEIGHT - 24, .33 * (WINDOW_WIDTH - 24), 18, "ID SOFTWARE", .3, 14, close credits_splashdamage ; open credits_idsoftware )

--- a/etmain/ui/hostgame.menu
+++ b/etmain/ui/hostgame.menu
@@ -191,9 +191,9 @@ menuDef {
     }
 
 // Buttons //
-	BUTTON( 6, WINDOW_HEIGHT-24, .33*(WINDOW_WIDTH-24), 18, _("BACK"), .3, 14, close hostgame ; open main )
-	BUTTON( 6+.33*(WINDOW_WIDTH-24)+6, WINDOW_HEIGHT-24, .34*(WINDOW_WIDTH-24), 18, _("ADVANCED"), .3, 14, close hostgame ; open hostgame_advanced )
-	BUTTON( 6+.33*(WINDOW_WIDTH-24)+6+.34*(WINDOW_WIDTH-24)+6, WINDOW_HEIGHT-24, .33*(WINDOW_WIDTH-24), 18, _("START SERVER"), .3, 14,
+	BUTTON( 6, WINDOW_HEIGHT-24, .33*(WINDOW_WIDTH-24), 18, _("^_BACK"), .3, 14, close hostgame ; open main )
+	BUTTON( 6+.33*(WINDOW_WIDTH-24)+6, WINDOW_HEIGHT-24, .34*(WINDOW_WIDTH-24), 18, _("^_ADVANCED"), .3, 14, close hostgame ; open hostgame_advanced )
+	BUTTON( 6+.33*(WINDOW_WIDTH-24)+6+.34*(WINDOW_WIDTH-24)+6, WINDOW_HEIGHT-24, .33*(WINDOW_WIDTH-24), 18, _("^_START SERVER"), .3, 14,
 		conditionalScript ui_dedicated 0
 		( "open hostgame_dedicated_warning" )
 		( "uiScript StartServer" ) )

--- a/etmain/ui/ingame_disconnect.menu
+++ b/etmain/ui/ingame_disconnect.menu
@@ -57,6 +57,6 @@ menuDef {
 	LABEL( SUBWINDOW_X+2, SUBWINDOW_Y+16, (SUBWINDOW_WIDTH)-4, 10, _("Do you want to disconnect"), .2, ITEM_ALIGN_CENTER, .5*((SUBWINDOW_WIDTH)-4), 8 )
 	LABEL( SUBWINDOW_X+2, SUBWINDOW_Y+28, (SUBWINDOW_WIDTH)-4, 10, _("from the server?"), .2, ITEM_ALIGN_CENTER, .5*((SUBWINDOW_WIDTH)-4), 8 )
 
-	BUTTON( SUBWINDOW_X+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .5*(SUBWINDOW_WIDTH-18), 18, _("YES"), .3, 14, close ingame_disconnect ; close main ; uiScript leave )
-	BUTTON( SUBWINDOW_X+6+.5*(SUBWINDOW_WIDTH-18)+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .5*(SUBWINDOW_WIDTH-18), 18, _("NO"), .3, 14, close ingame_disconnect ; open ingame_main )
+	BUTTON( SUBWINDOW_X+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .5*(SUBWINDOW_WIDTH-18), 18, _("^_YES"), .3, 14, close ingame_disconnect ; close main ; uiScript leave )
+	BUTTON( SUBWINDOW_X+6+.5*(SUBWINDOW_WIDTH-18)+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .5*(SUBWINDOW_WIDTH-18), 18, _("^_NO"), .3, 14, close ingame_disconnect ; open ingame_main )
 }

--- a/etmain/ui/ingame_main.menu
+++ b/etmain/ui/ingame_main.menu
@@ -35,23 +35,23 @@ menuDef {
 
 // Buttons //
 // FIXME: tooltips with BUTTONEXT don't work when conditionalScript or cvartest is used?! ...
-	BUTTONEXT( 6, 32, WINDOW_WIDTH-12, 18, _("LIMBO MENU"), .3, 14, exec "openlimbomenu" ; close ingame_main, tooltip _("Select your team, class, weapon and spawnpoint") )
-	BUTTONEXT( 6, 56, WINDOW_WIDTH-12, 18, _("VOTE"), .3, 14, uiScript clientCheckVote ;
+	BUTTONEXT( 6, 32, WINDOW_WIDTH-12, 18, _("^_LIMBO MENU"), .3, 14, exec "openlimbomenu" ; close ingame_main, tooltip _("Select your team, class, weapon and spawnpoint") )
+	BUTTONEXT( 6, 56, WINDOW_WIDTH-12, 18, _("^_VOTE"), .3, 14, uiScript clientCheckVote ;
 		conditionalScript cg_ui_novote 0
 		( "clearFocus ; open ingame_votedisabled" )
 		( "close ingame_main ; open ingame_vote" ),
 		cvarTest "authLevel" showCVar { RL_NONE } )
-	BUTTONEXT( 6, 56, WINDOW_WIDTH-12, 18, _("REFEREE"), .3, 14, close ingame_main ; open ingame_vote, cvarTest "authLevel" showCVar { RL_REFEREE } )
-	BUTTONEXT( 6, 56, WINDOW_WIDTH-12, 18, _("RCON"), .3, 14, close ingame_main ; open ingame_vote, cvarTest "authLevel" showCVar { RL_RCON } )
-	BUTTONEXT( 6, 80, WINDOW_WIDTH-12, 18, _("SERVER INFO"), .3, 14, clearFocus ; open ingame_serverinfo, tooltip _("Print all server info") )
-	BUTTONEXT( 6, 104, WINDOW_WIDTH-12, 18, _("OPTIONS"), .3, 14, close ingame_main ; open options, tooltip _("Set available game options") )
-	BUTTONEXT( 6, 128, WINDOW_WIDTH-12, 18, _("FAVORITE"), .3, 14, uiScript clientCheckFavorite ;
+	BUTTONEXT( 6, 56, WINDOW_WIDTH-12, 18, _("^_REFEREE"), .3, 14, close ingame_main ; open ingame_vote, cvarTest "authLevel" showCVar { RL_REFEREE } )
+	BUTTONEXT( 6, 56, WINDOW_WIDTH-12, 18, _("RCO^_N"), .3, 14, close ingame_main ; open ingame_vote, cvarTest "authLevel" showCVar { RL_RCON } )
+	BUTTONEXT( 6, 80, WINDOW_WIDTH-12, 18, _("^_SERVER INFO"), .3, 14, clearFocus ; open ingame_serverinfo, tooltip _("Print all server info") )
+	BUTTONEXT( 6, 104, WINDOW_WIDTH-12, 18, _("^_OPTIONS"), .3, 14, close ingame_main ; open options, tooltip _("Set available game options") )
+	BUTTONEXT( 6, 128, WINDOW_WIDTH-12, 18, _("^_FAVORITE"), .3, 14, uiScript clientCheckFavorite ;
 		conditionalScript cg_ui_favorite 0
 		( "open popupRemoveFavorite" )
         ( "open popupAddFavorite" ), tooltip _("Set or unset this server as favorite") )
-	BUTTONEXT( 6, 152, WINDOW_WIDTH-12, 18, _("CREDITS"), .3, 14, close ingame_main ; open credits_etlegacy, tooltip _("Look at the legacy hall of fame") )
-	BUTTONEXT( 6, 176, WINDOW_WIDTH-12, 18, _("DISCONNECT"), .3, 14, clearFocus ; open ingame_disconnect, tooltip _("Disconnect your connection from current server") )
-	BUTTONEXT( 6, 200, WINDOW_WIDTH-12, 18, _("EXIT"), .3, 14, clearFocus ; open quit, tooltip _("Don't press this. Be warned!") )
+	BUTTONEXT( 6, 152, WINDOW_WIDTH-12, 18, _("^_CREDITS"), .3, 14, close ingame_main ; open credits_etlegacy, tooltip _("Look at the legacy hall of fame") )
+	BUTTONEXT( 6, 176, WINDOW_WIDTH-12, 18, _("^_DISCONNECT"), .3, 14, clearFocus ; open ingame_disconnect, tooltip _("Disconnect your connection from current server") )
+	BUTTONEXT( 6, 200, WINDOW_WIDTH-12, 18, _("E^_XIT"), .3, 14, clearFocus ; open quit, tooltip _("Don't press this. Be warned!") )
 #ifdef OLD_CLIENT
 	BUTTONEXT( 6, 224, WINDOW_WIDTH-12, 18, _("^1UPGRADE NOW"), .3, 14, clearFocus ; uiScript validate_openURL "https://www.etlegacy.com", tooltip _("Upgrade!") )
 #endif

--- a/etmain/ui/ingame_serverinfo.menu
+++ b/etmain/ui/ingame_serverinfo.menu
@@ -73,9 +73,9 @@ menuDef {
 		notselectable
 	}
 
-	BUTTON( (SUBWINDOW_X)+6, (SUBWINDOW_Y)+(SUBWINDOW_HEIGHT)-24, .25*((SUBWINDOW_WIDTH)-24), 18, _("BACK"), .3, 14, close ingame_serverinfo ; open ingame_main )
-	BUTTON( (SUBWINDOW_X)+6+.25*((SUBWINDOW_WIDTH)-24)+6, (SUBWINDOW_Y)+(SUBWINDOW_HEIGHT)-24, .25*((SUBWINDOW_WIDTH)-24), 18, _("REFRESH"), .3, 14, uiScript ServerStatus )
-	BUTTON( (SUBWINDOW_X)+6+.25*((SUBWINDOW_WIDTH)-24)+6+.25*((SUBWINDOW_WIDTH)-24)+6, (SUBWINDOW_Y)+(SUBWINDOW_HEIGHT)-24, .5*((SUBWINDOW_WIDTH)-24), 18, _("FAVORITE"), .3, 14, clearFocus ; close ingame_serverinfo ; uiScript clientCheckFavorite ;
+	BUTTON( (SUBWINDOW_X)+6, (SUBWINDOW_Y)+(SUBWINDOW_HEIGHT)-24, .25*((SUBWINDOW_WIDTH)-24), 18, _("^_BACK"), .3, 14, close ingame_serverinfo ; open ingame_main )
+	BUTTON( (SUBWINDOW_X)+6+.25*((SUBWINDOW_WIDTH)-24)+6, (SUBWINDOW_Y)+(SUBWINDOW_HEIGHT)-24, .25*((SUBWINDOW_WIDTH)-24), 18, _("^_REFRESH"), .3, 14, uiScript ServerStatus )
+	BUTTON( (SUBWINDOW_X)+6+.25*((SUBWINDOW_WIDTH)-24)+6+.25*((SUBWINDOW_WIDTH)-24)+6, (SUBWINDOW_Y)+(SUBWINDOW_HEIGHT)-24, .5*((SUBWINDOW_WIDTH)-24), 18, _("^_FAVORITE"), .3, 14, clearFocus ; close ingame_serverinfo ; uiScript clientCheckFavorite ;
 		conditionalScript cg_ui_favorite 0
         ( "open popupRemoveFavorite" )
 		( "open popupAddFavorite" ) )

--- a/etmain/ui/ingame_vote.menu
+++ b/etmain/ui/ingame_vote.menu
@@ -83,12 +83,12 @@ menuDef {
 	}
 
 // Buttons //
-	BUTTONEXT( 6, 32, WINDOW_WIDTH-12, 18, _("MISC"), .3, 14, close ingame_vote ; open ingame_vote_misc, cvarTest "authLevel" showCVar { RL_NONE } )
-	BUTTONEXT( 6, 32, WINDOW_WIDTH-12, 18, _("MISC"), .3, 14, close ingame_vote ; open ingame_vote_misc_refrcon, cvarTest "authLevel" showCVar { RL_REFEREE RL_RCON } )
-	BUTTONEXT( 6, 56, WINDOW_WIDTH-12, 18, _("MAPS"), .3, 14, close ingame_vote ; open ingame_vote_map, cvarTest "authLevel" showCVar { RL_NONE } voteflag CV_SVF_MAP )
-	BUTTONEXT( 6, 56, WINDOW_WIDTH-12, 18, _("MAPS"), .3, 14, close ingame_vote ; open ingame_vote_map, cvarTest "authLevel" showCVar { RL_REFEREE RL_RCON } )
-	BUTTONEXT( 6, 80, WINDOW_WIDTH-12, 18, _("PLAYERS"), .3, 14, close ingame_vote ; open ingame_vote_players, cvarTest "authLevel" showCVar { RL_NONE } voteFlag $evalint(CV_SVF_KICK + CV_SVF_REFEREE + CV_SVF_MUTING) )
-	BUTTONEXT( 6, 80, WINDOW_WIDTH-12, 18, _("PLAYERS"), .3, 14, close ingame_vote ; open ingame_vote_players, cvarTest "authLevel" showCVar { RL_REFEREE RL_RCON } )
-	BUTTONEXT( 6, 104, WINDOW_WIDTH-12, 18, _("BOTS"), .3, 14, close ingame_vote ; open ingame_vote_bot, cvarTest "authLevel" showCVar { RL_REFEREE } )
-	BUTTON( 6, 128, WINDOW_WIDTH-12, 18, _("BACK"), .3, 14, close ingame_vote ; open ingame_main )
+	BUTTONEXT( 6, 32, WINDOW_WIDTH-12, 18, _("^_MISC"), .3, 14, close ingame_vote ; open ingame_vote_misc, cvarTest "authLevel" showCVar { RL_NONE } )
+	BUTTONEXT( 6, 32, WINDOW_WIDTH-12, 18, _("^_MISC"), .3, 14, close ingame_vote ; open ingame_vote_misc_refrcon, cvarTest "authLevel" showCVar { RL_REFEREE RL_RCON } )
+	BUTTONEXT( 6, 56, WINDOW_WIDTH-12, 18, _("M^_APS"), .3, 14, close ingame_vote ; open ingame_vote_map, cvarTest "authLevel" showCVar { RL_NONE } voteflag CV_SVF_MAP )
+	BUTTONEXT( 6, 56, WINDOW_WIDTH-12, 18, _("M^_APS"), .3, 14, close ingame_vote ; open ingame_vote_map, cvarTest "authLevel" showCVar { RL_REFEREE RL_RCON } )
+	BUTTONEXT( 6, 80, WINDOW_WIDTH-12, 18, _("^_PLAYERS"), .3, 14, close ingame_vote ; open ingame_vote_players, cvarTest "authLevel" showCVar { RL_NONE } voteFlag $evalint(CV_SVF_KICK + CV_SVF_REFEREE + CV_SVF_MUTING) )
+	BUTTONEXT( 6, 80, WINDOW_WIDTH-12, 18, _("^_PLAYERS"), .3, 14, close ingame_vote ; open ingame_vote_players, cvarTest "authLevel" showCVar { RL_REFEREE RL_RCON } )
+	BUTTONEXT( 6, 104, WINDOW_WIDTH-12, 18, _("B^_OTS"), .3, 14, close ingame_vote ; open ingame_vote_bot, cvarTest "authLevel" showCVar { RL_REFEREE } )
+	BUTTON( 6, 128, WINDOW_WIDTH-12, 18, _("^_BACK"), .3, 14, close ingame_vote ; open ingame_main )
 }

--- a/etmain/ui/ingame_vote_bot.menu
+++ b/etmain/ui/ingame_vote_bot.menu
@@ -54,9 +54,9 @@ menuDef {
 
 	BUTTON( 6, 104, .33*(WINDOW_WIDTH-24), 14, _("AXIS BOTS"), .24, 11, exec "set g_teamForceBalance 0; bot balanceteams 0; bot botteam 1; bot humanteam 2; bot kickall" )
 	BUTTON( 6+.33*(WINDOW_WIDTH-24)+6, 104, .34*(WINDOW_WIDTH-24), 14, _("ALLIED BOTS"), .24, 11, exec "set g_teamForceBalance 0; bot balanceteams 0; bot botteam 2; bot humanteam 1; bot kickall" )
-	BUTTON( 6+.33*(WINDOW_WIDTH-24)+6+.34*(WINDOW_WIDTH-24)+6, 104, .33*(WINDOW_WIDTH-24), 14, _("BALANCED"), .24, 11, exec "set g_teamForceBalance 1; bot balanceteams 1; bot botteam -1" )	
+	BUTTON( 6+.33*(WINDOW_WIDTH-24)+6+.34*(WINDOW_WIDTH-24)+6, 104, .33*(WINDOW_WIDTH-24), 14, _("BALANCED"), .24, 11, exec "set g_teamForceBalance 1; bot balanceteams 1; bot botteam -1" )
 
 	BUTTON( 6, WINDOW_HEIGHT-24, .33*(WINDOW_WIDTH-24), 18, _("BOTS ON"), .3, 14, exec "set omnibot_enable 1" )
 	BUTTON( 6+.33*(WINDOW_WIDTH-24)+6, WINDOW_HEIGHT-24, .34*(WINDOW_WIDTH-24), 18, _("BOTS OFF"), .3, 14, exec "bot minbots -1; bot maxbots -1;bot kickall;set omnibot_enable 0" )
-	BUTTON( 6+.33*(WINDOW_WIDTH-24)+6+.34*(WINDOW_WIDTH-24)+6, WINDOW_HEIGHT-24, .33*(WINDOW_WIDTH-24), 18, _("BACK"), .3, 14, close ingame_vote_bot ; open ingame_vote )	
+	BUTTON( 6+.33*(WINDOW_WIDTH-24)+6+.34*(WINDOW_WIDTH-24)+6, WINDOW_HEIGHT-24, .33*(WINDOW_WIDTH-24), 18, _("^_BACK"), .3, 14, close ingame_vote_bot ; open ingame_vote )
 }

--- a/etmain/ui/ingame_vote_map.menu
+++ b/etmain/ui/ingame_vote_map.menu
@@ -78,7 +78,7 @@ menuDef {
 	}
 
 // Buttons //
-	BUTTON( 6, WINDOW_HEIGHT-24, .5*(WINDOW_WIDTH-18), 18, _("BACK"), .3, 14, close ingame_vote_map ; open ingame_vote )
+	BUTTON( 6, WINDOW_HEIGHT-24, .5*(WINDOW_WIDTH-18), 18, _("^_BACK"), .3, 14, close ingame_vote_map ; open ingame_vote )
 	BUTTONEXT( 6+.5*(WINDOW_WIDTH-18)+6, WINDOW_HEIGHT-24, .5*(WINDOW_WIDTH-18), 18, _("OK"), .3, 14, uiScript voteMap ; uiScript closeingame, cvarTest "authLevel" showCVar { RL_NONE } )
 	BUTTONEXT( 6+.5*(WINDOW_WIDTH-18)+6, WINDOW_HEIGHT-24, .5*(WINDOW_WIDTH-18), 18, _("OK"), .3, 14, uiScript refMap ; uiScript closeingame, cvarTest "authLevel" showCVar { RL_REFEREE } )
 	BUTTONEXT( 6+.5*(WINDOW_WIDTH-18)+6, WINDOW_HEIGHT-24, .5*(WINDOW_WIDTH-18), 18, _("OK"), .3, 14, uiScript refMap ; uiScript closeingame, cvarTest "authLevel" showCVar { RL_RCON } )

--- a/etmain/ui/ingame_vote_misc.menu
+++ b/etmain/ui/ingame_vote_misc.menu
@@ -104,5 +104,5 @@ menuDef {
 	MULTILEFT( 8, 230+2, .66*(WINDOW_WIDTH-18), 10, _("Game Type:"), .2, 8, "ui_voteGameType", cvarFloatList { "Single-Map Objective" 2 "Stopwatch" 3 "Last Man Standing" 5 "Map Voting" 6 } voteflag CV_SVF_GAMETYPE, _("Select the game type to vote on") )
 	NAMEDBUTTONEXT( "bttnextGameType", 6+.80*(WINDOW_WIDTH-18)+6, 230, .20*(WINDOW_WIDTH-18), 14, _("OK"), .24, 11, uiScript voteGame; uiScript closeingame, voteflag CV_SVF_GAMETYPE )
 
-	BUTTON( 6, WINDOW_HEIGHT-24, WINDOW_WIDTH-12, 18, _("BACK"), .3, 14, close ingame_vote_misc ; open ingame_vote )
+	BUTTON( 6, WINDOW_HEIGHT-24, WINDOW_WIDTH-12, 18, _("^_BACK"), .3, 14, close ingame_vote_misc ; open ingame_vote )
 }

--- a/etmain/ui/ingame_vote_misc_refrcon.menu
+++ b/etmain/ui/ingame_vote_misc_refrcon.menu
@@ -112,5 +112,5 @@ menuDef {
 	BUTTONEXT( 6+.5*(WINDOW_WIDTH-18)+6, 266, .5*(WINDOW_WIDTH-18), 14, _("LOCK SPECS"), .24, 11, exec "cmd ref speclock" ; uiScript closeingame, settingDisabled CV_SVS_LOCKSPECS cvarTest "authLevel" showCVar { RL_REFEREE RL_RCON } )
 	BUTTONEXT( 6+.5*(WINDOW_WIDTH-18)+6, 266, .5*(WINDOW_WIDTH-18), 14, _("UNLOCK SPECS"), .24, 11, exec "cmd ref specunlock" ; uiScript closeingame, settingEnabled CV_SVS_LOCKSPECS cvarTest "authLevel" showCVar { RL_REFEREE RL_RCON } )
 
-	BUTTON( 6, WINDOW_HEIGHT-24, WINDOW_WIDTH-12, 18, _("BACK"), .3, 14, close ingame_vote_misc_refrcon ; open ingame_vote )
+	BUTTON( 6, WINDOW_HEIGHT-24, WINDOW_WIDTH-12, 18, _("^_BACK"), .3, 14, close ingame_vote_misc_refrcon ; open ingame_vote )
 }

--- a/etmain/ui/ingame_vote_players.menu
+++ b/etmain/ui/ingame_vote_players.menu
@@ -74,5 +74,5 @@ menuDef {
 	BUTTONEXT( 208, 158, WINDOW_WIDTH-208-6, 14, _("WARN"), .24, 11, open ingame_vote_players_warn, cvarTest "authLevel" showCVar { RL_REFEREE RL_RCON } )
 	BUTTONEXT( 208, 170, WINDOW_WIDTH-208-6, 14, _("BAN"), .24, 11, uiScript rconBan ; uiScript closeingame, cvarTest "authLevel" showCVar { RL_RCON } )
 
-	BUTTON( 6, WINDOW_HEIGHT-24, WINDOW_WIDTH-12, 18, _("BACK"), .3, 14, close ingame_vote_players ; open ingame_vote )
+	BUTTON( 6, WINDOW_HEIGHT-24, WINDOW_WIDTH-12, 18, _("^_BACK"), .3, 14, close ingame_vote_players ; open ingame_vote )
 }

--- a/etmain/ui/ingame_vote_players_warn.menu
+++ b/etmain/ui/ingame_vote_players_warn.menu
@@ -60,6 +60,6 @@ menuDef {
 	}
 	EDITFIELDLEFT( SUBWINDOW_X+4, SUBWINDOW_Y+16, (SUBWINDOW_WIDTH)-8, 10, _("Warning:"), .2, 8, "ui_warnreason", 128, 32, _("Warning message to send to a player") )
 
-	BUTTON( SUBWINDOW_X+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .5*(SUBWINDOW_WIDTH-18), 18, _("BACK"), .3, 14, close ingame_vote_players_warn ; open ingame_vote_players )
+	BUTTON( SUBWINDOW_X+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .5*(SUBWINDOW_WIDTH-18), 18, _("^_BACK"), .3, 14, close ingame_vote_players_warn ; open ingame_vote_players )
 	BUTTON( SUBWINDOW_X+6+.5*(SUBWINDOW_WIDTH-18)+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .5*(SUBWINDOW_WIDTH-18), 18, _("WARN"), .3, 14, uiScript refWarning ; uiScript closeingame )
 }

--- a/etmain/ui/main.menu
+++ b/etmain/ui/main.menu
@@ -102,16 +102,16 @@ menuDef {
 	CVARLABEL( 6+((MENU_WIDTH-12)/2), 18, MENU_WIDTH-12, 10, "cl_profile", .2, ITEM_ALIGN_CENTER, 0, 8 )
 
 // Buttons //
-	BUTTON( 6, 32, MENU_WIDTH-12, 18, _("PLAY"), .3, 14, close main ; /*close backgroundmusic ; open backgroundmusic_server ;*/ uiScript UpdateFilter ; uiScript ServerSort 2 ; open playonline )
+	BUTTON( 6, 32, MENU_WIDTH-12, 18, _("^_PLAY"), .3, 14, close main ; /*close backgroundmusic ; open backgroundmusic_server ;*/ uiScript UpdateFilter ; uiScript ServerSort 2 ; open playonline )
 #ifndef ANDROID
-	BUTTON( 6, 56, MENU_WIDTH-12, 18, _("HOST"), .3, 14, close main ; /*close backgroundmusic ; open backgroundmusic_server ;*/ uiScript loadArenas ; uiScript initHostGameFeatures ; open hostgame )
+	BUTTON( 6, 56, MENU_WIDTH-12, 18, _("^_HOST"), .3, 14, close main ; /*close backgroundmusic ; open backgroundmusic_server ;*/ uiScript loadArenas ; uiScript initHostGameFeatures ; open hostgame )
 #endif
-	BUTTON( 6, 80, MENU_WIDTH-12, 18, _("REPLAYS"), .3, 14, close main ; open viewreplay )
-	BUTTON( 6, 104, MENU_WIDTH-12, 18, _("OPTIONS"), .3, 14, close main ; open options )
-	BUTTON( 6, 128, MENU_WIDTH-12, 18, _("PROFILE"), .3, 14, close main ; open profile )
-	BUTTON( 6, 152, MENU_WIDTH-12, 18, _("MODS"), .3, 14, close main ; open mods )
-	BUTTON( 6, 176, MENU_WIDTH-12, 18, _("CREDITS"), .3, 14, close main ; open credits_etlegacy )
-	BUTTON( 6, 200, MENU_WIDTH-12, 18, _("EXIT"), .3, 14, clearFocus ; open quit )
+	BUTTON( 6, 80, MENU_WIDTH-12, 18, _("^_REPLAYS"), .3, 14, close main ; open viewreplay )
+	BUTTON( 6, 104, MENU_WIDTH-12, 18, _("^_OPTIONS"), .3, 14, close main ; open options )
+	BUTTON( 6, 128, MENU_WIDTH-12, 18, _("PRO^_FILE"), .3, 14, close main ; open profile )
+	BUTTON( 6, 152, MENU_WIDTH-12, 18, _("^_MODS"), .3, 14, close main ; open mods )
+	BUTTON( 6, 176, MENU_WIDTH-12, 18, _("CRE^_DITS"), .3, 14, close main ; open credits_etlegacy )
+	BUTTON( 6, 200, MENU_WIDTH-12, 18, _("E^_XIT"), .3, 14, clearFocus ; open quit )
 
 // Vanilla or old Legacy client warning //
 #ifdef OLD_CLIENT

--- a/etmain/ui/popup_addfavorite.menu
+++ b/etmain/ui/popup_addfavorite.menu
@@ -52,6 +52,6 @@ menuDef {
 	// note: this isn't set for listen servers
 	CVARLABEL( SUBWINDOW_X+2, SUBWINDOW_Y+34, (SUBWINDOW_WIDTH)-4, 10, "cl_currentServerIP", .2, ITEM_ALIGN_CENTER, .5*((SUBWINDOW_WIDTH)-4), 8 )
 
-	BUTTON( SUBWINDOW_X+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .5*(SUBWINDOW_WIDTH-18), 18, _("YES"), .3, 14, uiScript createFavoriteIngame ; close popupAddFavorite ; open ingame_main )
-	BUTTON( SUBWINDOW_X+6+.5*(SUBWINDOW_WIDTH-18)+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .5*(SUBWINDOW_WIDTH-18), 18, _("NO"), .3, 14, close popupAddFavorite ; open ingame_main )
+	BUTTON( SUBWINDOW_X+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .5*(SUBWINDOW_WIDTH-18), 18, _("^_YES"), .3, 14, uiScript createFavoriteIngame ; close popupAddFavorite ; open ingame_main )
+	BUTTON( SUBWINDOW_X+6+.5*(SUBWINDOW_WIDTH-18)+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .5*(SUBWINDOW_WIDTH-18), 18, _("^_NO"), .3, 14, close popupAddFavorite ; open ingame_main )
 }

--- a/etmain/ui/popup_errormessage.menu
+++ b/etmain/ui/popup_errormessage.menu
@@ -55,6 +55,6 @@ menuDef {
 
 	// FIXME: Add message we'll never support pb
 	// NAMEDBUTTON( "bttn_pbenable", SUBWINDOW_X+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-46, (SUBWINDOW_WIDTH-12), 18, "ENABLE PUNKBUSTER", .3, 14, clearFocus ; open playonline_enablepb )
-	BUTTON( SUBWINDOW_X+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .5*(SUBWINDOW_WIDTH-18), 18, _("BACK"), .3, 14, uiScript clearError ; close popupError_pbenable ; open main )
-	BUTTON( SUBWINDOW_X+6+.5*(SUBWINDOW_WIDTH-18)+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .5*(SUBWINDOW_WIDTH-18), 18, _("RECONNECT"), .3, 14, uiScript clearError ; close popupError_pbenable ; close backgroundmusic ; close background_1 ; uiScript reconnect )
+	BUTTON( SUBWINDOW_X+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .5*(SUBWINDOW_WIDTH-18), 18, _("^_BACK"), .3, 14, uiScript clearError ; close popupError_pbenable ; open main )
+	BUTTON( SUBWINDOW_X+6+.5*(SUBWINDOW_WIDTH-18)+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .5*(SUBWINDOW_WIDTH-18), 18, _("^_RECONNECT"), .3, 14, uiScript clearError ; close popupError_pbenable ; close backgroundmusic ; close background_1 ; uiScript reconnect )
 }

--- a/etmain/ui/popup_errormessage_pb.menu
+++ b/etmain/ui/popup_errormessage_pb.menu
@@ -53,6 +53,6 @@ menuDef {
 
 	CVARLABEL( SUBWINDOW_X+6, SUBWINDOW_Y+16, (SUBWINDOW_WIDTH)-12, 154, "com_errorMessage", .2, ITEM_ALIGN_LEFT, 0, 8 )
 
-	BUTTON( SUBWINDOW_X+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .5*(SUBWINDOW_WIDTH-18), 18, _("BACK"), .3, 14, uiScript clearError ; close popupError ; open main )
-	BUTTON( SUBWINDOW_X+6+.5*(SUBWINDOW_WIDTH-18)+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .5*(SUBWINDOW_WIDTH-18), 18, _("RECONNECT"), .3, 14, uiScript clearError ; close popupError ; close backgroundmusic ; close background_1 ; uiScript reconnect )
+	BUTTON( SUBWINDOW_X+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .5*(SUBWINDOW_WIDTH-18), 18, _("^_BACK"), .3, 14, uiScript clearError ; close popupError ; open main )
+	BUTTON( SUBWINDOW_X+6+.5*(SUBWINDOW_WIDTH-18)+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .5*(SUBWINDOW_WIDTH-18), 18, _("^_RECONNECT"), .3, 14, uiScript clearError ; close popupError ; close backgroundmusic ; close background_1 ; uiScript reconnect )
 }

--- a/etmain/ui/quit.menu
+++ b/etmain/ui/quit.menu
@@ -66,11 +66,11 @@ menuDef {
 	LABEL( SUBWINDOW_X+2, SUBWINDOW_Y+28, (SUBWINDOW_WIDTH)-4, 10, _("anything better to do!"), .2, ITEM_ALIGN_CENTER, .5*((SUBWINDOW_WIDTH)-4), 8 )
 
 #ifdef FUI
-	BUTTON( SUBWINDOW_X+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .5*(SUBWINDOW_WIDTH-18), 18, _("YES"), .3, 14, close quit ; close main ; open credits_quit )
-	BUTTON( SUBWINDOW_X+6+.5*(SUBWINDOW_WIDTH-18)+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .5*(SUBWINDOW_WIDTH-18), 18, _("NO"), .3, 14, close quit ; open main )
+	BUTTON( SUBWINDOW_X+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .5*(SUBWINDOW_WIDTH-18), 18, _("^_YES"), .3, 14, close quit ; close main ; open credits_quit )
+	BUTTON( SUBWINDOW_X+6+.5*(SUBWINDOW_WIDTH-18)+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .5*(SUBWINDOW_WIDTH-18), 18, _("^_NO"), .3, 14, close quit ; open main )
 #else
-	BUTTON( SUBWINDOW_X+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .5*(SUBWINDOW_WIDTH-18), 18, _("YES"), .3, 14, close quit ; close ingame_main ; open credits_quit )
-	BUTTON( SUBWINDOW_X+6+.5*(SUBWINDOW_WIDTH-18)+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .5*(SUBWINDOW_WIDTH-18), 18, _("NO"), .3, 14, close quit ; open ingame_main )
+	BUTTON( SUBWINDOW_X+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .5*(SUBWINDOW_WIDTH-18), 18, _("^_YES"), .3, 14, close quit ; close ingame_main ; open credits_quit )
+	BUTTON( SUBWINDOW_X+6+.5*(SUBWINDOW_WIDTH-18)+6, SUBWINDOW_Y+SUBWINDOW_HEIGHT-24, .5*(SUBWINDOW_WIDTH-18), 18, _("^_NO"), .3, 14, close quit ; open ingame_main )
 #endif // FUI
 
 }

--- a/etmain/ui/viewreplay.menu
+++ b/etmain/ui/viewreplay.menu
@@ -61,9 +61,9 @@ menuDef {
 	}
 
 	// Buttons //
-	BUTTON( 6, WINDOW_HEIGHT-24, .33*(WINDOW_WIDTH-24), 18, _("BACK"), .3, 14, close viewreplay ; open main )
-	BUTTON( 6+.33*(WINDOW_WIDTH-24)+6, WINDOW_HEIGHT-24, .34*(WINDOW_WIDTH-24), 18, _("DELETE"), .3, 14, conditionalScript ValidReplaySelected 2
+	BUTTON( 6, WINDOW_HEIGHT-24, .33*(WINDOW_WIDTH-24), 18, _("^_BACK"), .3, 14, close viewreplay ; open main )
+	BUTTON( 6+.33*(WINDOW_WIDTH-24)+6, WINDOW_HEIGHT-24, .34*(WINDOW_WIDTH-24), 18, _("^_DELETE"), .3, 14, conditionalScript ValidReplaySelected 2
 		( "clearFocus ; open viewreplay_delete" )
 		( "clearFocus" ) )
-	BUTTON( 6+.33*(WINDOW_WIDTH-24)+6+.34*(WINDOW_WIDTH-24)+6, WINDOW_HEIGHT-24, .33*(WINDOW_WIDTH-24), 18, _("VIEW"), .3, 14, uiScript RunDemo )
+	BUTTON( 6+.33*(WINDOW_WIDTH-24)+6+.34*(WINDOW_WIDTH-24)+6, WINDOW_HEIGHT-24, .33*(WINDOW_WIDTH-24), 18, _("^_VIEW"), .3, 14, uiScript RunDemo )
 }

--- a/src/qcommon/q_shared.h
+++ b/src/qcommon/q_shared.h
@@ -939,6 +939,28 @@ static ID_INLINE qboolean Q_IsColorString(const char *p)
 	return qtrue;
 }
 
+static ID_INLINE qboolean Q_IsAcceleratorString(const char *p)
+{
+	if (!p || p[0] != Q_COLOR_ESCAPE)
+	{
+		return qfalse;
+	}
+
+	if (p[1] != '_')
+	{
+		return qfalse;
+	}
+
+	// The char might an extended char or part of utf-8 so only check it if its
+	// valid
+	if (p[1] >= 0)
+	{
+		return (qboolean)isgraph(p[1]);
+	}
+
+	return qfalse;
+}
+
 /// removes color sequences from string
 char *Q_CleanStr(char *string);
 

--- a/src/ui/ui_main.c
+++ b/src/ui/ui_main.c
@@ -232,6 +232,7 @@ void _UI_DrawTopBottom(float x, float y, float w, float h, float size)
 
 /**
  * @brief UI_DrawRect
+ * Draw an unfilled rectangle.
  * Coordinates are 640*480 virtual values
  * @param[in] x
  * @param[in] y
@@ -575,9 +576,10 @@ void Text_Paint_Ext(float x, float y, float scalex, float scaley, vec4_t color, 
 
 	if (text)
 	{
-		const char *s    = text;
-		int        len   = Q_UTF8_Strlen(text);
-		int        count = 0;
+		const char *s             = text;
+		int        len            = Q_UTF8_Strlen(text);
+		int        count          = 0;
+		qboolean   is_accelerator = qfalse;
 
 		trap_R_SetColor(color);
 		Com_Memcpy(&newColor[0], &color[0], sizeof(vec4_t));
@@ -599,7 +601,14 @@ void Text_Paint_Ext(float x, float y, float scalex, float scaley, vec4_t color, 
 
 			glyph = Q_UTF8_GetGlyph(font, s);
 
-			if (Q_IsColorString(s))
+
+			if (Q_IsAcceleratorString(s))
+			{
+				is_accelerator = qtrue;
+				s             += 2;
+				continue;
+			}
+			else if (Q_IsColorString(s))
 			{
 				if (*(s + 1) == COLOR_NULL)
 				{
@@ -630,6 +639,17 @@ void Text_Paint_Ext(float x, float y, float scalex, float scaley, vec4_t color, 
 
 					colorBlack[3] = 1.0;
 				}
+
+				if (is_accelerator)
+				{
+					trap_R_SetColor(colorBlack);
+					UI_FillRect(x + (glyph->pitch * scalex),
+					            y - yadj + (glyph->imageHeight * scaley) + 1.0,
+					            glyph->imageWidth * scalex, 0.6, newColor);
+					trap_R_SetColor(newColor);
+					is_accelerator = qfalse;
+				}
+
 				Text_PaintCharExt(x + (glyph->pitch * scalex), y - yadj, glyph->imageWidth, glyph->imageHeight, scalex, scaley, glyph->s, glyph->t, glyph->s2, glyph->t2, glyph->glyph);
 
 				x += (glyph->xSkip * scalex) + adjust;

--- a/src/ui/ui_menu.c
+++ b/src/ui/ui_menu.c
@@ -914,6 +914,51 @@ void  Menus_Activate(menuDef_t *menu)
 		DC->startBackgroundTrack(menu->soundName, menu->soundName, 0);
 	}
 
+	// register accelerator onKey action
+	for (i = 0; i < menu->itemCount; i++)
+	{
+		itemDef_t *item = menu->items[i];
+		const char *s   = item->text;
+
+		int       len                  = 0;
+		int       count                = 0;
+		short int accelerator          = 0;
+		qboolean  accelerator_upcoming = qfalse;
+
+		if (s == NULL) {
+			continue;
+		}
+
+		len = Q_UTF8_Strlen(s);
+
+		while (s && *s && count < len)
+		{
+			if (Q_IsAcceleratorString(s))
+			{
+				accelerator_upcoming = qtrue;
+				s                   += 2;
+				continue;
+			}
+			else
+			{
+				if (accelerator_upcoming)
+				{
+					accelerator          = tolower(s[0]);
+					accelerator_upcoming = qfalse;
+					break;
+				}
+
+				s += Q_UTF8_Width(s);
+				count++;
+			}
+		}
+
+		if (accelerator != 0)
+		{
+			menu->onKey[accelerator] = item->action;
+		}
+	}
+
 	Display_CloseCinematics();
 
 }


### PR DESCRIPTION
This change adds Accelerator key functionality to ET's Menus, demo: https://www.youtube.com/watch?v=j33ZnEXoO54 by parsing `^_` metacharacters out of UI texts, highlighting them and registering their action to the onKey handler.

If the general idea of Accelerators are desirable and the current implementation suffices, I'd follow up filling in more Accelerators for UI Elements until it's in a release-able state.