### PR TITLE
etmain: add fixed v2base.script

### DIFF
--- a/etmain/mapscripts/v2base.script
+++ b/etmain/mapscripts/v2base.script
@@ -1,0 +1,879 @@
+//
+// Map: V2 Base
+// BSP: v2base
+// Author: SteelRat
+
+game_manager
+{
+	spawn
+	{
+		// Game rules
+		wm_number_of_objectives 7
+		wm_set_round_timelimit	30
+		wm_set_main_objective 1 0 1
+		wm_set_main_objective 1 1 2
+		wm_objective_status 1 0 1  // Obj1, Axis in control of Docs.
+		wm_objective_status 1 1 2	 // Obj1, Allies, not in control of Docs.
+		wm_objective_status 2 0 1  // Obj2, Axis have prevented Allies from transmitting docs.
+		wm_objective_status 2 1 2  // Obj2, Allies have not transmitted docs.
+		wm_objective_status 3 0 1  // Obj3, Axis have prevented Allies from destroying the Base Wall.
+		wm_objective_status 3 1 2  // Obj3, Allies have not destroyed the Base Wall.
+		wm_objective_status 4 0 2  // Obj4, Axis have not captured the tower.
+		wm_objective_status 4 1 2  // Obj4, Allies have not captured the tower.
+		wm_objective_status 5 0 1  // Obj5, Axis have defended the Storage Wall
+		wm_objective_status 5 1 2  // Obj5, Allies have not destroyed the Storage Wall
+		wm_objective_status 6 0 2  // Obj6, Axis have not destroyed the Allied Command post
+		wm_objective_status 6 1 2  // Obj6, Allies have not constructed the command post
+		wm_objective_status 7 0 2  // Obj5, Axis have not constructed the Command post
+		wm_objective_status 7 1 1  // Obj5, Allies have not destroyed the Axis Command post
+		wm_set_defending_team	0	 // Axis is defending team
+		accum 1 set 0			// Will be set to 1 if Allies have transmitted documents
+		// Stopwatch mode defending team (0=Axis, 1=Allies)
+		wm_set_defending_team	0
+		// Winner on expiration of round timer (0=Axis, 1=Allies)
+		wm_setwinner	0
+		setstate docsmarker default
+		disablespeaker sirens
+		wait 200
+
+
+		accum 4 set 0    // Controls the flag
+		
+
+
+// Objectives
+		// 1: Documents
+		// 2: Transmit docs
+		// 3: V2 Base Wall
+		// 4: Flag
+		// 5: Storage Wall
+		// 6: Allied command post
+		// 7: Axis command post
+
+
+		wait 250
+
+		// Stopwatch mode defending team (0=Axis, 1=Allies)
+		wm_set_defending_team	0
+
+		// Winner on expiration of round timer (0=Axis, 1=Allies)
+		wm_setwinner	0
+
+		wait 500
+		setautospawn	"Axis Spawn"	0
+		setautospawn	"Allied Spawn"	1
+
+		wait 2000
+		wm_addteamvoiceannounce 0 "axis_hq_compost_construct"
+		wm_addteamvoiceannounce 1 "allies_hq_compost_construct"
+		wm_teamvoiceannounce 0 "axis_hq_compost_construct"
+		wm_teamvoiceannounce 1 "allies_hq_compost_construct"
+		
+
+	}
+	trigger objective1
+	{
+	wm_objective_status 1 1 1		// Allies have transmitted the docs
+	wm_objective_status 1 0 2		// Axis have not prevented Allies from transmitting
+	wm_set_main_objective 1 0 0
+	wm_set_main_objective 1 1 1
+	accum 1 set 1
+	disablespeaker sirens
+	wm_announce "Allied team has transmitted the war documents!"
+	trigger game_manager checkgame
+	}	
+	trigger axis_object_stolen
+	{
+	wm_objective_status 1 1 1		// Allies have stolen the docs
+	wm_objective_status 1 0 2		// Axis have lost the docs
+	setstate docsmarker invisible
+	enablespeaker sirens
+	}
+	trigger axis_object_returned
+	{
+	wm_objective_status 1 0 1		// Axis have returned the docs
+	wm_objective_status 1 1 2		// Allies have lost the docs
+	accum 1 set 0
+	setstate docsmarker default
+	disablespeaker sirens
+	}
+
+	trigger allies_flag
+	{
+
+		wm_objective_status 4 0 2  // Obj4, Axis have not captured the tower.
+		wm_objective_status 4 1 1  // Obj4, Allies have captured the tower.
+		wm_announce	"Allies captures the Tower!"
+
+	}
+	
+	trigger axis_flag
+	{
+		wm_objective_status 4 0 1  // Obj4, Axis have captured the tower.
+		wm_objective_status 4 1 2  // Obj4, Allies have not captured the tower.
+
+
+		wm_announce	"Axis captures the Tower!"
+	}
+
+	trigger checkgame
+	{
+	accum 1 abort_if_not_equal 1
+	wm_setwinner 1
+	wait 1500
+	wm_endround
+	}
+
+	trigger objective2
+	{
+	wm_announce "Allies have destroyed the Base Wall!"
+	wm_objective_status 3 0 2  // Obj3, Axis have lost the Base Wall.
+	wm_objective_status 3 1 1  // Obj3, Allies have destroyed the Base Wall.
+	wait 200
+	trigger game_manager checkgame	
+	}
+	trigger objective3
+	{
+	wm_announce "Allies have destroyed the Storage Wall!"
+	wm_objective_status 5 0 2  // Obj3, Axis have lost the Storage Wall.
+	wm_objective_status 5 1 1  // Obj3, Allies have destroyed the Storage Wall.
+	wait 200
+	trigger game_manager checkgame	
+	}
+
+
+
+}
+basewall
+{	
+	spawn
+	{
+	wait 200
+	setstate debris3 invisible
+	constructible_class 3
+	}
+	death
+	{
+	setstate debris3 default
+	trigger game_manager objective2
+	}
+}
+storagewall
+{	
+	spawn
+	{
+	wait 50
+	setstate debris2 invisible
+	constructible_class 3
+	}
+	death
+	{
+	setstate debris2 default
+	trigger game_manager objective3
+	}
+}
+docsmarker
+{
+	spawn
+	{	
+	setstate docsmarker default
+	}
+	death
+	{
+	}
+}
+transmitter_obj
+	{
+	spawn
+	{
+	}
+	death
+	{
+	trigger game_manager objective1
+	}
+}
+
+
+// ================================================
+// ============    FORWARD SPAWN     ==============
+// ================================================
+
+forward_spawn
+{
+	spawn
+	{
+	// accum 4 set 2	// 0-Axis, 1-Allied
+	}
+
+
+	trigger axis_capture
+	{
+
+		accum 4 abort_if_not_equal 1
+
+		accum 4 set 0
+
+		trigger game_manager axis_flag
+
+		setautospawn	"Forward Spawn"	0
+		setautospawn	"Allied Spawn"	1
+
+		wait 1000
+
+		// *----------------------------------- vo ------------------------------------------*
+		//wm_teamvoiceannounce 0 "radar_axis_bunker_stop"
+
+		//wm_teamvoiceannounce 1 "radar_allies_bunker_capture"
+
+		//wm_addteamvoiceannounce 0 "radar_axis_bunker_stop"
+
+		//wm_addteamvoiceannounce 1 "radar_allies_bunker_capture"
+		// *---------------------------------------------------------------------------------*
+	}
+
+	trigger allied_capture
+	{
+
+		accum 4 abort_if_not_equal 0
+
+		accum 4 set 1
+
+		trigger game_manager allies_flag
+
+		setautospawn	"Axis Spawn"	0
+		setautospawn	"Forward Spawn"	1
+
+		wait 1000
+
+		// *----------------------------------- vo ------------------------------------------*
+		//wm_teamvoiceannounce 0 "radar_axis_bunker_captured"
+
+		//wm_teamvoiceannounce 1 "radar_allies_bunker_captured"
+
+		//wm_addteamvoiceannounce 0 "radar_axis_bunker_captured"
+
+		//wm_addteamvoiceannounce 1 "radar_allies_bunker_captured"
+		// *---------------------------------------------------------------------------------*
+
+	}
+}
+
+axis_radio_destroyed 
+{ 
+   spawn 
+   { 
+      wait 400 
+      setstate axis_radio_destroyed invisible 
+      setstate axis_radio_destroyed_model invisible 
+   } 
+
+   trigger hide 
+   { 
+      setstate axis_radio_destroyed invisible 
+      setstate axis_radio_destroyed_model invisible 
+   } 
+
+   trigger show 
+   { 
+      accum 0 abort_if_equal 0 
+      setstate axis_radio_destroyed default 
+      setstate axis_radio_destroyed_model default 
+   } 
+
+   trigger enable 
+   { 
+      accum 0 set 1 
+   } 
+} 
+
+axis_radio_closed 
+{ 
+   trigger hide 
+   { 
+      setstate axis_radio_closed invisible 
+      setstate axis_radio_closed_model invisible 
+   } 
+
+   trigger show 
+   { 
+      accum 0 abort_if_equal 1 
+      setstate axis_radio_closed default 
+      setstate axis_radio_closed_model default 
+   } 
+
+   trigger disable 
+   { 
+      accum 0 set 1 
+   } 
+} 
+
+axis_radio_built 
+{ 
+   spawn 
+   { 
+      wait 400 
+
+      constructible_class 2 
+
+      trigger axis_radio_built setup 
+   } 
+
+   trigger setup 
+   { 
+      setchargetimefactor 0 soldier 1 
+      setchargetimefactor 0 lieutenant 1 
+      setchargetimefactor 0 medic 1 
+      setchargetimefactor 0 engineer 1 
+      setchargetimefactor 0 covertops 1 
+      sethqstatus 0 0 
+   } 
+
+   buildstart final 
+   { 
+      trigger axis_radio_built_model trans 
+
+      trigger axis_radio_destroyed hide 
+      trigger axis_radio_closed    hide 
+   } 
+
+   built final 
+   { 
+      trigger axis_radio_built_model show 
+
+      trigger axis_radio_destroyed enable 
+      trigger axis_radio_closed    disable 
+
+      trigger axis_radio_built_model enable_axis_features 
+
+      enablespeaker axis_compost_sound 
+   } 
+
+   decayed final 
+   { 
+      trigger axis_radio_built_model hide 
+
+      trigger axis_radio_destroyed show 
+      trigger axis_radio_closed    show 
+   } 
+
+   death 
+   { 
+      trigger axis_radio_built_model hide 
+
+      trigger axis_radio_destroyed show 
+
+      trigger axis_radio_built_model disable_axis_features 
+
+      disablespeaker axis_compost_sound 
+   } 
+} 
+
+axis_radio_built_model 
+{ 
+   spawn 
+   { 
+      wait 400 
+      setstate axis_radio_built_model invisible 
+   } 
+
+   trigger show 
+   { 
+      setstate axis_radio_built_model default 
+   } 
+
+   trigger hide 
+   { 
+      setstate axis_radio_built_model invisible 
+   } 
+
+   trigger trans 
+   { 
+      setstate axis_radio_built_model underconstruction 
+   } 
+
+   trigger enable_axis_features 
+   { 
+      setchargetimefactor 0 soldier 0.75 
+      setchargetimefactor 0 lieutenant 0.75 
+      setchargetimefactor 0 medic 0.75 
+      setchargetimefactor 0 engineer 0.75 
+      setchargetimefactor 0 covertops 0.75 
+      sethqstatus 0 1 
+
+      wm_announce   "Axis Command Post constructed. Charge speed increased!" 
+
+      // *----------------------------------- vo ------------------------------------------* 
+      wm_teamvoiceannounce 0 "axis_hq_compost_constructed" 
+
+      wm_teamvoiceannounce 1 "allies_hq_compost_constructed_axis" 
+
+      wm_removeteamvoiceannounce 0 "axis_hq_compost_construct" 
+      // *----------------------------------- vo ------------------------------------------* 
+
+      wm_objective_status 7 0 1 
+      wm_objective_status 7 1 0 
+
+   } 
+
+   trigger disable_axis_features 
+   { 
+      // Some kind of UI pop-up to alert players 
+      wm_announce   "Allied team has destroyed the Axis Command Post!" 
+
+      // *----------------------------------- vo ------------------------------------------* 
+      wm_addteamvoiceannounce 0 "axis_hq_compost_construct" 
+
+      wm_teamvoiceannounce 0 "axis_hq_compost_damaged" 
+      // *----------------------------------- vo ------------------------------------------* 
+
+      setchargetimefactor 0 soldier 1 
+      setchargetimefactor 0 lieutenant 1 
+      setchargetimefactor 0 medic 1 
+      setchargetimefactor 0 engineer 1 
+      setchargetimefactor 0 covertops 1 
+      sethqstatus 0 0 
+
+      wm_objective_status 7 0 0 
+      wm_objective_status 7 1 1 
+   } 
+}
+
+
+allied_radio_destroyed 
+{ 
+   spawn 
+   { 
+      wait 400 
+      setstate allied_radio_destroyed invisible 
+      setstate allied_radio_destroyed_model invisible 
+   } 
+
+   trigger hide 
+   { 
+      setstate allied_radio_destroyed invisible 
+      setstate allied_radio_destroyed_model invisible 
+   } 
+
+   trigger show 
+   { 
+      accum 2 abort_if_equal 0 
+      setstate allied_radio_destroyed default 
+      setstate allied_radio_destroyed_model default 
+   } 
+
+   trigger enable 
+   { 
+      accum 2 set 1 
+   } 
+} 
+
+allied_radio_closed 
+{ 
+   trigger hide 
+   { 
+      setstate allied_radio_closed invisible 
+      setstate allied_radio_closed_model invisible 
+   } 
+
+   trigger show 
+   { 
+      accum 2 abort_if_equal 1 
+      setstate allied_radio_closed default 
+      setstate allied_radio_closed_model default 
+   } 
+
+   trigger disable 
+   { 
+      accum 2 set 1 
+   } 
+} 
+
+allied_radio_built 
+{ 
+   spawn 
+   { 
+      wait 400 
+
+      constructible_class 2 
+
+      trigger allied_radio_built setup 
+   } 
+
+   trigger setup 
+   { 
+      setchargetimefactor 1 soldier 1 
+      setchargetimefactor 1 lieutenant 1 
+      setchargetimefactor 1 medic 1 
+      setchargetimefactor 1 engineer 1 
+      setchargetimefactor 1 covertops 1 
+      sethqstatus 1 0 
+   } 
+
+   buildstart final 
+   { 
+      trigger allied_radio_built_model trans 
+
+      trigger allied_radio_destroyed hide 
+      trigger allied_radio_closed    hide 
+   } 
+
+   built final 
+   { 
+      trigger allied_radio_built_model show 
+
+      trigger allied_radio_destroyed enable 
+      trigger allied_radio_closed    disable 
+
+      trigger allied_radio_built_model enable_allied_features 
+
+      enablespeaker allied_compost_sound 
+   } 
+
+   decayed final 
+   { 
+      trigger allied_radio_built_model hide 
+
+      trigger allied_radio_destroyed show 
+      trigger allied_radio_closed    show 
+   } 
+
+   death 
+   { 
+      trigger allied_radio_built_model hide 
+
+      trigger allied_radio_destroyed show 
+
+      trigger allied_radio_built_model disable_allied_features 
+
+      disablespeaker allied_compost_sound 
+   } 
+} 
+
+allied_radio_built_model 
+{ 
+   spawn 
+   { 
+      wait 400 
+      setstate allied_radio_built_model invisible 
+   } 
+
+   trigger show 
+   { 
+      setstate allied_radio_built_model default 
+   } 
+
+   trigger hide 
+   { 
+      setstate allied_radio_built_model invisible 
+   } 
+
+   trigger trans 
+   { 
+      setstate allied_radio_built_model underconstruction 
+   } 
+
+   trigger enable_allied_features 
+   { 
+      setchargetimefactor 1 soldier 0.75 
+      setchargetimefactor 1 lieutenant 0.75 
+      setchargetimefactor 1 medic 0.75 
+      setchargetimefactor 1 engineer 0.75 
+      setchargetimefactor 1 covertops 0.75 
+      sethqstatus 1 1 
+
+      wm_announce   "Allied Command Post constructed. Charge speed increased!" 
+
+      // *----------------------------------- vo ------------------------------------------* 
+      wm_teamvoiceannounce 1 "allies_hq_compost_constructed" 
+
+      wm_teamvoiceannounce 0 "allies_hq_compost_constructed_axis" 
+
+      wm_removeteamvoiceannounce 1 "allies_hq_compost_construct" 
+      // *----------------------------------- vo ------------------------------------------* 
+
+      wm_objective_status 6 1 1 
+      wm_objective_status 6 0 0 
+
+   } 
+
+   trigger disable_allied_features 
+   { 
+      // Some kind of UI pop-up to alert players 
+      wm_announce   "Axis team has destroyed the Allied Command Post!" 
+
+      // *----------------------------------- vo ------------------------------------------* 
+      wm_addteamvoiceannounce 1 "allies_hq_compost_construct" 
+
+      wm_teamvoiceannounce 1 "allies_hq_compost_damaged" 
+      // *----------------------------------- vo ------------------------------------------* 
+
+      setchargetimefactor 1 soldier 1 
+      setchargetimefactor 1 lieutenant 1 
+      setchargetimefactor 1 medic 1 
+      setchargetimefactor 1 engineer 1 
+      setchargetimefactor 1 covertops 1 
+      sethqstatus 1 0 
+
+      wm_objective_status 6 1 0 
+      wm_objective_status 6 0 1 
+   } 
+} 
+construction_script 
+{ 
+   spawn 
+   { 
+      wait 200 
+      constructible_class 2 
+      trigger self startup 
+   } 
+
+   buildstart final 
+   { 
+   } 
+
+   built final 
+   { 
+      setstate construction_extra default 
+      setstate construction_mg42  default 
+      setstate const_tower        invisible 
+
+      // Some kind of UI pop-up to alert players 
+      wm_announce   "Allied team has constructed the Spawn MG42!" 
+   } 
+
+   decayed final 
+   { 
+      trigger self startup 
+   } 
+
+   death 
+   { 
+      trigger self startup 
+      // Some kind of UI pop-up to alert players 
+      wm_announce   "Axis team has destroyed the Spawn MG42!" 
+   } 
+
+   trigger startup 
+   { 
+      setstate construction_extra invisible 
+      setstate construction_mg42  invisible 
+      setstate const_tower        default 
+      repairmg42 construction_mg42 
+   } 
+} 
+allied_mg1_toi
+{
+	// First corner after crossing bridge - Barrel
+	trigger rubble_corner3
+	{
+		wait 850
+	}
+}
+allied_mg1
+{
+	spawn
+	{
+		wait 400
+		setstate almg3 invisible
+		constructible_class 2
+	}
+
+	trigger setup
+	{
+		setstate allied_mg1_materials default
+		setstate allied_mg1_materials_clip default
+		setstate allied_mg1_flag default
+		setstate almg3 invisible
+
+
+	}
+
+	buildstart final
+	{
+		setstate allied_mg1_materials default
+		setstate allied_mg1_materials_clip default
+		setstate allied_mg1_flag default
+		setstate almg3 underconstruction
+
+	}
+
+	built final
+	{
+		setstate allied_mg1_materials invisible
+		setstate allied_mg1_materials_clip invisible
+		setstate allied_mg1_flag invisible
+		setstate almg3 default
+
+
+
+
+		wm_announce "The Field MG42 has been constructed."
+
+		// *----------------------------------- vo ------------------------------------------*
+		//wm_teamvoiceannounce 0 "goldrush_axis_tankbar_constructed"
+
+		//wm_removeteamvoiceannounce 0 "goldrush_axis_tankbar_construct"
+		//wm_removeteamvoiceannounce 0 "goldrush_axis_tankbars_construct"
+		// *---------------------------------------------------------------------------------*
+	}
+
+	decayed final
+	{
+		setstate allied_mg1_materials default
+		setstate allied_mg1_materials_clip default
+		setstate allied_mg1_flag default
+		setstate almg3 invisible
+
+
+
+	}
+
+	death
+	{
+		setstate allied_mg1_materials default
+		setstate allied_mg1_materials_clip default
+		setstate allied_mg1_flag default
+		setstate almg3 invisible
+
+
+
+
+
+		wm_announce "The Field MG42 has been destroyed."
+
+		// *----------------------------------- vo ------------------------------------------*
+		//wm_addteamvoiceannounce 0 "goldrush_axis_tankbar_construct"
+
+		//wm_teamvoiceannounce 0 "goldrush_axis_tankbar_destroyed"
+
+		//wm_teamvoiceannounce 1 "goldrush_allies_tankbar_destroyed"
+		// *---------------------------------------------------------------------------------*
+	}
+
+	trigger remove
+	{
+		setstate allied_mg1_toi invisible
+		setstate allied_mg1_materials invisible
+		setstate allied_mg1_materials_clip invisible
+		setstate allied_mg1_flag invisible
+		setstate almg3 default
+
+		// *----------------------------------- vo ------------------------------------------*
+		//wm_removeteamvoiceannounce 0 "goldrush_axis_tankbar_construct"
+		//wm_removeteamvoiceannounce 0 "goldrush_axis_tankbars_construct"
+
+		//wm_removeteamvoiceannounce 1 "goldrush_allies_tankbar_destroy"
+		//wm_removeteamvoiceannounce 1 "goldrush_allies_tankbars_destroy"
+		// *---------------------------------------------------------------------------------*
+
+		remove
+	}
+}
+allied_mg2_toi
+{
+	trigger rubble_corner3
+	{
+		wait 850
+	}
+}
+allied_mg2
+{
+	spawn
+	{
+		wait 400
+		trigger allied_mg2 setup
+
+		constructible_class 2
+	}
+
+	trigger setup
+	{
+		setstate allied_mg2_materials default
+		setstate allied_mg2_materials_clip default
+		setstate allied_mg2_flag default
+
+
+
+	}
+
+	buildstart final
+	{
+		setstate allied_mg2_materials default
+		setstate allied_mg2_materials_clip default
+		setstate allied_mg2_flag default
+
+
+	}
+
+	built final
+	{
+		setstate allied_mg2_materials invisible
+		setstate allied_mg2_materials_clip invisible
+		setstate allied_mg2_flag invisible
+
+
+
+
+
+		wm_announce "The fortress Ladder has been constructed."
+
+		// *----------------------------------- vo ------------------------------------------*
+		//wm_teamvoiceannounce 0 "goldrush_axis_tankbar_constructed"
+
+		//wm_removeteamvoiceannounce 0 "goldrush_axis_tankbar_construct"
+		//wm_removeteamvoiceannounce 0 "goldrush_axis_tankbars_construct"
+		// *---------------------------------------------------------------------------------*
+	}
+
+	decayed final
+	{
+		setstate allied_mg2_materials default
+		setstate allied_mg2_materials_clip default
+		setstate allied_mg2_flag default
+
+
+
+
+	}
+
+	death
+	{
+		setstate allied_mg2_materials default
+		setstate allied_mg2_materials_clip default
+		setstate allied_mg2_flag default
+
+
+
+
+
+
+		wm_announce "The fortress Ladder has been destroyed."
+
+		// *----------------------------------- vo ------------------------------------------*
+		//wm_addteamvoiceannounce 0 "goldrush_axis_tankbar_construct"
+
+		//wm_teamvoiceannounce 0 "goldrush_axis_tankbar_destroyed"
+
+		//wm_teamvoiceannounce 1 "goldrush_allies_tankbar_destroyed"
+		// *---------------------------------------------------------------------------------*
+	}
+
+	trigger remove
+	{
+		setstate allied_mg2_toi invisible
+		setstate allied_mg2_materials invisible
+		setstate allied_mg2_materials_clip invisible
+		setstate allied_mg2_flag invisible
+
+
+		// *----------------------------------- vo ------------------------------------------*
+		//wm_removeteamvoiceannounce 0 "goldrush_axis_tankbar_construct"
+		//wm_removeteamvoiceannounce 0 "goldrush_axis_tankbars_construct"
+
+		//wm_removeteamvoiceannounce 1 "goldrush_allies_tankbar_destroy"
+		//wm_removeteamvoiceannounce 1 "goldrush_allies_tankbars_destroy"
+		// *---------------------------------------------------------------------------------*
+
+		remove
+	}
+}


### PR DESCRIPTION
Adds a missing opening bracket on `docsmarker` on `L175`, vanilla silently ignores this but legacy errors out. Similar fix was done for `v2_factory.script` earlier it seems, it also had a missing opening bracket in the script.