### PR TITLE
cmake: Add some C warnings

### DIFF
--- a/cmake/ETLPlatform.cmake
+++ b/cmake/ETLPlatform.cmake
@@ -13,6 +13,11 @@ set(ETL_ARCH_COUNT 1)
 
 add_library(os_libraries INTERFACE)
 
+# Enable specific C warnings
+if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wdeclaration-after-statement -Wunused-but-set-variable")
+endif()
+
 # Color diagnostics for build systems other than make
 if(UNIX)
 	if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")


### PR DESCRIPTION
Adding:

	-Wdeclaration-after-statement
		this warns about the C89 style where declarations are not
		allowed to come after statements, but must always be at the
		start of a body

	-Wunused-but-set-variable
		warns about unused variables

Adding these CFLAGS as of now produces 82 warnings, all of which are -Wdeclaration-after-statement