### PR TITLE
gitignore: Add '/.cache' dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /*.make
 CMakeLists.txt.user
 etmain/ui/git_version.h
+/.cache
 
 #
 # OS specific


### PR DESCRIPTION
Used by 'clangd'.