### PR TITLE
Fix all -Wdeclaration-after-statement warnings

### DIFF
--- a/src/botlib/l_precomp.c
+++ b/src/botlib/l_precomp.c
@@ -1485,9 +1485,9 @@ void PC_RemoveAllGlobalDefines(void)
  */
 define_t *PC_CopyDefine(source_t *source, define_t *define)
 {
-	(void)source;
 	define_t *newdefine;
 	token_t  *token, *newtoken, *lasttoken;
+	(void)source;
 	newdefine = (define_t *) GetMemory(sizeof(define_t) + strlen(define->name) + 1);
 	// copy the define name
 	newdefine->name = (char *) newdefine + sizeof(define_t);

--- a/src/cgame/cg_debriefing.c
+++ b/src/cgame/cg_debriefing.c
@@ -3564,6 +3564,9 @@ qboolean CG_Debriefing_PrestigeButton_KeyDown(panel_button_t *button, int key)
  */
 void CG_Debriefing_VoteButton_Draw(panel_button_t *button)
 {
+	qboolean hilight;
+	float    w;
+
 	if (cgs.gametype != GT_WOLF_MAPVOTE)
 	{
 		return;
@@ -3580,9 +3583,9 @@ void CG_Debriefing_VoteButton_Draw(panel_button_t *button)
 		clrBck[0] = Q_fabs(sin(cg.time / (float)BLINK_DIVISOR));
 		clrBck[3] = Q_fabs(cos(cg.time / (float)BLINK_DIVISOR));
 
-		qboolean hilight = BG_CursorInRect(&button->rect);
+		hilight = BG_CursorInRect(&button->rect);
 
-		float w = CG_Text_Width_Ext(button->text, 0.2f, 0, &cgs.media.limboFont2);
+		w = CG_Text_Width_Ext(button->text, 0.2f, 0, &cgs.media.limboFont2);
 
 		CG_FillRect(button->rect.x, button->rect.y, button->rect.w, button->rect.h, hilight ? clrBck_hi : clrBck);
 		CG_DrawRect_FixedBorder(button->rect.x, button->rect.y, button->rect.w, button->rect.h, 1, clrBdr);

--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -4516,6 +4516,7 @@ void CG_Coronas(void)
 		trace_t  tr;
 		float    dist;
 		vec3_t   dir;
+		float    fov;
 		qboolean visible, behind, toofar;
 
 		for (i = 0 ; i < cg.numCoronas ; ++i)
@@ -4536,7 +4537,7 @@ void CG_Coronas(void)
 				toofar = qtrue;
 			}
 			// dot = DotProduct(dir, cg.refdef_current->viewaxis[0]);
-			const float fov = cosf((cg.refdef_current->fov_x / 2) * (float)(M_PI / 180));
+			fov = cosf((cg.refdef_current->fov_x / 2) * (float)(M_PI / 180));
 			if (DotProduct(dir, cg.refdef_current->viewaxis[0]) >= -fov)
 			{
 				behind = qtrue;

--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -316,9 +316,12 @@ void CG_UpdateParentHUD(const char *oldParent, const char *newParent, int newPar
  */
 static void CG_DrawPicShadowed(float x, float y, float w, float h, qhandle_t icon)
 {
+	float ofsX;
+	float ofsY;
+
 	trap_R_SetColor(colorBlack);
-	float ofsX = (w * 1.07f) - w;
-	float ofsY = (h * 1.07f) - h;
+	ofsX = (w * 1.07f) - w;
+	ofsY = (h * 1.07f) - h;
 	CG_DrawPic(x + ofsX, y + ofsY, w, h, icon);
 	trap_R_SetColor(NULL);
 	CG_DrawPic(x, y, w, h, icon);
@@ -2860,6 +2863,8 @@ static qboolean CG_SpawnTimersText(char **s, char **rt)
 static char *CG_RoundTimerText()
 {
 	qtime_t qt;
+	char    *seconds;
+	char    *minutes;
 
 	if (cgs.gamestate != GS_PLAYING)
 	{
@@ -2871,8 +2876,8 @@ static char *CG_RoundTimerText()
 		return "0:00"; // round ended
 	}
 
-	char *seconds = qt.tm_sec > 9 ? va("%i", qt.tm_sec) : va("0%i", qt.tm_sec);
-	char *minutes = qt.tm_min > 9 ? va("%i", qt.tm_min) : va("0%i", qt.tm_min);
+	seconds = qt.tm_sec > 9 ? va("%i", qt.tm_sec) : va("0%i", qt.tm_sec);
+	minutes = qt.tm_min > 9 ? va("%i", qt.tm_min) : va("0%i", qt.tm_min);
 
 	return va("%s:%s", minutes, seconds);
 }
@@ -3799,6 +3804,7 @@ static anchorPoints_t CG_FindClosestAnchors(hudStucture_t *hud, hudComponent_t *
 qboolean CG_ComputeComponentPosition(hudComponent_t *comp, int depth)
 {
 	rectDef_t parentLoc, tmpLoc;
+	float     xAbs;
 
 	// force quit this insanity
 	if (depth > 10 || depth < 0)
@@ -3845,7 +3851,7 @@ qboolean CG_ComputeComponentPosition(hudComponent_t *comp, int depth)
 	}
 
 	// final location
-	float xAbs = Q_fabs(comp->internalLocation.x);
+	xAbs = Q_fabs(comp->internalLocation.x);
 
 	if (xAbs)
 	{

--- a/src/cgame/cg_drawtools.c
+++ b/src/cgame/cg_drawtools.c
@@ -1564,6 +1564,7 @@ void CG_DrawHelpWindow(float x, float y, int *status, const char *title, const h
                        const vec4_t backgroundColor, const vec4_t borderColor, const vec4_t backgroundColorTitle, const vec4_t borderColorTitle,
                        panel_button_text_t *fontHeader, panel_button_text_t *fontText)
 {
+	float        diff;
 	unsigned int i;
 	int          len, maxlen = 0;
 	int          w, h;
@@ -1584,7 +1585,7 @@ void CG_DrawHelpWindow(float x, float y, int *status, const char *title, const h
 	Vector4Copy(fontHeader->colour, hdrColor);
 	Vector4Copy(fontText->colour, tColor);
 
-	float diff = cg.fadeTime - trap_Milliseconds();
+	diff = cg.fadeTime - trap_Milliseconds();
 
 	// FIXME: Should compute all this stuff beforehand
 	// Compute required width

--- a/src/cgame/cg_hud_editor.c
+++ b/src/cgame/cg_hud_editor.c
@@ -2632,6 +2632,7 @@ static void CG_HudEditor_GridDraw(void)
 void CG_DrawHudEditor(void)
 {
 	static int altHud = -1;
+	qboolean   skip;
 
 	panel_button_t **buttons = hudComponentsPanel;
 	panel_button_t *button;
@@ -2653,7 +2654,7 @@ void CG_DrawHudEditor(void)
 	CG_DrawPic(cgDC.cursorx, cgDC.cursory, 32, 32, cgs.media.cursorIcon);
 
 	// start parsing hud components from the last focused button
-	qboolean skip = qtrue;
+	skip = qtrue;
 	for ( ; *buttons; buttons++)
 	{
 		button = (*buttons);
@@ -2874,14 +2875,14 @@ void CG_HudEditor_KeyHandling(int key, qboolean down)
 */
 void CG_HudEditorMouseMove_Handling(int x, int y)
 {
+	panel_button_t *button = lastFocusComponent;
+	static float   offsetX = 0;
+	static float   offsetY = 0;
+
 	if (!cg.editingHud)
 	{
 		return;
 	}
-
-	panel_button_t *button = lastFocusComponent;
-	static float   offsetX = 0;
-	static float   offsetY = 0;
 
 	if (button && !button->data[7])
 	{

--- a/src/cgame/cg_locations.c
+++ b/src/cgame/cg_locations.c
@@ -121,6 +121,8 @@ void CG_LocationsSave(const char *path)
 
 void CG_LocationsAdd(const char *message)
 {
+	location_t *loc;
+
 	if (!cg.editingLocations)
 	{
 		CG_Printf(S_COLOR_RED "Location editing is not enabled.\n");
@@ -133,7 +135,7 @@ void CG_LocationsAdd(const char *message)
 		return;
 	}
 
-	location_t *loc = &cgs.location[cgs.numLocations];
+	loc = &cgs.location[cgs.numLocations];
 
 	loc->index = cgs.numLocations;
 	Q_strncpyz(loc->message, message, sizeof(loc->message));

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -3115,17 +3115,23 @@ void QDECL CG_WriteToLog(const char *fmt, ...)
 
 int CG_RoundTime(qtime_t *qtime)
 {
-	int msec = cgs.timelimit * 60000.f;
+	int msec;
+	int seconds;
+	int mins;
+	int hours;
+	int tens;
+
+	msec = cgs.timelimit * 60000.f;
 	if (cgs.gamestate == GS_PLAYING)
 	{
 		msec -= cg.time - cgs.levelStartTime;
 	}
 
-	int seconds = msec / 1000;
-	int mins    = seconds / 60;
-	int hours   = mins / 60;
-	seconds -= mins * 60;
-	int tens = seconds / 10;
+	seconds        = msec / 1000;
+	mins           = seconds / 60;
+	hours          = mins / 60;
+	seconds       -= mins * 60;
+	tens           = seconds / 10;
 	seconds       -= tens * 10;
 	seconds        = Q_atoi(va("%i%i", tens, seconds));
 	qtime->tm_sec  = seconds;

--- a/src/cgame/cg_multiview.c
+++ b/src/cgame/cg_multiview.c
@@ -574,6 +574,7 @@ void CG_mvDraw(cg_window_t *sw)
 	float     b_x, b_y, b_w, b_h;
 	float     s     = 1.0f;
 	centity_t *cent = &cg_entities[pID];
+	float     zoomBinoc;
 
 	Com_Memset(&refdef, 0, sizeof(refdef_t));
 	Com_Memcpy(refdef.areamask, cg.snap->areamask, sizeof(refdef.areamask));
@@ -675,9 +676,9 @@ void CG_mvDraw(cg_window_t *sw)
 	refdef.y      = rd_y;
 	refdef.width  = rd_w;
 	refdef.height = rd_h;
-	float zoomBinoc = Com_Clamp(GetWeaponTableData(WP_BINOCULARS)->zoomIn,
-	                            GetWeaponTableData(WP_BINOCULARS)->zoomOut,
-	                            cg_zoomDefaultSniper.value);
+	zoomBinoc     = Com_Clamp(GetWeaponTableData(WP_BINOCULARS)->zoomIn,
+	                          GetWeaponTableData(WP_BINOCULARS)->zoomOut,
+	                          cg_zoomDefaultSniper.value);
 
 	refdef.fov_x = (cgs.clientinfo[pID].health > 0 &&
 					(/*cent->currentState.weapon == WP_SNIPERRIFLE ||*/   // WARNING: WARNOUT: this needs updating?

--- a/src/cgame/cg_predict.c
+++ b/src/cgame/cg_predict.c
@@ -128,6 +128,7 @@ float CG_ClientHitboxMaxZ(entityState_t *hitEnt, float def)
 {
 	centity_t *cent;
 	vec3_t    origin;
+	float     maxs;
 
 	if (!hitEnt)
 	{
@@ -153,7 +154,7 @@ float CG_ClientHitboxMaxZ(entityState_t *hitEnt, float def)
 		VectorMA(origin, 6.5f, cent->pe.headRefEnt.axis[2], origin); // up
 		VectorMA(origin, 0.5f, cent->pe.headRefEnt.axis[0], origin); // forward
 
-		float maxs = origin[2] - cent->lerpOrigin[2] - 6;
+		maxs = origin[2] - cent->lerpOrigin[2] - 6;
 		return (maxs < PRONE_BODYHEIGHT) ? PRONE_BODYHEIGHT : maxs;
 	}
 	else if (hitEnt->eFlags & EF_CROUCHING)
@@ -162,7 +163,7 @@ float CG_ClientHitboxMaxZ(entityState_t *hitEnt, float def)
 		VectorMA(origin, 6.5f, cent->pe.headRefEnt.axis[2], origin); // up
 		VectorMA(origin, 0.5f, cent->pe.headRefEnt.axis[0], origin); // forward
 
-		float maxs = origin[2] - cent->lerpOrigin[2] - 6;
+		maxs = origin[2] - cent->lerpOrigin[2] - 6;
 		return (maxs < CROUCH_IDLE_BODYHEIGHT) ? CROUCH_IDLE_BODYHEIGHT : maxs;
 	}
 	else

--- a/src/cgame/cg_scoreboard.c
+++ b/src/cgame/cg_scoreboard.c
@@ -1277,6 +1277,8 @@ qboolean CG_DrawScoreboard(void)
 	float    fontScale = cg_fontScaleSP.value;
 	int      maxrows;
 	int      absmaxrows;
+	qboolean players_with_specs_exceed_limit;
+	qboolean players_without_specs_exceed_limit;
 	qboolean use_mini_chars = qfalse;
 
 	x       += cgs.wideXoffset;
@@ -1336,11 +1338,11 @@ qboolean CG_DrawScoreboard(void)
 		absmaxrows = 30;
 	}
 
-	qboolean players_with_specs_exceed_limit = cg.teamPlayers[TEAM_SPECTATOR] > 0 && (
+	players_with_specs_exceed_limit = cg.teamPlayers[TEAM_SPECTATOR] > 0 && (
 		(cg.teamPlayers[TEAM_AXIS] + 1 + (cg.teamPlayers[TEAM_SPECTATOR] + 1) / 2) > maxrows ||
 		(cg.teamPlayers[TEAM_ALLIES] + 1 + (cg.teamPlayers[TEAM_SPECTATOR] + 1) / 2) > maxrows
 		);
-	qboolean players_without_specs_exceed_limit = cg.teamPlayers[TEAM_AXIS] > maxrows || cg.teamPlayers[TEAM_ALLIES] > maxrows;
+	players_without_specs_exceed_limit = cg.teamPlayers[TEAM_AXIS] > maxrows || cg.teamPlayers[TEAM_ALLIES] > maxrows;
 
 	if ((cg.snap->ps.pm_type != PM_INTERMISSION && players_with_specs_exceed_limit) || players_without_specs_exceed_limit)
 	{

--- a/src/cgame/cg_snapshot.c
+++ b/src/cgame/cg_snapshot.c
@@ -246,9 +246,11 @@ void CG_SetInitialSnapshot(snapshot_t *snap)
  */
 static void CG_TransitionSnapshot(void)
 {
-	centity_t  *cent;
-	snapshot_t *oldFrame;
-	int        i, id;
+	centity_t     *cent;
+	snapshot_t    *oldFrame;
+	int           i, id;
+	playerState_t *ops;
+	playerState_t *ps;
 
 	if (!cg.snap)
 	{
@@ -338,8 +340,8 @@ static void CG_TransitionSnapshot(void)
 			}
 		}
 
-		playerState_t *ops = &oldFrame->ps;
-		playerState_t *ps  = &cg.snap->ps;
+		ops = &oldFrame->ps;
+		ps  = &cg.snap->ps;
 
 		// teleporting checks are irrespective of prediction
 		if ((ps->eFlags ^ ops->eFlags) & EF_TELEPORT_BIT)

--- a/src/cgame/cg_weapons.c
+++ b/src/cgame/cg_weapons.c
@@ -2852,6 +2852,7 @@ static int CG_DefaultAnimFrameForWeapon(int weapon)
  */
 static void CG_WeaponAnimation(playerState_t *ps, weaponInfo_t *weapon, int *weapOld, int *weap, float *weapBackLerp)
 {
+	int          ws;
 	centity_t    *cent = &cg.predictedPlayerEntity;
 	clientInfo_t *ci   = &cgs.clientinfo[ps->clientNum];
 
@@ -2861,7 +2862,7 @@ static void CG_WeaponAnimation(playerState_t *ps, weaponInfo_t *weapon, int *wea
 		return;
 	}
 
-	int ws = BG_simpleWeaponState(ps->weaponstate);
+	ws = BG_simpleWeaponState(ps->weaponstate);
 
 	// okay to early out here since we can never reload, fire and switch at the same time
 	if (ws == WSTATE_FIRE && !(cg_weapAnims.integer & WEAPANIM_FIRING))
@@ -3863,6 +3864,9 @@ void CG_AddViewWeapon(playerState_t *ps)
 	// mounted gun drawing
 	if (ps->eFlags & EF_MOUNTEDTANK)
 	{
+		// FIXME: HACK dummy model to just draw _something_
+		refEntity_t flash;
+
 		Com_Memset(hand, 0, sizeof(refEntity_t));
 		CG_CalculateWeaponPosition(hand->origin, angles);
 		AnglesToAxis(angles, hand->axis);
@@ -3904,9 +3908,6 @@ void CG_AddViewWeapon(playerState_t *ps)
 				CG_ParticleImpactSmokePuffExtended(cgs.media.smokeParticleShader, cg.tankflashorg, 1000, 8, 20, 30, alpha, 8.f);
 			}
 		}
-
-		// FIXME: HACK dummy model to just draw _something_
-		refEntity_t flash;
 
 		Com_Memset(&flash, 0, sizeof(flash));
 		flash.renderfx = (RF_LIGHTING_ORIGIN | RF_DEPTHHACK);

--- a/src/client/cl_cgame.c
+++ b/src/client/cl_cgame.c
@@ -1309,6 +1309,10 @@ int clFrameTime;
  */
 int CL_FindIncrementThreshold(void)
 {
+	int LCM;
+	int min;
+	int clTime;
+
 	clFrameTime = cls.frametime;
 
 	// handles zero duration between frames (often happens on map change)
@@ -1319,7 +1323,7 @@ int CL_FindIncrementThreshold(void)
 
 	// calculates the least common multiple of clFrameTime and svFrameTime
 	// the LCM represents how long until the time over-run pattern repeats
-	int LCM = svFrameTime > clFrameTime ? svFrameTime : clFrameTime;
+	LCM = svFrameTime > clFrameTime ? svFrameTime : clFrameTime;
 	while (1)
 	{
 		if (LCM % clFrameTime == 0 && LCM % svFrameTime == 0)
@@ -1329,8 +1333,8 @@ int CL_FindIncrementThreshold(void)
 		++LCM;
 	}
 
-	int min    = 0;
-	int clTime = 0;
+	min    = 0;
+	clTime = 0;
 	// finds the worst amount of client over-run assuming no initial spare time
 	while (clTime <= LCM)
 	{
@@ -1430,6 +1434,7 @@ void CL_AdjustTimeDelta(void)
 			else
 			{
 				int svOldFrameTime = svFrameTime;
+				int spareTime;
 
 				if (com_sv_running->integer)
 				{
@@ -1448,7 +1453,7 @@ void CL_AdjustTimeDelta(void)
 					threshold = CL_FindIncrementThreshold();
 				}
 
-				int spareTime =
+				spareTime =
 					cl.snap.serverTime                    // server time
 					- (cls.realtime + cl.serverTimeDelta) // client time
 					- cl_extrapolationMargin->integer;    // margin time
@@ -1608,6 +1613,7 @@ void CL_SetCGameTime(void)
 		// or less latency to be added in the interest of better
 		// smoothness or better responsiveness.
 		int tn = cl_timeNudge->integer;
+		int spareTime;
 
 		if (tn < -30)
 		{
@@ -1631,7 +1637,7 @@ void CL_SetCGameTime(void)
 		// note if we are almost past the latest frame (without timeNudge),
 		// so we will try and adjust back a bit when the next snapshot arrives
 
-		int spareTime =
+		spareTime =
 			cl.snap.serverTime                     //server
 			- (cls.realtime + cl.serverTimeDelta); //client
 

--- a/src/client/cl_keys.c
+++ b/src/client/cl_keys.c
@@ -379,8 +379,9 @@ void Field_Draw(field_t *edit, int x, int y, int width, qboolean showCursor, qbo
  */
 void Field_Paste(field_t *edit)
 {
-	char   *cbd;
-	size_t pasteLen, i;
+	char     *cbd;
+	size_t   pasteLen, i;
+	uint32_t *chars;
 
 	cbd = IN_GetClipboardData();
 
@@ -391,7 +392,7 @@ void Field_Paste(field_t *edit)
 
 	// send as if typed, so insert / overstrike works properly
 	pasteLen = Q_UTF8_Strlen(cbd);
-	uint32_t *chars = Com_Allocate(sizeof(uint32_t) * pasteLen);
+	chars    = Com_Allocate(sizeof(uint32_t) * pasteLen);
 	Com_Memset(chars, 0, sizeof(uint32_t) * pasteLen);
 	Q_UTF8_ToUTF32(cbd, chars, &pasteLen);
 

--- a/src/client/cl_scrn.c
+++ b/src/client/cl_scrn.c
@@ -140,6 +140,10 @@ static void SRC_DrawSingleChar(int x, int y, int w, int h, int ch)
 	{
 		float       scaleX, scaleY, scale;
 		glyphInfo_t *info;
+		float       xx;
+		float       yy;
+		float       ww;
+		float       hh;
 
 		if (ch < 32)
 		{
@@ -164,10 +168,10 @@ static void SRC_DrawSingleChar(int x, int y, int w, int h, int ch)
 		scaleX *= scale;
 		scaleY *= scale;
 
-		float xx = (float)x + ((float)info->pitch * scaleX);
-		float yy = (float)y - ((float)info->top * scaleY) + 12;
-		float ww = (float)info->imageWidth * scaleX;
-		float hh = (float)info->imageHeight * scaleY;
+		xx = (float)x + ((float)info->pitch * scaleX);
+		yy = (float)y - ((float)info->top * scaleY) + 12;
+		ww = (float)info->imageWidth * scaleX;
+		hh = (float)info->imageHeight * scaleY;
 
 		// Just squash the icon font to match
 		if (ch < 32)

--- a/src/client/cl_ui.c
+++ b/src/client/cl_ui.c
@@ -115,13 +115,16 @@ void LAN_LoadCachedServers(void)
 		cJSON *serverObj = NULL;
 		cJSON_ArrayForEach(serverObj, root)
 		{
+			char *address;
+			char *name;
+
 			if (!cJSON_IsObject(serverObj))
 			{
 				continue;
 			}
 
-			char *address = Q_ReadStringValueJsonEx(serverObj, "address", "");
-			char *name    = Q_ReadStringValueJsonEx(serverObj, "name", "");
+			address = Q_ReadStringValueJsonEx(serverObj, "address", "");
+			name    = Q_ReadStringValueJsonEx(serverObj, "name", "");
 
 			if (*address && *name)
 			{

--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -435,15 +435,15 @@ void PM_TraceAllParts(trace_t *trace, float *legsOffset, vec3_t start, vec3_t en
 	// legs and head
 	if ((pm->ps->eFlags & EF_PRONE) || (pm->ps->eFlags & EF_DEAD))
 	{
+		trace_t  legtrace;
+		trace_t  headtrace;
+		qboolean adjust = qfalse;
+
 		// ignore head and legs completely if we're dead and either is stuck in solid
 		if (pm->pmext->deadInSolid)
 		{
 			return;
 		}
-
-		trace_t  legtrace;
-		trace_t  headtrace;
-		qboolean adjust = qfalse;
 
 		PM_TraceLegs(&legtrace, legsOffset, start, end, trace,
 		             pm->ps->viewangles, pm->trace, pm->ps->clientNum,

--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -3726,6 +3726,8 @@ void Cmd_SetViewpos_f(gentity_t *ent, unsigned int dwCommand, int value)
 	}
 	else if (trap_Argc() == 8)
 	{
+		qboolean useViewHeight;
+
 		for (i = 0; i < 3; i++)
 		{
 			trap_Argv(i + 1, buffer, sizeof(buffer));
@@ -3739,7 +3741,7 @@ void Cmd_SetViewpos_f(gentity_t *ent, unsigned int dwCommand, int value)
 		}
 
 		trap_Argv(7, buffer, sizeof(buffer));
-		qboolean useViewHeight = Q_atof(buffer);
+		useViewHeight = Q_atof(buffer);
 
 		if (useViewHeight)
 		{

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -4623,6 +4623,7 @@ void CheckVote(void)
 	{
 		int pcnt = vote_percent.integer;
 		int total;
+		int threshold;
 
 		if (pcnt > 99)
 		{
@@ -4662,7 +4663,7 @@ void CheckVote(void)
 			total = level.voteInfo.numVotingClients;
 		}
 
-		int threshold = pcnt * total / 100;
+		threshold = pcnt * total / 100;
 
 		if (level.voteInfo.voteYes > threshold || level.voteInfo.votePassed)
 		{

--- a/src/game/g_skillrating.c
+++ b/src/game/g_skillrating.c
@@ -1166,6 +1166,8 @@ void G_UpdateSkillRating(int winner)
  */
 float G_CalculateWinProbability(int team)
 {
+	int currentTime;
+
 	int       i;
 	float     c, t, winningMu, losingMu;
 	gclient_t *cl;
@@ -1188,7 +1190,7 @@ float G_CalculateWinProbability(int team)
 	}
 
 	// current play time
-	int currentTime = level.timeCurrent - level.startTime - level.timeDelta;
+	currentTime = level.timeCurrent - level.startTime - level.timeDelta;
 
 	// map side parameter
 	if (g_skillRating.integer > 1)
@@ -1270,6 +1272,8 @@ float G_CalculateWinProbability(int team)
 
 		while (sqlite3_step(sqlstmt) == SQLITE_ROW)
 		{
+			qboolean isPlaying;
+
 			// assign match data
 			sr_data.guid        = sqlite3_column_text(sqlstmt, 0);
 			sr_data.mu          = sqlite3_column_double(sqlstmt, 1);
@@ -1284,7 +1288,7 @@ float G_CalculateWinProbability(int team)
 			}
 
 			// player has reconnected
-			qboolean isPlaying = qfalse;
+			isPlaying = qfalse;
 
 			for (i = 0, cl = level.clients; i < level.maxclients; i++, cl++)
 			{

--- a/src/game/g_team.c
+++ b/src/game/g_team.c
@@ -2373,11 +2373,13 @@ void G_UpdateSpawnPointStatePlayerCounts()
 void G_UpdateSpawnPointState(gentity_t *ent)
 {
 	static char cs[MAX_STRING_CHARS];
+	spawnPointState_t *spawnPointState;
+
 	if (ent == NULL || !ent->count)
 	{
 		return;
 	}
-	spawnPointState_t *spawnPointState = &level.spawnPointStates[ent->count - CS_MULTI_SPAWNTARGETS];
+	spawnPointState = &level.spawnPointStates[ent->count - CS_MULTI_SPAWNTARGETS];
 	// update state
 	VectorCopy(ent->s.origin, spawnPointState->origin);
 	spawnPointState->team = (team_t)(ent->count2 & 0xF);

--- a/src/qcommon/files.c
+++ b/src/qcommon/files.c
@@ -4383,6 +4383,8 @@ static void FS_AddContainerDirectory(const char *subPath)
 	// We are in a non-pure server, so just try to mount the minimal required packs
 	for (int i = 0 ; i < fs_numServerReferencedPaks ; i++)
 	{
+		char *packName;
+
 		// Do we have the pack already
 		if (FS_HasPack(fs_serverReferencedPaks[i]))
 		{
@@ -4395,7 +4397,7 @@ static void FS_AddContainerDirectory(const char *subPath)
 			continue;
 		}
 
-		char *packName = strchr(fs_serverReferencedPakNames[i], '/');
+		packName = strchr(fs_serverReferencedPakNames[i], '/');
 		if (packName && *(packName + 1))
 		{
 			char       tmpPath[MAX_OSPATH] = { '\0' };

--- a/src/qcommon/json/json.c
+++ b/src/qcommon/json/json.c
@@ -50,6 +50,7 @@
 void Q_JSONInitWith(void *(*malloc_fn)(size_t sz), void (*free_fn)(void *ptr))
 {
 	static qboolean initDone = qfalse;
+	cJSON_Hooks     hooks;
 
 	if (initDone)
 	{
@@ -57,7 +58,7 @@ void Q_JSONInitWith(void *(*malloc_fn)(size_t sz), void (*free_fn)(void *ptr))
 	}
 
 	// This is mostly pointless now, but we might want to use custom allocators or a buffer at some point.
-	cJSON_Hooks hooks =
+	hooks = (cJSON_Hooks)
 	{
 		malloc_fn,
 		free_fn

--- a/src/qcommon/q_unicode.c
+++ b/src/qcommon/q_unicode.c
@@ -857,12 +857,13 @@ void Q_UTF8_ToUTF32(const char *string, uint32_t *charArray, size_t *outLen)
 
 void Q_UTF32_ToUTF8(const uint32_t *charArray, size_t arraySize, char *string, size_t *outLen)
 {
-	int len, i, x, byteOffset = 0;
+	int  len, i, x, byteOffset = 0;
+	char *str;
 
 	for (i = 0; i < arraySize; i++)
 	{
 		len = Q_UTF8_WidthCP(charArray[i]);
-		char *str = Q_UTF8_Encode(charArray[i]);
+		str = Q_UTF8_Encode(charArray[i]);
 
 		for (x = 0; x < len; x++)
 		{
@@ -964,6 +965,8 @@ size_t Q_UnescapeUnicode(char *fromStr, char *toStr, const size_t maxSize)
 {
 	char *str = fromStr;
 	int  l    = 0;
+	int  number;
+	char *buffer;
 
 	while (*str)
 	{
@@ -1006,7 +1009,7 @@ size_t Q_UnescapeUnicode(char *fromStr, char *toStr, const size_t maxSize)
 			}
 
 			tmpNumber[numberOffset] = '\0';
-			int number = Q_atoi(tmpNumber);
+			number                  = Q_atoi(tmpNumber);
 
 			// Ignore non printable keys
 			if (number < 32)
@@ -1015,7 +1018,7 @@ size_t Q_UnescapeUnicode(char *fromStr, char *toStr, const size_t maxSize)
 				continue;
 			}
 
-			char *buffer = Q_UTF8_Encode(number);
+			buffer = Q_UTF8_Encode(number);
 
 			while (*buffer)
 			{

--- a/src/renderer/tr_fbo.c
+++ b/src/renderer/tr_fbo.c
@@ -95,6 +95,8 @@ static void R_SetFBOViewport(frameBuffer_t *fb)
 
 void R_FBOSetViewport(frameBuffer_t *from, frameBuffer_t *to)
 {
+	frameBuffer_t *com;
+
 	if (!tr.useFBO)
 	{
 		return;
@@ -121,7 +123,7 @@ void R_FBOSetViewport(frameBuffer_t *from, frameBuffer_t *to)
 		return;
 	}
 
-	frameBuffer_t *com = NULL;
+	com = NULL;
 	if (from)
 	{
 		com = from;
@@ -590,12 +592,14 @@ void R_FboBlit(frameBuffer_t *from, frameBuffer_t *to)
 
 void R_FboRenderTo(frameBuffer_t *from, frameBuffer_t *to)
 {
+	frameBuffer_t *tmp;
+
 	if (!tr.useFBO)
 	{
 		return;
 	}
 
-	frameBuffer_t *tmp = current;
+	tmp = current;
 
 	if (!blitProgram)
 	{
@@ -629,6 +633,10 @@ void R_FboRenderTo(frameBuffer_t *from, frameBuffer_t *to)
 
 void R_InitFBO(void)
 {
+	int   samples;
+	int   stencil;
+	GLint blitProgramMap;
+
 	Com_Memset(&systemFbos, 0, sizeof(frameBuffer_t) * MAX_FBOS);
 
 	current     = NULL;
@@ -652,8 +660,8 @@ void R_InitFBO(void)
 	mainFbo   = NULL;
 	msMainFbo = NULL;
 
-	int samples = ri.Cvar_VariableIntegerValue("r_ext_multisample");
-	int stencil = ri.Cvar_VariableIntegerValue("r_stencilbits");
+	samples = ri.Cvar_VariableIntegerValue("r_ext_multisample");
+	stencil = ri.Cvar_VariableIntegerValue("r_stencilbits");
 
 	GL_CheckErrors();
 
@@ -674,7 +682,7 @@ void R_InitFBO(void)
 	// Setup the blitting program
 	blitProgram = R_CreateShaderProgram(fboBlitVert, fboBlitFrag);
 	R_UseShaderProgram(blitProgram);
-	GLint blitProgramMap = R_GetShaderProgramUniform(blitProgram, "u_CurrentMap");
+	blitProgramMap = R_GetShaderProgramUniform(blitProgram, "u_CurrentMap");
 	glUniform1i(blitProgramMap, 0);
 
 	R_UseShaderProgram(NULL);

--- a/src/renderer/tr_init.c
+++ b/src/renderer/tr_init.c
@@ -193,12 +193,12 @@ static void InitOpenGL(void)
 
 	if (glConfig.vidWidth == 0)
 	{
+		char  glConfigString[1024] = { 0 };
 		char  renderer_buffer[1024];
 		GLint temp;
 
 		Com_Memset(&glConfig, 0, sizeof(glConfig));
 
-		char glConfigString[1024] = { 0 };
 		Info_SetValueForKey(glConfigString, "type", "opengl");
 		Info_SetValueForKey(glConfigString, "major", "1");
 		Info_SetValueForKey(glConfigString, "minor", "1");

--- a/src/renderercommon/nanosvg/nanosvgrast.h
+++ b/src/renderercommon/nanosvg/nanosvgrast.h
@@ -854,7 +854,8 @@ static int nsvg__cmpEdge(const void *p, const void *q)
 
 static NSVGactiveEdge* nsvg__addActive(NSVGrasterizer* r, NSVGedge* e, float startPoint)
 {
-	 NSVGactiveEdge* z;
+	NSVGactiveEdge* z;
+	float dxdy;
 
 	if (r->freelist != NULL) {
 		// Restore from freelist.
@@ -866,7 +867,7 @@ static NSVGactiveEdge* nsvg__addActive(NSVGrasterizer* r, NSVGedge* e, float sta
 		if (z == NULL) return NULL;
 	}
 
-	float dxdy = (e->x1 - e->x0) / (e->y1 - e->y0);
+	dxdy = (e->x1 - e->x0) / (e->y1 - e->y0);
 //	STBTT_assert(e->y0 <= start_point);
 	// round dx down to avoid going too far
 	if (dxdy < 0)

--- a/src/sdl/sdl_glimp.c
+++ b/src/sdl/sdl_glimp.c
@@ -266,6 +266,7 @@ static char *GLimp_RatioToFraction(const double ratio, const int iterations)
 	for (i = 0; i < iterations; i++)
 	{
 		double delta = (double) numerator / (double) denominator - ratio;
+		double newDelta;
 
 		// Close enough for most resolutions
 		if (fabs(delta) < 0.002)
@@ -282,7 +283,7 @@ static char *GLimp_RatioToFraction(const double ratio, const int iterations)
 			denominator++;
 		}
 
-		double newDelta = fabs((double) numerator / (double) denominator - ratio);
+		newDelta = fabs((double) numerator / (double) denominator - ratio);
 		if (newDelta < bestDelta)
 		{
 			bestDelta       = newDelta;
@@ -590,8 +591,9 @@ static void GLimp_DetectAvailableModes(void)
  */
 static void GLimp_WindowLocation(glconfig_t *glConfig, int *x, int *y, const qboolean fullscreen)
 {
-	int displayIndex = 0, tmpX = SDL_WINDOWPOS_UNDEFINED, tmpY = SDL_WINDOWPOS_UNDEFINED;
-	int numDisplays = SDL_GetNumVideoDisplays();
+	int      displayIndex = 0, tmpX = SDL_WINDOWPOS_UNDEFINED, tmpY = SDL_WINDOWPOS_UNDEFINED;
+	int      numDisplays = SDL_GetNumVideoDisplays();
+	SDL_Rect rect;
 
 	if (!r_windowLocation->string || !r_windowLocation->string[0])
 	{
@@ -659,7 +661,6 @@ static void GLimp_WindowLocation(glconfig_t *glConfig, int *x, int *y, const qbo
 		return;
 	}
 
-	SDL_Rect rect;
 	SDL_GetDisplayBounds(displayIndex, &rect);
 
 	// SDL resets the values to displays origins when switching between windowed and fullscreen, so just move it a bit

--- a/src/sdl/sdl_input.c
+++ b/src/sdl/sdl_input.c
@@ -1383,10 +1383,12 @@ static void IN_WindowFocusLost()
 {
 	if (cls.rendererStarted && cls.glconfig.isFullscreen)
 	{
+		Uint32 flags;
+
 		Com_DPrintf("Trying to minimize. Checking SDL flags.\n");
 		// If according to the game flags we should minimize,
 		// then lets actually make sure and ask the windowing system for its opinion.
-		Uint32 flags = SDL_GetWindowFlags(GLimp_MainWindow());
+		flags = SDL_GetWindowFlags(GLimp_MainWindow());
 		if (flags & SDL_WINDOW_FULLSCREEN && flags & SDL_WINDOW_SHOWN && !(flags & SDL_WINDOW_MINIMIZED) && flags & SDL_WINDOW_INPUT_GRABBED)
 		{
 			Com_DPrintf("SDL says we are good to go and call minimize.\n");

--- a/src/server/sv_tracker.c
+++ b/src/server/sv_tracker.c
@@ -235,12 +235,13 @@ char *Tracker_createClientInfo(int clientNum)
 {
 	playerState_t *ps;
 	int           playerClass;
+	char          *modName;
 	ps = SV_GameClientNum(clientNum);
 
 	// PauluzzNL
 	// The indexes are different between mods, most mods use the default etmain value of 5 for STAT_PLAYER_CLASS, legacy mod uses index 4.
 	// may need to modify for more mods later
-	char *modName = Info_ValueForKey(Cvar_InfoString(CVAR_SERVERINFO | CVAR_SERVERINFO_NOUPDATE), "gamename");
+	modName = Info_ValueForKey(Cvar_InfoString(CVAR_SERVERINFO | CVAR_SERVERINFO_NOUPDATE), "gamename");
 	if (Q_strncmp(modName, "legacy", 6) == 0)
 	{
 		playerClass = ps->stats[STAT_PLAYER_CLASS];

--- a/src/tvgame/tvg_active.c
+++ b/src/tvgame/tvg_active.c
@@ -224,6 +224,8 @@ qboolean TVG_ClientInactivityTimer(gclient_t *client)
 	// start countdown
 	if (!client->inactivityWarning)
 	{
+		int secondsLeft;
+
 		if (level.time > client->inactivityTime - inactivity)
 		{
 			client->inactivityWarning     = qtrue;
@@ -231,7 +233,7 @@ qboolean TVG_ClientInactivityTimer(gclient_t *client)
 			client->inactivitySecondsLeft = inactivity;
 		}
 
-		int secondsLeft = (client->inactivityTime + inactivity - level.time) / 1000;
+		secondsLeft = (client->inactivityTime + inactivity - level.time) / 1000;
 
 		// countdown expired..
 		if (secondsLeft <= 0)

--- a/src/tvgame/tvg_cmds.c
+++ b/src/tvgame/tvg_cmds.c
@@ -992,6 +992,8 @@ qboolean TVG_Cmd_SetViewpos_f(gclient_t *client, tvcmd_reference_t *self)
 	}
 	else if (trap_Argc() == 8)
 	{
+		qboolean useViewHeight;
+
 		for (i = 0; i < 3; i++)
 		{
 			trap_Argv(i + 1, buffer, sizeof(buffer));
@@ -1005,7 +1007,7 @@ qboolean TVG_Cmd_SetViewpos_f(gclient_t *client, tvcmd_reference_t *self)
 		}
 
 		trap_Argv(7, buffer, sizeof(buffer));
-		qboolean useViewHeight = Q_atof(buffer);
+		useViewHeight = Q_atof(buffer);
 
 		if (useViewHeight)
 		{

--- a/src/ui/ui_main.c
+++ b/src/ui/ui_main.c
@@ -6476,7 +6476,8 @@ static int UI_CampaignCount(qboolean singlePlayer)
  */
 static void UI_InsertServerIntoDisplayList(int num, int position)
 {
-	int i;
+	int       i;
+	menuDef_t *menu;
 
 	if (position < 0 || position > uiInfo.serverStatus.numDisplayServers)
 	{
@@ -6495,7 +6496,7 @@ static void UI_InsertServerIntoDisplayList(int num, int position)
     // and so something with it before the list finishes loading, which can take a while.
     if (position < uiInfo.serverStatus.currentServer) {
         uiInfo.serverStatus.currentServer++;
-        menuDef_t *menu = Menus_FindByName("serverList");
+        menu = Menus_FindByName("serverList");
         Menu_SetFeederSelection(menu, FEEDER_SERVERS, uiInfo.serverStatus.currentServer, NULL);
     }
 }

--- a/src/ui/ui_menuitem.c
+++ b/src/ui/ui_menuitem.c
@@ -1598,6 +1598,7 @@ qboolean Item_TextField_HandleKey(itemDef_t *item, int key)
 	int            valueLen;
 	itemDef_t      *newItem = NULL;
 	editFieldDef_t *editPtr = (editFieldDef_t *)item->typeData;
+	size_t         cutOff;
 
 	if (!item->cvar)
 	{
@@ -1612,7 +1613,7 @@ qboolean Item_TextField_HandleKey(itemDef_t *item, int key)
 	if (editPtr->maxChars && valueLen > editPtr->maxChars)
 	{
 		valueLen = editPtr->maxChars;
-		size_t cutOff = Q_UTF8_ByteOffset(buff, editPtr->maxChars);
+		cutOff   = Q_UTF8_ByteOffset(buff, editPtr->maxChars);
 		Com_Memset(&buff[cutOff], 0, sizeof(buff) - cutOff);
 	}
 
@@ -3219,6 +3220,7 @@ void Item_Model_Paint(itemDef_t *item)
 	vec3_t      mins, maxs, origin;
 	vec3_t      angles;
 	modelDef_t  *modelPtr = (modelDef_t *)item->typeData;
+	float       len;
 
 	if (modelPtr == NULL)
 	{
@@ -3256,7 +3258,7 @@ void Item_Model_Paint(itemDef_t *item)
 	// calculate distance so the model nearly fills the box
 	//if (qtrue)
 	//{
-	float len = 0.5f * (maxs[2] - mins[2]);
+	len = 0.5f * (maxs[2] - mins[2]);
 
 	origin[0] = len / 0.268f;        // len / tan( fov/2 )
 	//origin[0] = len / tan(w/2);


### PR DESCRIPTION
As promised a followup to 247d7fd270a9ba8f1d4f8b4fff8b70c70e5d16c0 to appease the 82 introduced mixing declarations and statements warnings.

Changes validated by `crustify`.