### PR TITLE
game: fix teleport bit not working when switching teams

### DIFF
--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -956,7 +956,7 @@ void respawn(gentity_t *ent)
 
 	G_DPrintf("Respawning %s, %i lives left\n", ent->client->pers.netname, ent->client->ps.persistant[PERS_RESPAWNS_LEFT]);
 
-	ClientSpawn(ent, qfalse, qfalse, qtrue);
+	ClientSpawn(ent, qfalse, qfalse, qtrue, qtrue);
 }
 
 /**
@@ -2642,7 +2642,7 @@ void ClientBegin(int clientNum)
 		G_clientFlagIndicator(ent);
 	}
 
-	ClientSpawn(ent, qfalse, qtrue, qtrue);
+	ClientSpawn(ent, qfalse, qtrue, qtrue, qfalse);
 
 	if (client->sess.sessionTeam == TEAM_AXIS || client->sess.sessionTeam == TEAM_ALLIES)
 	{
@@ -2895,7 +2895,7 @@ static qboolean isMortalSelfDamage(gentity_t *ent)
  * @param[in] teamChange
  * @param[in] restoreHealth
  */
-void ClientSpawn(gentity_t *ent, qboolean revived, qboolean teamChange, qboolean restoreHealth)
+void ClientSpawn(gentity_t *ent, qboolean revived, qboolean teamChange, qboolean restoreHealth, qboolean toggleTeleport)
 {
 	int                index = ent - g_entities;
 	vec3_t             spawn_origin, spawn_angles;
@@ -2959,9 +2959,13 @@ void ClientSpawn(gentity_t *ent, qboolean revived, qboolean teamChange, qboolean
 
 	client->pers.teamState.state = TEAM_ACTIVE;
 
-	// toggle the teleport bit so the client knows to not lerp
-	flags  = ent->client->ps.eFlags & EF_TELEPORT_BIT;
-	flags ^= EF_TELEPORT_BIT;
+	flags = ent->client->ps.eFlags & EF_TELEPORT_BIT;
+
+	if (toggleTeleport)
+	{
+		// toggle the teleport bit so the client knows to not lerp
+		flags ^= EF_TELEPORT_BIT;
+	}
 
 	// unlagged reset history markers
 	G_ResetMarkers(ent);

--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -5082,7 +5082,7 @@ void Cmd_SwapPlacesWithBot_f(gentity_t *ent, int botNum)
 	client->sess.playerWeapon  = ent->client->sess.latchPlayerWeapon = cl.sess.playerWeapon;
 	client->sess.playerWeapon2 = ent->client->sess.latchPlayerWeapon2 = cl.sess.playerWeapon2;
 	// spawn them in
-	ClientSpawn(ent, qfalse, qtrue, qtrue);
+	ClientSpawn(ent, qfalse, qtrue, qtrue, qtrue);
 	// restore items
 	client->pers = saved;
 	Com_Memcpy(ent->client->ps.persistant, persistant, sizeof(persistant));

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1697,7 +1697,7 @@ gentity_t *SelectSpawnPoint(vec3_t avoidPoint, vec3_t origin, vec3_t angles);
 void respawn(gentity_t *ent);
 void BeginIntermission(void);
 void InitBodyQue(void);
-void ClientSpawn(gentity_t *ent, qboolean revived, qboolean teamChange, qboolean restoreHealth);
+void ClientSpawn(gentity_t *ent, qboolean revived, qboolean teamChange, qboolean restoreHealth, qboolean toggleTeleport);
 void player_die(gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int damage, meansOfDeath_t meansOfDeath);
 void AddKillScore(gentity_t *ent, int score);
 void CalculateRanks(void);

--- a/src/game/g_weapon.c
+++ b/src/game/g_weapon.c
@@ -347,7 +347,7 @@ void ReviveEntity(gentity_t *ent, gentity_t *traceEnt)
 	// keep class special weapon time to keep them from exploiting revives
 	oldclasstime = traceEnt->client->ps.classWeaponTime;
 
-	ClientSpawn(traceEnt, qtrue, qfalse, qtrue);
+	ClientSpawn(traceEnt, qtrue, qfalse, qtrue, qtrue);
 
 #ifdef FEATURE_OMNIBOT
 	Bot_Event_Revived(traceEnt - g_entities, ent);


### PR DESCRIPTION
- When team switching teleport bit gets toggled twice which causes client to interpolate the entity (VET/ETPro bug).
- Also fixes all 4 past events being played (even not existing event 0) when team switching because eventSequence is set to 0 (which ends up being -4 on client) - caused by change in https://github.com/etlegacy/etlegacy/commit/5f3c160e1c78d4377bc1812380e696aaadd42416 
- This 4 events being played on client became very apparent when converting tv_84 legacy demos to dm_84 demos because the events get played on every player entity respawn not just team switch.