### PR TITLE
cgame: fix aspect ratio correction for limbo/debriefing mouse movement

### DIFF
--- a/src/cgame/cg_debriefing.c
+++ b/src/cgame/cg_debriefing.c
@@ -2700,24 +2700,10 @@ void CG_Debriefing_MouseEvent(int x, int y)
 	}
 
 	cgs.cursorX += x;
-	if (cgs.cursorX < 0)
-	{
-		cgs.cursorX = 0;
-	}
-	else if (cgs.cursorX > SCREEN_WIDTH)
-	{
-		cgs.cursorX = SCREEN_WIDTH;
-	}
+	cgs.cursorX  = Com_Clamp(0, SCREEN_WIDTH_SAFE, cgs.cursorX);
 
 	cgs.cursorY += y;
-	if (cgs.cursorY < 0)
-	{
-		cgs.cursorY = 0;
-	}
-	else if (cgs.cursorY > SCREEN_HEIGHT)
-	{
-		cgs.cursorY = SCREEN_HEIGHT;
-	}
+	cgs.cursorY  = Com_Clamp(0, SCREEN_HEIGHT_SAFE, cgs.cursorY);
 }
 
 /**

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -92,15 +92,6 @@ Q_EXPORT intptr_t vmMain(intptr_t command, intptr_t arg0, intptr_t arg1, intptr_
 	case CG_MOUSE_EVENT:
 		cgDC.cursorx = cgs.cursorX;
 		cgDC.cursory = cgs.cursorY;
-		// when the limbopanel is open, we want the cursor to be able to move all the way to the right edge of the screen..
-		// ... same for the debriefing screen
-		if (cg.showGameView || cgs.dbShowing)
-		{
-			if (!Ccg_Is43Screen())
-			{
-				cgDC.cursorx *= cgs.adr43;
-			}
-		}
 		CG_MouseEvent(arg0, arg1);
 		return 0;
 	case CG_EVENT_HANDLING:


### PR DESCRIPTION
`CG_MouseEvent` already handles aspect ratio correction for mouse movement in limbo, so this was applying it twice for that. Debriefing cursor handling was done separately from the limbo handling, which was relying on the adjustment done at the syscall, so in order to keep that correct, handle the correction in `CG_Debriefing_MouseEvent` instead.

Fixes #2605 