### PR TITLE
renderer: fix SonarCloud array bound issue

### DIFF
--- a/src/renderer/tr_backend.c
+++ b/src/renderer/tr_backend.c
@@ -900,7 +900,7 @@ void RE_UploadCinematic(int w, int h, int cols, int rows, const byte *data, int 
 	int     start;
 	image_t *image;
 
-	if (client < 0 || client > (sizeof(tr.scratchImage) / sizeof(tr.scratchImage[0])))
+	if (client < 0 || client >= (sizeof(tr.scratchImage) / sizeof(tr.scratchImage[0])))
 	{
 		Ren_Drop("RE_UploadCinematic: image offset out of range");
 	}


### PR DESCRIPTION
This SonarCloud report was marked as false-positive, while I believe this is a true-positive issue.
We noticed your feedback and we decided to take a look to improve.

https://sonarcloud.io/project/issues?id=etlegacy_etlegacy2&issues=AY9Y8kEHq42NS6QGFOc-&open=AY9Y8kEHq42NS6QGFOc-&tab=code

I agree that the report steps could be improved on our end though.

---

Issue: If `client` holds the value 32, the control flow will avoid the `Ren_Drop` and lead to accessing out-of-bounds elements of the `tr.scratchImage` array. This is an off-by-one bug.