### PR TITLE
cgame: fix allied rank icons using wrong shaders

### DIFF
--- a/etmain/scripts/legacy_gfx_hud.shader
+++ b/etmain/scripts/legacy_gfx_hud.shader
@@ -6,7 +6,7 @@
 //========================================//
 // HUD Ranks
 //========================================//
-gfx/hud/ranks/rank2
+gfx/hud/ranks/arank2
 {
 	nomipmaps
 	nopicmip
@@ -17,7 +17,7 @@ gfx/hud/ranks/rank2
 	}
 }
 
-gfx/hud/ranks/rank3
+gfx/hud/ranks/arank3
 {
 	nomipmaps
 	nopicmip
@@ -28,7 +28,7 @@ gfx/hud/ranks/rank3
 	}
 }
 
-gfx/hud/ranks/rank4
+gfx/hud/ranks/arank4
 {
 	nomipmaps
 	nopicmip
@@ -39,7 +39,7 @@ gfx/hud/ranks/rank4
 	}
 }
 
-gfx/hud/ranks/rank5
+gfx/hud/ranks/arank5
 {
 	nomipmaps
 	nopicmip
@@ -50,7 +50,7 @@ gfx/hud/ranks/rank5
 	}
 }
 
-gfx/hud/ranks/rank6
+gfx/hud/ranks/arank6
 {
 	nomipmaps
 	nopicmip
@@ -61,7 +61,7 @@ gfx/hud/ranks/rank6
 	}
 }
 
-gfx/hud/ranks/rank7
+gfx/hud/ranks/arank7
 {
 	nomipmaps
 	nopicmip
@@ -72,7 +72,7 @@ gfx/hud/ranks/rank7
 	}
 }
 
-gfx/hud/ranks/rank8
+gfx/hud/ranks/arank8
 {
 	nomipmaps
 	nopicmip
@@ -83,7 +83,7 @@ gfx/hud/ranks/rank8
 	}
 }
 
-gfx/hud/ranks/rank9
+gfx/hud/ranks/arank9
 {
 	nomipmaps
 	nopicmip
@@ -94,7 +94,7 @@ gfx/hud/ranks/rank9
 	}
 }
 
-gfx/hud/ranks/rank10
+gfx/hud/ranks/arank10
 {
 	nomipmaps
 	nopicmip
@@ -105,7 +105,7 @@ gfx/hud/ranks/rank10
 	}
 }
 
-gfx/hud/ranks/rank11
+gfx/hud/ranks/arank11
 {
 	nomipmaps
 	nopicmip

--- a/etmain/scripts/legacy_models_players.shader
+++ b/etmain/scripts/legacy_models_players.shader
@@ -6,7 +6,7 @@
 //========================================//
 // Helmet ranks
 //========================================//
-models/players/temperate/common/rank2
+models/players/temperate/common/arank2
 {
 	polygonoffset
 	{
@@ -16,7 +16,7 @@ models/players/temperate/common/rank2
 	}
 }
 
-models/players/temperate/common/rank3
+models/players/temperate/common/arank3
 {
 	polygonoffset
 	{
@@ -26,7 +26,7 @@ models/players/temperate/common/rank3
 	}
 }
 
-models/players/temperate/common/rank4
+models/players/temperate/common/arank4
 {
 	polygonoffset
 	{
@@ -36,7 +36,7 @@ models/players/temperate/common/rank4
 	}
 }
 
-models/players/temperate/common/rank5
+models/players/temperate/common/arank5
 {
 	polygonoffset
 	{
@@ -46,7 +46,7 @@ models/players/temperate/common/rank5
 	}
 }
 
-models/players/temperate/common/rank6
+models/players/temperate/common/arank6
 {
 	polygonoffset
 	{
@@ -56,7 +56,7 @@ models/players/temperate/common/rank6
 	}
 }
 
-models/players/temperate/common/rank7
+models/players/temperate/common/arank7
 {
 	polygonoffset
 	{
@@ -66,7 +66,7 @@ models/players/temperate/common/rank7
 	}
 }
 
-models/players/temperate/common/rank8
+models/players/temperate/common/arank8
 {
 	polygonoffset
 	{
@@ -76,7 +76,7 @@ models/players/temperate/common/rank8
 	}
 }
 
-models/players/temperate/common/rank9
+models/players/temperate/common/arank9
 {
 	polygonoffset
 	{
@@ -86,7 +86,7 @@ models/players/temperate/common/rank9
 	}
 }
 
-models/players/temperate/common/rank10
+models/players/temperate/common/arank10
 {
 	polygonoffset
 	{
@@ -96,7 +96,7 @@ models/players/temperate/common/rank10
 	}
 }
 
-models/players/temperate/common/rank11
+models/players/temperate/common/arank11
 {
 	polygonoffset
 	{

--- a/src/cgame/cg_statsranksmedals.c
+++ b/src/cgame/cg_statsranksmedals.c
@@ -48,8 +48,8 @@ rankicon_t rankicons[NUM_EXPERIENCE_LEVELS][2][2] =
 	},
 	{
 		{
-			{ 0, "gfx/hud/ranks/rank2",                     128, 128 },
-			{ 0, "models/players/temperate/common/rank2",   128, 128 }
+			{ 0, "gfx/hud/ranks/arank2",                    128, 128 },
+			{ 0, "models/players/temperate/common/arank2",  128, 128 }
 		},
 		{
 			{ 0, "gfx/hud/ranks/xrank2",                    128, 128 },
@@ -58,8 +58,8 @@ rankicon_t rankicons[NUM_EXPERIENCE_LEVELS][2][2] =
 	},
 	{
 		{
-			{ 0, "gfx/hud/ranks/rank3",                     128, 128 },
-			{ 0, "models/players/temperate/common/rank3",   128, 128 }
+			{ 0, "gfx/hud/ranks/arank3",                    128, 128 },
+			{ 0, "models/players/temperate/common/arank3",  128, 128 }
 		},
 		{
 			{ 0, "gfx/hud/ranks/xrank3",                    128, 128 },
@@ -68,8 +68,8 @@ rankicon_t rankicons[NUM_EXPERIENCE_LEVELS][2][2] =
 	},
 	{
 		{
-			{ 0, "gfx/hud/ranks/rank4",                     128, 128 },
-			{ 0, "models/players/temperate/common/rank4",   128, 128 }
+			{ 0, "gfx/hud/ranks/arank4",                    128, 128 },
+			{ 0, "models/players/temperate/common/arank4",  128, 128 }
 		},
 		{
 			{ 0, "gfx/hud/ranks/xrank4",                    128, 128 },
@@ -78,8 +78,8 @@ rankicon_t rankicons[NUM_EXPERIENCE_LEVELS][2][2] =
 	},
 	{
 		{
-			{ 0, "gfx/hud/ranks/rank5",                     128, 128 },
-			{ 0, "models/players/temperate/common/rank5",   128, 128 }
+			{ 0, "gfx/hud/ranks/arank5",                    128, 128 },
+			{ 0, "models/players/temperate/common/arank5",  128, 128 }
 		},
 		{
 			{ 0, "gfx/hud/ranks/xrank5",                    128, 128 },
@@ -88,8 +88,8 @@ rankicon_t rankicons[NUM_EXPERIENCE_LEVELS][2][2] =
 	},
 	{
 		{
-			{ 0, "gfx/hud/ranks/rank6",                     128, 128 },
-			{ 0, "models/players/temperate/common/rank6",   128, 128 }
+			{ 0, "gfx/hud/ranks/arank6",                    128, 128 },
+			{ 0, "models/players/temperate/common/arank6",  128, 128 }
 		},
 		{
 			{ 0, "gfx/hud/ranks/xrank6",                    128, 128 },
@@ -98,8 +98,8 @@ rankicon_t rankicons[NUM_EXPERIENCE_LEVELS][2][2] =
 	},
 	{
 		{
-			{ 0, "gfx/hud/ranks/rank7",                     128, 128 },
-			{ 0, "models/players/temperate/common/rank7",   128, 128 }
+			{ 0, "gfx/hud/ranks/arank7",                    128, 128 },
+			{ 0, "models/players/temperate/common/arank7",  128, 128 }
 		},
 		{
 			{ 0, "gfx/hud/ranks/xrank7",                    128, 128 },
@@ -108,8 +108,8 @@ rankicon_t rankicons[NUM_EXPERIENCE_LEVELS][2][2] =
 	},
 	{
 		{
-			{ 0, "gfx/hud/ranks/rank8",                     128, 128 },
-			{ 0, "models/players/temperate/common/rank8",   128, 128 }
+			{ 0, "gfx/hud/ranks/arank8",                    128, 128 },
+			{ 0, "models/players/temperate/common/arank8",  128, 128 }
 		},
 		{
 			{ 0, "gfx/hud/ranks/xrank8",                    128, 128 },
@@ -118,8 +118,8 @@ rankicon_t rankicons[NUM_EXPERIENCE_LEVELS][2][2] =
 	},
 	{
 		{
-			{ 0, "gfx/hud/ranks/rank9",                     128, 128 },
-			{ 0, "models/players/temperate/common/rank9",   128, 128 }
+			{ 0, "gfx/hud/ranks/arank9",                    128, 128 },
+			{ 0, "models/players/temperate/common/arank9",  128, 128 }
 		},
 		{
 			{ 0, "gfx/hud/ranks/xrank9",                    128, 128 },
@@ -128,8 +128,8 @@ rankicon_t rankicons[NUM_EXPERIENCE_LEVELS][2][2] =
 	},
 	{
 		{
-			{ 0, "gfx/hud/ranks/rank10",                    128, 128 },
-			{ 0, "models/players/temperate/common/rank10",  128, 128 }
+			{ 0, "gfx/hud/ranks/arank10",                   128, 128 },
+			{ 0, "models/players/temperate/common/arank10", 128, 128 }
 		},
 		{
 			{ 0, "gfx/hud/ranks/xrank10",                   128, 128 },
@@ -138,8 +138,8 @@ rankicon_t rankicons[NUM_EXPERIENCE_LEVELS][2][2] =
 	},
 	{
 		{
-			{ 0, "gfx/hud/ranks/rank11",                    128, 128 },
-			{ 0, "models/players/temperate/common/rank11",  128, 128 }
+			{ 0, "gfx/hud/ranks/arank11",                   128, 128 },
+			{ 0, "models/players/temperate/common/arank11", 128, 128 }
 		},
 		{
 			{ 0, "gfx/hud/ranks/xrank11",                   128, 128 },


### PR DESCRIPTION
Because the shader file in legacy pk3 does not match the name of the shader in pak0.pk3, the game does not reliably override the shaders with same names from the pak0's `gfx_hud.shader`. Using unique names that are only present in the shaders used in legacy pk3, we ensure we're using the correct shaders.

Fixes #1251, #2615 