### PR TITLE
cgame: fix localent indexing in CG_RailTrail2

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -3260,7 +3260,7 @@ qboolean CG_CalcMuzzlePoint(int entityNum, vec3_t muzzle);
 void CG_Bullet(int weapon, vec3_t end, int sourceEntityNum, int targetEntityNum);
 
 void CG_RailTrail(vec3_t color, vec3_t start, vec3_t end, int type, int index);
-void CG_RailTrail2(vec3_t color, vec3_t start, vec3_t end, int index, int sideNum);
+void CG_RailTrail2(const vec3_t color, const vec3_t start, const vec3_t end, int index, int sideNum);
 
 void CG_AddViewWeapon(playerState_t *ps);
 void CG_AddPlayerWeapon(refEntity_t *parent, playerState_t *ps, centity_t *cent);

--- a/src/cgame/cg_weapons.c
+++ b/src/cgame/cg_weapons.c
@@ -663,12 +663,12 @@ static void CG_GrenadeTrail(centity_t *ent, const weaponInfo_t *wi)
  * @param[in] index
  * @param[in] sideNum
  */
-void CG_RailTrail2(vec3_t color, vec3_t start, vec3_t end, int index, int sideNum)
+void CG_RailTrail2(const vec3_t color, const vec3_t start, const vec3_t end, int index, int sideNum)
 {
 	localEntity_t *le;
 	refEntity_t   *re;
 
-	if (index)
+	if (index >= 0)
 	{
 		le = CG_FindLocalEntity(index, sideNum);
 


### PR DESCRIPTION
The check should be `>= 0` as it's checking for a valid local entity, this way you can pass in a negative index to the function to always alloc a new local entity. This is what `VISIBLE_TRIGGERS` debug code does for drawing bounding boxes of triggers.