### PR TITLE
etmain: Fix climbing animations

### DIFF
--- a/etmain/animations/human/base/body.aninc
+++ b/etmain/animations/human/base/body.aninc
@@ -118,10 +118,10 @@
 
 		//drop				2975	5	0	20	0	0	0
 
-		climb_up			2981	21	21	20	-1	0	0
-		climb_dis			3003	31	0	20	0	0	0
-		climb_start			3035	46	0	20	0	0	0
-		climb_down			3082	28	28	20	-1	0	0
+		climb_up			2981	21	21	10	-1	0	0
+		climb_dis			3004	7	0	40	0	0	0
+		climb_start			2981	1	0	100	-1	1	0  // effectively disable
+		climb_down			3082	28	28	12	-1	0	0
 
 		jump_1step_2h		3111	11	0	20	0	0	0
 		jump_1step_1h		3131	11	0	20	0	0	0

--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -1840,8 +1840,10 @@ static void PM_GroundTraceMissed(void)
  */
 static void PM_GroundTrace(void)
 {
-	vec3_t  point;
-	trace_t trace;
+ 	vec3_t       point;
+ 	trace_t      trace;
+ 	const vec3_t upwards = { 0.0f, 0.0f, 1.0f };
+ 	float        upwardsdirection;
 
 	point[0] = pm->ps->origin[0];
 	point[1] = pm->ps->origin[1];
@@ -1891,8 +1893,16 @@ static void PM_GroundTrace(void)
 		{
 			Com_Printf("%i:kickoff\n", c_pmove);
 		}
-		// go into jump animation (but not under water)
-		if (pm->waterlevel < 3)
+
+		// play jump animation only when not underwater and when being kicked
+		// _somewhat_ towards the sky or anywhere downwards
+		VectorNormalize2(pm->ps->velocity, point);  // reuse point var
+		upwardsdirection = DotProduct(point, upwards);
+		// NOTE: the positive cutoff value for 'upwardsdirection' below has been
+		// determined by running across the terrain of official maps and finding
+		// a constant that triggers only for visually distinct (steep) slopes,
+		// such that the jump anim playback becomes reproducible/consistent
+		if (pm->waterlevel < 3 && (upwardsdirection >= 0.335f || upwardsdirection <= 0.0f))
 		{
 			if (pm->cmd.forwardmove >= 0)
 			{

--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -1894,15 +1894,18 @@ static void PM_GroundTrace(void)
 			Com_Printf("%i:kickoff\n", c_pmove);
 		}
 
-		// play jump animation only when not underwater and when being kicked
-		// _somewhat_ towards the sky or anywhere downwards
+		// play jump animation only:
+		//   1. when not underwater
+		//   2. when being kicked _somewhat_ towards the sky or anywhere
+		//      downwards
+		//   3. when not on a ladder
 		VectorNormalize2(pm->ps->velocity, point);  // reuse point var
 		upwardsdirection = DotProduct(point, upwards);
 		// NOTE: the positive cutoff value for 'upwardsdirection' below has been
 		// determined by running across the terrain of official maps and finding
 		// a constant that triggers only for visually distinct (steep) slopes,
 		// such that the jump anim playback becomes reproducible/consistent
-		if (pm->waterlevel < 3 && (upwardsdirection >= 0.335f || upwardsdirection <= 0.0f))
+		if (pm->waterlevel < 3 && (upwardsdirection >= 0.335f || upwardsdirection <= 0.0f) && !(pm->ps->pm_flags & PMF_LADDER))
 		{
 			if (pm->cmd.forwardmove >= 0)
 			{
@@ -4784,7 +4787,7 @@ void PM_CheckLadderMove(void)
 	// if we have just mounted the ladder
 	if (pml.ladder && !wasOnLadder && pm->ps->velocity[2] < 0)        // only play anim if going down ladder
 	{
-		BG_AnimScriptEvent(pm->ps, pm->character->animModelInfo, ANIM_ET_CLIMB_MOUNT, qfalse, qfalse);
+		BG_AnimScriptEvent(pm->ps, pm->character->animModelInfo, ANIM_ET_CLIMB_MOUNT, qfalse, qtrue);
 	}
 }
 


### PR DESCRIPTION
Climbing animations went through a regression between OG 2.60b ET and
current ETL, this commit addresses these regressions and cleans climbing
animations up along it.

- 'climb_dis' and 'climb_start' were way too slow and lengthy - causing
  the bugged-looking animations when leaving or entering a ladder

- 'climb_start' was effectly ditched, as it's rarely played and causes
  the player model to clip into the terrain on most occassions

- note that 'climb_dis' is actually played always when leaving a ladder,
  this means it's played both when climbing up and leaving the ladder,
  but also just the same when climbing down and leaving the ladder

- sometimes when grabbing a ladder to climb up, a jump animation is
  played, this is due to a kickoff/OTG event which plays the jump
  animation and is dependent on the surface one stands on when grabbing
  the ladder - this is addressed by gating the animation behind an
  additional check for being on a ladder

- when grabbing al adder to climb down, a jump animation is also played
  via 'PM_GroundTraceMissed'/freefall, as when falling onto a ladder
  from above, for a few frames there is no contact yet with the ladder -
  to remedy this, the 'ANIM_ET_CLIMB_MOUNT' animation, which triggers
  shortly after is set to 'force' to overrule the few animation frames
  of the previous jump animation

- 'climb_up' was way too fast, climbing looked comical, made slower

- 'climb_down' was too fast, made slower