### PR TITLE
Allow ETL_HOME env-var to set homedir

### DIFF
--- a/src/sys/sys_unix.c
+++ b/src/sys/sys_unix.c
@@ -131,6 +131,11 @@ char *Sys_DefaultHomePath(void)
 {
 	char *p;
 
+	if ((p = getenv("ETL_HOME")) != NULL)
+	{
+		Q_strncpyz(homePath, p, sizeof(homePath));
+	}
+
 	if (!*homePath)
 	{
 		if ((p = getenv("HOME")) != NULL)


### PR DESCRIPTION
Assists in running ETL multiple times locally with different configs, e.g. for debugging purposes.