### PR TITLE
cgame: Fix 'FIGHT!' voice line when following

### DIFF
--- a/src/cgame/cg_servercmds.c
+++ b/src/cgame/cg_servercmds.c
@@ -518,7 +518,7 @@ void CG_ParseWolfinfo(void)
 	{
 		if (cg_announcer.integer)
 		{
-			// @XXX Workaround for #522
+			// FIXME : Workaround
 			// As upon a warmup end, 'trap_S_Respatialize' seems to be called
 			// only _after_ calling this place here (which would make
 			// 'trap_S_StartLocalSound' work correctly) - we add this edge case

--- a/src/cgame/cg_servercmds.c
+++ b/src/cgame/cg_servercmds.c
@@ -518,7 +518,16 @@ void CG_ParseWolfinfo(void)
 	{
 		if (cg_announcer.integer)
 		{
-			trap_S_StartLocalSound(cgs.media.countFight, CHAN_ANNOUNCER);
+			// @XXX Workaround for #522
+			// As upon a warmup end, 'trap_S_Respatialize' seems to be called
+			// only _after_ calling this place here (which would make
+			// 'trap_S_StartLocalSound' work correctly) - we add this edge case
+			// to play the 'FIGHT' announcer voice line on the spectator itself.
+			if (cg.snap->ps.pm_flags & PMF_FOLLOW) {
+				trap_S_StartSound(NULL, cg.clientNum, CHAN_ANNOUNCER, cgs.media.countFight);
+			} else {
+				trap_S_StartLocalSound(cgs.media.countFight, CHAN_ANNOUNCER);
+			}
 		}
 
 		Pri("^1FIGHT!\n");


### PR DESCRIPTION
Once warmup ends while following another player as spectator, the "FIGHT!" line gets written but the voice line is not played.

The issue happens as 'listener_number' in 'src/client/snd_dma.c' is still set to the entity of the player to be followed, despite that after warmup a spectator is reset to unfollow and due to timing, 'listener_number' is not correctly reset to the spectator (via 'respatialize') before the voice line sample is actually queued.

Thus the voice line is played in the wrong place and can't be heard by the spectator.

This commit fixes this issue, not by addressing the timing issue between 'respatialize' and match start, but by always forcing the "FIGHT" voice line to be played on the spectator's position when following another player.

Fixes https://github.com/etlegacy/etlegacy/issues/522