### PR TITLE
mod: properly hide mouse cursor if menu bypasses mouse input

### DIFF
--- a/src/cgame/cg_camera.c
+++ b/src/cgame/cg_camera.c
@@ -293,7 +293,7 @@ void CG_CameraEditorDraw(void)
 
 		// render cursor
 		trap_R_SetColor(NULL);
-		CG_DrawPic(cgDC.cursorx, cgDC.cursory, 32, 32, cgs.media.cursorIcon);
+		CG_DrawCursor(cgDC.cursorx, cgDC.cursory);
 	}
 }
 

--- a/src/cgame/cg_debriefing.c
+++ b/src/cgame/cg_debriefing.c
@@ -1933,7 +1933,7 @@ qboolean CG_Debriefing_Draw(void)
 
 	BG_PanelButtonsRender(chatPanelButtons);
 	BG_PanelButtonsRender(buttonsPanel);
-	CG_DrawPic(cgDC.cursorx, cgDC.cursory, 32, 32, cgs.media.cursorIcon);
+	CG_DrawCursor(cgDC.cursorx, cgDC.cursory);
 
 	return qtrue;
 }

--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -4258,7 +4258,7 @@ static void CG_Draw2D(void)
 	{
 		// draw cursor
 		trap_R_SetColor(NULL);
-		CG_DrawPic(cgDC.cursorx - 14, cgDC.cursory - 14, 32, 32, cgs.media.cursorIcon);
+		CG_DrawCursor(cgDC.cursorx - 14, cgDC.cursory - 14);
 	}
 
 	if (cg.showFireteamMenu)

--- a/src/cgame/cg_drawtools.c
+++ b/src/cgame/cg_drawtools.c
@@ -1687,3 +1687,13 @@ float CG_ComputeScale(hudComponent_t *comp /*, float height, float scale, fontHe
 	return comp->hardScale * (comp->scale / 100.f);
 	//return (height / (Q_UTF8_GlyphScale(font) * Q_UTF8_GetGlyph(font, "A")->height)) * (scale / 100.f);
 }
+
+void CG_DrawCursor(float x, float y)
+{
+	if (!cgDC.cursorVisible)
+	{
+		return;
+	}
+
+	CG_DrawPic(x, y, CURSOR_SIZE, CURSOR_SIZE, cgs.media.cursorIcon);
+}

--- a/src/cgame/cg_hud_editor.c
+++ b/src/cgame/cg_hud_editor.c
@@ -2651,7 +2651,7 @@ void CG_DrawHudEditor(void)
 	CG_HudEditor_HelpDraw();
 
 	trap_R_SetColor(NULL);
-	CG_DrawPic(cgDC.cursorx, cgDC.cursory, 32, 32, cgs.media.cursorIcon);
+	CG_DrawCursor(cgDC.cursorx, cgDC.cursory);
 
 	// start parsing hud components from the last focused button
 	skip = qtrue;

--- a/src/cgame/cg_info.c
+++ b/src/cgame/cg_info.c
@@ -1718,7 +1718,7 @@ void CG_DrawDemoControls(int x, int y, int w, vec4_t borderColor, vec4_t bgColor
 	{
 		// render cursor
 		trap_R_SetColor(NULL);
-		CG_DrawPic(cgDC.cursorx, cgDC.cursory, 32, 32, cgs.media.cursorIcon);
+		CG_DrawCursor(cgDC.cursorx, cgDC.cursory);
 	}
 }
 

--- a/src/cgame/cg_limbopanel.c
+++ b/src/cgame/cg_limbopanel.c
@@ -167,18 +167,18 @@ static panel_button_t rightLimboPannel =
 #define MEDAL_PIC_X     450.f
 #define MEDAL_PIC_SIZE  (630.f - MEDAL_PIC_X)
 #define MEDAL_PIC(number)                \
-	static panel_button_t medalPic ## number = {         \
-		NULL,                                   \
-		NULL,                                   \
-		{ MEDAL_PIC_X + MEDAL_PIC_GAP + ((number) * (MEDAL_PIC_GAP + MEDAL_PIC_WIDTH)),119,                                                                           MEDAL_PIC_WIDTH, 26 }, \
-		{ number,                  0,                                                                             0,               0, 0, 0, 0, 0},        \
-		NULL,                      /* font       */              \
-		NULL,                      /* keyDown    */                  \
-		NULL,                      /* keyUp  */                  \
-		CG_LimboPanel_RenderMedal,              \
-		NULL,                                   \
-		0,                                   \
-	}
+		static panel_button_t medalPic ## number = {         \
+			NULL,                                   \
+			NULL,                                   \
+			{ MEDAL_PIC_X + MEDAL_PIC_GAP + ((number) * (MEDAL_PIC_GAP + MEDAL_PIC_WIDTH)),119,                                                                           MEDAL_PIC_WIDTH, 26 }, \
+			{ number,                  0,                                                                             0,               0, 0, 0, 0, 0},        \
+			NULL,                      /* font       */              \
+			NULL,                      /* keyDown    */                  \
+			NULL,                      /* keyUp  */                  \
+			CG_LimboPanel_RenderMedal,              \
+			NULL,                                   \
+			0,                                   \
+		}
 
 MEDAL_PIC(0);
 MEDAL_PIC(1);
@@ -195,18 +195,18 @@ MEDAL_PIC(6);
 #define SKILL_PIC_X     450.f
 #define SKILL_PIC_SIZE  (630.f - SKILL_PIC_X)
 #define SKILL_PIC(number)                \
-	static panel_button_t skillPic ## number = {         \
-		NULL,                                   \
-		NULL,                                   \
-		{ SKILL_PIC_X + SKILL_PIC_GAP + ((number) * (SKILL_PIC_GAP + SKILL_PIC_WIDTH)),119,                                                                           SKILL_PIC_WIDTH, 26 }, \
-		{ number,                     0,                                                                             0,               0, 0, 0, 0, 0}, \
-		NULL,                         /* font       */              \
-		NULL,                         /* keyDown    */              \
-		NULL,                         /* keyUp  */                  \
-		CG_LimboPanel_RenderPrestige,        \
-		NULL,                                \
-		0,                                   \
-	}
+		static panel_button_t skillPic ## number = {         \
+			NULL,                                   \
+			NULL,                                   \
+			{ SKILL_PIC_X + SKILL_PIC_GAP + ((number) * (SKILL_PIC_GAP + SKILL_PIC_WIDTH)),119,                                                                           SKILL_PIC_WIDTH, 26 }, \
+			{ number,                     0,                                                                             0,               0, 0, 0, 0, 0}, \
+			NULL,                         /* font       */              \
+			NULL,                         /* keyDown    */              \
+			NULL,                         /* keyUp  */                  \
+			CG_LimboPanel_RenderPrestige,        \
+			NULL,                                \
+			0,                                   \
+		}
 
 SKILL_PIC(0);
 SKILL_PIC(1);
@@ -226,45 +226,45 @@ SKILL_PIC(6);
 #define TEAM_COUNTER_SPACING    4.f
 
 #define TEAM_COUNTER(number)             \
-	static panel_button_t teamCounter ## number = {      \
-		NULL,                                   \
-		NULL,                                   \
-		{ TEAM_COUNTER_X + TEAM_COUNTER_GAP + ((number) * (TEAM_COUNTER_GAP + TEAM_COUNTER_WIDTH)),236,                                                                                       TEAM_COUNTER_WIDTH, 14 },  \
-		{ 1,                         number,                                                                                    0,                  0, 0, 0, 0, 0},        \
-		NULL,                        /* font       */              \
-		NULL,                        /* keyDown    */                  \
-		NULL,                        /* keyUp  */                  \
-		CG_LimboPanel_RenderCounter,            \
-		NULL,                                   \
-		0,                                   \
-	};                                          \
-	static panel_button_t teamCounterLight ## number = { \
-		NULL,                                   \
-		NULL,                                   \
-		{ TEAM_COUNTER_X + TEAM_COUNTER_GAP + ((number) * (TEAM_COUNTER_GAP + TEAM_COUNTER_WIDTH)) - 20,236,                                                                                            16, 16 }, \
-		{ 1,                       number,                                                                                         0,  0, 0, 0, 0, 0},        \
-		NULL,                      /* font       */              \
-		NULL,                      /* keyDown    */                  \
-		NULL,                      /* keyUp  */                  \
-		CG_LimboPanel_RenderLight,              \
-		NULL,                                   \
-		0,                                   \
-	};                                          \
-	static panel_button_t teamButton ## number = {       \
-		NULL,                                   \
-		NULL,                                   \
-		{ TEAM_COUNTER_X + TEAM_COUNTER_GAP + ((number) * (TEAM_COUNTER_GAP + TEAM_COUNTER_WIDTH) + (TEAM_COUNTER_BUTTON_DIFF / 2.f)) - 17 + TEAM_COUNTER_SPACING, \
-		  188 + TEAM_COUNTER_SPACING, \
-		  TEAM_COUNTER_WIDTH - TEAM_COUNTER_BUTTON_DIFF + 20 - 2 * TEAM_COUNTER_SPACING, \
-		  44 - 2 * TEAM_COUNTER_SPACING },  \
-		{ number,                                                                        0,0, 0, 0, 0, 0, 0 },        \
-		NULL,                                                                            /* font       */              \
-		CG_LimboPanel_TeamButton_KeyDown,                                                /* keyDown    */ \
-		NULL,                                                                            /* keyUp  */                  \
-		CG_LimboPanel_RenderTeamButton,         \
-		NULL,                                   \
-		0,                                   \
-	}
+		static panel_button_t teamCounter ## number = {      \
+			NULL,                                   \
+			NULL,                                   \
+			{ TEAM_COUNTER_X + TEAM_COUNTER_GAP + ((number) * (TEAM_COUNTER_GAP + TEAM_COUNTER_WIDTH)),236,                                                                                       TEAM_COUNTER_WIDTH, 14 },  \
+			{ 1,                         number,                                                                                    0,                  0, 0, 0, 0, 0},        \
+			NULL,                        /* font       */              \
+			NULL,                        /* keyDown    */                  \
+			NULL,                        /* keyUp  */                  \
+			CG_LimboPanel_RenderCounter,            \
+			NULL,                                   \
+			0,                                   \
+		};                                          \
+		static panel_button_t teamCounterLight ## number = { \
+			NULL,                                   \
+			NULL,                                   \
+			{ TEAM_COUNTER_X + TEAM_COUNTER_GAP + ((number) * (TEAM_COUNTER_GAP + TEAM_COUNTER_WIDTH)) - 20,236,                                                                                            16, 16 }, \
+			{ 1,                       number,                                                                                         0,  0, 0, 0, 0, 0},        \
+			NULL,                      /* font       */              \
+			NULL,                      /* keyDown    */                  \
+			NULL,                      /* keyUp  */                  \
+			CG_LimboPanel_RenderLight,              \
+			NULL,                                   \
+			0,                                   \
+		};                                          \
+		static panel_button_t teamButton ##       number = {       \
+			NULL,                                   \
+			NULL,                                   \
+			{ TEAM_COUNTER_X + TEAM_COUNTER_GAP + ((number) * (TEAM_COUNTER_GAP + TEAM_COUNTER_WIDTH) + (TEAM_COUNTER_BUTTON_DIFF / 2.f)) - 17 + TEAM_COUNTER_SPACING, \
+			  188 + TEAM_COUNTER_SPACING, \
+			  TEAM_COUNTER_WIDTH - TEAM_COUNTER_BUTTON_DIFF + 20 - 2 * TEAM_COUNTER_SPACING, \
+			  44 - 2 * TEAM_COUNTER_SPACING },  \
+			{ number,                                                                    0,0, 0, 0, 0, 0, 0 },        \
+			NULL,                                                                        /* font       */              \
+			CG_LimboPanel_TeamButton_KeyDown,                                            /* keyDown    */ \
+			NULL,                                                                        /* keyUp  */                  \
+			CG_LimboPanel_RenderTeamButton,         \
+			NULL,                                   \
+			0,                                   \
+		}
 
 TEAM_COUNTER(0);
 TEAM_COUNTER(1);
@@ -278,30 +278,30 @@ TEAM_COUNTER(2);
 //#define CLASS_COUNTER_LIGHT_DIFF 4.f
 #define CLASS_COUNTER_BUTTON_DIFF (-18.f)
 #define CLASS_COUNTER(number)            \
-	static panel_button_t classCounter ## number = {     \
-		NULL,                                   \
-		NULL,                                   \
-		{ CLASS_COUNTER_X + CLASS_COUNTER_GAP + ((number) * (CLASS_COUNTER_GAP + CLASS_COUNTER_WIDTH)),302,                                                                                           CLASS_COUNTER_WIDTH, 14 }, \
-		{ 0,                         number,                                                                                        0,                   0, 0, 0, 0, 0},        \
-		NULL,                        /* font       */              \
-		NULL,                        /* keyDown    */                  \
-		NULL,                        /* keyUp  */                  \
-		CG_LimboPanel_RenderCounter,            \
-		NULL,                                   \
-		0,                                      \
-	};                                          \
-	static panel_button_t classButton ## number = {      \
-		NULL,                                   \
-		NULL,                                   \
-		{ CLASS_COUNTER_X + CLASS_COUNTER_GAP + ((number) * (CLASS_COUNTER_GAP + CLASS_COUNTER_WIDTH)) + (CLASS_COUNTER_BUTTON_DIFF / 2.f),266,                                                                                                                               CLASS_COUNTER_WIDTH - CLASS_COUNTER_BUTTON_DIFF, 34 },   \
-		{ 0,                             number,                                                                                                                            0,                                               0, 0, 0, 0, 0},        \
-		NULL,                            /* font       */              \
-		CG_LimboPanel_ClassButton_KeyDown,/* keyDown   */  \
-		NULL,                            /* keyUp  */                  \
-		CG_LimboPanel_RenderClassButton,        \
-		NULL,                                   \
-		0,                                      \
-	}
+		static panel_button_t classCounter ## number = {     \
+			NULL,                                   \
+			NULL,                                   \
+			{ CLASS_COUNTER_X + CLASS_COUNTER_GAP + ((number) * (CLASS_COUNTER_GAP + CLASS_COUNTER_WIDTH)),302,                                                                                           CLASS_COUNTER_WIDTH, 14 }, \
+			{ 0,                         number,                                                                                        0,                   0, 0, 0, 0, 0},        \
+			NULL,                        /* font       */              \
+			NULL,                        /* keyDown    */                  \
+			NULL,                        /* keyUp  */                  \
+			CG_LimboPanel_RenderCounter,            \
+			NULL,                                   \
+			0,                                      \
+		};                                          \
+		static panel_button_t classButton ## number = {      \
+			NULL,                                   \
+			NULL,                                   \
+			{ CLASS_COUNTER_X + CLASS_COUNTER_GAP + ((number) * (CLASS_COUNTER_GAP + CLASS_COUNTER_WIDTH)) + (CLASS_COUNTER_BUTTON_DIFF / 2.f),266,                                                                                                                               CLASS_COUNTER_WIDTH - CLASS_COUNTER_BUTTON_DIFF, 34 },   \
+			{ 0,                             number,                                                                                                                            0,                                               0, 0, 0, 0, 0},        \
+			NULL,                            /* font       */              \
+			CG_LimboPanel_ClassButton_KeyDown,/* keyDown   */  \
+			NULL,                            /* keyUp  */                  \
+			CG_LimboPanel_RenderClassButton,        \
+			NULL,                                   \
+			0,                                      \
+		}
 
 static panel_button_t classBar =
 {
@@ -338,18 +338,18 @@ CLASS_COUNTER(3);
 CLASS_COUNTER(4);
 
 #define FILTER_BUTTON(number) \
-	static panel_button_t filterButton ## number = { \
-		NULL,                               \
-		NULL,                               \
-		{ 14,                      50 + ((number) * 30), 26, 26 },     \
-		{ number,                  0,                    0,  0, 0, 0, 0, 0},    \
-		NULL,                      /* font       */          \
-		CG_LimboPanel_Filter_KeyDown,/* keyDown    */              \
-		NULL,                      /* keyUp  */              \
-		CG_LimboPanel_Filter_Draw,          \
-		NULL,                               \
-		0,                                  \
-	}
+		static panel_button_t filterButton ## number = { \
+			NULL,                               \
+			NULL,                               \
+			{ 14,                      50 + ((number) * 30), 26, 26 },     \
+			{ number,                  0,                    0,  0, 0, 0, 0, 0},    \
+			NULL,                      /* font       */          \
+			CG_LimboPanel_Filter_KeyDown,/* keyDown    */              \
+			NULL,                      /* keyUp  */              \
+			CG_LimboPanel_Filter_Draw,          \
+			NULL,                               \
+			0,                                  \
+		}
 
 FILTER_BUTTON(0);
 FILTER_BUTTON(1);
@@ -376,18 +376,18 @@ static panel_button_t filterTitleText =
 };
 
 #define LEFT_FRAME(shader, number, x, y, w, h) \
-	static panel_button_t leftFrame0 ## number = {   \
-		shader,                             \
-		NULL,                               \
-		{ x,                       y, w, h },                     \
-		{ 0,                       0, 0, 0, 0, 0, 0, 0},         \
-		NULL,                      /* font       */          \
-		NULL,                      /* keyDown    */              \
-		NULL,                      /* keyUp  */              \
-		BG_PanelButtonsRender_Img,          \
-		NULL,                               \
-		0,                                  \
-	}
+		static panel_button_t leftFrame0 ## number = {   \
+			shader,                             \
+			NULL,                               \
+			{ x,                       y, w, h },                     \
+			{ 0,                       0, 0, 0, 0, 0, 0, 0},         \
+			NULL,                      /* font       */          \
+			NULL,                      /* keyDown    */              \
+			NULL,                      /* keyUp  */              \
+			BG_PanelButtonsRender_Img,          \
+			NULL,                               \
+			0,                                  \
+		}
 
 #define LF_X1 64
 #define LF_X2 416
@@ -3568,7 +3568,7 @@ qboolean CG_LimboPanel_Draw(void)
 	BG_PanelButtonsRender(limboPanelButtons);
 
 	trap_R_SetColor(NULL);
-	CG_DrawPic(cgDC.cursorx, cgDC.cursory, 32, 32, cgs.media.cursorIcon);
+	CG_DrawCursor(cgDC.cursorx, cgDC.cursory);
 
 	if (cgs.ccRequestedObjective != -1)
 	{
@@ -3831,7 +3831,7 @@ void CG_LimboPanel_SetDefaultWeapon(int slot)
 	}
 	else
 	{
-        cgs.ccSelectedSecondaryWeapon = BG_GetBestSecondaryWeapon(CG_LimboPanel_GetClass(), CG_LimboPanel_GetTeam(), cgs.ccSelectedPrimaryWeapon, cgs.clientinfo[cg.clientNum].skill);
+		cgs.ccSelectedSecondaryWeapon = BG_GetBestSecondaryWeapon(CG_LimboPanel_GetClass(), CG_LimboPanel_GetTeam(), cgs.ccSelectedPrimaryWeapon, cgs.clientinfo[cg.clientNum].skill);
 	}
 }
 

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -4491,4 +4491,6 @@ void CG_DrawHelpWindow(float x, float y, int *status, const char *title, const h
 
 float CG_ComputeScale(hudComponent_t *comp /*, float height, float scale, fontHelper_t *font*/);
 
+void CG_DrawCursor(float x, float y);
+
 #endif // #ifndef INCLUDE_CG_LOCAL_H

--- a/src/cgame/cg_newDraw.c
+++ b/src/cgame/cg_newDraw.c
@@ -755,6 +755,9 @@ void CG_EventHandling(int type, qboolean fForced)
 		trap_Cvar_Set("cl_bypassMouseInput", "0");
 	}
 
+	// assume we want to draw cursor
+	cgDC.cursorVisible = qtrue;
+
 	switch (type)
 	{
 	// Demo support
@@ -849,6 +852,7 @@ void CG_EventHandling(int type, qboolean fForced)
 		else if (cgs.eventHandling == CGAME_EVENT_FIRETEAMMSG)
 		{
 			cg.showFireteamMenu = qfalse;
+			cgDC.cursorVisible  = qfalse;
 			trap_Cvar_Set("cl_bypassmouseinput", "0");
 		}
 		else if (cgs.eventHandling == CGAME_EVENT_SHOUTCAST)
@@ -858,11 +862,13 @@ void CG_EventHandling(int type, qboolean fForced)
 				trap_UI_Popup(UIMENU_INGAME);
 			}
 
+			cgDC.cursorVisible = qfalse;
 			trap_Cvar_Set("cl_bypassmouseinput", "0");
 		}
 		else if (cgs.eventHandling == CGAME_EVENT_SPAWNPOINTMSG)
 		{
 			cg.showSpawnpointsMenu = qfalse;
+			cgDC.cursorVisible     = qfalse;
 			trap_Cvar_Set("cl_bypassmouseinput", "0");
 		}
 		else if (cg.snap && cg.snap->ps.pm_type == PM_INTERMISSION && fForced)

--- a/src/cgame/cg_newDraw.c
+++ b/src/cgame/cg_newDraw.c
@@ -852,7 +852,6 @@ void CG_EventHandling(int type, qboolean fForced)
 		else if (cgs.eventHandling == CGAME_EVENT_FIRETEAMMSG)
 		{
 			cg.showFireteamMenu = qfalse;
-			cgDC.cursorVisible  = qfalse;
 			trap_Cvar_Set("cl_bypassmouseinput", "0");
 		}
 		else if (cgs.eventHandling == CGAME_EVENT_SHOUTCAST)
@@ -861,14 +860,11 @@ void CG_EventHandling(int type, qboolean fForced)
 			{
 				trap_UI_Popup(UIMENU_INGAME);
 			}
-
-			cgDC.cursorVisible = qfalse;
 			trap_Cvar_Set("cl_bypassmouseinput", "0");
 		}
 		else if (cgs.eventHandling == CGAME_EVENT_SPAWNPOINTMSG)
 		{
 			cg.showSpawnpointsMenu = qfalse;
-			cgDC.cursorVisible     = qfalse;
 			trap_Cvar_Set("cl_bypassmouseinput", "0");
 		}
 		else if (cg.snap && cg.snap->ps.pm_type == PM_INTERMISSION && fForced)
@@ -905,17 +901,20 @@ void CG_EventHandling(int type, qboolean fForced)
 		cgs.ftMenuPos       = -1;
 		cgs.ftMenuMode      = 0;
 		cg.showFireteamMenu = qtrue;
+		cgDC.cursorVisible  = qfalse;
 		trap_Cvar_Set("cl_bypassmouseinput", "1");
 		trap_Key_SetCatcher(KEYCATCH_CGAME);
 	}
 	else if (type == CGAME_EVENT_SHOUTCAST)
 	{
+		cgDC.cursorVisible = qfalse;
 		trap_Cvar_Set("cl_bypassmouseinput", "1");
 		trap_Key_SetCatcher(KEYCATCH_CGAME);
 	}
 	else if (type == CGAME_EVENT_SPAWNPOINTMSG)
 	{
 		cg.showSpawnpointsMenu = qtrue;
+		cgDC.cursorVisible     = qfalse;
 		trap_Cvar_Set("cl_bypassmouseinput", "1");
 		trap_Key_SetCatcher(KEYCATCH_CGAME);
 	}

--- a/src/cgame/cg_newDraw.c
+++ b/src/cgame/cg_newDraw.c
@@ -860,6 +860,7 @@ void CG_EventHandling(int type, qboolean fForced)
 			{
 				trap_UI_Popup(UIMENU_INGAME);
 			}
+
 			trap_Cvar_Set("cl_bypassmouseinput", "0");
 		}
 		else if (cgs.eventHandling == CGAME_EVENT_SPAWNPOINTMSG)

--- a/src/cgame/cg_sound.c
+++ b/src/cgame/cg_sound.c
@@ -2164,7 +2164,7 @@ void CG_SpeakerEditorDraw(void)
 
 		// render cursor
 		trap_R_SetColor(NULL);
-		CG_DrawPic(cgDC.cursorx, cgDC.cursory, 32, 32, cgs.media.cursorIcon);
+		CG_DrawCursor(cgDC.cursorx, cgDC.cursory);
 	}
 }
 

--- a/src/cgame/cg_window.c
+++ b/src/cgame/cg_window.c
@@ -493,7 +493,7 @@ void CG_windowDraw(void)
 	// Mouse cursor lays on top of everything
 	if (cg.mvTotalClients > 0 && cg.time < cgs.cursorUpdate && fAllowMV)
 	{
-		CG_DrawPic(cgDC.cursorx, cgDC.cursory, 32, 32, cgs.media.cursorIcon);
+		CG_DrawCursor(cgDC.cursorx, cgDC.cursory);
 	}
 #endif
 
@@ -725,7 +725,7 @@ void CG_cursorUpdate(void)
 	int                charHeight = CG_Text_Height_Ext("A", fontScale, 0, &cgs.media.limboFont2);
 	int                charWidth  = CG_Text_Width_Ext("A", fontScale, 0, &cgs.media.limboFont2);
 	cg_window_t        *w;
-	cg_windowHandler_t *wh    = &cg.winHandler;
+	cg_windowHandler_t *wh = &cg.winHandler;
 	qboolean           fFound = qfalse, fUpdateOverlay = qfalse;
 	qboolean           fSelect, fResize;
 
@@ -754,9 +754,9 @@ void CG_cursorUpdate(void)
 			// If the current window is selected, and the button is down, then allow the update
 			// to occur, as quick mouse movements can move it past the window borders
 			if (!fFound &&
-			    (
-			        ((w->mvInfo & MV_SELECTED) && fSelect) ||
-			        (!fSelect && nx >= w->x && nx < w->x + w->w && ny >= w->y && ny < w->y + w->h)
+				(
+					((w->mvInfo & MV_SELECTED) && fSelect) ||
+					(!fSelect && nx >= w->x && nx < w->x + w->w && ny >= w->y && ny < w->y + w->h)
 			    ))
 			{
 				if (!(w->mvInfo & MV_SELECTED))

--- a/src/ui/ui_main.c
+++ b/src/ui/ui_main.c
@@ -1022,7 +1022,7 @@ void UI_Refresh(int realtime)
 		uiClientState_t cstate;
 
 		trap_GetClientState(&cstate);
-		if (cstate.connState <= CA_DISCONNECTED || cstate.connState >= CA_ACTIVE)
+		if ((cstate.connState <= CA_DISCONNECTED || cstate.connState >= CA_ACTIVE) && uiInfo.uiDC.cursorVisible)
 		{
 			UI_DrawHandlePic(uiInfo.uiDC.cursorx, uiInfo.uiDC.cursory, 32, 32, uiInfo.uiDC.Assets.cursor);
 		}
@@ -6491,14 +6491,15 @@ static void UI_InsertServerIntoDisplayList(int num, int position)
 	}
 	uiInfo.serverStatus.displayServers[position] = num;
 
-    // If we're inserting a server before the currently selected one, increment the selected item.
-    // This has improved UX over changing the item out from under the user, who might want to select a server
-    // and so something with it before the list finishes loading, which can take a while.
-    if (position < uiInfo.serverStatus.currentServer) {
-        uiInfo.serverStatus.currentServer++;
-        menu = Menus_FindByName("serverList");
-        Menu_SetFeederSelection(menu, FEEDER_SERVERS, uiInfo.serverStatus.currentServer, NULL);
-    }
+	// If we're inserting a server before the currently selected one, increment the selected item.
+	// This has improved UX over changing the item out from under the user, who might want to select a server
+	// and so something with it before the list finishes loading, which can take a while.
+	if (position < uiInfo.serverStatus.currentServer)
+	{
+		uiInfo.serverStatus.currentServer++;
+		menu = Menus_FindByName("serverList");
+		Menu_SetFeederSelection(menu, FEEDER_SERVERS, uiInfo.serverStatus.currentServer, NULL);
+	}
 }
 
 /**
@@ -8860,6 +8861,9 @@ void UI_SetActiveMenu(uiMenuCommand_t menu)
 	{
 		menutype = menu;
 
+		// assume we want to draw cursor
+		uiInfo.uiDC.cursorVisible = qtrue;
+
 		switch (menu)
 		{
 		case UIMENU_NONE:
@@ -8960,48 +8964,42 @@ void UI_SetActiveMenu(uiMenuCommand_t menu)
 			return;
 
 		case UIMENU_WM_QUICKMESSAGE:
-			uiInfo.uiDC.cursorx = 639;
-			uiInfo.uiDC.cursory = 479;
+			uiInfo.uiDC.cursorVisible = qfalse;
 			trap_Key_SetCatcher(KEYCATCH_UI);
 			Menus_CloseAll();
 			Menus_OpenByName("wm_quickmessage");
 			return;
 
 		case UIMENU_WM_QUICKMESSAGEALT:
-			uiInfo.uiDC.cursorx = 639;
-			uiInfo.uiDC.cursory = 479;
+			uiInfo.uiDC.cursorVisible = qfalse;
 			trap_Key_SetCatcher(KEYCATCH_UI);
 			Menus_CloseAll();
 			Menus_OpenByName("wm_quickmessageAlt");
 			return;
 
 		case UIMENU_WM_FTQUICKMESSAGE:
-			uiInfo.uiDC.cursorx = 639;
-			uiInfo.uiDC.cursory = 479;
+			uiInfo.uiDC.cursorVisible = qfalse;
 			trap_Key_SetCatcher(KEYCATCH_UI);
 			Menus_CloseAll();
 			Menus_OpenByName("wm_ftquickmessage");
 			return;
 
 		case UIMENU_WM_FTQUICKMESSAGEALT:
-			uiInfo.uiDC.cursorx = 639;
-			uiInfo.uiDC.cursory = 479;
+			uiInfo.uiDC.cursorVisible = qfalse;
 			trap_Key_SetCatcher(KEYCATCH_UI);
 			Menus_CloseAll();
 			Menus_OpenByName("wm_ftquickmessageAlt");
 			return;
 
 		case UIMENU_WM_TAPOUT:
-			uiInfo.uiDC.cursorx = 639;
-			uiInfo.uiDC.cursory = 479;
+			uiInfo.uiDC.cursorVisible = qfalse;
 			trap_Key_SetCatcher(KEYCATCH_UI);
 			Menus_CloseAll();
 			Menus_OpenByName("tapoutmsg");
 			return;
 
 		case UIMENU_WM_TAPOUT_LMS:
-			uiInfo.uiDC.cursorx = 639;
-			uiInfo.uiDC.cursory = 479;
+			uiInfo.uiDC.cursorVisible = qfalse;
 			trap_Key_SetCatcher(KEYCATCH_UI);
 			Menus_CloseAll();
 			Menus_OpenByName("tapoutmsglms");
@@ -9017,32 +9015,28 @@ void UI_SetActiveMenu(uiMenuCommand_t menu)
 			return;
 
 		case UIMENU_WM_CLASS:
-			uiInfo.uiDC.cursorx = 639;
-			uiInfo.uiDC.cursory = 479;
+			uiInfo.uiDC.cursorVisible = qfalse;
 			trap_Key_SetCatcher(KEYCATCH_UI);
 			Menus_CloseAll();
 			Menus_OpenByName("wm_class");
 			return;
 
 		case UIMENU_WM_CLASSALT:
-			uiInfo.uiDC.cursorx = 639;
-			uiInfo.uiDC.cursory = 479;
+			uiInfo.uiDC.cursorVisible = qfalse;
 			trap_Key_SetCatcher(KEYCATCH_UI);
 			Menus_CloseAll();
 			Menus_OpenByName("wm_classAlt");
 			return;
 
 		case UIMENU_WM_TEAM:
-			uiInfo.uiDC.cursorx = 639;
-			uiInfo.uiDC.cursory = 479;
+			uiInfo.uiDC.cursorVisible = qfalse;
 			trap_Key_SetCatcher(KEYCATCH_UI);
 			Menus_CloseAll();
 			Menus_OpenByName("wm_team");
 			return;
 
 		case UIMENU_WM_TEAMALT:
-			uiInfo.uiDC.cursorx = 639;
-			uiInfo.uiDC.cursory = 479;
+			uiInfo.uiDC.cursorVisible = qfalse;
 			trap_Key_SetCatcher(KEYCATCH_UI);
 			Menus_CloseAll();
 			Menus_OpenByName("wm_teamAlt");

--- a/src/ui/ui_main.c
+++ b/src/ui/ui_main.c
@@ -1022,9 +1022,14 @@ void UI_Refresh(int realtime)
 		uiClientState_t cstate;
 
 		trap_GetClientState(&cstate);
+
+		// Note: this is the only place where cursor drawing is explicitly called in UI,
+		// so it's just checking if the cursor should be visible or not.
+		// If cursor drawing is explicitly called somewhere else in UI, this should probably
+		// be refactored into a separate cursor drawing function (see CG_DrawCursor)
 		if ((cstate.connState <= CA_DISCONNECTED || cstate.connState >= CA_ACTIVE) && uiInfo.uiDC.cursorVisible)
 		{
-			UI_DrawHandlePic(uiInfo.uiDC.cursorx, uiInfo.uiDC.cursory, 32, 32, uiInfo.uiDC.Assets.cursor);
+			UI_DrawHandlePic(uiInfo.uiDC.cursorx, uiInfo.uiDC.cursory, CURSOR_SIZE, CURSOR_SIZE, uiInfo.uiDC.Assets.cursor);
 		}
 	}
 }

--- a/src/ui/ui_shared.h
+++ b/src/ui/ui_shared.h
@@ -127,6 +127,8 @@
 #define SLIDER_THUMB_HEIGHT 12.0f    ///< 20.0
 #define NUM_CROSSHAIRS      16
 
+#define CURSOR_SIZE 32.0f
+
 /**
  * @struct windowDef_s
  * @typedef Window
@@ -559,6 +561,7 @@ typedef struct
 	int frameTime;
 	int cursorx;
 	int cursory;
+	qboolean cursorVisible;
 	qboolean debug;
 
 	cachedAssets_t Assets;


### PR DESCRIPTION
Instead of doing silly hacks that move the mouse cursor off-screen when opening a menu which sets `cl_bypassmouseinput 1`, just don't draw it in the first place. This also fixes the cursor position resetting when opening a menu which bypasses mouse input, retaining the previous position when a mouse-controlled menu was opened the last time.

The cursor drawing is a somewhat complex system so I'd appreciate if some testing was done on this, to make sure the cursor is visible/hidden in the correct places. I've tested the following menus:

* main/in-game menu
* vsay menu
* ft menu
* class/teams/spawnpoint menu
* chat
* limbo
* speaker editor
* HUD editor
* demo info window (pause/seek/rewind controls)
* intermission
* shoutcaster mode (since it has it's own event handling, cursor isn't drawn)

refs #724