### PR TITLE
cgame: add support for devmap-specific map autoexecs

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1582,6 +1582,8 @@ typedef struct
 	qboolean updateOldestValidCmd;                    ///< whenever snapshot transition happens save oldest valid command
 	int oldestValidCmd;                               ///< that will be used as a next starting point for prediction
 	                                                  ///< instead of iterating through whole CMD_BACKUP array every frame
+
+	qboolean mapConfigLoaded; // qtrue if map-specific autoexec was loaded
 } cg_t;
 
 #define MAX_LOCKER_DEBRIS 5
@@ -2703,8 +2705,6 @@ typedef struct cgs_s
 	qboolean sv_cheats;         // server allows cheats
 	int sv_fps;                 // FPS server wants to send
 	sampledStat_t sampledStat;  // fps client sample data
-
-	qboolean mapConfigLoaded; // map-specific autoexec status
 
 } cgs_t;
 

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2704,6 +2704,8 @@ typedef struct cgs_s
 	int sv_fps;                 // FPS server wants to send
 	sampledStat_t sampledStat;  // fps client sample data
 
+	qboolean mapConfigLoaded; // map-specific autoexec status
+
 } cgs_t;
 
 //==============================================================================
@@ -3023,7 +3025,8 @@ void CG_QueueMusic(void);
 
 void CG_UpdateCvars(void);
 
-qboolean CG_execFile(const char *filename);
+qboolean CG_ConfigFileExists(const char *filename);
+void CG_execFile(const char *filename);
 int CG_CrosshairPlayer(void);
 int CG_LastAttacker(void);
 void CG_KeyEvent(int key, qboolean down);

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -856,7 +856,7 @@ void CG_MapAutoexec(qboolean cheats)
 	if (CG_ConfigFileExists(filename))
 	{
 		CG_execFile(filename);
-		cgs.mapConfigLoaded = qtrue;
+		cg.mapConfigLoaded = qtrue;
 	}
 	else
 	{
@@ -866,7 +866,7 @@ void CG_MapAutoexec(qboolean cheats)
 		if (CG_ConfigFileExists(filename))
 		{
 			CG_execFile(filename);
-			cgs.mapConfigLoaded = qtrue;
+			cg.mapConfigLoaded = qtrue;
 		}
 	}
 }
@@ -2867,12 +2867,11 @@ void CG_Init(int serverMessageNum, int serverCommandSequence, int clientNum, qbo
 	CG_AssetCache();
 
 	// try execing map autoexec scripts
-	cgs.mapConfigLoaded = qfalse;
 	CG_MapAutoexec(cgs.sv_cheats);
 
 	// if cheats are enabled but devmap-specific configs aren't found,
 	// fallback to regular configs
-	if (cgs.sv_cheats && !cgs.mapConfigLoaded)
+	if (cgs.sv_cheats && !cg.mapConfigLoaded)
 	{
 		CG_MapAutoexec(qfalse);
 	}

--- a/src/cgame/cg_playerstate.c
+++ b/src/cgame/cg_playerstate.c
@@ -214,12 +214,24 @@ void CG_Respawn(qboolean revived)
 	{
 		if ((cgs.clientinfo[cg.clientNum].team == TEAM_AXIS || cgs.clientinfo[cg.clientNum].team == TEAM_ALLIES) && (cgs.clientinfo[cg.clientNum].cls != oldCls))
 		{
-			CG_execFile(va("autoexec_%s", BG_ClassnameForNumberFilename(cgs.clientinfo[cg.clientNum].cls)));
+			const char *classCfg = va("autoexec_%s", BG_ClassnameForNumberFilename(cgs.clientinfo[cg.clientNum].cls));
+
+			if (CG_ConfigFileExists(classCfg))
+			{
+				CG_execFile(classCfg);
+			}
+
 			oldCls = cgs.clientinfo[cg.clientNum].cls;
 		}
 		if (cgs.clientinfo[cg.clientNum].team != oldTeam)
 		{
-			CG_execFile(va("autoexec_%s", BG_TeamnameForNumber(cgs.clientinfo[cg.clientNum].team)));
+			const char *teamCfg = va("autoexec_%s", BG_TeamnameForNumber(cgs.clientinfo[cg.clientNum].team));
+
+			if (CG_ConfigFileExists(teamCfg))
+			{
+				CG_execFile(teamCfg);
+			}
+
 			oldTeam = cgs.clientinfo[cg.clientNum].team;
 		}
 	}


### PR DESCRIPTION
When cheats are enabled, try to execute `autoexec_devmap_mapname` or `autoexec_devmap_default` first, and if not found, fallback to regular map autoexecs.

This also refactors the config loading a bit, there's now a separate function to check if a file exists, so the return value of `CG_execFile` doesn't need to be ignored.