### PR TITLE
etmain: Reframe 1P knife animations

### DIFF
--- a/etmain/models/multiplayer/knife/weapon.cfg
+++ b/etmain/models/multiplayer/knife/weapon.cfg
@@ -18,18 +18,18 @@ newfmt
 //   /   /   /   /   /   /
 
 0	1	20	1	0	0	0	// IDLE1
-0	1	20	1	0	0	0	// IDLE2
+0	0	0	0	0	0	0	// IDLE2 notused
 
-1	5	20	0	0	0	0	// ATTACK1
-1	5	20	0	0	0	0	// ATTACK2
-1	5	20	0	0	0	0	// ATTACK3
+0	0	0	0	0	0	0	// ATTACK1 notused
+0	0	0	0	0	0	0	// ATTACK2 notused
+3	4	20	0	0	0	0	// ATTACK_LASTSHOT
 
-7	5	20	0	0	0	0	// DROP
-12	4	20	0	0	0	0	// RAISE
-12	4	16	0	0	0	0	// RELOAD1
-12	4	16	4	0	0	0	// RELOAD2
-12	4	16	0	0	0	0	// RELOAD3
+7	5	12	0	0	0	0	// DROP
+12	4	12	0	0	0	0	// RAISE
+0	0	0	0	0	0	0	// RELOAD1 notused
+0	0	0	0	0	0	0	// RELOAD2 notused
+0	0	0	0	0	0	0	// RELOAD3 notused
 
-0	1	20	1	0	0	0	// ALTSWITCH
-0	1	20	1	0	0	0	// ALTSWITCH
-0	1	20	0	0	0	0	// DROP2
+0	0	0	0	0	0	0	// ALTSWITCH notused
+0	0	0	0	0	0	0	// ALTSWITCH notused
+0	0	0	0	0	0	0	// DROP2     notused


### PR DESCRIPTION
**Comparison**: https://www.youtube.com/watch?v=QKHzMWG44fM

----

By trimming frames from ATTACK_LASTSHOT we can get animations that are both smoother, match sound better and better represent the hit detection of the attack.

DROP and RISE was lowered for a smoother transition from/to weapon switch into firing.