### PR TITLE
etmain: Reframe 1P mg42 animations

### DIFF
--- a/etmain/models/multiplayer/mg42/weapon.cfg
+++ b/etmain/models/multiplayer/mg42/weapon.cfg
@@ -18,18 +18,18 @@ newfmt
 //   /   /   /   /   /   /
 
 0	1	20	1	0	0	0	// IDLE1
-134	1	20	1	0	0	0 	// IDLE2			// idle in prone
+134	1	20	1	0	0	0 	// IDLE2 (prone)
 
 1	8	20	8	0	0	0	// ATTACK1
-158	3	20	3	0	0	0	// ATTACK2			// attack in prone
-9	10	20	0	0	0	0	// ATTACK_LASTSHOT
+158	3	20	3	0	0	0	// ATTACK2 (prone)
+0	0	0	0	0	0	0	// ATTACK_LASTSHOT notused
 
-19	11	40	0	0	0	0	// DROP
-30	25	45	0	0	0	0	// RAISE
-53	36	14	1	0	0	0	// RELOAD1
-160	27	9	0	0	0	0	// RELOAD2			// reload in prone
-103	31	18	0	0	0	0	// RELOAD3			// raise and set
+19	15	25	0	0	0	0	// DROP
+40	21	30	0	0	0	0	// RAISE
+53	36	12	1	0	0	0	// RELOAD1
+160	27	9	0	0	0	0	// RELOAD2 (prone)
+0	0	0	0	0	0	0	// RELOAD3 notused
 
-111	20	18	0	0	0	0	// ALTSWITCHFROM	// set bipod
-186	19	18	0	0	0	0	// ALTSWITCHTO		// unset bipod
-186	30	24	0	0	0	0	// DROP2			// unset and drop
+111	24	16	0	0	0	0	// ALTSWITCHFROM (setup bipod)
+186	19	10	0	0	0	0	// ALTSWITCHTO (dismantle bipod)
+0	0	0	0	0	0	0	// DROP2 notused


### PR DESCRIPTION
**Comparison**: https://www.youtube.com/watch?v=wOVkD4Y6ZSo

----

By both extending frames and slightly slowing fps down on ALTSWICHFROM, setting up the bipod now happens smoothly and bridges a previously existing abrupt framejump.

Slowing both ALTSWITCHTO and RELOAD1 down now matches the actual duration of both and smooths right into firing.

DROP and RISE were both adjusted by extending/trimming frames and slowing down to have a smoother switch, less abrupt transitions into firing and making the weapon be drawn more from the bottom rather than from the side, which looked especially jarring on widescreen displays.