### PR TITLE
Cleanup hweapon comments / unused persEnum_t entries

### DIFF
--- a/src/cgame/cg_view.c
+++ b/src/cgame/cg_view.c
@@ -1069,7 +1069,7 @@ static int CG_CalcFov(void)
 #endif
 	    )
 	{
-		// mg42 zoom
+		// stationary heavy weapon (e.g. misc_mg42, misc_aagun) zoom
 		if (cg.snap->ps.persistant[PERS_HWEAPON_USE])
 		{
 			fov_x = 55;
@@ -2415,9 +2415,9 @@ void CG_DrawActiveFrame(int serverTime, qboolean demoPlayback)
 			CG_AddAtmosphericEffects();
 		}
 
-		// mg42
 		if (!cg.showGameView && !cgs.dbShowing)
 		{
+			// stationary heavy weapon (e.g. misc_mg42, misc_aagun)
 			if (!cg.snap->ps.persistant[PERS_HWEAPON_USE])
 			{
 				CG_AddViewWeapon(&cg.predictedPlayerState);

--- a/src/cgame/cg_weapons.c
+++ b/src/cgame/cg_weapons.c
@@ -3136,9 +3136,9 @@ void CG_AddPlayerWeapon(refEntity_t *parent, playerState_t *ps, centity_t *cent)
 		return;
 	}
 
+	// stationary heavy weapon (e.g. misc_mg42, misc_aagun) muzzle flash
 	if ((cent->currentState.eFlags & EF_MG42_ACTIVE) || (cent->currentState.eFlags & EF_AAGUN_ACTIVE))
 	{
-		// MG42 Muzzle Flash
 		if (cg.time - cent->muzzleFlashTime < MUZZLE_FLASH_TIME)
 		{
 			CG_MG42EFX(cent);

--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -2118,7 +2118,7 @@ static void PM_Footsteps(void)
 	// all cyclic walking effects
 	pm->xyspeed = sqrt(pm->ps->velocity[0] * pm->ps->velocity[0] +  pm->ps->velocity[1] * pm->ps->velocity[1]);
 
-	// mg42, always idle
+	// stationary heavy weapon (e.g. misc_mg42, misc_aagun), always idle
 	if (pm->ps->persistant[PERS_HWEAPON_USE])
 	{
 		animResult = BG_AnimScriptAnimation(pm->ps, pm->character->animModelInfo, ANIM_MT_IDLE, qtrue);

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -553,7 +553,7 @@ typedef struct pmoveExt_s
 	int silencedSideArm;           ///< Keep track of whether the luger/colt is silenced "in holster", prolly want to do this for the kar98 etc too
 	float sprintTime;
 
-	// MG42 aiming
+	// stationary heavy weapon (e.g. misc_mg42, misc_aagun) aiming
 	float varc, harc;
 	vec3_t centerangles;
 
@@ -707,8 +707,7 @@ typedef enum
 	PERS_HEADSHOTS,                ///< Deprecated. Remove?
 	PERS_BLEH_3,
 
-	// mg42                        ///< TODO: I don't understand these here. Can someone explain?
-	PERS_HWEAPON_USE,              ///< enum 12 - don't change
+	PERS_HWEAPON_USE,              ///< non-zero when using a stationary hweapon (mg42=1, aagun=2) - enum 12 - don't change
 	// wolfkick
 	PERS_WOLFKICK
 } persEnum_t;

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -692,24 +692,26 @@ typedef enum
  */
 typedef enum
 {
-	PERS_SCORE = 0,                ///< !!! MUST NOT CHANGE, SERVER AND GAME BOTH REFERENCE !!!
-	PERS_HITS,                     ///< Deprecated. Remove?
+	/// !!! MUST NOT CHANGE, SERVER AND GAME BOTH REFERENCE !!!
+	PERS_SCORE = 0,
+	PERS_UNUSED_01,                ///< previously PERS_HITS
 	PERS_RANK,
 	PERS_TEAM,
 	PERS_SPAWN_COUNT,              ///< incremented every respawn
 	PERS_ATTACKER,                 ///< clientnum of last damage inflicter
 	PERS_KILLED,                   ///< count of the number of times you died
-	// these were added for single player awards tracking
+	// { these were added for single player awards tracking
 	PERS_RESPAWNS_LEFT,            ///< number of remaining respawns
 	PERS_RESPAWNS_PENALTY,         ///< how many respawns you have to sit through before respawning again
-
+	// }
 	PERS_REVIVE_COUNT,
-	PERS_HEADSHOTS,                ///< Deprecated. Remove?
-	PERS_BLEH_3,
-
-	PERS_HWEAPON_USE,              ///< non-zero when using a stationary hweapon (mg42=1, aagun=2) - enum 12 - don't change
-	// wolfkick
-	PERS_WOLFKICK
+	PERS_UNUSED_10,                ///< previously PERS_HEADSHOTS
+	PERS_UNUSED_11,                ///< previously PERS_BLEH_3
+	PERS_HWEAPON_USE,              ///< non-zero when using a stationary hweapon (mg42=1, aagun=2)
+	PERS_UNUSED_13,                ///< previously PERS_WOLFKICK
+	PERS_UNUSED_14,
+	PERS_UNUSED_15,
+	// MAX_PERSISTANT
 } persEnum_t;
 
 // entityState_t->eFlags

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -444,7 +444,7 @@ struct gentity_s
 
 	qboolean active;
 
-	// mg42
+	// stationary heavy weapon aiming (e.g. misc_mg42, misc_aagun)
 	float harc;
 	float varc;
 

--- a/src/game/g_spawn.c
+++ b/src/game/g_spawn.c
@@ -197,7 +197,7 @@ field_t fields[] =
 	// for target_unlock
 	{ "key",          FOFS(key),            F_INT,       0 },
 
-	// mg42
+	// stationary heavy weapon aiming (e.g. misc_mg42, misc_aagun)
 	{ "harc",         FOFS(harc),           F_FLOAT,     0 },
 	{ "varc",         FOFS(varc),           F_FLOAT,     0 },
 

--- a/src/game/g_weapon.c
+++ b/src/game/g_weapon.c
@@ -4213,7 +4213,7 @@ void FireWeapon(gentity_t *ent)
 		return;
 	}
 
-	// mg42
+	// stationary heavy weapon (e.g. misc_mg42, misc_aagun)
 	if (ent->client->ps.persistant[PERS_HWEAPON_USE] && ent->active)
 	{
 		return;


### PR DESCRIPTION
Specify that some comments on `mg42` are about stationary misc_mg42, not about the wieldable mg42 weapon to increase grep-ability.

Also clean up some unused `persEnum_t` entries.