### PR TITLE
mod: fix some altweapons not being properly unset on revive, refs #2643 #2637

### DIFF
--- a/src/cgame/cg_playerstate.c
+++ b/src/cgame/cg_playerstate.c
@@ -176,15 +176,6 @@ void CG_Respawn(qboolean revived)
 	trap_SendConsoleCommand("-zoom\n");
 	cg.binocZoomTime = 0;
 
-	// ensure scoped weapons are reset after revive
-	if (revived)
-	{
-		if (GetWeaponTableData(cg.snap->ps.weapon)->type & WEAPON_TYPE_SCOPED)
-		{
-			CG_FinishWeaponChange(cg.snap->ps.weapon, GetWeaponTableData(cg.snap->ps.weapon)->weapAlts);
-		}
-	}
-
 	// clear pmext
 	Com_Memset(&cg.pmext, 0, sizeof(cg.pmext));
 

--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -5198,11 +5198,6 @@ void PmoveSingle(pmove_t *pmove)
 	if (pm->ps->pm_type == PM_DEAD)
 	{
 		PM_DeadMove();
-
-		if (GetWeaponTableData(pm->ps->weapon)->type & WEAPON_TYPE_SET)
-		{
-			pm->ps->weapon = GetWeaponTableData(pm->ps->weapon)->weapAlts;
-		}
 	}
 	else if (GetWeaponTableData(pm->ps->weapon)->type & WEAPON_TYPE_SCOPED)
 	{

--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -3230,7 +3230,12 @@ void ClientSpawn(gentity_t *ent, qboolean revived, qboolean teamChange, qboolean
 		}
 		else
 		{
-			if (COM_BitCheck(client->ps.weapons, oldWeapon))
+			// unset some alt weapons
+			if (GetWeaponTableData(oldWeapon)->weapAlts && GetWeaponTableData(oldWeapon)->type & (WEAPON_TYPE_SET | WEAPON_TYPE_SCOPED))
+			{
+				client->ps.weapon = oldNextWeapon = GetWeaponTableData(oldWeapon)->weapAlts;
+			}
+			else if (COM_BitCheck(client->ps.weapons, oldWeapon))
 			{
 				client->ps.weapon = oldWeapon;
 			}


### PR DESCRIPTION
- moves altweapon handling on revive into one place
- moves WEAPON_TYPE_SET handling outside of pmove, because otherwise it is basically impossible to know what was the weapon player died with when revived and although it makes sense to unset some altweapons instantly it creates even more convoluted altweapon mechanism than it already is. Client can't predict being dead anyway, so in my opinion it should rather happen in player_die if anything.
- refs https://github.com/etlegacy/etlegacy/commit/1ea52623bd6c6c8d93bedd2455dbd685e6045936
- refs #2643 #2637