### PR TITLE
game: fix more issues with alt weapons on revive

### DIFF
--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -2909,7 +2909,7 @@ void ClientSpawn(gentity_t *ent, qboolean revived, qboolean teamChange, qboolean
 	int                savedPing;
 	int                savedTeam;
 	int                savedDeathTime;
-	int                oldWeapon, oldNextWeapon, oldWeaponstate, oldSilencedSideArm;
+	int                oldWeapon, oldNextWeapon, oldSilencedSideArm;
 	int                oldAmmo[MAX_WEAPONS];                          // total amount of ammo
 	int                oldAmmoclip[MAX_WEAPONS];                      // ammo in clip
 	int                oldWeapons[MAX_WEAPONS / (sizeof(int) * 8)];   // 64 bits for weapons held
@@ -2992,7 +2992,6 @@ void ClientSpawn(gentity_t *ent, qboolean revived, qboolean teamChange, qboolean
 	{
 		oldWeapon          = client->ps.weapon;
 		oldNextWeapon      = client->ps.nextWeapon;
-		oldWeaponstate     = client->ps.weaponstate;
 		oldSilencedSideArm = client->pmext.silencedSideArm;
 
 		Com_Memcpy(oldAmmo, client->ps.ammo, sizeof(int) * MAX_WEAPONS);
@@ -3233,7 +3232,7 @@ void ClientSpawn(gentity_t *ent, qboolean revived, qboolean teamChange, qboolean
 			// unset some alt weapons
 			if (GetWeaponTableData(oldWeapon)->weapAlts && GetWeaponTableData(oldWeapon)->type & (WEAPON_TYPE_SET | WEAPON_TYPE_SCOPED))
 			{
-				client->ps.weapon = oldNextWeapon = GetWeaponTableData(oldWeapon)->weapAlts;
+				client->ps.weapon = GetWeaponTableData(oldWeapon)->weapAlts;
 			}
 			else if (COM_BitCheck(client->ps.weapons, oldWeapon))
 			{
@@ -3248,16 +3247,6 @@ void ClientSpawn(gentity_t *ent, qboolean revived, qboolean teamChange, qboolean
 			}
 
 			client->pmext.silencedSideArm = oldSilencedSideArm;
-		}
-
-		// cgame's prevent the flying nade effect (best visible with M7 when swapping while raising)
-		if (BG_simpleWeaponState(oldWeaponstate) == WSTATE_SWITCH)
-		{
-			client->ps.nextWeapon = client->ps.weapon;
-		}
-		else
-		{
-			client->ps.nextWeapon = oldNextWeapon;
 		}
 	}
 


### PR DESCRIPTION
Removing cgame's visual bug fix from game because it causes some other issues when ps.nextWeapon is incorrectly set to alt weapon which makes it impossible to switch to said alt weapon. I noticed it in last commit https://github.com/etlegacy/etlegacy/commit/44ff5a89d21e33b96516b3b7dc5b9742a274342f but instead of removing it I added oldNextWeapon = GetWeaponTableData(oldWeapon)->weapAlts, but since then I found another bug which that code doesn't cover.

It's possible that a fix exists, but since I hate how altweapons are basically a messy hack I don't want to deal with it constantly (and that visual bug fix is a hack in on itself).