### PR TITLE
cgame: Add HUD "No Countdown" style to 'followtext'

### DIFF
--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -3060,6 +3060,7 @@ void CG_DrawFollow(hudComponent_t *comp)
 	float heightIconsOffset;
 	float scale;
 	float iconsSize;
+	const qboolean showCountdown = !(comp->style & FOLLOW_NO_COUNTDOWN);
 
 #ifdef FEATURE_MULTIVIEW
 	// MV following info for mainview
@@ -3135,7 +3136,7 @@ void CG_DrawFollow(hudComponent_t *comp)
 					int deployTime   = ((cgs.clientinfo[cg.snap->ps.clientNum].team == TEAM_AXIS) ? cg_redlimbotime.integer : cg_bluelimbotime.integer) / 1000;
 					int reinfDepTime = CG_CalculateReinfTime(cgs.clientinfo[cg.snap->ps.clientNum].team) + cg.snap->ps.persistant[PERS_RESPAWNS_PENALTY] * deployTime;
 
-					if (reinfDepTime > 1)
+					if (showCountdown && reinfDepTime > 1)
 					{
 						Com_sprintf(deploytime, sizeof(deploytime), CG_TranslateString("Bonus Life! Deploying in ^3%d ^*seconds"), reinfDepTime);
 					}
@@ -3149,7 +3150,7 @@ void CG_DrawFollow(hudComponent_t *comp)
 					Com_sprintf(deploytime, sizeof(deploytime), "%s", CG_TranslateString("No more deployments this round"));
 				}
 			}
-			else
+			else if (showCountdown)
 			{
 				int reinfTime = CG_CalculateReinfTime(cgs.clientinfo[cg.snap->ps.clientNum].team);
 

--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -3060,7 +3060,6 @@ void CG_DrawFollow(hudComponent_t *comp)
 	float heightIconsOffset;
 	float scale;
 	float iconsSize;
-	const qboolean showCountdown = !(comp->style & FOLLOW_NO_COUNTDOWN);
 
 #ifdef FEATURE_MULTIVIEW
 	// MV following info for mainview
@@ -3127,7 +3126,7 @@ void CG_DrawFollow(hudComponent_t *comp)
 			CG_DrawRect_FixedBorder(comp->location.x, comp->location.y, comp->location.w, comp->location.h, 1, comp->colorBorder);
 		}
 
-		if (cgs.gametype != GT_WOLF_LMS)
+		if (cgs.gametype != GT_WOLF_LMS && !(comp->style & FOLLOW_NO_COUNTDOWN))
 		{
 			if (cg.snap->ps.persistant[PERS_RESPAWNS_LEFT] == 0)
 			{
@@ -3136,7 +3135,7 @@ void CG_DrawFollow(hudComponent_t *comp)
 					int deployTime   = ((cgs.clientinfo[cg.snap->ps.clientNum].team == TEAM_AXIS) ? cg_redlimbotime.integer : cg_bluelimbotime.integer) / 1000;
 					int reinfDepTime = CG_CalculateReinfTime(cgs.clientinfo[cg.snap->ps.clientNum].team) + cg.snap->ps.persistant[PERS_RESPAWNS_PENALTY] * deployTime;
 
-					if (showCountdown && reinfDepTime > 1)
+					if (reinfDepTime > 1)
 					{
 						Com_sprintf(deploytime, sizeof(deploytime), CG_TranslateString("Bonus Life! Deploying in ^3%d ^*seconds"), reinfDepTime);
 					}
@@ -3150,7 +3149,7 @@ void CG_DrawFollow(hudComponent_t *comp)
 					Com_sprintf(deploytime, sizeof(deploytime), "%s", CG_TranslateString("No more deployments this round"));
 				}
 			}
-			else if (showCountdown)
+			else
 			{
 				int reinfTime = CG_CalculateReinfTime(cgs.clientinfo[cg.snap->ps.clientNum].team);
 

--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -75,7 +75,7 @@ const hudComponentFields_t hudComponentFields[] =
 	{ HUDF(votetext),           CG_DrawVote,                      0.22f,  { "Complaint" } }, // FIXME: outside cg_draw_hud
 	{ HUDF(spectatortext),      CG_DrawSpectatorMessage,          0.22f,  { 0 } },           // FIXME: outside cg_draw_hud
 	{ HUDF(limbotext),          CG_DrawLimboMessage,              0.22f,  { "No Wounded Msg" } },// FIXME: outside cg_draw_hud
-	{ HUDF(followtext),         CG_DrawFollow,                    0.22f,  { 0 } },           // FIXME: outside cg_draw_hud
+	{ HUDF(followtext),         CG_DrawFollow,                    0.22f,  { "No Countdown" } },           // FIXME: outside cg_draw_hud
 	{ HUDF(demotext),           CG_DrawDemoMessage,               0.22f,  { "Details" } },
 	{ HUDF(missilecamera),      CG_DrawMissileCamera,             0.22f,  { 0 } },           // FIXME: outside cg_draw_hud
 	{ HUDF(sprinttext),         CG_DrawPlayerSprint,              0.25f,  { "Draw Suffix" } },

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2197,6 +2197,12 @@ enum
 	COMPASS_ALWAYS_DRAW          = BIT(7),
 };
 
+// Follow filters
+enum
+{
+	FOLLOW_NO_COUNTDOWN = BIT(0),
+};
+
 /// Locations
 #define MAX_C_LOCATIONS 1024
 


### PR DESCRIPTION
Add a way to keep the followtext without the reinforce countdown, which can also be inferred from the roundtimer.