### PR TITLE
etmain: Fix 1P knife attack regression

### DIFF
--- a/etmain/models/multiplayer/knife/weapon.cfg
+++ b/etmain/models/multiplayer/knife/weapon.cfg
@@ -20,7 +20,7 @@ newfmt
 0	1	20	1	0	0	0	// IDLE1
 0	0	0	0	0	0	0	// IDLE2 notused
 
-0	0	0	0	0	0	0	// ATTACK1 notused
+3	4	20	0	0	0	0	// ATTACK1 (e.g. after using 'give ammo' cheat)
 0	0	0	0	0	0	0	// ATTACK2 notused
 3	4	20	0	0	0	0	// ATTACK_LASTSHOT
 


### PR DESCRIPTION
Under some circumstances ATTACK1 turned out to be used.
(e.g. when `/give ammo` cheat is used)

Readd ATTACK1.