### PR TITLE
Add some missing header includes & Fix circular 'q_shared.h' include

### DIFF
--- a/src/botlib/be_interface.h
+++ b/src/botlib/be_interface.h
@@ -36,6 +36,8 @@
 #ifndef INCLUDE_BE_INTERFACE_H
 #define INCLUDE_BE_INTERFACE_H
 
+#include "botlib.h"
+
 extern botlib_import_t botimport;
 
 #endif // #ifndef INCLUDE_BE_INTERFACE_H

--- a/src/botlib/botlib.h
+++ b/src/botlib/botlib.h
@@ -35,6 +35,8 @@
 #ifndef INCLUDE_BOTLIB_H
 #define INCLUDE_BOTLIB_H
 
+#include "../qcommon/q_shared.h"
+
 #define BOTLIB_API_VERSION      2
 
 #define MAX_DEBUGPOLYS      4096

--- a/src/botlib/l_precomp.h
+++ b/src/botlib/l_precomp.h
@@ -36,6 +36,8 @@
 #ifndef INCLUDE_L_PRECOMP_H
 #define INCLUDE_L_PRECOMP_H
 
+#include "l_script.h"
+
 #ifndef _MAX_PATH
 #define MAX_PATH            MAX_QPATH
 #endif

--- a/src/botlib/l_script.h
+++ b/src/botlib/l_script.h
@@ -36,6 +36,8 @@
 #ifndef INCLUDE_L_SCRIPT_H
 #define INCLUDE_L_SCRIPT_H
 
+#include "../qcommon/q_shared.h"
+
 /// undef if binary numbers of the form 0b... or 0B... are not allowed
 #define BINARYNUMBERS
 /// undef if not using the token.intvalue and token.floatvalue

--- a/src/cgame/cg_public.h
+++ b/src/cgame/cg_public.h
@@ -35,6 +35,8 @@
 #ifndef INCLUDE_CG_PUBLIC_H
 #define INCLUDE_CG_PUBLIC_H
 
+#include "../qcommon/q_shared.h"
+
 /// Allow a lot of command backups for very fast systems
 /// multiple commands may be combined into a single packet, so this
 /// needs to be larger than PACKET_BACKUP

--- a/src/client/keys.h
+++ b/src/client/keys.h
@@ -35,6 +35,7 @@
 #ifndef INCLUDE_KEYS_H
 #define INCLUDE_KEYS_H
 
+#include "../qcommon/qcommon.h"
 #include "../ui/keycodes.h"
 
 /**

--- a/src/client/snd_public.h
+++ b/src/client/snd_public.h
@@ -35,6 +35,8 @@
 #ifndef INCLUDE_SND_PUBLIC_H
 #define INCLUDE_SND_PUBLIC_H
 
+#include "../qcommon/q_shared.h"
+
 // background track queuing
 #define QUEUED_PLAY_ONCE    -1
 #define QUEUED_PLAY_LOOPED  -2

--- a/src/game/bg_local.h
+++ b/src/game/bg_local.h
@@ -36,6 +36,8 @@
 #ifndef INCLUDE_BG_LOCAL_H
 #define INCLUDE_BG_LOCAL_H
 
+#include "bg_public.h"
+
 #define MIN_WALK_NORMAL 0.7f     ///< Can't walk on very steep slopes
 
 #define STEPSIZE        18

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -39,6 +39,8 @@
 #ifndef INCLUDE_BG_PUBLIC_H
 #define INCLUDE_BG_PUBLIC_H
 
+#include "../qcommon/q_shared.h"
+
 #define GAME_VERSION        "Enemy Territory"
 #define GAME_VERSION_DATED  (GAME_VERSION ", ET 2.60b")
 

--- a/src/game/g_mdx.h
+++ b/src/game/g_mdx.h
@@ -29,6 +29,8 @@
 #ifndef INCLUDE_G_MDX_H
 #define INCLUDE_G_MDX_H
 
+#include "../tvgame/tvg_local.h"
+
 //TODO: enable this later on when fixed (&& figured out how the fuck it works)
 /*
 #ifdef ETLEGACY_DEBUG

--- a/src/game/g_public.h
+++ b/src/game/g_public.h
@@ -36,6 +36,8 @@
 #ifndef INCLUDE_G_PUBLIC_H
 #define INCLUDE_G_PUBLIC_H
 
+#include "../qcommon/q_shared.h"
+
 #define GAME_API_VERSION    8
 
 //===============================================================

--- a/src/irc/irc_client.h
+++ b/src/irc/irc_client.h
@@ -39,6 +39,8 @@
 #ifndef IRC_CLIENT_H
 #define IRC_CLIENT_H
 
+#include "../qcommon/q_shared.h"
+
 /* IRC control cvars */
 extern cvar_t *irc_mode;
 extern cvar_t *irc_server;

--- a/src/qcommon/cm_patch.h
+++ b/src/qcommon/cm_patch.h
@@ -35,6 +35,8 @@
 #ifndef INCLUDE_CM_PATCH_H
 #define INCLUDE_CM_PATCH_H
 
+#include "../qcommon/q_shared.h"
+
 /*
 
 This file does not reference any globals, and has these entry points:

--- a/src/qcommon/cm_polylib.h
+++ b/src/qcommon/cm_polylib.h
@@ -36,6 +36,8 @@
 #ifndef INCLUDE_CM_POLYLIB_H
 #define INCLUDE_CM_POLYLIB_H
 
+#include "../qcommon/q_shared.h"
+
 typedef struct
 {
 	int numpoints;

--- a/src/qcommon/q_math.h
+++ b/src/qcommon/q_math.h
@@ -36,7 +36,8 @@
 #ifndef INCLUDE_Q_MATH_H
 #define INCLUDE_Q_MATH_H
 
-#include "q_shared.h"
+#include "q_primitives.h"
+#include "q_platform.h"
 
 typedef float vec_t;
 typedef vec_t vec2_t[2];

--- a/src/qcommon/q_primitives.h
+++ b/src/qcommon/q_primitives.h
@@ -1,0 +1,118 @@
+/*
+* Wolfenstein: Enemy Territory GPL Source Code
+* Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company.
+*
+* ET: Legacy
+* Copyright (C) 2012-2024 ET:Legacy team <mail@etlegacy.com>
+*
+* This file is part of ET: Legacy - http://www.etlegacy.com
+*
+* ET: Legacy is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* ET: Legacy is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with ET: Legacy. If not, see <http://www.gnu.org/licenses/>.
+*
+* In addition, Wolfenstein: Enemy Territory GPL Source Code is also
+* subject to certain additional terms. You should have received a copy
+* of these additional terms immediately following the terms and conditions
+* of the GNU General Public License which accompanied the source code.
+* If not, please request a copy in writing from id Software at the address below.
+*
+* id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, Maryland 20850 USA.
+*/
+/**
+* @file q_primitives.h
+* @brief Primitives
+*/
+
+#ifndef INCLUDE_Q_PRIMITIVES_H
+#define INCLUDE_Q_PRIMITIVES_H
+
+#ifdef Q3_VM
+
+#include "bg_lib.h"
+
+typedef int intptr_t;
+
+#else
+
+#include <assert.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <string.h>
+#include <stdlib.h>
+
+#ifdef __aarch64__ // ARM definition seems to not work here
+
+#include <stddef.h>
+
+#endif
+
+#include <time.h>
+#include <ctype.h>
+#include <limits.h>
+#include <sys/stat.h>
+#include <float.h>
+
+#if defined (_MSC_VER) && (_MSC_VER >= 1600)
+#include <stdint.h>
+
+// vsnprintf is ISO/IEC 9899:1999
+// abstracting this to make it portable
+int Q_vsnprintf(char *str, size_t size, const char *format, va_list args);
+#elif defined (_MSC_VER)
+#include <io.h>
+
+typedef signed __int64 int64_t;
+typedef signed __int32 int32_t;
+typedef signed __int16 int16_t;
+typedef signed __int8 int8_t;
+typedef unsigned __int64 uint64_t;
+typedef unsigned __int32 uint32_t;
+typedef unsigned __int16 uint16_t;
+typedef unsigned __int8 uint8_t;
+
+// vsnprintf is ISO/IEC 9899:1999
+// abstracting this to make it portable
+int Q_vsnprintf(char *str, size_t size, const char *format, va_list args);
+#else // not using MSVC
+
+#include <stdint.h>
+
+#define Q_vsnprintf vsnprintf
+#endif // defined (_MSC_VER) && (_MSC_VER >= 1600)
+#endif // Q3_VM
+
+
+typedef unsigned char byte;
+
+/**
+ * @enum qboolean
+ * @brief Boolean definition
+ */
+typedef enum
+{
+	qfalse, qtrue
+} qboolean;
+
+/**
+ * @union floatint_t
+ * @brief
+ */
+typedef union
+{
+	float f;
+	int32_t i;
+	uint32_t ui;
+} floatint_t;
+
+#endif // #ifndef INCLUDE_Q_PRIMITIVES_H

--- a/src/qcommon/q_shared.h
+++ b/src/qcommon/q_shared.h
@@ -157,62 +157,7 @@
 
  **********************************************************************/
 
-#ifdef Q3_VM
-
-#include "bg_lib.h"
-
-typedef int intptr_t;
-
-#else
-
-#include <assert.h>
-#include <math.h>
-#include <stdio.h>
-#include <stdarg.h>
-#include <string.h>
-#include <stdlib.h>
-
-#ifdef __aarch64__ // ARM definition seems to not work here
-
-#include <stddef.h>
-
-#endif
-
-#include <time.h>
-#include <ctype.h>
-#include <limits.h>
-#include <sys/stat.h>
-#include <float.h>
-
-#if defined (_MSC_VER) && (_MSC_VER >= 1600)
-#include <stdint.h>
-
-// vsnprintf is ISO/IEC 9899:1999
-// abstracting this to make it portable
-int Q_vsnprintf(char *str, size_t size, const char *format, va_list args);
-#elif defined (_MSC_VER)
-#include <io.h>
-
-typedef signed __int64 int64_t;
-typedef signed __int32 int32_t;
-typedef signed __int16 int16_t;
-typedef signed __int8 int8_t;
-typedef unsigned __int64 uint64_t;
-typedef unsigned __int32 uint32_t;
-typedef unsigned __int16 uint16_t;
-typedef unsigned __int8 uint8_t;
-
-// vsnprintf is ISO/IEC 9899:1999
-// abstracting this to make it portable
-int Q_vsnprintf(char *str, size_t size, const char *format, va_list args);
-#else // not using MSVC
-
-#include <stdint.h>
-
-#define Q_vsnprintf vsnprintf
-#endif // defined (_MSC_VER) && (_MSC_VER >= 1600)
-#endif // Q3_VM
-
+#include "q_primitives.h"
 #include "q_platform.h"
 
 //======================= WIN32 DEFINES =================================
@@ -395,28 +340,6 @@ static ID_INLINE float idSqrt(float x)
 #endif // __ANDROID__
 
 //=============================================================
-
-typedef unsigned char byte;
-
-/**
- * @enum qboolean
- * @brief Boolean definition
- */
-typedef enum
-{
-	qfalse, qtrue
-} qboolean;
-
-/**
- * @union floatint_t
- * @brief
- */
-typedef union
-{
-	float f;
-	int32_t i;
-	uint32_t ui;
-} floatint_t;
 
 typedef int qhandle_t;
 typedef int sfxHandle_t;

--- a/src/qcommon/q_unicode.h
+++ b/src/qcommon/q_unicode.h
@@ -45,6 +45,8 @@
 #ifndef INCLUDE_Q_UNICODE_H
 #define INCLUDE_Q_UNICODE_H
 
+#include "../qcommon/q_shared.h"
+
 // The version in which unicode was added
 #define UNICODE_SUPPORT_VERSION 273
 

--- a/src/qcommon/qfiles.h
+++ b/src/qcommon/qfiles.h
@@ -37,6 +37,8 @@
 #ifndef INCLUDE_QFILES_H
 #define INCLUDE_QFILES_H
 
+#include "../qcommon/q_shared.h"
+
 // surface geometry should not exceed these limits
 #define SHADER_MAX_VERTEXES 10000 ///< Arnout: 1024+1 (1 buffer for RB_EndSurface overflow check) // was 4000, 1000 in q3ta //Jacker changed from 1025 to 10000
 #define SHADER_MAX_INDEXES  (6 * SHADER_MAX_VERTEXES)

--- a/src/renderercommon/tr_types.h
+++ b/src/renderercommon/tr_types.h
@@ -38,6 +38,8 @@
 #ifndef INCLUDE_TR_TYPES_H
 #define INCLUDE_TR_TYPES_H
 
+#include "../qcommon/q_shared.h"
+
 // renderer2 BEGIN
 #define MAX_REF_LIGHTS      1024
 #define MAX_BONES           128         ///< RB: same as MDX_MAX_BONES

--- a/src/tvgame/tvg_public.h
+++ b/src/tvgame/tvg_public.h
@@ -36,6 +36,8 @@
 #ifndef INCLUDE_G_PUBLIC_H
 #define INCLUDE_G_PUBLIC_H
 
+#include "../qcommon/q_shared.h"
+
 #define GAME_API_VERSION    8
 
 //===============================================================

--- a/src/ui/ui_public.h
+++ b/src/ui/ui_public.h
@@ -34,6 +34,8 @@
 #ifndef INCLUDE_UI_PUBLIC_H
 #define INCLUDE_UI_PUBLIC_H
 
+#include "../qcommon/q_shared.h"
+
 #define UI_API_VERSION  4
 
 /**


### PR DESCRIPTION
```
Add some missing header includes
```

&

```
qcommon: Fix circular 'q_shared.h' include

Fix the following circular/recursive include:

           src/qcommon/q_shared.h
includes → src/qcommon/q_math.h
includes → src/qcommon/q_shared.h

By factoring out the required parts used by 'q_math.h' from 'q_shared.h'
into 'q_primitives.h'.
```