### PR TITLE
client: fix clc.demo.demoName being empty on demo playback

### DIFF
--- a/src/client/cl_demo.c
+++ b/src/client/cl_demo.c
@@ -1473,7 +1473,6 @@ void CL_PlayDemo_f(void)
 	{
 		Com_FuncDrop("couldn't open %s", name);
 	}
-	Q_strncpyz(clc.demo.demoName, demoFile, sizeof(clc.demo.demoName));
 
 	Con_Close();
 
@@ -1481,6 +1480,8 @@ void CL_PlayDemo_f(void)
 	CL_AllocateDemoPoints();
 	CL_ParseDemo();
 #endif
+
+	Q_strncpyz(clc.demo.demoName, demoFile, sizeof(clc.demo.demoName));
 
 	if (Cmd_Argc() == 3)
 	{


### PR DESCRIPTION
`CL_ParseDemo` wipes the `clc` struct entirely, so we lose the demo filename right after we set it. Outside of demo recording, this variable is actually only ever used for `video` command for automatic naming of video files and nothing else, which now actually functions properly since the name isn't wiped.