### PR TITLE
client: add video-pipe to pipe video/audio to ffmpeg

### DIFF
--- a/src/client/cl_avi.c
+++ b/src/client/cl_avi.c
@@ -78,6 +78,8 @@ typedef struct aviFileData_s
 	int chunkStackTop;
 
 	byte *cBuffer, *eBuffer;
+
+	qboolean pipe;
 } aviFileData_t;
 
 static aviFileData_t afd;
@@ -224,7 +226,16 @@ static void CL_WriteAVIHeader(void)
 				WRITE_4BYTES(afd.framePeriod);  //dwMicroSecPerFrame
 				WRITE_4BYTES(afd.maxRecordSize * afd.frameRate);    //dwMaxBytesPerSec
 				WRITE_4BYTES(0);    //dwReserved1
-				WRITE_4BYTES(0x110);    //dwFlags bits HAS_INDEX and IS_INTERLEAVED
+
+				if (afd.pipe)
+				{
+					WRITE_4BYTES(0x100); //dwFlags bits IS_INTERLEAVED=0x100
+				}
+				else
+				{
+					WRITE_4BYTES(0x110); //dwFlags bits HAS_INDEX and IS_INTERLEAVED
+				}
+
 				WRITE_4BYTES(afd.numVideoFrames);   //dwTotalFrames
 				WRITE_4BYTES(0);    //dwInitialFrame
 
@@ -252,7 +263,7 @@ static void CL_WriteAVIHeader(void)
 					WRITE_4BYTES(56);   //"strh" "chunk" size
 					WRITE_STRING("vids");
 
-					if (afd.motionJpeg)
+					if (afd.motionJpeg && !afd.pipe)
 					{
 						WRITE_STRING("MJPG");
 					}
@@ -286,7 +297,7 @@ static void CL_WriteAVIHeader(void)
 					WRITE_2BYTES(1);    //biPlanes
 					WRITE_2BYTES(24);   //biBitCount
 
-					if (afd.motionJpeg)  //biCompression
+					if (afd.motionJpeg && !afd.pipe)  //biCompression
 					{
 						WRITE_STRING("MJPG");
 						WRITE_4BYTES(afd.width * afd.height);   //biSizeImage
@@ -356,13 +367,40 @@ static void CL_WriteAVIHeader(void)
 }
 
 /**
+ * @brief CL_ValidatePipeFormat
+ * @param[in] fileName
+ * @return qtrue if pipe format is valid
+ */
+static qboolean CL_ValidatePipeFormat(const char *s)
+{
+	while (*s != '\0')
+	{
+		if (*s == '.' && *(s + 1) == '.' && (*(s + 2) == '/' || *(s + 2) == '\\'))
+		{
+			return qfalse;
+		}
+		if (*s == ':' && *(s + 1) == ':')
+		{
+			return qfalse;
+		}
+		if (*s == '>' || *s == '|' || *s == '&')
+		{
+			return qfalse;
+		}
+		s++;
+	}
+
+	return qtrue;
+}
+
+/**
  * @brief Creates an AVI file and gets it into a state where
  * writing the actual data can begin
  *
  * @param[in] fileName
  * @return
  */
-qboolean CL_OpenAVIForWriting(const char *fileName)
+qboolean CL_OpenAVIForWriting(const char *fileName, qboolean pipe)
 {
 	if (afd.fileOpen)
 	{
@@ -371,34 +409,48 @@ qboolean CL_OpenAVIForWriting(const char *fileName)
 
 	Com_Memset(&afd, 0, sizeof(aviFileData_t));
 
-
-	// Don't start if a framerate has not been chosen
-	if (cl_avidemo->integer <= 0)
+	if (pipe)
 	{
-		Com_Printf(S_COLOR_RED "cl_avidemo must be >= 1\n");
-		return qfalse;
+		char       cmd[MAX_OSPATH * 4];
+		const char *ospath;
+		const char *cmd_fmt = "ffmpeg -f avi -i - -threads 0 -y %s \"%s\" 2> \"%s-log.txt\"";
+
+		if (!CL_ValidatePipeFormat(cl_aviPipeFormat->string))
+		{
+			Com_Printf(S_COLOR_RED "Invalid pipe format: %s\n", cl_aviPipeFormat->string);
+			return qfalse;
+		}
+
+		ospath = FS_BuildOSPath(Cvar_VariableString("fs_homepath"), "", fileName);
+		Com_sprintf(cmd, sizeof(cmd), cmd_fmt, cl_aviPipeFormat->string, ospath, ospath);
+
+		if ((afd.f = FS_PipeOpenWrite(cmd, fileName)) <= 0)
+		{
+			return qfalse;
+		}
 	}
-
-
-	if ((afd.f = FS_FOpenFileWrite(fileName)) <= 0)
+	else
 	{
-		return qfalse;
-	}
+		if ((afd.f = FS_FOpenFileWrite(fileName)) <= 0)
+		{
+			return qfalse;
+		}
 
-	if ((afd.idxF = FS_FOpenFileWrite(va("%s" INDEX_FILE_EXTENSION, fileName))) <= 0)
-	{
-		FS_FCloseFile(afd.f);
-		return qfalse;
+		if ((afd.idxF = FS_FOpenFileWrite(va("%s" INDEX_FILE_EXTENSION, fileName))) <= 0)
+		{
+			FS_FCloseFile(afd.f);
+			return qfalse;
+		}
 	}
 
 	Q_strncpyz(afd.fileName, fileName, MAX_QPATH);
 
-	afd.frameRate   = cl_avidemo->integer;
+	afd.frameRate   = cl_aviFrameRate->integer;
 	afd.framePeriod = (int)(1000000.0f / afd.frameRate);
 	afd.width       = cls.glconfig.windowWidth;
 	afd.height      = cls.glconfig.windowHeight;
 
-	if (cl_aviMotionJpeg->integer)
+	if (cl_aviMotionJpeg->integer && !pipe)
 	{
 		afd.motionJpeg = qtrue;
 	}
@@ -453,14 +505,24 @@ qboolean CL_OpenAVIForWriting(const char *fileName)
 	// correct amount of space at the beginning of the file
 	CL_WriteAVIHeader();
 
-	SafeFS_Write(buffer, bufIndex, afd.f);
-	afd.fileSize = bufIndex;
+	if (pipe)
+	{
+		afd.pipe = qtrue;
+		SafeFS_Write(buffer, bufIndex, afd.f);
+		bufIndex = 0;
+	}
+	else
+	{
+		SafeFS_Write(buffer, bufIndex, afd.f);
+		afd.fileSize = bufIndex;
 
-	bufIndex = 0;
-	START_CHUNK("idx1");
-	SafeFS_Write(buffer, bufIndex, afd.idxF);
+		bufIndex = 0;
+		START_CHUNK("idx1");
+		SafeFS_Write(buffer, bufIndex, afd.idxF);
 
-	afd.moviSize = 4;           // For the "movi"
+		afd.moviSize = 4;           // For the "movi"
+	}
+
 	afd.fileOpen = qtrue;
 
 	return qtrue;
@@ -473,10 +535,15 @@ qboolean CL_OpenAVIForWriting(const char *fileName)
  */
 static qboolean CL_CheckFileSize(int bytesToAdd)
 {
-	unsigned int newFileSize = afd.fileSize +           // Current file size
-	                           bytesToAdd +            // What we want to add
-	                           (afd.numIndices * 16) + // The index
-	                           4;                      // The index size
+	unsigned int newFileSize;
+
+	if (afd.pipe)
+	{
+		return qfalse;
+	}
+
+	// current file size + what we want to add + the index + the index size
+	newFileSize = afd.fileSize + bytesToAdd + (afd.numIndices * 16) + 4;
 
 	// I assume all the operating systems
 	// we target can handle a 2Gb file
@@ -486,7 +553,7 @@ static qboolean CL_CheckFileSize(int bytesToAdd)
 		CL_CloseAVI();
 
 		// ...And open a new one
-		CL_OpenAVIForWriting(va("%s_", afd.fileName));
+		CL_OpenAVIForWriting(va("%s_", afd.fileName), videoPipe);
 
 		return qtrue;
 	}
@@ -524,15 +591,21 @@ void CL_WriteAVIVideoFrame(const byte *imageBuffer, int size)
 	SafeFS_Write(buffer, 8, afd.f);
 	SafeFS_Write(imageBuffer, size, afd.f);
 	SafeFS_Write(padding, paddingSize, afd.f);
-	afd.fileSize += (chunkSize + paddingSize);
 
 	afd.numVideoFrames++;
-	afd.moviSize += (chunkSize + paddingSize);
 
 	if (size > afd.maxRecordSize)
 	{
 		afd.maxRecordSize = size;
 	}
+
+	if (afd.pipe)
+	{
+		return;
+	}
+
+	afd.fileSize += (chunkSize + paddingSize);
+	afd.moviSize += (chunkSize + paddingSize);
 
 	// Index
 	bufIndex = 0;
@@ -597,21 +670,24 @@ void CL_WriteAVIAudioFrame(const byte *pcmBuffer, int size)
 		SafeFS_Write(buffer, 8, afd.f);
 		SafeFS_Write(pcmCaptureBuffer, bytesInBuffer, afd.f);
 		SafeFS_Write(padding, paddingSize, afd.f);
-		afd.fileSize += (chunkSize + paddingSize);
-
 		afd.numAudioFrames++;
-		afd.moviSize     += (chunkSize + paddingSize);
-		afd.a.totalBytes += bytesInBuffer;
 
-		// Index
-		bufIndex = 0;
-		WRITE_STRING("01wb");   //dwIdentifier
-		WRITE_4BYTES(0);        //dwFlags
-		WRITE_4BYTES(chunkOffset);  //dwOffset
-		WRITE_4BYTES(bytesInBuffer);    //dwLength
-		SafeFS_Write(buffer, 16, afd.idxF);
+		if (!afd.pipe)
+		{
+			afd.fileSize     += (chunkSize + paddingSize);
+			afd.moviSize     += (chunkSize + paddingSize);
+			afd.a.totalBytes += bytesInBuffer;
 
-		afd.numIndices++;
+			// Index
+			bufIndex = 0;
+			WRITE_STRING("01wb");   //dwIdentifier
+			WRITE_4BYTES(0);        //dwFlags
+			WRITE_4BYTES(chunkOffset);  //dwOffset
+			WRITE_4BYTES(bytesInBuffer);    //dwLength
+			SafeFS_Write(buffer, 16, afd.idxF);
+
+			afd.numIndices++;
+		}
 
 		bytesInBuffer = 0;
 	}
@@ -647,6 +723,19 @@ qboolean CL_CloseAVI(void)
 		return qfalse;
 	}
 
+	Z_Free(afd.cBuffer);
+	Z_Free(afd.eBuffer);
+
+	if (afd.pipe)
+	{
+		Com_Printf("Wrote %d:%d (v:a) frames to pipe: %s\n", afd.numVideoFrames, afd.numAudioFrames, afd.fileName);
+		FS_FCloseFile(afd.f);
+		afd.f        = 0;
+		afd.fileOpen = qfalse;
+		afd.pipe     = qfalse;
+		return qtrue;
+	}
+
 	afd.fileOpen = qfalse;
 
 	(void) FS_Seek(afd.idxF, 4, FS_SEEK_SET);
@@ -654,9 +743,6 @@ qboolean CL_CloseAVI(void)
 	WRITE_4BYTES(indexSize);
 	SafeFS_Write(buffer, bufIndex, afd.idxF);
 	FS_FCloseFile(afd.idxF);
-
-	Z_Free(afd.cBuffer);
-	Z_Free(afd.eBuffer);
 
 	// Write index
 
@@ -699,7 +785,7 @@ qboolean CL_CloseAVI(void)
 
 	FS_FCloseFile(afd.f);
 
-	Com_Printf("Wrote %d:%d frames to %s\n", afd.numVideoFrames, afd.numAudioFrames, afd.fileName);
+	Com_Printf("Wrote %d:%d (v:a) frames to: %s\n", afd.numVideoFrames, afd.numAudioFrames, afd.fileName);
 
 	return qtrue;
 }

--- a/src/client/cl_avi.c
+++ b/src/client/cl_avi.c
@@ -99,7 +99,14 @@ static ID_INLINE void SafeFS_Write(const void *buffer, int len, fileHandle_t f)
 {
 	if (FS_Write(buffer, len, f) < len)
 	{
-		Com_Error(ERR_DROP, "Failed to write avi file");
+		if (videoPipe)
+		{
+			Com_Error(ERR_DROP, "Failed to write avi file.\n\nMake sure the path to ffmpeg binary is part of $PATH environmental variable, or is placed next to the ETL executable.\n");
+		}
+		else
+		{
+			Com_Error(ERR_DROP, "Failed to write avi file\n");
+		}
 	}
 }
 

--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -76,6 +76,9 @@ cvar_t *cl_avidemo;
 cvar_t *cl_forceavidemo;
 cvar_t *cl_avidemotype;
 cvar_t *cl_aviMotionJpeg;
+cvar_t *cl_aviFrameRate;
+cvar_t *cl_aviPipeFormat;
+cvar_t *cl_aviPipeExtension;
 
 cvar_t *cl_freelook;
 cvar_t *cl_sensitivity;
@@ -160,6 +163,8 @@ void CL_ServerStatus_f(void);
 void CL_ServerStatusResponse(netadr_t from, msg_t *msg);
 
 void CL_WavStopRecord_f(void);
+
+qboolean videoPipe;
 
 /**
  * @brief CL_PurgeCache
@@ -2376,6 +2381,34 @@ void CL_CheckUserinfo(void)
 	}
 }
 
+
+/**
+ * @brief CL_GetVideoExtension
+ * @return extension
+ */
+static const char *CL_GetVideoExtension(void)
+{
+	const char *extension;
+
+	if (videoPipe)
+	{
+		if (cl_aviPipeExtension->string && cl_aviPipeExtension->string[0] != '\0')
+		{
+			extension = cl_aviPipeExtension->string;
+		}
+		else
+		{
+			extension = "mp4";
+		}
+	}
+	else
+	{
+		extension = "avi";
+	}
+
+	return extension;
+}
+
 /**
  * @brief This function will be called when the AVI recording will start either by video or cl_avidemo commands
  * @param[in] aviname
@@ -2386,8 +2419,9 @@ void CL_StartVideoRecording(const char *aviname)
 
 	if (!aviname)
 	{
-		int i, last;
-		int a, b, c, d;
+		int        i, last;
+		int        a, b, c, d;
+		const char *ext = CL_GetVideoExtension();
 
 		for (i = 0; i <= 9999; i++)
 		{
@@ -2400,8 +2434,8 @@ void CL_StartVideoRecording(const char *aviname)
 			c     = last / 10;
 			last -= c * 10;
 			d     = last;
-			Com_Printf("videos/%s%d%d%d%d.avi\n", clc.demo.demoName, a, b, c, d);
-			Com_sprintf(filename, MAX_OSPATH, "videos/%s%d%d%d%d.avi", clc.demo.demoName, a, b, c, d);
+			Com_Printf("videos/%s_%d%d%d%d.%s\n", clc.demo.demoName, a, b, c, d, ext);
+			Com_sprintf(filename, MAX_OSPATH, "videos/%s_%d%d%d%d.%s", clc.demo.demoName, a, b, c, d, ext);
 
 			if (!FS_FileExists(filename))
 			{
@@ -2414,11 +2448,11 @@ void CL_StartVideoRecording(const char *aviname)
 			Com_Printf(S_COLOR_RED "ERROR: no free file names to create video\n");
 			return;
 		}
-		CL_OpenAVIForWriting(filename);
+		CL_OpenAVIForWriting(filename, videoPipe);
 	}
 	else
 	{
-		CL_OpenAVIForWriting(aviname);
+		CL_OpenAVIForWriting(aviname, videoPipe);
 	}
 }
 
@@ -2427,28 +2461,46 @@ void CL_StartVideoRecording(const char *aviname)
  */
 void CL_Video_f(void)
 {
-	char filename[MAX_OSPATH];
+	char       filename[MAX_OSPATH];
+	const char *ext;
 
 	if (!clc.demo.playing)
 	{
-		Com_Printf("The video command can only be used when playing back demos\n");
+		Com_Printf("The %s command can only be used when playing back demos\n", Cmd_Argv(0));
 		return;
 	}
 
-	Cvar_Set("cl_avidemotype", "2");
-	if (cl_avidemo->integer <= 0)
+	if (cl_avidemo->integer != 0)
 	{
-		Cvar_Set("cl_avidemo", "30");
+		Com_Printf("The %s command cannot be used unless cl_avidemo is 0\n", Cmd_Argv(0));
 	}
 
+	videoPipe = !Q_stricmp(Cmd_Argv(0), "video-pipe");
+	ext       = CL_GetVideoExtension();
+
+	Cvar_Set("cl_avidemotype", "2");
+
+	// explicit filename
 	if (Cmd_Argc() > 1)
 	{
-		// explicit filename
-		Com_sprintf(filename, MAX_OSPATH, "videos/%s.avi", Cmd_Argv(1));
+		const char *name = Cmd_Argv(1);
+
+		// magic token $demo = use current demo name as video name
+		if (!Q_stricmp(name, "$demo"))
+		{
+			Com_sprintf(filename, sizeof(filename), "videos/%s.%s", clc.demo.demoName, ext);
+		}
+		else
+		{
+			Com_sprintf(filename, sizeof(filename), "videos/%s.%s", name, ext);
+		}
+
+		// allow setting video framerate via the video command
 		if (Cmd_Argc() == 3)
 		{
-			Cvar_Set("cl_avidemo", Cmd_Argv(2));
+			Cvar_Set("cl_aviFrameRate", Cmd_Argv(2));
 		}
+
 		CL_StartVideoRecording(filename);
 	}
 	else
@@ -2506,19 +2558,24 @@ void CL_CaptureFrameVideo(void)
 
 static void CL_FrameHandleVideo(int *msec)
 {
+	qboolean videoActive = CL_VideoRecording();
+	qboolean inGame      = cls.state == CA_ACTIVE;
+
 	// if recording an avi, lock to a fixed fps
-	if (cl_avidemo->integer && *msec && ((cls.state == CA_ACTIVE && clc.demo.playing) || cl_forceavidemo->integer))
+	if ((cl_avidemo->integer && *msec && ((inGame && clc.demo.playing) || cl_forceavidemo->integer))
+	    || (videoActive && (inGame && clc.demo.playing)))
 	{
-		float fps;
-		float frameDuration;
+		float     fps;
+		float     frameDuration;
+		const int videoFps = videoActive ? cl_aviFrameRate->integer : cl_avidemo->integer;
 
 		if (com_timescale->value > 0.0f)
 		{
-			fps = MIN(cl_avidemo->integer * com_timescale->value, 1000.0f);
+			fps = MIN(videoFps * com_timescale->value, 1000.0f);
 		}
 		else
 		{
-			fps = MIN(cl_avidemo->integer, 1000.0f);
+			fps = MIN(videoFps, 1000.0f);
 		}
 		frameDuration = MAX(1000.0f / fps, 1.0f); // + clc.aviVideoFrameRemainder;
 
@@ -2527,8 +2584,7 @@ static void CL_FrameHandleVideo(int *msec)
 		*msec = (int)frameDuration;
 		//clc.aviVideoFrameRemainder = frameDuration + msec;
 	}
-	else if ((!cl_avidemo->integer && CL_VideoRecording())
-	         || (cl_avidemo->integer && (cls.state != CA_ACTIVE || !cl_forceavidemo->integer)))
+	else if ((cl_avidemo->integer && (!inGame || !cl_forceavidemo->integer)) || (videoActive && !inGame))
 	{
 		CL_StopVideo_f();
 	}
@@ -3155,6 +3211,14 @@ void CL_Init(void)
 	cl_avidemotype   = Cvar_Get("cl_avidemotype", "0", CVAR_ARCHIVE);
 	cl_aviMotionJpeg = Cvar_Get("cl_avimotionjpeg", "0", CVAR_TEMP);
 
+	cl_aviFrameRate = Cvar_GetAndDescribe("cl_aviFrameRate", "25", CVAR_ARCHIVE, "Framerate to use for video recording with video and video-pipe");
+	Cvar_CheckRange(cl_aviFrameRate, 1, 1000, qtrue);
+
+	cl_aviPipeFormat = Cvar_GetAndDescribe("cl_aviPipeFormat",
+	                                       "-preset medium -crf 23 -vcodec libx264 -flags +cgop -pix_fmt yuvj420p -bf 2 -codec:a aac -strict -2 -b:a 160k -movflags faststart",
+	                                       CVAR_ARCHIVE, "ffmpeg command line passed to the encoder when using video-pipe");
+	cl_aviPipeExtension = Cvar_GetAndDescribe("cl_aviPipeExtension", "mp4", CVAR_ARCHIVE, "Extension to use for video files when using video-pipe");
+
 	rconAddress = Cvar_Get("rconAddress", "", 0);
 
 	cl_yawspeed      = Cvar_Get("cl_yawspeed", "140", CVAR_ARCHIVE_ND);
@@ -3319,6 +3383,7 @@ void CL_Init(void)
 
 	// Avi recording
 	Cmd_AddCommand("video", CL_Video_f, "Starts AVI recording during demo view.");
+	Cmd_AddCommand("video-pipe", CL_Video_f, "Pipe video and audio to ffmpeg for video recording.");
 	Cmd_AddCommand("stopvideo", CL_StopVideo_f, "Stops AVI recording.");
 
 	Cmd_AddCommand("save_favs", CL_SaveFavServersToFile_f, "Saves the favcache.dat file into mod/profile path of fs_homepath.");
@@ -3418,6 +3483,7 @@ void CL_Shutdown(void)
 	Cmd_RemoveCommand("fs_referencedList");
 	Cmd_RemoveCommand("model");
 	Cmd_RemoveCommand("video");
+	Cmd_RemoveCommand("video-pipe");
 	Cmd_RemoveCommand("stopvideo");
 
 	Cmd_RemoveCommand("save_favs");

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -466,6 +466,9 @@ extern cvar_t *cl_showMouseRate;
 
 extern cvar_t *cl_avidemo;
 extern cvar_t *cl_aviMotionJpeg;
+extern cvar_t *cl_aviFrameRate;
+extern cvar_t *cl_aviPipeFormat;
+extern cvar_t *cl_aviPipeExtension;
 
 extern cvar_t *m_pitch;
 extern cvar_t *m_yaw;
@@ -502,6 +505,10 @@ extern cvar_t *cl_consoleKeys;
 //=================================================
 
 // cl_main
+
+// video recording - are we using "video" or "video-pipe"?
+extern qboolean videoPipe;
+
 void CL_WriteWaveOpen(void);
 void CL_WriteWaveClose(void);
 void CL_Init(void);
@@ -544,7 +551,7 @@ void CL_Record(const char *name);
 
 // cl_avi
 
-qboolean CL_OpenAVIForWriting(const char *fileName);
+qboolean CL_OpenAVIForWriting(const char *fileName, qboolean pipe);
 void CL_TakeVideoFrame(void);
 void CL_WriteAVIVideoFrame(const byte *imageBuffer, int size);
 void CL_WriteAVIAudioFrame(const byte *pcmBuffer, int size);

--- a/src/client/snd_dma.c
+++ b/src/client/snd_dma.c
@@ -363,7 +363,7 @@ static sfx_t *S_FindName(const char *name)
 
 	sfx = &knownSfx[i];
 	Com_Memset(sfx, 0, sizeof(*sfx));
-    Q_strncpyz(sfx->soundName, name, sizeof(sfx->soundName));
+	Q_strncpyz(sfx->soundName, name, sizeof(sfx->soundName));
 
 	sfx->next     = sfxHash[hash];
 	sfxHash[hash] = sfx;
@@ -1548,7 +1548,7 @@ void S_GetSoundtime(void)
 
 	if (CL_VideoRecording())
 	{
-		float fps           = MIN(cl_avidemo->integer, 1000.0f);
+		float fps           = MIN(cl_aviFrameRate->integer, 1000.0f);
 		float frameDuration = MAX(dma.speed / fps, 1.0f); // +clc.aviSoundFrameRemainder;
 
 		int msec = (int)frameDuration;

--- a/src/qcommon/qcommon.h
+++ b/src/qcommon/qcommon.h
@@ -827,6 +827,8 @@ int FS_GetModList(char *listbuf, int bufsize);
 fileHandle_t FS_FOpenFileWrite(const char *fileName);
 // will properly create any needed paths and deal with seperater character issues
 
+fileHandle_t FS_PipeOpenWrite(const char *cmd, const char *filename);
+
 long FS_filelength(fileHandle_t f);
 fileHandle_t FS_SV_FOpenFileWrite(const char *fileName);
 long FS_SV_FOpenFileRead(const char *fileName, fileHandle_t *fp);


### PR DESCRIPTION
Pipes video/audio to `ffmpeg` for video recording. If `ffmpeg` isn't part of `$PATH`, the executable must be placed next to the etl binary.

Old `video` command no longer uses `cl_avidemo` to set framerate for video, this is instead controller by `cl_aviFrameRate`. `cl_avidemo` only sets framerate for the classic screenshot-based avidemo, everything else now uses `cl_aviFrameRate`.

* `ffmpeg` command line can be set with `cl_aviPipeFormat`
* `cl_aviPipeExtension` can be used to override the default `.mp4` extension used by `video-pipe` - this is useful if using `-f <container>` flag in `ffmpeg` to override the auto-detected video container
* magic token `$demo` can be used for both `video` and `video-pipe` to automatically use the demo name as the filename (note: this doesn't currently work, needs #2654 to be merged)
* overriding video framerate is still supported with `video/video-pipe <name> <fps>`