### PR TITLE
client: fix TTF console font scaling with r_scale

### DIFF
--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -1498,7 +1498,7 @@ static void CL_ConsoleFont_f(void)
 
 		if (font && font[0])
 		{
-			re.RegisterFont(font, SMALLCHAR_HEIGHT, &cls.consoleFont, qtrue);
+			re.RegisterFont(font, smallCharHeight, &cls.consoleFont, qtrue);
 		}
 	}
 }
@@ -2848,10 +2848,10 @@ void CL_InitRenderer(void)
 	Com_Memset(&cls.consoleFont, 0, sizeof(cls.consoleFont));
 	if (fontName && fontName[0])
 	{
-		re.RegisterFont(fontName, SMALLCHAR_HEIGHT, &cls.consoleFont, qtrue);
+		re.RegisterFont(fontName, smallCharHeight, &cls.consoleFont, qtrue);
 	}
 	Com_Memset(&cls.etIconFont, 0, sizeof(cls.etIconFont));
-	re.RegisterFont("ETL-icon-font", SMALLCHAR_HEIGHT, &cls.etIconFont, qfalse);
+	re.RegisterFont("ETL-icon-font", smallCharHeight, &cls.etIconFont, qfalse);
 
 	cls.whiteShader = re.RegisterShader("white");
 

--- a/src/client/cl_scrn.c
+++ b/src/client/cl_scrn.c
@@ -159,7 +159,7 @@ static void SRC_DrawSingleChar(int x, int y, int w, int h, int ch)
 			return;
 		}
 
-		scale = cls.consoleFont.glyphScale;
+		scale = cls.consoleFont.glyphScale * ((float)smallCharHeight / (float)SMALLCHAR_HEIGHT);
 
 		// FIXME: fix the magic numbers at some point
 		scaleX = 0.3f; // (float)w / (float)info->imageWidth;


### PR DESCRIPTION
When using custom TTF font with `con_fontName`, the font size ignored `r_scale` value completely. This was only issue with TTF fonts, the built-in default console font from 2.60b worked fine.

`r_scale 2 + r_mode 16` before:

![shot0004](https://github.com/user-attachments/assets/cc98e719-5d0c-4c3b-99e6-3f2680a65462)

After:
![shot0005](https://github.com/user-attachments/assets/3c38d914-40d4-401c-9daf-34edaf2b51de)
