### PR TITLE
tvgame: add lua support, refs #229

### DIFF
--- a/cmake/ETLSources.cmake
+++ b/cmake/ETLSources.cmake
@@ -101,7 +101,6 @@ FILE(GLOB QAGAME_SRC
 
 FILE(GLOB TVGAME_SRC
     "src/game/bg_*.c"
-	"src/game/g_mdx*"
 	"src/game/g_strparse*"
 	"src/game/surfaceflags*"
 	"src/game/g_match_tokens.c"

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -48,6 +48,8 @@
 #define USE_MDXFILE
 #endif
 
+#define DEFAULT_HEALTH 100
+
 #define SPRINTTIME 20000.0f
 
 #define DEFAULT_GRAVITY     800

--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -1329,7 +1329,7 @@ int G_CountTeamMedics(team_t team, qboolean alivecheck)
 void AddMedicTeamBonus(gclient_t *client)
 {
 	// compute health mod
-	client->pers.maxHealth = 100 + 10 * G_CountTeamMedics(client->sess.sessionTeam, qfalse);
+	client->pers.maxHealth = DEFAULT_HEALTH + 10 * G_CountTeamMedics(client->sess.sessionTeam, qfalse);
 
 	if (client->pers.maxHealth > 125)
 	{

--- a/src/server/sv_cl_parse.c
+++ b/src/server/sv_cl_parse.c
@@ -120,7 +120,7 @@ void SV_CL_SystemInfoChanged(void)
 		Cvar_SetCheatState();
 	}
 
-	SV_CL_SetPurePaks(qfalse);
+	SV_CL_SetPurePaks(!sv_pure->integer);
 }
 
 /**
@@ -488,7 +488,8 @@ void SV_CL_DeltaEntity(msg_t *msg, svclSnapshot_t *frame, int newnum, entityStat
 
 		if (state->number < MAX_CLIENTS)
 		{
-			gEnt->r.contents = CONTENTS_SOLID;
+			gEnt->r.contents = CONTENTS_BODY;
+			gEnt->r.ownerNum = ENTITYNUM_NONE;
 		}
 
 		gEnt->s.number = newnum;

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -99,12 +99,10 @@ void SV_SetConfigstring(int index, const char *val)
 	sv.configstringsmodified[index] = qtrue;
 
 #ifdef DEDICATED
-	if (svcls.isTVGame && svcls.state != CA_LOADING)
+	if (svcls.isTVGame && svcls.state != CA_LOADING &&
+	    (index == CS_SERVERINFO || index == CS_WOLFINFO))
 	{
-		if (index == CS_SERVERINFO || index == CS_WOLFINFO)
-		{
-			SV_CL_ConfigstringInfoChanged(index);
-		}
+		SV_CL_ConfigstringInfoChanged(index);
 	}
 #endif // DEDICATED
 
@@ -358,15 +356,14 @@ void SV_BoundMaxClients(int minimum)
 	{
 		Cvar_Set("sv_maxclients", va("%i", minimum));
 	}
-	else if (sv_maxclients->integer > MAX_CLIENTS)
-	{
+	else if (sv_maxclients->integer > MAX_CLIENTS
 #ifdef DEDICATED
-		// no limit for etltv slave server
-		if (svcls.state <= CA_DISCONNECTED)
+	         // no limit for etltv slave server
+	         && svcls.state <= CA_DISCONNECTED
 #endif // DEDICATED
-		{
-			Cvar_Set("sv_maxclients", va("%i", MAX_CLIENTS));
-		}
+	         )
+	{
+		Cvar_Set("sv_maxclients", va("%i", MAX_CLIENTS));
 	}
 }
 

--- a/src/tvgame/tvg_active.c
+++ b/src/tvgame/tvg_active.c
@@ -35,18 +35,18 @@
 #include "tvg_local.h"
 
 /**
- * @brief G_SpectatorAttackFollow
+ * @brief TVG_SpectatorAttackFollow
  * @param client
  * @return true if a player was found to follow, otherwise false
  */
-qboolean G_SpectatorAttackFollow(gclient_t *client)
+qboolean TVG_SpectatorAttackFollow(gclient_t *client)
 {
 	trace_t       tr;
 	vec3_t        forward, right, up;
 	vec3_t        start, end;
 	vec3_t        mins, maxs;
-	static vec3_t enlargeMins = { -64.0f, -64.0f, -48.0f };
-	static vec3_t enlargeMaxs = { 64.0f, 64.0f, 0.0f };
+	static vec3_t enlargeMins = { -12.0f, -12.0f, -12.0f };
+	static vec3_t enlargeMaxs = { 12.0f, 12.0f, 0.0f };
 
 	AngleVectors(client->ps.viewangles, forward, right, up);
 	VectorCopy(client->ps.origin, start);
@@ -60,7 +60,7 @@ qboolean G_SpectatorAttackFollow(gclient_t *client)
 	// also put the start-point a bit forward, so we don't start the trace in solid..
 	VectorMA(start, 75.0f, forward, start);
 
-	trap_Trace(&tr, start, mins, maxs, end, client - level.clients, CONTENTS_SOLID | CONTENTS_BODY | CONTENTS_CORPSE);
+	trap_Trace(&tr, start, mins, maxs, end, ENTITYNUM_NONE, CONTENTS_BODY);
 
 	if (tr.entityNum < MAX_CLIENTS && level.ettvMasterClients[tr.entityNum].valid)
 	{
@@ -142,11 +142,11 @@ void TVG_SpectatorThink(gclient_t *client, usercmd_t *ucmd)
 	    client->sess.spectatorState != SPECTATOR_FOLLOW &&
 	    client->sess.sessionTeam == TEAM_SPECTATOR)        // don't do it if on a team
 	{
-		/*if (G_SpectatorAttackFollow(client))
+		if (TVG_SpectatorAttackFollow(client))
 		{
 			return;
 		}
-		else*/
+		else
 		{
 			// not clicked on a player?.. then follow next,
 			// to prevent constant traces done by server.
@@ -428,7 +428,7 @@ void TVG_ClientEndFrame(gclient_t *client)
 		client->sess.nextCommandDecreaseTime = level.time + 1000;
 	}
 
-	if ((client->sess.sessionTeam == TEAM_SPECTATOR))
+	if (client->sess.sessionTeam == TEAM_SPECTATOR)
 	{
 		TVG_SpectatorClientEndFrame(client);
 	}

--- a/src/tvgame/tvg_local.h
+++ b/src/tvgame/tvg_local.h
@@ -128,7 +128,7 @@ typedef struct tvcmd_reference_s
 	int updateInterval;
 	int lastUpdateTime;
 	qboolean floodProtected;
-	mods_t mods; // excluded mods for CMD_USAGE_AUTOUPDATE
+	int mods; // excluded mods for CMD_USAGE_AUTOUPDATE
 	qboolean (*pCommand)(gclient_t *client, struct tvcmd_reference_s *self);
 	const char *pszHelpInfo;
 } tvcmd_reference_t;
@@ -150,51 +150,27 @@ struct gentity_s
 	// EXPECTS THE FIELDS IN THAT ORDER!
 	//================================
 
-	struct gclient_s *client;       ///< NULL if not a client
-
 	qboolean inuse;
 
 	const char *classname;          ///< set in QuakeEd
 	int spawnflags;                 ///< set in QuakeEd
 
-	qboolean neverFree;             ///< if true, FreeEntity will only unlink
-	///< bodyque uses this
-
 	int flags;                      ///< FL_* variables
 
 	int freetime;                   ///< level.time when the object was freed
 
-	int eventTime;                  ///< events will be cleared EVENT_VALID_MSEC after set
-	qboolean freeAfterEvent;
-	qboolean unlinkAfterEvent;
-
-	int clipmask;                   ///< brushes with this content value will be collided against
-	///< when moving.  items and corpses do not collide against
-	///< players, for instance
-
-	float angle;                    ///< set in editor, -1 = up, -2 = down
 	char *target;
 
 	char *targetname;
 	int targetnamehash;             ///< adding a hash for this for faster lookups
 
-	int nextthink;
 	void (*free)(gentity_t *self);
-	void (*think)(gentity_t *self);
-	void (*reached)(gentity_t *self);           ///< movers call this when hitting endpoint
-	void (*blocked)(gentity_t *self, gentity_t *other);
-	void (*touch)(gentity_t *self, gentity_t *other, trace_t *trace);
-	void (*use)(gentity_t *self, gentity_t *other, gentity_t *activator);
-	void (*pain)(gentity_t *self, gentity_t *attacker, int damage, vec3_t point);
-	void (*die)(gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int damage, meansOfDeath_t mod);
 
 	gentity_t *enemy;
 
 	int allowteams;
 
 	int spawnTime;
-
-	int spawnId;                        ///< team_CTF_redspawn/team_CTF_bluespawn minor spawnpoint id
 };
 
 /**
@@ -260,30 +236,20 @@ typedef struct
  * @brief Client data that stays across multiple levels or tournament restarts
  * this is achieved by writing all the data to vmCvar strings at game shutdown
  * time and reading them back at connection time.  Anything added here
- * MUST be dealt with in G_InitSessionData() / G_ReadSessionData() / G_WriteSessionData()
+ * MUST be dealt with in TVG_InitSessionData() / TVG_ReadSessionData() / TVG_WriteSessionData()
  */
 typedef struct
 {
 	team_t sessionTeam;
-	int spectatorTime;                                  ///< for determining next-in-line to play
 	spectatorState_t spectatorState;
 	int spectatorClient;                                ///< for chasecam and follow mode
 	int playerType;                                     ///< class
-	weapon_t playerWeapon;                              ///< primary weapon
-	weapon_t playerWeapon2;                             ///< secondary weapon
-	int userSpawnPointValue;                            ///< index of objective to spawn nearest to (returned from UI)
-	int latchPlayerType;                                ///< latched class
-	weapon_t latchPlayerWeapon;                         ///< latched primary weapon
-	weapon_t latchPlayerWeapon2;                        ///< latched secondary weapon
 	//int ignoreClients[MAX_CLIENTS / (sizeof(int) * 8)];
 	qboolean muted;
 	int skill[SK_NUM_SKILLS];                           ///< skill
 
 	int referee;
-	int shoutcaster;
 	int spec_team;
-
-	qboolean versionOK;
 
 	// flood protection
 	int nextReliableTime;                               ///< next time a command can be executed when flood limited
@@ -305,8 +271,6 @@ typedef struct ipFilter_s
 	unsigned compare;
 } ipFilter_t;
 
-#define MAX_COMPLAINTIPS 5
-
 /**
  * @struct clientPersistant_t
  * @brief Client data that stays across multiple respawns, but is cleared
@@ -318,32 +282,19 @@ typedef struct
 	usercmd_t cmd;                      ///< we would lose angles if not persistant
 	usercmd_t oldcmd;                   ///< previous command processed by pmove()
 	qboolean localClient;               ///< true if "ip" info key is "localhost"
-	qboolean initialSpawn;              ///< the first spawn should be at a cool location
 	qboolean activateLean;
-	qboolean pmoveFixed;
-	int pmoveMsec;
 
 	char netname[MAX_NETNAME];
 	char client_ip[MAX_IP4_LENGTH];     ///< ip 'caching' - it won't change
 	char cl_guid[MAX_GUID_LENGTH + 1];
 
-	int maxHealth;                      ///<
 	int enterTime;                      ///< level.time the client entered the game
 	int connectTime;                    ///< level.time the client first connected to the server
 	playerTeamState_t teamState;        ///< status in teamplay games
-
-	int lastSpawnTime;
-
-	unsigned int autoaction;            ///< End-of-match auto-requests
-	unsigned int clientFlags;           ///< Client settings that need server involvement
-	unsigned int clientMaxPackets;      ///< Client com_maxpacket settings
-	unsigned int clientTimeNudge;       ///< Client cl_timenudge settings
 	int cmd_debounce;                   ///< Dampening of command spam
 
 	bg_character_t *character;
 	int characterIndex;
-
-	ipFilter_t complaintips[MAX_COMPLAINTIPS];
 } clientPersistant_t;
 
 /**
@@ -376,8 +327,6 @@ struct gclient_s
 
 	qboolean noclip;
 
-	// we can't just use pers.lastCommand.time, because
-	// of the g_sycronousclients case
 	int buttons;
 	int oldbuttons;
 	int latched_buttons;
@@ -385,23 +334,15 @@ struct gclient_s
 	int wbuttons;
 	int oldwbuttons;
 	int latched_wbuttons;
-	vec3_t oldOrigin;
 
 	// timers
-	int respawnTime;                        ///< can respawn when time > this, force after g_forcerespwan
 	int inactivityTime;                     ///< kick players when time > this
 	qboolean inactivityWarning;             ///< qtrue if the five seoond warning has been given
 	int inactivitySecondsLeft;              ///< for displaying a counting-down time on clients (milliseconds before activity kicks in..)
 
-	int saved_persistant[MAX_PERSISTANT];   ///< Save ps->persistant here during Limbo
-
 	pmoveExt_t pmext;
 
-	int disguiseClientNum;
-
 	wantsPlayerInfoStats_t wantsInfoStats[INFO_NUM];
-
-	qboolean activateHeld;                  ///< client is holding down +activate
 };
 
 // this structure is cleared as each map is entered
@@ -492,13 +433,10 @@ typedef struct level_locals_s
 
 	int framenum;
 	int time;                                   ///< in msec
-	int overTime;                               ///< workaround for dual objective timelimit bug
 	int previousTime;                           ///< so movers can back up when blocked
 	int frameTime;                              ///< time delta
 
 	int startTime;                              ///< level.time the map was started
-
-	qboolean restarted;                         ///< waiting for a map_restart to fire
 
 	int numConnectedClients;
 	int *sortedClients;
@@ -516,13 +454,9 @@ typedef struct level_locals_s
 	/// player/AI model scripting (server repository)
 	animScriptData_t animScriptData;
 
-	int lastRestartTime;
-
 	qboolean fLocalHost;
-	int timeCurrent;                            ///< Real game clock
-	int timeDelta;                              ///< Offset from internal clock - used to calculate real match time
 
-	qboolean mapcoordsValid, tracemapLoaded;
+	qboolean mapcoordsValid;
 	vec2_t mapcoordsMins, mapcoordsMaxs;
 
 	qboolean tempTraceIgnoreEnts[MAX_GENTITIES];
@@ -530,12 +464,6 @@ typedef struct level_locals_s
 	// sv_cvars
 	svCvar_t svCvars[MAX_SVCVARS];
 	int svCvarsCount;
-
-	int frameStartTime;
-
-	demoState_t demoState;     ///< server demo state
-	int demoClientsNum;        ///< number of reserved slots for demo clients
-	int demoClientBotNum;      ///< clientNum of bot that collects stats during recording, optional
 
 	qboolean intermission;
 
@@ -553,12 +481,12 @@ typedef struct level_locals_s
 
 } level_locals_t;
 
-// g_spawn.c
-#define G_SpawnString(key, def, out) TVG_SpawnStringExt(key, def, out, __FILE__, __LINE__)
-#define G_SpawnFloat(key, def, out) TVG_SpawnFloatExt(key, def, out, __FILE__, __LINE__)
-#define G_SpawnInt(key, def, out) TVG_SpawnIntExt(key, def, out, __FILE__, __LINE__)
-#define G_SpawnVector(key, def, out) TVG_SpawnVectorExt(key, def, out, __FILE__, __LINE__)
-#define G_SpawnVector2D(key, def, out) TVG_SpawnVector2DExt(key, def, out, __FILE__, __LINE__)
+// tvg_spawn.c
+#define TVG_SpawnString(key, def, out) TVG_SpawnStringExt(key, def, out, __FILE__, __LINE__)
+#define TVG_SpawnFloat(key, def, out) TVG_SpawnFloatExt(key, def, out, __FILE__, __LINE__)
+#define TVG_SpawnInt(key, def, out) TVG_SpawnIntExt(key, def, out, __FILE__, __LINE__)
+#define TVG_SpawnVector(key, def, out) TVG_SpawnVectorExt(key, def, out, __FILE__, __LINE__)
+#define TVG_SpawnVector2D(key, def, out) TVG_SpawnVector2DExt(key, def, out, __FILE__, __LINE__)
 
 qboolean TVG_SpawnStringExt(const char *key, const char *defaultString, char **out, const char *file, int line);      // spawn string returns a temporary reference, you must CopyString() if you want to keep it
 qboolean TVG_SpawnFloatExt(const char *key, const char *defaultString, float *out, const char *file, int line);
@@ -575,7 +503,7 @@ qboolean TVG_CallSpawn(gentity_t *ent);
 char *TVG_AddSpawnVarToken(const char *string);
 void TVG_ParseField(const char *key, const char *value, gentity_t *ent);
 
-// g_cmds.c
+// tvg_cmds.c
 qboolean TVG_Cmd_Score_f(gclient_t *client, tvcmd_reference_t *self);
 qboolean TVG_Cmd_Ignore_f(gclient_t *client, tvcmd_reference_t *self);
 qboolean TVG_Cmd_UnIgnore_f(gclient_t *client, tvcmd_reference_t *self);
@@ -608,45 +536,30 @@ qboolean TVG_CommandsAutoUpdate(tvcmd_reference_t *tvcmd);
 
 qboolean TVG_ServerIsFloodProtected(void);
 
-void G_EntitySound(gentity_t *ent, const char *soundId, int volume); // Unused.
-void G_EntitySoundNoCut(gentity_t *ent, const char *soundId, int volume); // Unused.
+// tvg_utils.c
+int TVG_FindConfigstringIndex(const char *name, int start, int max, qboolean create);
+void TVG_RemoveConfigstringIndex(const char *name, int start, int max);
 
-// g_utils.c
-int G_FindConfigstringIndex(const char *name, int start, int max, qboolean create);
-void G_RemoveConfigstringIndex(const char *name, int start, int max);
+int TVG_ModelIndex(const char *name);
+int TVG_SoundIndex(const char *name);
+int TVG_SkinIndex(const char *name);
+int TVG_ShaderIndex(const char *name);
+int TVG_CharacterIndex(const char *name);
+int TVG_StringIndex(const char *string);
+void TVG_TeamCommand(team_t team, const char *cmd);
 
-int G_ModelIndex(const char *name);
-int G_SoundIndex(const char *name);
-int G_SkinIndex(const char *name);
-int G_ShaderIndex(const char *name);
-int G_CharacterIndex(const char *name);
-int G_StringIndex(const char *string);
-qboolean G_AllowTeamsAllowed(gentity_t *ent, gentity_t *activator);
-void G_UseEntity(gentity_t *ent, gentity_t *other, gentity_t *activator);
-void G_TeamCommand(team_t team, const char *cmd);
+gentity_t *TVG_Find(gentity_t *from, int fieldofs, const char *match);
+gentity_t *TVG_FindByTargetname(gentity_t *from, const char *match);
+gentity_t *TVG_PickTarget(const char *targetname);
 
-gentity_t *G_Find(gentity_t *from, int fieldofs, const char *match);
-gentity_t *G_FindInt(gentity_t *from, int fieldofs, int match);
-gentity_t *G_FindFloat(gentity_t *from, int fieldofs, float match);
-gentity_t *G_FindVector(gentity_t *from, int fieldofs, const vec3_t match);
-gentity_t *G_FindByTargetname(gentity_t *from, const char *match);
-gentity_t *G_FindByTargetnameFast(gentity_t *from, const char *match, int hash);
-gentity_t *G_PickTarget(const char *targetname);
-void G_SetMovedir(vec3_t angles, vec3_t movedir);
-
-void G_InitGentity(gentity_t *e);
-gentity_t *G_Spawn(void);
-gentity_t *G_TempEntity(vec3_t origin, entity_event_t event);
-gentity_t *G_TempEntityNotLinked(entity_event_t event);
-void G_Sound(gentity_t *ent, int soundIndex);
+void TVG_InitGentity(gentity_t *e);
+gentity_t *TVG_Spawn(void);
 void TVG_AnimScriptSound(int soundIndex, vec3_t org, int client);
-void G_FreeEntity(gentity_t *ent);
-void G_ClientSound(gentity_t *ent, int soundIndex);
+void TVG_FreeEntity(gentity_t *ent);
 
-char *vtos(const vec3_t v);
+char *TVG_VecToStr(const vec3_t v);
 
-void G_AddEvent(gentity_t *ent, int event, int eventParm);
-void TVG_SetOrigin(gentity_t *ent, vec3_t origin);
+void TVG_AddEvent(gclient_t *client, int event, int eventParm);
 
 /**
  * @struct mapVotePlayersCount_s
@@ -714,7 +627,6 @@ gentity_t *SelectSpawnPoint(vec3_t avoidPoint, vec3_t origin, vec3_t angles);
 
 void TVG_ClientSpawn(gclient_t *client);
 void TVG_CalculateRanks(void);
-qboolean SpotWouldTelefrag(gentity_t *spot);
 
 // *LUA* & map configs g_sha1.c
 char *G_SHA1(const char *string);
@@ -738,7 +650,7 @@ void TVG_Say(gclient_t *client, gclient_t *target, int mode, const char *chatTex
 void TVG_SayTo(gclient_t *ent, gclient_t *other, int mode, int color, const char *name, const char *message, qboolean localize);   // removed static declaration so it would link
 qboolean TVG_Cmd_Follow_f(gclient_t *client, tvcmd_reference_t *self);
 void TVG_Say_f(gclient_t *client, int mode /*, qboolean arg0*/);
-void G_PlaySound_Cmd(void);
+void TVG_PlaySound_Cmd(void);
 int TVG_ClientNumbersFromString(char *s, int *plist);
 int TVG_ClientNumberFromString(gclient_t *to, char *s);
 int TVG_MasterClientNumbersFromString(char *s, int *plist);
@@ -833,6 +745,7 @@ extern vmCvar_t server_motd5;
 #ifdef FEATURE_LUA
 extern vmCvar_t lua_modules;
 extern vmCvar_t lua_allowedModules;
+extern vmCvar_t tvg_luaModuleList;
 #endif
 
 extern vmCvar_t tvg_voiceChatsAllowed;
@@ -879,7 +792,6 @@ void trap_LocateGameData(gentity_t *gEnts, int numGEntities, int sizeofGEntity_t
 void trap_DropClient(int clientNum, const char *reason, int length);
 void trap_SendServerCommand(int clientNum, const char *text);
 void trap_SetConfigstring(int num, const char *string);
-void trap_TVG_SetConfigstring(int num, const char *string);
 void trap_GetConfigstring(int num, char *buffer, int bufferSize);
 void trap_GetUserinfo(int num, char *buffer, int bufferSize);
 void trap_SetUserinfo(int num, const char *buffer);
@@ -932,12 +844,6 @@ void TVG_RemoveFromAllIgnoreLists(int clientNum);
 
 #define CMD_DEBOUNCE    5000    ///< 5s between cmds
 
-#define EOM_WEAPONSTATS 0x01    ///< Dump of player weapon stats at end of match.
-#define EOM_MATCHINFO   0x02    ///< Dump of match stats at end of match.
-
-#define AA_STATSALL     0x01    ///< Client AutoAction: Dump ALL player stats
-#define AA_STATSTEAM    0x02    ///< Client AutoAction: Dump TEAM player stats
-
 /**
  * @struct team_info
  * @brief Team extras
@@ -951,10 +857,10 @@ typedef struct
 	int timeouts;
 } team_info;
 
-// g_main.c
+// tvg_main.c
 void TVG_UpdateCvars(void);
 
-// g_cmds_ext.c
+// tvg_cmds_ext.c
 qboolean TVG_commandCheck(gclient_t *client, const char *cmd);
 void TVG_SendCommands(void);
 qboolean TVG_commandHelp(gclient_t *client, const char *pszCommand, unsigned int dwCommand);
@@ -970,10 +876,7 @@ qboolean TVG_weaponRankings_cmd(gclient_t *client, tvcmd_reference_t *self);
 qboolean TVG_weaponStats_cmd(gclient_t *client, tvcmd_reference_t *self);
 qboolean TVG_weaponStatsLeaders_cmd(gclient_t *client, qboolean doTop, qboolean doWindow);
 
-void TVG_globalSound(const char *sound);
-
-
-// g_referee.c
+// tvg_referee.c
 qboolean TVG_Cmd_AuthRcon_f(gclient_t *client, tvcmd_reference_t *self);
 qboolean TVG_ref_cmd(gclient_t *client, tvcmd_reference_t *self);
 qboolean TVG_refCommandCheck(gclient_t *client, const char *cmd);
@@ -998,7 +901,6 @@ void TVG_TempTraceIgnoreBodies(void);
 void TVG_TempTraceIgnorePlayersAndBodies(void);
 void TVG_TempTraceIgnorePlayers(void);
 void TVG_TempTraceIgnorePlayersFromTeam(team_t team);
-void TVG_TempTraceIgnoreEntities(gentity_t *ent);
 
 /**
  * @enum fieldtype_t

--- a/src/tvgame/tvg_lua.c
+++ b/src/tvgame/tvg_lua.c
@@ -120,7 +120,7 @@ static int _et_FindMod(lua_State *L)
  *        success = et.IPCSend( vmnumber, message )
  * @param[in] vmnumber
  * @param[in] message
- * @param[out] success
+ * @return success
  */
 static int _et_IPCSend(lua_State *L)
 {
@@ -229,7 +229,7 @@ static int _et_G_LogPrint(lua_State *L)
  * @brief _et_ConcatArgs
  *        args = et.ConcatArgs( index )
  * @param[in] index
- * @param[out] args
+ * @return args
  */
 static int _et_ConcatArgs(lua_State *L)
 {
@@ -242,7 +242,7 @@ static int _et_ConcatArgs(lua_State *L)
 /**
  * @brief _et_trap_Argc
  *        argcount = et.trap_Argc()
- * @param[out] argcount
+ * @return argcount
  */
 static int _et_trap_Argc(lua_State *L)
 {
@@ -254,7 +254,7 @@ static int _et_trap_Argc(lua_State *L)
  * @brief _et_trap_Argv
  *        arg = et.trap_Argv( argnum )
  * @param[in] argnum
- * @param[out] arg
+ * @return arg
  */
 static int _et_trap_Argv(lua_State *L)
 {
@@ -272,7 +272,7 @@ static int _et_trap_Argv(lua_State *L)
  * @brief _et_trap_Cvar_Get
  *        cvarvalue = et.trap_Cvar_Get( cvarname )
  * @param[in] cvarname
- * @param[out] cvarvalue
+ * @return cvarvalue
  */
 static int _et_trap_Cvar_Get(lua_State *L)
 {
@@ -289,6 +289,7 @@ static int _et_trap_Cvar_Get(lua_State *L)
  *        et.trap_Cvar_Set( cvarname, cvarvalue )
  * @param[in] cvarname
  * @param[in] cvarvalue
+ * @return
  */
 static int _et_trap_Cvar_Set(lua_State *L)
 {
@@ -305,7 +306,7 @@ static int _et_trap_Cvar_Set(lua_State *L)
  * @brief _et_trap_GetConfigstring
  *        configstringvalue = et.trap_GetConfigstring( index )
  * @param[in] index
- * @param[out] configstringvalue
+ * @return configstringvalue
  */
 static int _et_trap_GetConfigstring(lua_State *L)
 {
@@ -322,6 +323,7 @@ static int _et_trap_GetConfigstring(lua_State *L)
  *        et.trap_SetConfigstring( index, configstringvalue )
  * @param[in] index
  * @param[in] configstringvalue
+ * @return
  */
 static int _et_trap_SetConfigstring(lua_State *L)
 {
@@ -339,6 +341,7 @@ static int _et_trap_SetConfigstring(lua_State *L)
  *        et.trap_SendConsoleCommand( when, command )
  * @param[in] when
  * @param[in] command
+ * @return
  */
 static int _et_trap_SendConsoleCommand(lua_State *L)
 {
@@ -356,7 +359,7 @@ static int _et_trap_SendConsoleCommand(lua_State *L)
  *        infostring = et.Info_RemoveKey( infostring, key )
  * @param[in] infostring
  * @param[in] key
- * @param[out] infostring
+ * @return infostring
  */
 static int _et_Info_RemoveKey(lua_State *L)
 {
@@ -375,7 +378,7 @@ static int _et_Info_RemoveKey(lua_State *L)
  * @param[in] infostring
  * @param[in] key
  * @param[in] value
- * @param[out] infostring
+ * @return infostring
  */
 static int _et_Info_SetValueForKey(lua_State *L)
 {
@@ -394,7 +397,7 @@ static int _et_Info_SetValueForKey(lua_State *L)
  *        keyvalue = et.Info_ValueForKey( infostring, key )
  * @param[in] infostring
  * @param[in] key
- * @param[out] keyvalue
+ * @return keyvalue
  */
 static int _et_Info_ValueForKey(lua_State *L)
 {
@@ -409,7 +412,7 @@ static int _et_Info_ValueForKey(lua_State *L)
  * @brief _et_Q_CleanStr
  *        cleanstring = et.Q_CleanStr( string )
  * @param[in] string
- * @param[out] cleanstring
+ * @return cleanstring
  */
 static int _et_Q_CleanStr(lua_State *L)
 {
@@ -428,8 +431,7 @@ static int _et_Q_CleanStr(lua_State *L)
  *        fd, len = et.trap_FS_FOpenFile( filename, mode )
  * @param[in] filename
  * @param[in] mode
- * @param[out] fd
- * @param[out] len
+ * @return fd, len
  */
 static int _et_trap_FS_FOpenFile(lua_State *L)
 {
@@ -449,7 +451,7 @@ static int _et_trap_FS_FOpenFile(lua_State *L)
  *        filedata = et.trap_FS_Read( fd, count )
  * @param[in] fd
  * @param[in] count
- * @param[out] filedata
+ * @return filedata
  */
 static int _et_trap_FS_Read(lua_State *L)
 {
@@ -478,7 +480,7 @@ static int _et_trap_FS_Read(lua_State *L)
  * @param[in] filedata
  * @param[in] count
  * @param[in] fd
- * @param[out] count
+ * @return count
  */
 static int _et_trap_FS_Write(lua_State *L)
 {
@@ -494,6 +496,7 @@ static int _et_trap_FS_Write(lua_State *L)
  * @brief _et_trap_FS_FCloseFile
  *        et.trap_FS_FCloseFile( fd )
  * @param[in] fd
+ * @return
  */
 static int _et_trap_FS_FCloseFile(lua_State *L)
 {
@@ -507,6 +510,7 @@ static int _et_trap_FS_FCloseFile(lua_State *L)
  *        et.trap_FS_Rename( oldname, newname )
  * @param[in] oldname
  * @param[in] newname
+ * @return
  */
 static int _et_trap_FS_Rename(lua_State *L)
 {
@@ -524,7 +528,7 @@ extern char bigTextBuffer[100000];
  *        filelist = et.trap_FS_GetFileList( dirname, fileextension )
  * @param[in] dirname
  * @param[in] fileextension
- * @param[out] filelist
+ * @return filelist
  */
 static int _et_trap_FS_GetFileList(lua_State *L)
 {
@@ -555,6 +559,7 @@ static int _et_trap_FS_GetFileList(lua_State *L)
  * @brief _et_TVG_SoundIndex
  *        soundindex = et.TVG_SoundIndex( filename )
  * @param[in] filename
+ * @return
  */
 static int _et_TVG_SoundIndex(lua_State *L)
 {
@@ -568,7 +573,7 @@ static int _et_TVG_SoundIndex(lua_State *L)
  * @brief _et_TVG_ModelIndex
  *        modelindex = et.TVG_ModelIndex( filename )
  * @param[in] filename
- * @param[out] modelindex
+ * @return modelindex
  */
 static int _et_TVG_ModelIndex(lua_State *L)
 {
@@ -581,7 +586,7 @@ static int _et_TVG_ModelIndex(lua_State *L)
 /**
  * @brief _et_trap_Milliseconds
  *        milliseconds = et.trap_Milliseconds()
- * @param[out] milliseconds
+ * @return milliseconds
  */
 static int _et_trap_Milliseconds(lua_State *L)
 {
@@ -595,7 +600,7 @@ static int _et_trap_Milliseconds(lua_State *L)
  *        success = et.isBitSet(bit,value)
  * @param[in] bit
  * @param[in] value
- * @param[out] success
+ * @return success
  */
 static int _et_isBitSet(lua_State *L)
 {
@@ -844,7 +849,7 @@ static const tvgame_field_t level_fields[] =
  * @brief _et_getfield fields helper function
  * @param[in] fieldname
  * @param[in] fieldFlag
- * @param[out] game_field_t
+ * @return game_field_t
  */
 static tvgame_field_t *_et_getfield(char *fieldname, int fieldFlag)
 {
@@ -1114,7 +1119,7 @@ static void _et_setusercmd(lua_State *L, usercmd_t *cmd)
  * @param[in] field
  * @param[in] addr
  * @param[in] arrayIndex
- * @param[out] success
+ * @return success
  */
 static int _et_field_get(lua_State *L, tvgame_field_t *field, uintptr_t addr, int arrayIndex)
 {
@@ -1193,7 +1198,7 @@ static int _et_field_get(lua_State *L, tvgame_field_t *field, uintptr_t addr, in
  *        et.level_get( fieldname, arrayindex )
  * @param[in] fieldname
  * @param[in] arrayindex
- * @param[out] requested field value
+ * @return requested field value
  */
 static int _et_level_get(lua_State *L)
 {
@@ -1216,7 +1221,7 @@ static int _et_level_get(lua_State *L)
  * @param[in] entnum
  * @param[in] fieldname
  * @param[in] arrayindex
- * @param[out] requested field value
+ * @return requested field value
  */
 static int _et_gentity_get(lua_State *L)
 {
@@ -1240,7 +1245,7 @@ static int _et_gentity_get(lua_State *L)
  * @param[in] clientnum
  * @param[in] fieldname
  * @param[in] arrayindex
- * @param[out] requested field value
+ * @return requested field value
  */
 static int _et_gclient_get(lua_State *L)
 {
@@ -1264,7 +1269,7 @@ static int _et_gclient_get(lua_State *L)
  * @param[in] clientnum
  * @param[in] fieldname
  * @param[in] arrayindex
- * @param[out] requested field value
+ * @return requested field value
  */
 static int _et_ps_get(lua_State *L)
 {
@@ -1310,6 +1315,7 @@ static int _et_ps_get(lua_State *L)
  * @param[in] fieldname
  * @param[in] arrayindex
  * @param[in] value
+ * @return
  */
 static int _et_gclient_set(lua_State *L)
 {
@@ -1395,6 +1401,7 @@ static int _et_gclient_set(lua_State *L)
  * @param[in] client
  * @param[in] event
  * @param[in] eventparm
+ * @return
  */
 static int _et_TVG_AddEvent(lua_State *L)
 {
@@ -1458,7 +1465,7 @@ static void _et_gettrace(lua_State *L, trace_t *tr)
 /**
  * @brief _etH_toVec3
  * @param[in] inx
- * @param[out] vec3_t
+ * @return vec3_t
  */
 static vec3_t *_etH_toVec3(lua_State *L, int inx)
 {
@@ -1480,6 +1487,7 @@ static vec3_t *_etH_toVec3(lua_State *L, int inx)
  * @param[in] end
  * @param[in] entNum
  * @param[in] mask
+ * @return
  */
 static int _et_trap_Trace(lua_State *L)
 {
@@ -1528,6 +1536,7 @@ static int _et_trap_Trace(lua_State *L)
  *        et.trap_SendServerCommand( clientnum, command )
  * @param[in] clientNum
  * @param[in] command
+ * @return
  */
 static int _et_trap_SendServerCommand(lua_State *L)
 {
@@ -1544,6 +1553,7 @@ static int _et_trap_SendServerCommand(lua_State *L)
  * @param[in] clientNum
  * @param[in] reason
  * @param[in] ban_time
+ * @return
  */
 static int _et_trap_DropClient(lua_State *L)
 {
@@ -1561,6 +1571,7 @@ static int _et_trap_DropClient(lua_State *L)
 *         if there is none or more than one match nil is returned.
  *        clientnum = et.ClientNumberFromString( string )
  * @param[in] string
+ * @return
  */
 static int _et_ClientNumberFromString(lua_State *L)
 {
@@ -1585,6 +1596,7 @@ static int _et_ClientNumberFromString(lua_State *L)
 *         if there is none or more than one match nil is returned.
  *        clientnum = et.MasterClientNumberFromString( string )
  * @param[in] string
+ * @return
  */
 static int _et_MasterClientNumberFromString(lua_State *L)
 {
@@ -1609,6 +1621,7 @@ static int _et_MasterClientNumberFromString(lua_State *L)
  * @param[in] clientNum
  * @param[in] mode
  * @param[in] text
+ * @return
  */
 static int _et_TVG_Say(lua_State *L)
 {
@@ -1626,6 +1639,7 @@ static int _et_TVG_Say(lua_State *L)
  * @param[in] clientNum
  * @param[in] duration
  * @param[in] reason
+ * @return
  */
 static int _et_MutePlayer(lua_State *L)
 {
@@ -1675,6 +1689,7 @@ static int _et_MutePlayer(lua_State *L)
  * @brief _et_UnmutePlayer
  *        et.UnmutePlayer( clientnum )
  * @param[in] clientNum
+ * @return
  */
 static int _et_UnmutePlayer(lua_State *L)
 {
@@ -1698,6 +1713,7 @@ static int _et_UnmutePlayer(lua_State *L)
  * @brief _et_TeleportPlayer teleport shifts origin[2] by +1
  *        et.TeleportPlayer( clientnum, vec3_t origin, vec3_t angles )
  * @param[in] clientNum
+ * @return
  */
 static int _et_TeleportPlayer(lua_State *L)
 {
@@ -1737,6 +1753,7 @@ static int _et_TeleportPlayer(lua_State *L)
  * @brief _et_trap_GetUserinfo
  *        userinfo = et.trap_GetUserinfo( clientnum )
  * @param[in] clientNum
+ * @return userinfo
  */
 static int _et_trap_GetUserinfo(lua_State *L)
 {
@@ -1753,6 +1770,7 @@ static int _et_trap_GetUserinfo(lua_State *L)
  *        et.trap_SetUserinfo( clientnum, userinfo )
  * @param[in] clientNum
  * @param[in] userinfo
+ * @return
  */
 static int _et_trap_SetUserinfo(lua_State *L)
 {
@@ -1767,6 +1785,7 @@ static int _et_trap_SetUserinfo(lua_State *L)
  * @brief _et_ClientUserinfoChanged
  *        et.ClientUserinfoChanged( clientNum )
  * @param[in] clientNum
+ * @return
  */
 static int _et_ClientUserinfoChanged(lua_State *L)
 {
@@ -1866,6 +1885,7 @@ static const luaL_Reg etlib[] =
 /**
  * @brief TVG_LuaRunIsolated creates and runs specified module in isolated state
  * @param[in] modName
+ * @return
  */
 qboolean TVG_LuaRunIsolated(const char *modName)
 {
@@ -1960,6 +1980,7 @@ qboolean TVG_LuaRunIsolated(const char *modName)
 
 /**
  * @brief TVG_LuaInit initialises the Lua API interface
+ * @return
  */
 qboolean TVG_LuaInit(void)
 {
@@ -2063,6 +2084,7 @@ qboolean TVG_LuaInit(void)
  * @param[in] func
  * @param[in] nargs
  * @param[in] nresults
+ * @return
  */
 qboolean TVG_LuaCall(lua_vm_t *vm, const char *func, int nargs, int nresults)
 {
@@ -2093,6 +2115,7 @@ qboolean TVG_LuaCall(lua_vm_t *vm, const char *func, int nargs, int nresults)
                                   if the function does not exist, returns qfalse.
  * @param[in] vm
  * @param[in] name
+ * @return
  */
 qboolean TVG_LuaGetNamedFunction(lua_vm_t *vm, const char *name)
 {
@@ -2116,7 +2139,7 @@ qboolean TVG_LuaGetNamedFunction(lua_vm_t *vm, const char *name)
  * @brief TVG_LuaStackDump dump the lua stack to console
  *                         executed by the ingame "lua_api" command
  */
-void TVG_LuaStackDump()
+void TVG_LuaStackDump(void)
 {
 	lua_vm_t *vm = (lua_vm_t *) Com_Allocate(sizeof(lua_vm_t));
 
@@ -2639,6 +2662,7 @@ static void TVG_RegisterConstants(lua_vm_t *vm)
 /**
  * @brief TVG_LuaStartVM starts one individual virtual machine.
  * @param[in] vm
+ * @return
  */
 qboolean TVG_LuaStartVM(lua_vm_t *vm)
 {
@@ -2753,6 +2777,7 @@ qboolean TVG_LuaStartVM(lua_vm_t *vm)
 /**
  * @brief TVG_LuaStopVM stops one virtual machine, and calls its et_Quit callback.
  * @param[in] vm
+ * @return
  */
 void TVG_LuaStopVM(lua_vm_t *vm)
 {
@@ -2859,6 +2884,7 @@ void TVG_LuaStatus(gclient_t *client)
 /**
  * @brief TVG_LuaGetVM retrieves the VM for a given lua_State
  * @param[in] L
+ * @return
  */
 lua_vm_t *TVG_LuaGetVM(lua_State *L)
 {
@@ -2995,7 +3021,7 @@ void TVG_LuaHook_RunFrame(int levelTime)
  * @param[in] clientNum
  * @param[in] firstTime
  * @param[in] isBot
- * @param[out] reject reason
+ * @return reject reason
  */
 qboolean TVG_LuaHook_ClientConnect(int clientNum, qboolean firstTime, qboolean isBot, char *reason)
 {
@@ -3183,7 +3209,7 @@ void TVG_LuaHook_ClientSpawn(int clientNum)
  *        intercepted = et_ClientCommand( clientNum, command ) callback
  * @param[in] clientNum
  * @param[in] command
- * @param[out] intercepted
+ * @return intercepted
  */
 qboolean TVG_LuaHook_ClientCommand(int clientNum, char *command)
 {
@@ -3231,7 +3257,7 @@ qboolean TVG_LuaHook_ClientCommand(int clientNum, char *command)
  * @brief TVG_LuaHook_ConsoleCommand
  *        intercepted = et_ConsoleCommand( command ) callback
  * @param[in] command
- * @param[out] intercepted
+ * @return intercepted
  */
 qboolean TVG_LuaHook_ConsoleCommand(char *command)
 {

--- a/src/tvgame/tvg_lua.c
+++ b/src/tvgame/tvg_lua.c
@@ -1171,18 +1171,18 @@ static int _et_field_get(lua_State *L, tvgame_field_t *field, uintptr_t addr, in
 	case FIELD_INT_ARRAY:
 		if (field->flags & FIELD_FLAG_NOPTR)
 		{
-			lua_pushinteger(L, (*(int *)(*(uintptr_t *)addr + (sizeof(int) * arrayIndex))));
+			lua_pushinteger(L, (*(int *)(*(uintptr_t *)addr + (sizeof(int) * (int)luaL_optinteger(L, arrayIndex, 0)))));
 		}
 		else
 		{
-			lua_pushinteger(L, (*(int *)(addr + (sizeof(int) * arrayIndex))));
+			lua_pushinteger(L, (*(int *)(addr + (sizeof(int) * (int)luaL_optinteger(L, arrayIndex, 0)))));
 		}
 		return 1;
 	case FIELD_TRAJECTORY:
 		_et_gettrajectory(L, (trajectory_t *)addr);
 		return 1;
 	case FIELD_FLOAT_ARRAY:
-		lua_pushnumber(L, (*(float *)(addr + (sizeof(int) * arrayIndex))));
+		lua_pushnumber(L, (*(float *)(addr + (sizeof(int) * (int)luaL_optinteger(L, arrayIndex, 0)))));
 		return 1;
 	case FIELD_USERCMD:
 		_et_getusercmd(L, (usercmd_t *)addr);
@@ -1212,7 +1212,7 @@ static int _et_level_get(lua_State *L)
 		return 0;
 	}
 
-	return _et_field_get(L, field, (uintptr_t)&level, (int)luaL_optinteger(L, 2, 0));
+	return _et_field_get(L, field, (uintptr_t)&level, 2);
 }
 
 /**
@@ -1236,7 +1236,7 @@ static int _et_gentity_get(lua_State *L)
 		return 0;
 	}
 
-	return _et_field_get(L, field, (uintptr_t)ent, (int)luaL_optinteger(L, 3, 0));
+	return _et_field_get(L, field, (uintptr_t)ent, 3);
 }
 
 /**
@@ -1260,7 +1260,7 @@ static int _et_gclient_get(lua_State *L)
 		return 0;
 	}
 
-	return _et_field_get(L, field, (uintptr_t)client, (int)luaL_optinteger(L, 3, 0));
+	return _et_field_get(L, field, (uintptr_t)client, 3);
 }
 
 /**
@@ -1305,7 +1305,7 @@ static int _et_ps_get(lua_State *L)
 		return 0;
 	}
 
-	return _et_field_get(L, field, (uintptr_t)&client, (int)luaL_optinteger(L, 3, 0));
+	return _et_field_get(L, field, (uintptr_t)&client, 3);
 }
 
 /**

--- a/src/tvgame/tvg_lua.c
+++ b/src/tvgame/tvg_lua.c
@@ -1703,7 +1703,7 @@ static int _et_TeleportPlayer(lua_State *L)
 {
 	int       clientnum = (int)luaL_checkinteger(L, 1);
 	gclient_t *client   = level.clients + clientnum;
-	vec3_t    pos, angles;
+	vec3_t    origin, angles;
 
 	if (!lua_istable(L, 2))
 	{
@@ -1723,10 +1723,10 @@ static int _et_TeleportPlayer(lua_State *L)
 		return 0;
 	}
 
-	VectorCopy(*_etH_toVec3(L, 2), pos);
+	VectorCopy(*_etH_toVec3(L, 2), origin);
 	VectorCopy(*_etH_toVec3(L, 3), angles);
 
-	TVG_TeleportPlayer(client, pos, angles);
+	TVG_TeleportPlayer(client, origin, angles);
 
 	return 0;
 }

--- a/src/tvgame/tvg_lua.h
+++ b/src/tvgame/tvg_lua.h
@@ -44,12 +44,13 @@
 #define FIELD_TRAJECTORY    6
 #define FIELD_FLOAT_ARRAY   7
 #define FIELD_WEAPONSTAT    8
-//#define FIELD_WEAPONSTAT_EXT	9
+#define FIELD_USERCMD       9
 
-#define FIELD_FLAG_GENTITY  1 ///< marks a gentity_s field
-#define FIELD_FLAG_GCLIENT  2 ///< marks a gclient_s field
+#define FIELD_FLAG_GENTITY  1  ///< marks a gentity_s field
+#define FIELD_FLAG_GCLIENT  2  ///< marks a gclient_s field
 #define FIELD_FLAG_NOPTR    4
-#define FIELD_FLAG_READONLY 8 ///< read-only access
+#define FIELD_FLAG_READONLY 8  ///< read-only access
+#define FIELD_FLAG_LEVEL    16 ///< marks a level_locals_t field
 
 // define HOSTARCH and EXTENSION depending on host architecture
 #if defined WIN32
@@ -70,11 +71,13 @@
 #define lua_regconststring(L, n) (lua_pushstring(L, #n), lua_pushstring(L, n), lua_settable(L, -3))
 //#define lua_regconststring(L, n) (lua_pushstring(L, n), lua_setfield(L, -2, #n))
 
-// macros to add gentity and gclient fields
+// macros to add gentity, gclient and level fields
 #define _et_gentity_addfield(n, t, f) { #n, t, offsetof(struct gentity_s, n), FIELD_FLAG_GENTITY + f }
 #define _et_gentity_addfieldalias(n, a, t, f) { #n, t, offsetof(struct gentity_s, a), FIELD_FLAG_GENTITY + f }
 #define _et_gclient_addfield(n, t, f) { #n, t, offsetof(struct gclient_s, n), FIELD_FLAG_GCLIENT + f }
 #define _et_gclient_addfieldalias(n, a, t, f) { #n, t, offsetof(struct gclient_s, a), FIELD_FLAG_GCLIENT + f }
+#define _et_level_addfield(n, t, f) { #n, t, offsetof(struct level_locals_s, n), FIELD_FLAG_LEVEL + f }
+#define _et_level_addfieldalias(n, a, t, f) { #n, t, offsetof(struct level_locals_s, a), FIELD_FLAG_LEVEL + f }
 
 /**
  * @struct lua_vm_s
@@ -93,16 +96,16 @@ typedef struct
 } lua_vm_t;
 
 /**
- * @struct gentity_field_s
+ * @struct tvgame_field_s
  * @brief
  */
-typedef struct
+typedef struct tvgame_field_s
 {
 	const char *name;
 	int type;
 	unsigned long mapping;
 	int flags;
-} gentity_field_t;
+} tvgame_field_t;
 
 extern lua_vm_t *lVM[LUA_NUM_VM];
 
@@ -130,40 +133,30 @@ typedef struct luaPrintFunctions_s
 } luaPrintFunctions_t;
 
 // API
-qboolean G_LuaInit(void);
-qboolean G_LuaCall(lua_vm_t *vm, const char *func, int nargs, int nresults);
-qboolean G_LuaGetNamedFunction(lua_vm_t *vm, const char *name);
-qboolean G_LuaStartVM(lua_vm_t *vm);
-qboolean G_LuaRunIsolated(const char *modName);
-void G_LuaStopVM(lua_vm_t *vm);
-void G_LuaShutdown(void);
-void G_LuaRestart(void);
-void G_LuaStatus(gentity_t *ent);
-void G_LuaStackDump();
-lua_vm_t *G_LuaGetVM(lua_State *L);
+qboolean TVG_LuaInit(void);
+qboolean TVG_LuaCall(lua_vm_t *vm, const char *func, int nargs, int nresults);
+qboolean TVG_LuaGetNamedFunction(lua_vm_t *vm, const char *name);
+qboolean TVG_LuaStartVM(lua_vm_t *vm);
+qboolean TVG_LuaRunIsolated(const char *modName);
+void TVG_LuaStopVM(lua_vm_t *vm);
+void TVG_LuaShutdown(void);
+void TVG_LuaRestart(void);
+void TVG_LuaStatus(gclient_t *client);
+void TVG_LuaStackDump();
+lua_vm_t *TVG_LuaGetVM(lua_State *L);
 
 // Callbacks
-void G_LuaHook_InitGame(int levelTime, int randomSeed, int restart);
-void G_LuaHook_ShutdownGame(int restart);
-void G_LuaHook_RunFrame(int levelTime);
-qboolean G_LuaHook_ClientConnect(int clientNum, qboolean firstTime, qboolean isBot, char *reason);
-void G_LuaHook_ClientDisconnect(int clientNum);
-void G_LuaHook_ClientBegin(int clientNum);
-void G_LuaHook_ClientUserinfoChanged(int clientNum);
-void G_LuaHook_ClientSpawn(int clientNum);
-qboolean G_LuaHook_ClientCommand(int clientNum, char *command);
-qboolean G_LuaHook_ConsoleCommand(char *command);
-qboolean G_LuaHook_UpgradeSkill(int cno, skillType_t skill);
-qboolean G_LuaHook_SetPlayerSkill(int cno, skillType_t skill);
-void G_LuaHook_Print(printMessageType_t category, char *text);
-qboolean G_LuaHook_Obituary(int victim, int killer, int meansOfDeath);
-qboolean G_LuaHook_Damage(int target, int attacker, int damage, int dflags, meansOfDeath_t mod);
-void G_LuaHook_SpawnEntitiesFromString();
-qboolean G_ScriptAction_Delete(gentity_t *ent, char *params);
-qboolean G_LuaHook_WeaponFire(int clientNum, weapon_t weapon, gentity_t **pFiredShot);
-qboolean G_LuaHook_FixedMGFire(int clientNum);
-qboolean G_LuaHook_MountedMGFire(int clientNum);
-qboolean G_LuaHook_AAGunFire(int clientNum);
+void TVG_LuaHook_InitGame(int levelTime, int randomSeed, int restart);
+void TVG_LuaHook_ShutdownGame(int restart);
+void TVG_LuaHook_RunFrame(int levelTime);
+qboolean TVG_LuaHook_ClientConnect(int clientNum, qboolean firstTime, qboolean isBot, char *reason);
+void TVG_LuaHook_ClientDisconnect(int clientNum);
+void TVG_LuaHook_ClientBegin(int clientNum);
+void TVG_LuaHook_ClientUserinfoChanged(int clientNum);
+void TVG_LuaHook_ClientSpawn(int clientNum);
+qboolean TVG_LuaHook_ClientCommand(int clientNum, char *command);
+qboolean TVG_LuaHook_ConsoleCommand(char *command);
+void TVG_LuaHook_Print(printMessageType_t category, char *text);
 
 #endif // #ifndef INCLUDE_G_LUA_H
 

--- a/src/tvgame/tvg_public.h
+++ b/src/tvgame/tvg_public.h
@@ -275,9 +275,7 @@ typedef enum
 
 	GAME_MESSAGERECEIVED = 14,      ///< ( int cno, const char *buf, int buflen, int commandTime );
 
-	GAME_DEMOSTATECHANGED,          ///< (demoState_t demoState, int demoClientsNum) // server demo playback
-
-	GAME_ETTV = 1000,
+	GAME_ETTV = 1000,               ///< ETTV backward compatibility
 
 } gameExport_t;
 

--- a/src/tvgame/tvg_session.c
+++ b/src/tvgame/tvg_session.c
@@ -65,23 +65,15 @@ void TVG_WriteClientSessionData(gclient_t *client, qboolean restart)
 	}
 
 	cJSON_AddNumberToObject(root, "sessionTeam", client->sess.sessionTeam);
-	cJSON_AddNumberToObject(root, "spectatorTime", client->sess.spectatorTime);
 	cJSON_AddNumberToObject(root, "spectatorState", client->sess.spectatorState);
 	cJSON_AddNumberToObject(root, "spectatorClient", client->sess.spectatorClient);
 	cJSON_AddNumberToObject(root, "playerType", client->sess.playerType);
-	cJSON_AddNumberToObject(root, "playerWeapon", client->sess.playerWeapon);
-	cJSON_AddNumberToObject(root, "playerWeapon2", client->sess.playerWeapon2);
-	cJSON_AddNumberToObject(root, "latchPlayerType", client->sess.latchPlayerType);
-	cJSON_AddNumberToObject(root, "latchPlayerWeapon", client->sess.latchPlayerWeapon);
-	cJSON_AddNumberToObject(root, "latchPlayerWeapon2", client->sess.latchPlayerWeapon2);
 	cJSON_AddNumberToObject(root, "referee", client->sess.referee);
-	cJSON_AddNumberToObject(root, "shoutcaster", client->sess.shoutcaster);
 
 	cJSON_AddNumberToObject(root, "muted", client->sess.muted);
 	//cJSON_AddNumberToObject(root, "ignoreClients1", client->sess.ignoreClients[0]);
 	//cJSON_AddNumberToObject(root, "ignoreClients2", client->sess.ignoreClients[1]);
 	cJSON_AddNumberToObject(root, "enterTime", client->pers.enterTime);
-	cJSON_AddNumberToObject(root, "userSpawnPointValue", restart ? client->sess.userSpawnPointValue : 0);
 
 	cJSON_AddNumberToObject(root, "spec_team", client->sess.spec_team);
 	cJSON_AddNumberToObject(root, "tvchat", client->sess.tvchat);
@@ -106,24 +98,16 @@ void TVG_ReadSessionData(gclient_t *client)
 
 	root = Q_FSReadJsonFrom(fileName);
 
-	client->sess.sessionTeam        = Q_ReadIntValueJson(root, "sessionTeam");
-	client->sess.spectatorTime      = Q_ReadIntValueJson(root, "spectatorTime");
-	client->sess.spectatorState     = Q_ReadIntValueJson(root, "spectatorState");
-	client->sess.spectatorClient    = Q_ReadIntValueJson(root, "spectatorClient");
-	client->sess.playerType         = Q_ReadIntValueJson(root, "playerType");
-	client->sess.playerWeapon       = Q_ReadIntValueJson(root, "playerWeapon");
-	client->sess.playerWeapon2      = Q_ReadIntValueJson(root, "playerWeapon2");
-	client->sess.latchPlayerType    = Q_ReadIntValueJson(root, "latchPlayerType");
-	client->sess.latchPlayerWeapon  = Q_ReadIntValueJson(root, "latchPlayerWeapon");
-	client->sess.latchPlayerWeapon2 = Q_ReadIntValueJson(root, "latchPlayerWeapon2");
-	client->sess.referee            = Q_ReadIntValueJson(root, "referee");
-	client->sess.shoutcaster        = Q_ReadIntValueJson(root, "shoutcaster");
+	client->sess.sessionTeam     = Q_ReadIntValueJson(root, "sessionTeam");
+	client->sess.spectatorState  = Q_ReadIntValueJson(root, "spectatorState");
+	client->sess.spectatorClient = Q_ReadIntValueJson(root, "spectatorClient");
+	client->sess.playerType      = Q_ReadIntValueJson(root, "playerType");
+	client->sess.referee         = Q_ReadIntValueJson(root, "referee");
 
 	client->sess.muted = Q_ReadIntValueJson(root, "muted");
 	//client->sess.ignoreClients[0]    = Q_ReadIntValueJson(root, "ignoreClients1");
 	//client->sess.ignoreClients[1]    = Q_ReadIntValueJson(root, "ignoreClients2");
-	client->pers.enterTime           = Q_ReadIntValueJson(root, "enterTime");
-	client->sess.userSpawnPointValue = Q_ReadIntValueJson(root, "userSpawnPointValue");
+	client->pers.enterTime = Q_ReadIntValueJson(root, "enterTime");
 
 	client->sess.spec_team = Q_ReadIntValueJson(root, "spec_team");
 	client->sess.tvchat    = Q_ReadIntValueJson(root, "tvchat");
@@ -140,17 +124,9 @@ void TVG_InitSessionData(gclient_t *client, const char *userinfo)
 {
 	clientSession_t *sess = &client->sess;
 
-	// initial team determination
-	sess->sessionTeam = TEAM_SPECTATOR;
-
+	sess->sessionTeam    = TEAM_SPECTATOR;
 	sess->spectatorState = SPECTATOR_FREE;
-	sess->spectatorTime  = level.time;
-
-	sess->latchPlayerType    = sess->playerType = 0;
-	sess->latchPlayerWeapon  = sess->playerWeapon = WP_NONE;
-	sess->latchPlayerWeapon2 = sess->playerWeapon2 = WP_NONE;
-
-	sess->userSpawnPointValue = 0;
+	sess->playerType     = 0;
 
 	//Com_Memset(sess->ignoreClients, 0, sizeof(sess->ignoreClients));
 

--- a/src/tvgame/tvg_spawn.c
+++ b/src/tvgame/tvg_spawn.c
@@ -335,7 +335,7 @@ gentity_t *TVG_SpawnGEntityFromSpawnVars(void)
 	gentity_t *ent;
 	char      *str;
 
-	ent = G_Spawn(); // get the next free entity
+	ent = TVG_Spawn(); // get the next free entity
 
 	for (i = 0 ; i < level.numSpawnVars ; i++)
 	{
@@ -343,17 +343,17 @@ gentity_t *TVG_SpawnGEntityFromSpawnVars(void)
 	}
 
 	// check for "notteam" / "notfree" flags
-	G_SpawnInt("notteam", "0", &i);
+	TVG_SpawnInt("notteam", "0", &i);
 	if (i)
 	{
 		G_Printf("G_SpawnGEntityFromSpawnVars Warning: Can't spawn entity in team games - returning NULL\n");
 
-		G_FreeEntity(ent);
+		TVG_FreeEntity(ent);
 		return NULL;
 	}
 
 	// allowteams handling
-	G_SpawnString("allowteams", "", &str);
+	TVG_SpawnString("allowteams", "", &str);
 	if (str[0])
 	{
 		str = Q_strlwr(str);
@@ -387,7 +387,7 @@ gentity_t *TVG_SpawnGEntityFromSpawnVars(void)
 	// if we didn't get a classname, don't bother spawning anything
 	if (!TVG_CallSpawn(ent))
 	{
-		G_FreeEntity(ent);
+		TVG_FreeEntity(ent);
 	}
 
 	return ent;
@@ -493,22 +493,22 @@ void SP_worldspawn(void)
 {
 	char *s;
 
-	G_SpawnString("classname", "", &s);
+	TVG_SpawnString("classname", "", &s);
 	if (Q_stricmp(s, "worldspawn"))
 	{
 		G_Error("SP_worldspawn: The first entity isn't 'worldspawn'\n");
 	}
 
 	level.mapcoordsValid = qfalse;
-	if (G_SpawnVector2D("mapcoordsmins", "-128 128", level.mapcoordsMins) &&     // top left
-	    G_SpawnVector2D("mapcoordsmaxs", "128 -128", level.mapcoordsMaxs))       // bottom right
+	if (TVG_SpawnVector2D("mapcoordsmins", "-128 128", level.mapcoordsMins) &&     // top left
+	    TVG_SpawnVector2D("mapcoordsmaxs", "128 -128", level.mapcoordsMaxs))       // bottom right
 	{
 		level.mapcoordsValid = qtrue;
 	}
 
 	BG_InitLocations(level.mapcoordsMins, level.mapcoordsMaxs);
 
-	G_SpawnString("spawnflags", "0", &s);
+	TVG_SpawnString("spawnflags", "0", &s);
 	g_entities[ENTITYNUM_WORLD].spawnflags   = Q_atoi(s);
 	g_entities[ENTITYNUM_WORLD].r.worldflags = g_entities[ENTITYNUM_WORLD].spawnflags;
 
@@ -545,10 +545,6 @@ void TVG_SpawnEntitiesFromString(void)
 	{
 		TVG_SpawnGEntityFromSpawnVars();
 	}
-
-#ifdef FEATURE_LUA
-	G_LuaHook_SpawnEntitiesFromString();
-#endif
 
 	G_Printf("Disable spawning!\n");
 	level.spawning = qfalse;            // any future calls to G_Spawn*() will be errors

--- a/src/tvgame/tvg_svcmds.c
+++ b/src/tvgame/tvg_svcmds.c
@@ -506,14 +506,7 @@ void Svcmd_EntityList_f(void)
 		// print the ents which are in use
 		//Q_strcat(line, sizeof(line), va("^7%4i: ", e));
 
-		if (check->neverFree)
-		{
-			Com_sprintf(line, 128, "^1%4i: ", e);
-		}
-		else
-		{
-			Com_sprintf(line, 128, "^7%4i: ", e);
-		}
+		Com_sprintf(line, 128, "^7%4i: ", e);
 
 		if (check->s.eType <= ET_EVENTS) // print events
 		{
@@ -1368,8 +1361,8 @@ static consoleCommandTable_t consoleCommandTable[] =
 	{ "cp",            Svcmd_CP_f         },
 	{ "sv_cvarempty",  CC_cvarempty       },
 	{ "sv_cvar",       CC_svcvar          },
-	{ "playsound",     G_PlaySound_Cmd    },
-	{ "playsound_env", G_PlaySound_Cmd    },
+	{ "playsound",     TVG_PlaySound_Cmd  },
+	{ "playsound_env", TVG_PlaySound_Cmd  },
 
 	{ "ref",           Svcmd_Ref_f        },                            // console also gets ref commands
 	{ "qsay",          Svcmd_Qsay_f       },
@@ -1389,21 +1382,21 @@ qboolean TVG_ConsoleCommand(void)
 #ifdef FEATURE_LUA
 	if (!Q_stricmp(cmd, "lua_status"))
 	{
-		G_LuaStatus(NULL);
+		TVG_LuaStatus(NULL);
 		return qtrue;
 	}
 	else if (!Q_stricmp(cmd, "lua_restart"))
 	{
-		G_LuaRestart();
+		TVG_LuaRestart();
 		return qtrue;
 	}
 	else if (Q_stricmp(cmd, "lua_api") == 0)
 	{
-		G_LuaStackDump();
+		TVG_LuaStackDump();
 		return qtrue;
 	}
 	// *LUA* API callbacks
-	else if (G_LuaHook_ConsoleCommand(cmd))
+	else if (TVG_LuaHook_ConsoleCommand(cmd))
 	{
 		return qtrue;
 	}

--- a/src/tvgame/tvg_syscalls.c
+++ b/src/tvgame/tvg_syscalls.c
@@ -284,16 +284,6 @@ void trap_SendServerCommand(int clientNum, const char *text)
  */
 void trap_SetConfigstring(int num, const char *string)
 {
-	//SystemCall(G_SET_CONFIGSTRING, num, string);
-}
-
-/**
-* @brief trap_TVG_SetConfigstring
-* @param[in] num
-* @param[in] string
-*/
-void trap_TVG_SetConfigstring(int num, const char *string)
-{
 	SystemCall(G_SET_CONFIGSTRING, num, string);
 }
 

--- a/src/tvgame/tvg_utils.c
+++ b/src/tvgame/tvg_utils.c
@@ -42,14 +42,14 @@ model / sound configstring indexes
 */
 
 /**
- * @brief G_FindConfigstringIndex
+ * @brief TVG_FindConfigstringIndex
  * @param[in] name
  * @param[in] start
  * @param[in] max
  * @param[in] create
  * @return
  */
-int G_FindConfigstringIndex(const char *name, int start, int max, qboolean create)
+int TVG_FindConfigstringIndex(const char *name, int start, int max, qboolean create)
 {
 	int  i;
 	char s[MAX_STRING_CHARS];
@@ -79,7 +79,7 @@ int G_FindConfigstringIndex(const char *name, int start, int max, qboolean creat
 
 	if (i == max)
 	{
-		G_Error("G_FindConfigstringIndex: overflow '%s' (%i %i) max: %i\n", name, start, start + i, max);
+		G_Error("TVG_FindConfigstringIndex: overflow '%s' (%i %i) max: %i\n", name, start, start + i, max);
 	}
 
 	trap_SetConfigstring(start + i, name);
@@ -95,7 +95,7 @@ int G_FindConfigstringIndex(const char *name, int start, int max, qboolean creat
  * @param[in] start
  * @param[in] max
  */
-void G_RemoveConfigstringIndex(const char *name, int start, int max)
+void TVG_RemoveConfigstringIndex(const char *name, int start, int max)
 {
 	int  i, j;
 	char s[MAX_STRING_CHARS];
@@ -130,65 +130,65 @@ void G_RemoveConfigstringIndex(const char *name, int start, int max)
 }
 
 /**
- * @brief G_ModelIndex
+ * @brief TVG_ModelIndex
  * @param[in] name
  * @return
  */
-int G_ModelIndex(const char *name)
+int TVG_ModelIndex(const char *name)
 {
-	return G_FindConfigstringIndex(name, CS_MODELS, MAX_MODELS, qtrue);
+	return TVG_FindConfigstringIndex(name, CS_MODELS, MAX_MODELS, qtrue);
 }
 
 /**
- * @brief G_SoundIndex
+ * @brief TVG_SoundIndex
  * @param[in] name
  * @return
  */
-int G_SoundIndex(const char *name)
+int TVG_SoundIndex(const char *name)
 {
-	return G_FindConfigstringIndex(name, CS_SOUNDS, MAX_SOUNDS, qtrue) + GAMESOUND_MAX;
+	return TVG_FindConfigstringIndex(name, CS_SOUNDS, MAX_SOUNDS, qtrue) + GAMESOUND_MAX;
 }
 
 /**
- * @brief G_SkinIndex
+ * @brief TVG_SkinIndex
  * @param[in] name
  * @return
  */
-int G_SkinIndex(const char *name)
+int TVG_SkinIndex(const char *name)
 {
-	return G_FindConfigstringIndex(name, CS_SKINS, MAX_CS_SKINS, qtrue);
+	return TVG_FindConfigstringIndex(name, CS_SKINS, MAX_CS_SKINS, qtrue);
 }
 
 /**
- * @brief G_ShaderIndex
+ * @brief TVG_ShaderIndex
  * @param[in] name
  * @return
  */
-int G_ShaderIndex(const char *name)
+int TVG_ShaderIndex(const char *name)
 {
-	return G_FindConfigstringIndex(name, CS_SHADERS, MAX_CS_SHADERS, qtrue);
+	return TVG_FindConfigstringIndex(name, CS_SHADERS, MAX_CS_SHADERS, qtrue);
 }
 
 /**
- * @brief G_CharacterIndex
+ * @brief TVG_CharacterIndex
  * @param[in] name
  * @return
  *
  * @note Unused
  */
-int G_CharacterIndex(const char *name)
+int TVG_CharacterIndex(const char *name)
 {
-	return G_FindConfigstringIndex(name, CS_CHARACTERS, MAX_CHARACTERS, qtrue);
+	return TVG_FindConfigstringIndex(name, CS_CHARACTERS, MAX_CHARACTERS, qtrue);
 }
 
 /**
- * @brief G_StringIndex
+ * @brief TVG_StringIndex
  * @param[in] string
  * @return
  */
-int G_StringIndex(const char *string)
+int TVG_StringIndex(const char *string)
 {
-	return G_FindConfigstringIndex(string, CS_STRINGS, MAX_CSSTRINGS, qtrue);
+	return TVG_FindConfigstringIndex(string, CS_STRINGS, MAX_CSSTRINGS, qtrue);
 }
 
 //=====================================================================
@@ -198,7 +198,7 @@ int G_StringIndex(const char *string)
  * @param[in] team
  * @param[in] cmd
  */
-void G_TeamCommand(team_t team, const char *cmd)
+void TVG_TeamCommand(team_t team, const char *cmd)
 {
 	int i;
 
@@ -225,7 +225,7 @@ void G_TeamCommand(team_t team, const char *cmd)
  * @param[in] match
  * @return
  */
-gentity_t *G_Find(gentity_t *from, int fieldofs, const char *match)
+gentity_t *TVG_Find(gentity_t *from, int fieldofs, const char *match)
 {
 	char      *s;
 	gentity_t *max = &g_entities[level.num_entities];
@@ -260,127 +260,12 @@ gentity_t *G_Find(gentity_t *from, int fieldofs, const char *match)
 }
 
 /**
- * @brief Like G_Find, but searches for integer values.
- * @param[in,out] from
- * @param[in] fieldofs
- * @param[in] match
- * @return
- */
-gentity_t *G_FindInt(gentity_t *from, int fieldofs, int match)
-{
-	int       i;
-	gentity_t *max = &g_entities[level.num_entities];
-
-	if (!from)
-	{
-		from = g_entities;
-	}
-	else
-	{
-		from++;
-	}
-
-	for ( ; from < max ; from++)
-	{
-		if (!from->inuse)
-		{
-			continue;
-		}
-		i = *(int *) ((byte *)from + fieldofs);
-		if (i == match)
-		{
-			return from;
-		}
-	}
-
-	return NULL;
-}
-
-/**
- * @brief Like G_Find, but searches for float values..
- * @param[in,out] from
- * @param[in] fieldofs
- * @param[in] match
- * @return
- */
-gentity_t *G_FindFloat(gentity_t *from, int fieldofs, float match)
-{
-	float     f;
-	gentity_t *max = &g_entities[level.num_entities];
-
-	if (!from)
-	{
-		from = g_entities;
-	}
-	else
-	{
-		from++;
-	}
-
-	for ( ; from < max ; from++)
-	{
-		if (!from->inuse)
-		{
-			continue;
-		}
-		f = *(float *) ((byte *)from + fieldofs);
-		if (f == match)
-		{
-			return from;
-		}
-	}
-
-	return NULL;
-}
-
-/**
- * @brief Like G_Find, but searches for vector values..
- * @param[in,out] from
- * @param[in] fieldofs
- * @param[in] match
- * @return
- */
-gentity_t *G_FindVector(gentity_t *from, int fieldofs, const vec3_t match)
-{
-	vec3_t    vec;
-	gentity_t *max = &g_entities[level.num_entities];
-
-	if (!from)
-	{
-		from = g_entities;
-	}
-	else
-	{
-		from++;
-	}
-
-	for ( ; from < max ; from++)
-	{
-		if (!from->inuse)
-		{
-			continue;
-		}
-		vec[0] = *(vec_t *) ((byte *)from + fieldofs + 0);
-		vec[1] = *(vec_t *) ((byte *)from + fieldofs + 4);
-		vec[2] = *(vec_t *) ((byte *)from + fieldofs + 8);
-
-		if (vec[0] == match[0] && vec[1] == match[1] && vec[2] == match[2])
-		{
-			return from;
-		}
-	}
-
-	return NULL;
-}
-
-
-/**
- * @brief G_FindByTargetname
+ * @brief TVG_FindByTargetname
  * @param[in,out] from
  * @param[in] match
  * @return
  */
-gentity_t *G_FindByTargetname(gentity_t *from, const char *match)
+gentity_t *TVG_FindByTargetname(gentity_t *from, const char *match)
 {
 	gentity_t *max = &g_entities[level.num_entities];
 	int       hash;
@@ -389,50 +274,9 @@ gentity_t *G_FindByTargetname(gentity_t *from, const char *match)
 
 	if (hash == -1) // if there is no name (not empty string!) BG_StringHashValue returns -1
 	{
-		G_Printf("G_FindByTargetname WARNING: invalid match pointer '%s' - run devmap & g_scriptdebug 1 to get more info about\n", match);
+		G_Printf("TVG_FindByTargetname WARNING: invalid match pointer '%s' - run devmap & g_scriptdebug 1 to get more info about\n", match);
 		return NULL;
 	}
-
-	if (!from)
-	{
-		from = g_entities;
-	}
-	else
-	{
-		from++;
-	}
-
-	for ( ; from < max ; from++)
-	{
-		if (!from->inuse)
-		{
-			continue;
-		}
-
-		if (!from->targetname) // there are ents with no targetname set
-		{
-			continue;
-		}
-
-		if (from->targetnamehash == hash && !Q_stricmp(from->targetname, match))
-		{
-			return from;
-		}
-	}
-
-	return NULL;
-}
-
-/**
- * @brief This version should be used for loops, saves the constant hash building
- * @param[in,out] from
- * @param[in] match
- * @param[in] hash
- * @return
- */
-gentity_t *G_FindByTargetnameFast(gentity_t *from, const char *match, int hash)
-{
-	gentity_t *max = &g_entities[level.num_entities];
 
 	if (!from)
 	{
@@ -471,7 +315,7 @@ gentity_t *G_FindByTargetnameFast(gentity_t *from, const char *match, int hash)
  * @param[in] targetname
  * @return
  */
-gentity_t *G_PickTarget(const char *targetname)
+gentity_t *TVG_PickTarget(const char *targetname)
 {
 	gentity_t *ent        = NULL;
 	int       num_choices = 0;
@@ -479,13 +323,13 @@ gentity_t *G_PickTarget(const char *targetname)
 
 	if (!targetname)
 	{
-		//G_Printf("G_PickTarget called with NULL targetname\n");
+		//G_Printf("TVG_PickTarget called with NULL targetname\n");
 		return NULL;
 	}
 
 	while (1)
 	{
-		ent = G_FindByTargetname(ent, targetname);
+		ent = TVG_FindByTargetname(ent, targetname);
 		if (!ent)
 		{
 			break;
@@ -499,7 +343,7 @@ gentity_t *G_PickTarget(const char *targetname)
 
 	if (!num_choices)
 	{
-		G_Printf(S_COLOR_YELLOW "WARNING G_PickTarget: target %s not found or isn't in use - this might be a bug (returning NULL)\n", targetname);
+		G_Printf(S_COLOR_YELLOW "WARNING TVG_PickTarget: target %s not found or isn't in use - this might be a bug (returning NULL)\n", targetname);
 		return NULL;
 	}
 
@@ -507,68 +351,11 @@ gentity_t *G_PickTarget(const char *targetname)
 }
 
 /**
- * @brief G_AllowTeamsAllowed
- * @param[in] ent
- * @param[in] activator
- * @return
- */
-qboolean G_AllowTeamsAllowed(gentity_t *ent, gentity_t *activator)
-{
-	if (ent->allowteams && activator && activator->client)
-	{
-		if (activator->client->sess.sessionTeam != TEAM_SPECTATOR)
-		{
-			int checkTeam = activator->client->sess.sessionTeam;
-
-			if (!(ent->allowteams & checkTeam))
-			{
-				if ((ent->allowteams & ALLOW_DISGUISED_CVOPS) && activator->client->ps.powerups[PW_OPS_DISGUISED])
-				{
-					if (checkTeam == TEAM_AXIS)
-					{
-						checkTeam = TEAM_ALLIES;
-					}
-					else if (checkTeam == TEAM_ALLIES)
-					{
-						checkTeam = TEAM_AXIS;
-					}
-				}
-
-				if (!(ent->allowteams & checkTeam))
-				{
-					return qfalse;
-				}
-			}
-		}
-	}
-
-	return qtrue;
-}
-
-/**
- * @brief Added to allow more checking on what uses what
- * @param[in,out] ent
- * @param[in] other
- * @param[in] activator
- */
-void G_UseEntity(gentity_t *ent, gentity_t *other, gentity_t *activator)
-{
-	// check for allowteams
-	if (!G_AllowTeamsAllowed(ent, activator))
-	{
-		return;
-	}
-
-	// Woop we got through, let's use the entity
-	ent->use(ent, other, activator);
-}
-
-/**
  * @brief This is just a convenience function for printing vectors
  * @param[in] v
  * @return
  */
-char *vtos(const vec3_t v)
+char *TVG_VecToStr(const vec3_t v)
 {
 	static int  index;
 	static char str[8][32];
@@ -584,47 +371,15 @@ char *vtos(const vec3_t v)
 }
 
 /**
- * @brief The editor only specifies a single value for angles (yaw),
- * but we have special constants to generate an up or down direction.
- * Angles will be cleared, because it is being used to represent a direction
- * instead of an orientation.
- *
- * @param[in,out] angles
- * @param[out] movedir
- */
-void G_SetMovedir(vec3_t angles, vec3_t movedir)
-{
-	static vec3_t VEC_UP       = { 0, -1, 0 };
-	static vec3_t MOVEDIR_UP   = { 0, 0, 1 };
-	static vec3_t VEC_DOWN     = { 0, -2, 0 };
-	static vec3_t MOVEDIR_DOWN = { 0, 0, -1 };
-
-	if (VectorCompare(angles, VEC_UP))
-	{
-		VectorCopy(MOVEDIR_UP, movedir);
-	}
-	else if (VectorCompare(angles, VEC_DOWN))
-	{
-		VectorCopy(MOVEDIR_DOWN, movedir);
-	}
-	else
-	{
-		AngleVectors(angles, movedir, NULL, NULL);
-	}
-	VectorClear(angles);
-}
-
-/**
- * @brief G_InitGentity
+ * @brief TVG_InitGentity
  * @param[in,out] e
  */
-void G_InitGentity(gentity_t *e)
+void TVG_InitGentity(gentity_t *e)
 {
 	e->inuse      = qtrue;
 	e->classname  = "noclass";
 	e->s.number   = e - g_entities;
 	e->r.ownerNum = ENTITYNUM_NONE;
-	e->nextthink  = 0;
 	e->free       = NULL;
 
 	// mark the time
@@ -644,7 +399,7 @@ void G_InitGentity(gentity_t *e)
  *
  * @return
  */
-gentity_t *G_Spawn(void)
+gentity_t *TVG_Spawn(void)
 {
 	int       i = 0, force;
 	gentity_t *e = NULL;
@@ -670,7 +425,7 @@ gentity_t *G_Spawn(void)
 			}
 
 			// reuse this slot
-			G_InitGentity(e);
+			TVG_InitGentity(e);
 			return e;
 		}
 		if (i != ENTITYNUM_MAX_NORMAL)
@@ -695,7 +450,7 @@ gentity_t *G_Spawn(void)
 	trap_LocateGameData(level.gentities, level.num_entities, sizeof(gentity_t),
 	                    &level.clients[0].ps, sizeof(level.clients[0]));
 
-	G_InitGentity(e);
+	TVG_InitGentity(e);
 	return e;
 }
 
@@ -704,7 +459,7 @@ gentity_t *G_Spawn(void)
  *
  * @param[in,out] ent
  */
-void G_FreeEntity(gentity_t *ent)
+void TVG_FreeEntity(gentity_t *ent)
 {
 	if (ent->free)
 	{
@@ -713,11 +468,6 @@ void G_FreeEntity(gentity_t *ent)
 
 	trap_UnlinkEntity(ent);       // unlink from world
 
-	if (ent->neverFree)
-	{
-		return;
-	}
-
 	// this tiny hack fixes level.num_entities rapidly reaching MAX_GENTITIES-1
 	// some very often spawned entities don't have to relax (=spawned, immediately freed and not transmitted)
 	// before all game entities did relax - now  ET_TEMPHEAD, ET_TEMPLEGS and ET_EVENTS no longer relax
@@ -725,7 +475,7 @@ void G_FreeEntity(gentity_t *ent)
 	// - optimization: if events are freed EVENT_VALID_MSEC has already passed (keep in mind these are broadcasted)
 	// - when enabled g_debugHitboxes, g_debugPlayerHitboxes or g_debugbullets 3 we want visible trace effects - don't free immediately
 	// FIXME: remove tmp var l_free if we are sure there are no issues caused by this change (especially on network games)
-	if (ent->s.eType == ET_TEMPHEAD || ent->s.eType == ET_TEMPLEGS || ent->s.eType == ET_CORPSE || ent->s.eType >= ET_EVENTS)
+	if (ent->s.eType == ET_CORPSE || ent->s.eType >= ET_EVENTS)
 	{
 		// debug
 		if (g_developer.integer)
@@ -755,133 +505,29 @@ void G_FreeEntity(gentity_t *ent)
 	}
 }
 
-/**
- * @brief Spawns an event entity that will be auto-removed.
- *
- * @details The origin will be snapped to save net bandwidth, so care
- * must be taken if the origin is right on a surface (snap towards start vector first)
- *
- * @param[in] origin
- * @param[in] event
- * @return
- */
-gentity_t *G_TempEntity(vec3_t origin, entity_event_t event)
-{
-	gentity_t *e;
-	vec3_t    snapped;
-
-	e = G_Spawn();
-
-	e->s.eType = ET_EVENTS + event;
-
-	e->classname      = "tempEntity";
-	e->eventTime      = level.time;
-	e->r.eventTime    = level.time;
-	e->freeAfterEvent = qtrue;
-
-	VectorCopy(origin, snapped);
-	SnapVector(snapped);        // save network bandwidth
-	TVG_SetOrigin(e, snapped);
-
-	// find cluster for PVS
-	trap_LinkEntity(e);
-
-	return e;
-}
-
-/**
- * @brief Spawns an event entity that will be auto-removed
- * Use this for non visible and not origin based events like global sounds etc.
- *
- * @param[in] event
- *
- * @return
- *
- * @note Don't forget to call e->r.svFlags = SVF_BROADCAST; after
- */
-gentity_t *G_TempEntityNotLinked(entity_event_t event)
-{
-	gentity_t *e;
-
-	e = G_Spawn();
-
-	e->s.eType        = ET_EVENTS + event;
-	e->classname      = "tempEntity";
-	e->eventTime      = level.time;
-	e->r.eventTime    = level.time;
-	e->freeAfterEvent = qtrue;
-	e->r.linked       = qtrue; // don't link for real
-
-	return e;
-}
-
 //==============================================================================
 
 /**
  * @brief Adds an event+parm and twiddles the event counter
- * @param[in,out] ent
+ * @param[in,out] client
  * @param[in] event
  * @param[in] eventParm
  */
-void G_AddEvent(gentity_t *ent, int event, int eventParm)
+void TVG_AddEvent(gclient_t *client, int event, int eventParm)
 {
 	if (!event)
 	{
-		G_Printf(S_COLOR_YELLOW "WARNING G_AddEvent: zero event added for entity %i\n", ent->s.number);
+		G_Printf(S_COLOR_YELLOW "WARNING G_AddEvent: zero event added for client %i\n", client - level.clients);
 		return;
 	}
 
 	// use the sequential event list
-	if (ent->client)
+	if (client)
 	{
 		// commented in - externalEvents not being handled properly in Wolf right now
-		ent->client->ps.events[ent->client->ps.eventSequence & (MAX_EVENTS - 1)]     = event;
-		ent->client->ps.eventParms[ent->client->ps.eventSequence & (MAX_EVENTS - 1)] = eventParm;
-		ent->client->ps.eventSequence++;
-	}
-	else
-	{
-		// commented in - externalEvents not being handled properly in Wolf right now
-		ent->s.events[ent->s.eventSequence & (MAX_EVENTS - 1)]     = event;
-		ent->s.eventParms[ent->s.eventSequence & (MAX_EVENTS - 1)] = eventParm;
-		ent->s.eventSequence++;
-	}
-	ent->eventTime   = level.time;
-	ent->r.eventTime = level.time;
-}
-
-/**
- * @brief Removed channel parm, since it wasn't used, and could cause confusion
- * @param[in] ent
- * @param[in] soundIndex
- */
-void G_Sound(gentity_t *ent, int soundIndex)
-{
-	gentity_t *te;
-
-	te = G_TempEntity(ent->r.currentOrigin, EV_GENERAL_SOUND);
-
-	te->s.eventParm = soundIndex;
-}
-
-/**
- * @brief G_ClientSound
- * @param[in] ent
- * @param[in] soundIndex
- */
-void G_ClientSound(gentity_t *ent, int soundIndex)
-{
-	if (ent && ent->client)
-	{
-		gentity_t *te;
-
-		te = G_TempEntityNotLinked(EV_GLOBAL_CLIENT_SOUND);
-
-		te->s.teamNum   = (ent->client - level.clients);
-		te->s.eventParm = soundIndex;
-
-		te->r.singleClient = ent->s.number;
-		te->r.svFlags      = SVF_SINGLECLIENT | SVF_BROADCAST;
+		client->ps.events[client->ps.eventSequence & (MAX_EVENTS - 1)]     = event;
+		client->ps.eventParms[client->ps.eventSequence & (MAX_EVENTS - 1)] = eventParm;
+		client->ps.eventSequence++;
 	}
 }
 
@@ -893,48 +539,12 @@ void G_ClientSound(gentity_t *ent, int soundIndex)
  */
 void TVG_AnimScriptSound(int soundIndex, vec3_t org, int client)
 {
-	gentity_t *e = &g_entities[client];
+	gclient_t *cl = &level.clients[client];
 
-	G_AddEvent(e, EV_GENERAL_SOUND, soundIndex);
+	TVG_AddEvent(cl, EV_GENERAL_SOUND, soundIndex);
 }
 
 //==============================================================================
-
-/**
- * @brief Sets the pos trajectory for a fixed position
- * @param[out] ent
- * @param[in] origin
- */
-void TVG_SetOrigin(gentity_t *ent, vec3_t origin)
-{
-	VectorCopy(origin, ent->s.pos.trBase);
-	ent->s.pos.trType     = TR_STATIONARY;
-	ent->s.pos.trTime     = 0;
-	ent->s.pos.trDuration = 0;
-	VectorClear(ent->s.pos.trDelta);
-
-	VectorCopy(origin, ent->s.origin);
-	VectorCopy(origin, ent->r.currentOrigin);
-
-	if (ent->client)
-	{
-		VectorCopy(origin, ent->client->ps.origin);
-	}
-}
-
-/**
-* @brief Plays specified sound globally.
-* @param[in] sound
-*/
-void TVG_globalSound(const char *sound)
-{
-	gentity_t *te;
-
-	te = G_TempEntityNotLinked(EV_GLOBAL_SOUND);
-
-	te->s.eventParm = G_SoundIndex(sound);
-	te->r.svFlags  |= SVF_BROADCAST;
-}
 
 /**
 * @brief Teleport player to a given origin and angles
@@ -1044,55 +654,9 @@ void TVG_TempTraceIgnorePlayersFromTeam(team_t team)
 
 	for (i = 0; i < MAX_CLIENTS; i++)
 	{
-		if (g_entities[i].client && g_entities[i].client->sess.sessionTeam == team)
+		if (g_entities[i].s.teamNum == team)
 		{
 			TVG_TempTraceIgnoreEntity(&g_entities[i]);
-		}
-	}
-}
-
-/**
-* @brief TVG_TempTraceIgnoreEntities
-* @param[in] ent
-*/
-void TVG_TempTraceIgnoreEntities(gentity_t *ent)
-{
-	int           i;
-	int           listLength;
-	int           list[MAX_GENTITIES];
-	gentity_t     *hit;
-	vec3_t        BBmins, BBmaxs;
-	static vec3_t range = { CH_BREAKABLE_DIST, CH_BREAKABLE_DIST, CH_BREAKABLE_DIST };
-
-	if (!ent->client)
-	{
-		return;
-	}
-
-	VectorSubtract(ent->client->ps.origin, range, BBmins);
-	VectorAdd(ent->client->ps.origin, range, BBmaxs);
-
-	listLength = trap_EntitiesInBox(BBmins, BBmaxs, list, MAX_GENTITIES);
-
-	for (i = 0; i < listLength; i++)
-	{
-		hit = &g_entities[list[i]];
-
-		if (hit->s.eType == ET_OID_TRIGGER || hit->s.eType == ET_TRIGGER_MULTIPLE
-		    || hit->s.eType == ET_TRIGGER_FLAGONLY || hit->s.eType == ET_TRIGGER_FLAGONLY_MULTIPLE)
-		{
-			TVG_TempTraceIgnoreEntity(hit);
-		}
-
-		if (hit->s.eType == ET_CORPSE && !(ent->client->ps.stats[STAT_PLAYER_CLASS] == PC_COVERTOPS))
-		{
-			TVG_TempTraceIgnoreEntity(hit);
-		}
-
-		if (hit->client && (!(ent->client->ps.stats[STAT_PLAYER_CLASS] == PC_MEDIC) || (ent->client->ps.stats[STAT_PLAYER_CLASS] == PC_MEDIC && ent->client->sess.sessionTeam != hit->client->sess.sessionTeam))
-		    && hit->client->ps.pm_type == PM_DEAD && !(hit->client->ps.pm_flags & PMF_LIMBO))
-		{
-			TVG_TempTraceIgnoreEntity(hit);
 		}
 	}
 }


### PR DESCRIPTION
Main differences from legacy mod for scripts:
- remove some hooks and functions that are not relevant to tvgame
- add et.gentity_get access to master server entityState_t and entityShared_t structs
- add et.level_get added access to level_locals_t struct
- add et.ps_get access to master server players playerState_t struct
- add et.gclient_get access to viewers gclient_t struct
- add et.client_set access to viewers gclient_t struct
- only viewers struct is writeable (at least as of now)
- remove and add a bunch of accessible fields
- add et.TeleportPlayer( clientnum, vec3_t origin, vec3_t angles )
- add clientnum = et.MasterClientNumberFromString( string ) searches through master clients for one partial match with string 

Changes unrelated to scripts:
- lua works only for sv_pure 0 slave server because otherwise lua scripts cannot be read (in short because of extension whitelist in file system, might be not possible to properly fix)
- renamed functions
- updated functions comments

Changes unrelated to LUA:
- fix incorrect mods type in tvcmd_reference_t
- refactor some if statements
- remove g_mdx.c from build
- remove not needed or "incompatible" code
- init r.ownerNum to ENTITYNUM_NONE for player entities
- fix and add SpectatorAttackFollow trace
- remove CVAR_SERVERINFO flag from g_fixedphysics, g_fixedphysicsfps and g_pronedelay cvars
- G_ETTV gameexport is now only kept for ETTV compatibility

refs #229