### PR TITLE
etmain: Reframe 1P panzerfaust animations

### DIFF
--- a/etmain/models/weapons2/panzerfaust/weapon.cfg
+++ b/etmain/models/weapons2/panzerfaust/weapon.cfg
@@ -18,18 +18,18 @@ newfmt
 //   /   /   /   /   /   /
 
 61	1	20	1	0	0	0	// IDLE1
-0	1	20	1	0	0	0	// IDLE2
+0	0	0	0	0	0	0	// IDLE2 notused
 
-62	38	15	0	0	0	1	// ATTACK1
-62	38	15	0	0	0	0	// ATTACK2
-62	38	14	0	0	0	1	// ATTACK3
+0	0	0	0	0	0	0	// ATTACK1 notused
+0	0	0	0	0	0	0	// ATTACK2 notused
+62	38	11	0	0	0	1	// ATTACK_LASTSHOT
 
-20	15	20	0	0	0	0	// DROP
-40	21	20	0	0	0	0	// RAISE
-40	21	20	0	0	0	0	// RELOAD1
-0	1	20	1	0	0	0	// RELOAD2
-0	1	20	1	0	0	0	// RELOAD3
+25	15	20	0	0	0	0	// DROP
+41	4	12	0	0	0	0	// RAISE
+0	0	0	0	0	0	0	// RELOAD1 notused
+0	0	0	0	0	0	0	// RELOAD2 notused
+0	0	0	0	0	0	0	// RELOAD3 notused
 
-61	1	20	1	0	0	0	// ALTSWITCH
-61	1	20	1	0	0	0	// ALTSWITCH
-0	1	20	1	0	0	0	// DROP2
+0	0	0	0	0	0	0	// ALTSWITCHFROM notused
+0	0	0	0	0	0	0	// ALTSWITCHTO notused
+0	0	0	0	0	0	0	// DROP2 notused

--- a/src/cgame/cg_weapons.c
+++ b/src/cgame/cg_weapons.c
@@ -3107,6 +3107,14 @@ void CG_AddPlayerWeapon(refEntity_t *parent, playerState_t *ps, centity_t *cent)
 			return;
 		}
 	}
+	else if (ps && weaponNum == WP_PANZERFAUST)
+	{
+		// 1P - don't pull out another panzerfaust right after firing
+		if (ps->weaponstate == WEAPON_DROPPING && !ps->ammoclip[weaponNum])
+		{
+			return;
+		}
+	}
 
 	// no weapon when on mg_42
 	if (cent->currentState.eFlags & EF_MOUNTEDTANK)


### PR DESCRIPTION
**Comparison**: https://www.youtube.com/watch?v=FEdS9nEc6rQ

---

skip DROP animation right after firing - i.e. don't pull out another panzerfaust right after firing one.

ATTACK_LASTSHOT was slightly slowed to slightly better align with the firing.

RAISE was slightly adjusted to better match the swap duration.

DROP was reframed significantly to show shutting the lid, which previously was cut off and which also circumvents a cross-screen warping effect that could happen on widescreen.

As a result quickswapping and post-firing now look significantly better.