### PR TITLE
Reconcile entityState_s.groundEntityNum air states

### DIFF
--- a/src/cgame/cg_ents.c
+++ b/src/cgame/cg_ents.c
@@ -812,7 +812,7 @@ static void CG_Item(centity_t *cent)
 
 			if (es->eFlags & EF_SPINNING)
 			{
-				if (es->groundEntityNum == -1 || !es->groundEntityNum)     // spinning with a stand will spin the stand and the attached weap (only when in the air)
+				if (es->groundEntityNum == ENTITYNUM_NONE)     // spinning with a stand will spin the stand and the attached weap (only when in the air)
 				{
 					VectorCopy(cg.autoAnglesSlow, cent->lerpAngles);
 					VectorCopy(cg.autoAnglesSlow, cent->lastLerpAngles);
@@ -863,7 +863,7 @@ static void CG_Item(centity_t *cent)
 
 			if (es->eFlags & EF_SPINNING)      // spinning will override the angles set by a stand
 			{
-				if (es->groundEntityNum == -1 || !es->groundEntityNum)     // spinning with a stand will spin the stand and the attached weap (only when in the air)
+				if (es->groundEntityNum == ENTITYNUM_NONE)     // spinning with a stand will spin the stand and the attached weap (only when in the air)
 				{
 					VectorCopy(cg.autoAnglesSlow, cent->lerpAngles);
 					VectorCopy(cg.autoAnglesSlow, cent->lastLerpAngles);

--- a/src/game/g_etbot_interface.cpp
+++ b/src/game/g_etbot_interface.cpp
@@ -3829,7 +3829,7 @@ public:
 		gentity_t *pEnt = EntityFromHandle(_ent);
 		if (pEnt)
 		{
-			if (pEnt->s.groundEntityNum > 0 && pEnt->s.groundEntityNum < ENTITYNUM_MAX_NORMAL)
+			if (pEnt->s.groundEntityNum >= 0 && pEnt->s.groundEntityNum < ENTITYNUM_NONE)
 			{
 				moveent = HandleFromEntity(&g_entities[pEnt->s.groundEntityNum]);
 			}

--- a/src/game/g_items.c
+++ b/src/game/g_items.c
@@ -848,6 +848,7 @@ gentity_t *LaunchItem(gitem_t *item, vec3_t origin, vec3_t velocity, int ownerNu
 	dropped->s.eType           = ET_ITEM;
 	dropped->s.modelindex      = item->id ; // store item number in modelindex
 	dropped->s.otherEntityNum2 = 1; // this is taking modelindex2's place for a dropped item
+	dropped->s.groundEntityNum = ENTITYNUM_NONE;
 
 	dropped->classname = item->classname;
 	dropped->item      = item;
@@ -1274,8 +1275,8 @@ void G_RunItem(gentity_t *ent)
 	int     contents;
 	int     mask = ent->clipmask ? ent->clipmask : MASK_SOLID;
 
-	// if groundentity has been set to -1, it may have been pushed off an edge
-	if (ent->s.groundEntityNum == -1)
+	// if groundentity has been set to ENTITYNUM_NONE, it may have been pushed off an edge
+	if (ent->s.groundEntityNum == ENTITYNUM_NONE)
 	{
 		if (ent->s.pos.trType != TR_GRAVITY)
 		{
@@ -1324,7 +1325,7 @@ void G_RunItem(gentity_t *ent)
 			VectorClear(ent->s.pos.trDelta);
 			ent->s.pos.trType      = TR_GRAVITY;
 			ent->s.pos.trTime      = level.time;
-			ent->s.groundEntityNum = -1;
+			ent->s.groundEntityNum = ENTITYNUM_NONE;
 		}
 
 		G_RunThink(ent);

--- a/src/game/g_missile.c
+++ b/src/game/g_missile.c
@@ -75,7 +75,7 @@ void G_BounceMissile(gentity_t *ent, trace_t *trace)
 	}
 
 	// set ground entity
-	if (ent->s.groundEntityNum != -1)
+	if (ent->s.groundEntityNum != ENTITYNUM_NONE)
 	{
 		ground = &g_entities[ent->s.groundEntityNum];
 	}
@@ -473,7 +473,7 @@ void MissileGroundCheck(gentity_t *self)
 
 	if (tr.fraction == 1.f)
 	{
-		self->s.groundEntityNum = -1;
+		self->s.groundEntityNum = ENTITYNUM_NONE;
 	}
 }
 
@@ -493,7 +493,7 @@ void G_RunMissile(gentity_t *ent)
 	{
 		MissileGroundCheck(ent);
 
-		if (ent->s.groundEntityNum == -1)
+		if (ent->s.groundEntityNum == ENTITYNUM_NONE)
 		{
 			if (ent->s.pos.trType != TR_GRAVITY)
 			{

--- a/src/game/g_mover.c
+++ b/src/game/g_mover.c
@@ -364,7 +364,7 @@ qboolean G_TryPushingEntity(gentity_t *check, gentity_t *pusher, vec3_t move, ve
 	// may have pushed them off an edge
 	if (check->s.groundEntityNum != pusher->s.number)
 	{
-		check->s.groundEntityNum = -1;
+		check->s.groundEntityNum = ENTITYNUM_NONE;
 	}
 
 	block = G_TestEntityPosition(check);
@@ -472,7 +472,7 @@ qboolean G_TryPushingEntity(gentity_t *check, gentity_t *pusher, vec3_t move, ve
 	block = G_TestEntityPosition(check);
 	if (!block)
 	{
-		check->s.groundEntityNum = -1;
+		check->s.groundEntityNum = ENTITYNUM_NONE;
 		pushed_p--;
 		return qtrue;
 	}

--- a/src/game/g_props.c
+++ b/src/game/g_props.c
@@ -1138,7 +1138,7 @@ void Just_Got_Thrown(gentity_t *self)
 {
 	float len = 0;
 
-	if (self->s.groundEntityNum == -1)
+	if (self->s.groundEntityNum == ENTITYNUM_NONE)
 	{
 		self->nextthink = level.time + FRAMETIME;
 
@@ -1239,7 +1239,7 @@ void Props_Activated(gentity_t *self)
 		self->physicsObject = qtrue;
 		self->physicsBounce = 0.2f;
 
-		self->s.groundEntityNum = -1;
+		self->s.groundEntityNum = ENTITYNUM_NONE;
 
 		self->s.pos.trType = TR_GRAVITY;
 		self->s.pos.trTime = level.time;
@@ -1298,7 +1298,7 @@ void Props_Activated(gentity_t *self)
 
 		prop->classname = self->classname;
 
-		prop->s.groundEntityNum = -1;
+		prop->s.groundEntityNum = ENTITYNUM_NONE;
 
 		VectorCopy(self->r.currentOrigin, prop->s.origin2);
 
@@ -1400,7 +1400,7 @@ void Props_Chair_Think(gentity_t *self)
 		}
 	}
 
-	if (self->s.groundEntityNum == -1)
+	if (self->s.groundEntityNum == ENTITYNUM_NONE)
 	{
 		self->physicsObject = qtrue;
 		self->physicsBounce = 0.2f;
@@ -1507,7 +1507,7 @@ void Prop_Check_Ground(gentity_t *self)
 
 	if (tr.fraction == 1.f)
 	{
-		self->s.groundEntityNum = -1;
+		self->s.groundEntityNum = ENTITYNUM_NONE;
 	}
 }
 

--- a/src/qcommon/q_shared.h
+++ b/src/qcommon/q_shared.h
@@ -1603,7 +1603,9 @@ typedef struct entityState_s
 	int otherEntityNum;     ///< shotgun sources, etc
 	int otherEntityNum2;
 
-	int groundEntityNum;    ///< -1 = in air
+	int groundEntityNum;    ///< ENTITYNUM_NONE when in air when - otherwise the
+							///entity number of the entity it is atop, also see
+							///ENTITYNUM_WORLD
 
 	int constantLight;      ///< r + (g<<8) + (b<<16) + (intensity<<24)
 	int dl_intensity;       ///< used for coronas


### PR DESCRIPTION
Entities are currently said to be in air when groundEntityNum on their state is either 0 or -1.

0 however is already an existing entity number and -1 can't be transmitted word sized.

This commit reconciles both states with ENTITYNUM_NONE throughout the codebase.