### PR TITLE
cgame: Fix limbo key handling on open weaponpanel case

### DIFF
--- a/src/cgame/cg_limbopanel.c
+++ b/src/cgame/cg_limbopanel.c
@@ -3483,6 +3483,13 @@ void CG_LimboPanel_Setup(void)
 		cgs.ccSelectedLayer = CG_CurLayerForZ((int)cg.predictedPlayerEntity.lerpOrigin[2]);
 	}
 
+	// clear focus button in case limbo was abruptly closed via K_ESCAPE,
+	// otherwise breaks key handling
+	if (BG_PanelButtons_GetFocusButton() != NULL)
+	{
+		BG_PanelButtons_SetFocusButton(NULL);
+	}
+
 	for ( ; *buttons; buttons++)
 	{
 		button = (*buttons);


### PR DESCRIPTION
If you have the weapon panel open, by pressing left mouse button down and not releasing it, and then quit limbo via ESC or your limbokey, weapon panel will not be cleared as the focus button.

Thus, if you open up your limbo menu again thereafter, key handling will be broken and you won't be able e.g. anymore to select a team.

This commit fixes this issue by always clearing any previously set focus button when you open up the limbo menu.