### PR TITLE
etmain: Reframe 1P flamethrower animations

### DIFF
--- a/etmain/models/weapons2/flamethrower/weapon.cfg
+++ b/etmain/models/weapons2/flamethrower/weapon.cfg
@@ -17,19 +17,19 @@ newfmt
 ///   /   /   /   /   /   ______________________________/
 //   /   /   /   /   /   /
 
-0	1	20	1	0	0	0	// IDLE1
-0	1	20	1	0	0	0	// IDLE2
+0	1	20	0	0	0	0	// IDLE1
+0	0	0	0	0	0	0	// IDLE2 notused
 
-0	1	20	1	0	0	0	// ATTACK1
-0	1	20	1	0	0	0	// ATTACK2
-0	1	20	1	0	0	0	// ATTACK3
+1	1	30	0	0	0	0	// ATTACK1
+0	0	0	0	0	0	0	// ATTACK2 notused
+6	2	12	0	0	0	0	// ATTACK_LASTSHOT
 
-7	5	20	0	0	0	0	// DROP
-12	4	16	0	0	0	0	// RAISE
-12	4	16	0	0	0	0	// RELOAD1
-12	4	16	4	0	0	0	// RELOAD2
-12	4	16	0	0	0	0	// RELOAD3
+9	5	7	0	0	0	0	// DROP
+12	5	13	0	0	0	0	// RAISE
+0	0	0	0	0	0	0	// RELOAD1 notused
+0	0	0	0	0	0	0	// RELOAD2 notused
+0	0	0	0	0	0	0	// RELOAD3 notused
 
-0	1	20	1	0	0	0	// ALTSWITCH
-0	1	20	1	0	0	0	// ALTSWITCH
-0	1	20	1	0	0	0	// DROP2
+0	0	0	0	0	0	0	// ALTSWITCHFROM notused
+0	0	0	0	0	0	0	// ALTSWITCHTO notused
+0	0	0	0	0	0	0	// DROP2 notused

--- a/src/cgame/cg_weapons.c
+++ b/src/cgame/cg_weapons.c
@@ -3601,6 +3601,33 @@ void CG_AddPlayerWeapon(refEntity_t *parent, playerState_t *ps, centity_t *cent)
 		CG_PositionRotatedEntityOnTag(&flash, &gun, "tag_flash");
 	}
 
+	// @XXX hardcode offset flash positions, to correct wrong official
+	// muzzle locations in some cases
+	{
+		vec3_t  forward;
+		float flash_offset = 0.0f;
+
+		switch (weaponNum) {
+			case WP_FLAMETHROWER:
+				// adjust flamethrower muzzle according to cg_fov
+				flash_offset = (((cg.refdef.fov_y / 73.739784 /*90 fov*/) - 1.0) * -3) - 0.4f;
+
+				// pull the flame back slightly while raising
+				if ((cg.snap->ps.weapAnim & ~ANIM_TOGGLEBIT) == WEAP_RAISE) {
+					flash_offset -= 0.5;
+				}
+				break;
+			default:
+				break;
+		}
+
+      if (flash_offset != 0.0f) {
+         AxisToAngles(flash.axis, angles);
+         AngleVectors(angles, forward, NULL, NULL);
+         VectorMA(flash.origin, flash_offset, forward, flash.origin);
+      }
+	}
+
 	// store this position for other cgame elements to access
 	cent->pe.gunRefEnt      = gun;
 	cent->pe.gunRefEntFrame = cg.clientFrame;


### PR DESCRIPTION
Comparison: https://www.youtube.com/watch?v=KlyigmoebPQ

---

Add an ATTACK1 anim that slightly pulls back the flamethrower while shooting.

Add a slower ATTACK_LASTSHOT anim that plays when out of ammo.

Adjust RAISE and DROP animations to be more smooth and less abrupt.

Fix "hover"-flame, which occurs on cg_fov values other than 90, by adding a 'fov_y' dependent offset - as a result the idle flame should now always stick to the muzzle.