### PR TITLE
client: add con_scale to scale console text size

### DIFF
--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -3014,12 +3014,6 @@ void CL_SetConsoleScale(float factor)
 		return;
 	}
 
-	// adjustments are already made since the last time scaling was changed, we can exit
-	if (!con_scale->modified)
-	{
-		return;
-	}
-
 	if (con.scale != factor)
 	{
 		con_scale->modified = qtrue;

--- a/src/client/cl_scrn.c
+++ b/src/client/cl_scrn.c
@@ -138,7 +138,7 @@ static void SRC_DrawSingleChar(int x, int y, int w, int h, int ch)
 	}
 	else
 	{
-		float       scaleX, scaleY, scale;
+		float       scaleX, scaleY, scale, renderScale;
 		glyphInfo_t *info;
 		float       xx;
 		float       yy;
@@ -159,7 +159,8 @@ static void SRC_DrawSingleChar(int x, int y, int w, int h, int ch)
 			return;
 		}
 
-		scale = cls.consoleFont.glyphScale * ((float)smallCharHeight / (float)SMALLCHAR_HEIGHT);
+		renderScale = (float)smallCharHeight / (float)SMALLCHAR_HEIGHT;
+		scale       = cls.consoleFont.glyphScale * renderScale;
 
 		// FIXME: fix the magic numbers at some point
 		scaleX = 0.3f; // (float)w / (float)info->imageWidth;
@@ -169,7 +170,7 @@ static void SRC_DrawSingleChar(int x, int y, int w, int h, int ch)
 		scaleY *= scale;
 
 		xx = (float)x + ((float)info->pitch * scaleX);
-		yy = (float)y - ((float)info->top * scaleY) + 12;
+		yy = (float)y - ((float)info->top * scaleY) + (12 * renderScale);
 		ww = (float)info->imageWidth * scaleX;
 		hh = (float)info->imageHeight * scaleY;
 

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -718,8 +718,6 @@ typedef struct
 	char version[256];
 	char date[16];
 	char arch[64];
-	float versionWidth;                 ///< longest string out of the version strings (version, date, arch)
-	                                    ///< used to determine console linewidth
 } console_t;
 
 extern console_t con;

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -502,6 +502,8 @@ extern cvar_t *cl_defaultProfile;
 
 extern cvar_t *cl_consoleKeys;
 
+extern cvar_t *con_scale;
+
 //=================================================
 
 // cl_main
@@ -548,6 +550,9 @@ void CL_TranslateStringMod(const char *string, char *dest_buffer);
 void CL_OpenURL(const char *url);
 
 void CL_Record(const char *name);
+
+void CL_RegisterConsoleFont(void);
+void CL_SetConsoleScale(float factor);
 
 // cl_avi
 
@@ -673,8 +678,8 @@ qboolean CL_UpdateVisiblePings_f(int source);
 
 #define CON_TEXTSIZE    131072
 
-extern int smallCharWidth;      ///< SMALLCHAR_WIDTH with renderer scale accounted for
-extern int smallCharHeight;     ///< SMALLCHAR_HEIGHT with renderer scale accounted for
+extern int smallCharWidth;      ///< SMALLCHAR_WIDTH with renderer + console scale accounted for
+extern int smallCharHeight;     ///< SMALLCHAR_HEIGHT with renderer + console scale accounted for
 
 /**
  * @struct console_t
@@ -707,6 +712,14 @@ typedef struct
 	vec4_t color;                       ///< for transparent lines
 
 	int highlightOffset;                ///< highligting start offset (if == 0) then no hightlight
+
+	float scale;                        ///< current console scale
+
+	char version[256];
+	char date[16];
+	char arch[64];
+	float versionWidth;                 ///< longest string out of the version strings (version, date, arch)
+	                                    ///< used to determine console linewidth
 } console_t;
 
 extern console_t con;
@@ -756,7 +769,6 @@ void SCR_DrawChar(int x, int y, float w, float h, int ch, qboolean nativeResolut
 void SCR_DrawStringExt(int x, int y, float w, float h, const char *string, float *setColor, qboolean forceColor, qboolean noColorEscape, qboolean dropShadow, qboolean nativeResolution);
 
 #define SCR_DrawSmallChar(x, y, ch) SCR_DrawChar(x, y, SMALLCHAR_WIDTH, SMALLCHAR_HEIGHT, ch, qtrue)
-// ignores embedded color control characters
 #define SCR_DrawSmallString(x, y, string, setColor, forceColor, noColorEscape) SCR_DrawStringExt(x, y, SMALLCHAR_WIDTH, SMALLCHAR_HEIGHT, string, setColor, forceColor, noColorEscape, qfalse, qtrue)
 
 // cl_cin.c

--- a/src/renderer/tr_init.c
+++ b/src/renderer/tr_init.c
@@ -228,14 +228,11 @@ static void InitOpenGL(void)
 			glConfig.maxTextureSize = 0;
 		}
 
-		ri.CL_SetScaling(1.0f);
-
 		if (r_scale->value)
 		{
-			float scale = Com_Clamp(0.2f, 4.f, r_scale->value);
+			const float scale = Com_Clamp(0.2f, 4.f, r_scale->value);
 			glConfig.vidWidth  *= scale;
 			glConfig.vidHeight *= scale;
-			ri.CL_SetScaling(scale);
 		}
 	}
 

--- a/src/renderer_vk/tr_init.c
+++ b/src/renderer_vk/tr_init.c
@@ -218,14 +218,11 @@ static void InitOpenGL(void)
 			glConfig.maxTextureSize = 0;
 		}
 
-		ri.CL_SetScaling(1.0f);
-
 		if (r_scale->value)
 		{
-			float scale = Com_Clamp(0.2f, 4.f, r_scale->value);
+			const float scale = Com_Clamp(0.2f, 4.f, r_scale->value);
 			glConfig.vidWidth  *= scale;
 			glConfig.vidHeight *= scale;
-			ri.CL_SetScaling(scale);
 		}
 	}
 

--- a/src/renderercommon/tr_public.h
+++ b/src/renderercommon/tr_public.h
@@ -244,7 +244,6 @@ typedef struct
 	/// avi output stuff
 	qboolean (*CL_VideoRecording)(void);
 	void (*CL_WriteAVIVideoFrame)(const byte *buffer, int size);
-	void (*CL_SetScaling)(float scale);
 
 #ifdef FEATURE_PNG
 	int (*zlib_compress)(Bytef *dest, uLongf *destLen, const Bytef *source, uLong sourceLen);


### PR DESCRIPTION
`con_scale` (0.5 - 4) scales console text size

* Split version string into 3 separate fields: platform, date and game version.
* Small cosmetic improvements to alignment.
* Slightly decreased maximum line width to not overlap with the new split version info.
* Version string auto-hides if the string would take over > 66% of the entire input field due to high scale + low resolution.

Currently if using TTF/OTF fonts, the font isn't automatically re-registered at the scaled point size, since there's no way to currently free an already registered font, and changing `con_scale` few times would just fill up `MAX_FONTS` quickly (see fixme in `CL_SetConsoleScale`). `vid_restart` is required to re-register the correctly scaled font. Did not feel like writing a way to do that in the scope of this PR.

Would not mind another set of eyes on this, so I'm gonna mark this as a draft for now. Could probably at least use a bit of cleanup and streamlining but this console code is frankly quite awful to work with.

fixes #2460 