### PR TITLE
cgame: Make Smoke Bomb puff direction deterministic

### DIFF
--- a/src/cgame/cg_effects.c
+++ b/src/cgame/cg_effects.c
@@ -133,7 +133,7 @@ localEntity_t *CG_SmokePuff(const vec3_t p, const vec3_t vel,
 	le->radius  = radius;
 
 	re             = &le->refEntity;
-	re->rotation   = Q_random(&seed) * 360;
+	re->rotation   = Q_RandomFloat(&seed) * 360;
 	re->radius     = radius;
 	re->shaderTime = startTime / 1000.0f;
 
@@ -889,8 +889,8 @@ typedef struct smokesprite_s
 	vec3_t pos;
 	vec4_t colour;
 
-	vec3_t dir;
-	float dist;
+	vec3_t dir;  // direction
+	float dist;  // distance
 	float size;
 
 	centity_t *smokebomb;
@@ -1050,7 +1050,7 @@ qboolean CG_SpawnSmokeSprite(centity_t *cent, float dist)
 		//VectorCopy( cent->lerpOrigin, smokesprite->pos );
 		//smokesprite->pos[2] += 32;
 		VectorCopy(cent->origin2, smokesprite->pos);
-		VectorCopy(bytedirs[rand() % NUMVERTEXNORMALS], smokesprite->dir);
+		VectorCopy(bytedirs[Q_LCG(cent->currentState.time + cent->miscInt /*sprite number*/) % NUMVERTEXNORMALS], smokesprite->dir);
 		smokesprite->dir[2]   *= .5f;
 		smokesprite->size      = 16.f;
 		smokesprite->colour[0] = .35f; // + crandom() * .1f;
@@ -1069,6 +1069,9 @@ qboolean CG_SpawnSmokeSprite(centity_t *cent, float dist)
 			cent->miscTime++;
 		}
 	}
+
+	// advance smoke sprite number
+	cent->miscInt++;
 
 	return qtrue;
 }

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -392,7 +392,7 @@ typedef struct centity_s
 	int overheatTime;
 	int previousEvent;
 	int previousEventSequence;
-	int teleportFlag;
+	int miscInt;
 
 	int trailTime;                  ///< so missile trails can handle dropped initial packets
 	int miscTime;

--- a/src/cgame/cg_snapshot.c
+++ b/src/cgame/cg_snapshot.c
@@ -78,6 +78,8 @@ static void CG_ResetEntity(centity_t *cent)
 
 	cent->moving     = qfalse;
 	cent->akimboFire = qfalse;
+
+	cent->miscInt = 0;
 }
 
 /**

--- a/src/qcommon/q_math.c
+++ b/src/qcommon/q_math.c
@@ -3270,20 +3270,20 @@ void mat4_from_angles(mat4_t m, vec_t pitch, vec_t yaw, vec_t roll)
 
 /**
  * @brief Q_ClosestMultiple
- * @param[in] n the number 
+ * @param[in] n the number
  * @param[in] x the multiple
  * @return closest multiple number
  */
 int Q_ClosestMultiple(int n, int x)
-{    
-    if (x > n)
-    {
-        return x;
-    }
-    
-    n = n + x * 0.5f; 
-    n = n - (n % x); 
-    return n; 
+{
+	if (x > n)
+	{
+		return x;
+	}
+
+	n = n + x * 0.5f;
+	n = n - (n % x);
+	return n;
 }
 
 /**
@@ -3291,10 +3291,10 @@ int Q_ClosestMultiple(int n, int x)
  * @param[in] n
  * @param[in] x
  * @param[in] digit
- * @return 
+ * @return
  */
 float Q_ClosestMultipleFloat(float n, float x, int decimal)
 {
-    float coeff = pow(10, decimal);
-    return Q_ClosestMultiple(n * coeff, x * coeff) / coeff;
+	float coeff = pow(10, decimal);
+	return Q_ClosestMultiple(n * coeff, x * coeff) / coeff;
 }

--- a/src/qcommon/q_math.c
+++ b/src/qcommon/q_math.c
@@ -194,36 +194,26 @@ vec3_t bytedirs[NUMVERTEXNORMALS] =
 //==============================================================
 
 /**
- * @brief Q_rand
+ * @brief random function producing ints with a passed seed
  * @param[in,out] seed
  * @return
  */
-int Q_rand(int *seed)
+int Q_RandomInt(int *seed)
 {
-	*seed = (int)(69069U * *seed + 1U);
+	*seed = Q_LCG(*seed);
 	return *seed;
 }
 
 /**
- * @brief Q_random
- * @param[in] seed
+ * @brief random function producing floats with a passed seed
+ * @param[in,out] seed
  * @return
  */
-float Q_random(int *seed)
+float Q_RandomFloat(int *seed)
 {
-	return (float)(Q_rand(seed) & 0xffff) / (float)0x10000;
+	*seed = Q_LCG(*seed);
+	return (float)(*seed & 0xffff) / (float)0x10000;
 }
-
-/**
- * @brief Q_crandom
- * @param[in] seed
- * @return
- */
-float Q_crandom(int *seed)
-{
-	return 2.0f * (Q_random(seed) - 0.5f);
-}
-
 
 //=======================================================
 

--- a/src/qcommon/q_math.h
+++ b/src/qcommon/q_math.h
@@ -450,9 +450,18 @@ void BoundsAdd(vec3_t mins, vec3_t maxs, const vec3_t mins2, const vec3_t maxs2)
 
 float Q_acos(float c);
 
-int Q_rand(int *seed);
-float Q_random(int *seed);
-float Q_crandom(int *seed);
+/**
+ * @brief LCG
+ * @param x
+ * @return
+ */
+static inline int Q_LCG(int x)
+{
+	return (int)(69069U * x + 1U);
+}
+
+int Q_RandomInt(int *seed);
+float Q_RandomFloat(int *seed);
 
 #define random()    ((rand() & 0x7fff) / ((float)0x7fff))
 #define crandom()   (2.0f * (random() - 0.5f))


### PR DESCRIPTION
Instead of chosing random directions upon the creation of each Smoke sprite/puff, rely on a hashed value, derived from the server timestamp attached to the smoke bomb entity + it's current smoke puff number.

Shamelessly repurpose the unused 'teleportFlag' field of 'centity_t', to track the smoke puff number.

Fixes https://github.com/etlegacy/etlegacy/issues/2622