### PR TITLE
server: Reduce sv_{,dl_}timeout

### DIFF
--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -1157,8 +1157,8 @@ void SV_Init(void)
 	sv_rconPassword    = Cvar_Get("rconPassword", "", CVAR_TEMP);
 	sv_privatePassword = Cvar_Get("sv_privatePassword", "", CVAR_TEMP);
 	sv_fps             = Cvar_Get("sv_fps", "20", CVAR_TEMP);
-	sv_timeout         = Cvar_Get("sv_timeout", "60", CVAR_TEMP); // used in game (also vid_restart)
-	sv_dl_timeout      = Cvar_Get("sv_dl_timeout", "300", CVAR_TEMP); // in between this time a client should download the biggest custom pk3
+	sv_timeout         = Cvar_Get("sv_timeout", "10", CVAR_TEMP); // used in game (also vid_restart)
+	sv_dl_timeout      = Cvar_Get("sv_dl_timeout", "60", CVAR_TEMP); // in between this time a client should download the biggest custom pk3
 	sv_zombietime      = Cvar_Get("sv_zombietime", "2", CVAR_TEMP);
 	Cvar_Get("nextmap", "", CVAR_TEMP);
 

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -1464,9 +1464,9 @@ void SV_CheckTimeouts(void)
 {
 	client_t *cl;
 	int      i;
-	int      droppoint    = svs.time - 1000 * sv_timeout->integer;    // default 60 - used in game and while vid_restart
+	int      droppoint    = svs.time - 1000 * sv_timeout->integer;    // default 10 - used in game and while vid_restart
 	int      zombiepoint  = svs.time - 1000 * sv_zombietime->integer; // default 2
-	int      droppoint_dl = svs.time - 1000 * sv_dl_timeout->integer; // default 300
+	int      droppoint_dl = svs.time - 1000 * sv_dl_timeout->integer; // default 60
 
 	for (i = 0, cl = svs.clients ; i < sv_maxclients->integer ; i++, cl++)
 	{


### PR DESCRIPTION
sv_timeout    from 60 to 10
sv_dl_timeout from 300 to 60

If a client crashes or shoots the process down, these take effect.