### PR TITLE
qcommon: fix 64-bit VM_Call/SystemCall argument expansion

### DIFF
--- a/src/qcommon/q_shared.h
+++ b/src/qcommon/q_shared.h
@@ -1974,7 +1974,28 @@ void Com_ParseUA(userAgent_t *ua, const char *string);
  * @brief This should be something like INT_MAX but that would need limits.h everywhere so meh and negative values should be somewhat safe
  */
 #define VM_CALL_END (intptr_t)(-1337)
-#define SystemCall(...) syscall(__VA_ARGS__, VM_CALL_END)
+
+#define GET_SYSCALL_MACRO(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, NAME, ...) NAME
+
+#define SystemCall_0(arg) syscall(arg, VM_CALL_END)
+#define SystemCall_1(arg, a1) syscall(arg, (intptr_t)(a1), VM_CALL_END)
+#define SystemCall_2(arg, a1, a2) syscall(arg, (intptr_t)(a1), (intptr_t)(a2), VM_CALL_END)
+#define SystemCall_3(arg, a1, a2, a3) syscall(arg, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), VM_CALL_END)
+#define SystemCall_4(arg, a1, a2, a3, a4) syscall(arg, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), VM_CALL_END)
+#define SystemCall_5(arg, a1, a2, a3, a4, a5) syscall(arg, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), VM_CALL_END)
+#define SystemCall_6(arg, a1, a2, a3, a4, a5, a6) syscall(arg, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), VM_CALL_END)
+#define SystemCall_7(arg, a1, a2, a3, a4, a5, a6, a7) syscall(arg, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), (intptr_t)(a7), VM_CALL_END)
+#define SystemCall_8(arg, a1, a2, a3, a4, a5, a6, a7, a8) syscall(arg, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), (intptr_t)(a7), (intptr_t)(a8), VM_CALL_END)
+#define SystemCall_9(arg, a1, a2, a3, a4, a5, a6, a7, a8, a9) syscall(arg, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), (intptr_t)(a7), (intptr_t)(a8), (intptr_t)(a9), VM_CALL_END)
+#define SystemCall_10(arg, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) syscall(arg, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), (intptr_t)(a7), (intptr_t)(a8), (intptr_t)(a9), (intptr_t)(a10), VM_CALL_END)
+#define SystemCall_11(arg, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11) syscall(arg, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), (intptr_t)(a7), (intptr_t)(a8), (intptr_t)(a9), (intptr_t)(a10), (intptr_t)(a11), VM_CALL_END)
+#define SystemCall_12(arg, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12) syscall(arg, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), (intptr_t)(a7), (intptr_t)(a8), (intptr_t)(a9), (intptr_t)(a10), (intptr_t)(a11), (intptr_t)(a12), VM_CALL_END)
+#define SystemCall_13(arg, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13) syscall(arg, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), (intptr_t)(a7), (intptr_t)(a8), (intptr_t)(a9), (intptr_t)(a10), (intptr_t)(a11), (intptr_t)(a12), (intptr_t)(a13), VM_CALL_END)
+#define SystemCall_14(arg, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14) syscall(arg, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), (intptr_t)(a7), (intptr_t)(a8), (intptr_t)(a9), (intptr_t)(a10), (intptr_t)(a11), (intptr_t)(a12), (intptr_t)(a13), (intptr_t)(a14), VM_CALL_END)
+#define SystemCall_15(arg, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) syscall(arg, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), (intptr_t)(a7), (intptr_t)(a8), (intptr_t)(a9), (intptr_t)(a10), (intptr_t)(a11), (intptr_t)(a12), (intptr_t)(a13), (intptr_t)(a14), (intptr_t)(a15), VM_CALL_END)
+#define SystemCall_16(arg, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) syscall(arg, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), (intptr_t)(a7), (intptr_t)(a8), (intptr_t)(a9), (intptr_t)(a10), (intptr_t)(a11), (intptr_t)(a12), (intptr_t)(a13), (intptr_t)(a14), (intptr_t)(a15), (intptr_t)(a16), VM_CALL_END)
+
+#define SystemCall(...) EXPAND(GET_SYSCALL_MACRO(__VA_ARGS__, SystemCall_16, SystemCall_15, SystemCall_14, SystemCall_13, SystemCall_12, SystemCall_11, SystemCall_10, SystemCall_9, SystemCall_8, SystemCall_7, SystemCall_6, SystemCall_5, SystemCall_4, SystemCall_3, SystemCall_2, SystemCall_1, SystemCall_0)(__VA_ARGS__))
 
 #ifdef ETLEGACY_DEBUG
 #if defined(_MSC_VER)

--- a/src/qcommon/q_shared.h
+++ b/src/qcommon/q_shared.h
@@ -1973,7 +1973,7 @@ void Com_ParseUA(userAgent_t *ua, const char *string);
  *
  * @brief This should be something like INT_MAX but that would need limits.h everywhere so meh and negative values should be somewhat safe
  */
-#define VM_CALL_END (-1337)
+#define VM_CALL_END (intptr_t)(-1337)
 #define SystemCall(...) syscall(__VA_ARGS__, VM_CALL_END)
 
 #ifdef ETLEGACY_DEBUG

--- a/src/qcommon/qcommon.h
+++ b/src/qcommon/qcommon.h
@@ -519,8 +519,24 @@ void VM_Clear(void);
 vm_t *VM_Restart(vm_t *vm);
 void VM_Error(errorParm_t errorParm, const char *module, const char *filename);
 
+#define GET_VM_MACRO(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, NAME, ...) NAME
+
+#define VM_Call_0(vm, callNum) VM_CallFunc(vm, callNum, VM_CALL_END)
+#define VM_Call_1(vm, callNum, a1) VM_CallFunc(vm, callNum, (intptr_t)(a1), VM_CALL_END)
+#define VM_Call_2(vm, callNum, a1, a2) VM_CallFunc(vm, callNum, (intptr_t)(a1), (intptr_t)(a2), VM_CALL_END)
+#define VM_Call_3(vm, callNum, a1, a2, a3) VM_CallFunc(vm, callNum, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), VM_CALL_END)
+#define VM_Call_4(vm, callNum, a1, a2, a3, a4) VM_CallFunc(vm, callNum, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), VM_CALL_END)
+#define VM_Call_5(vm, callNum, a1, a2, a3, a4, a5) VM_CallFunc(vm, callNum, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), VM_CALL_END)
+#define VM_Call_6(vm, callNum, a1, a2, a3, a4, a5, a6) VM_CallFunc(vm, callNum, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), VM_CALL_END)
+#define VM_Call_7(vm, callNum, a1, a2, a3, a4, a5, a6, a7) VM_CallFunc(vm, callNum, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), (intptr_t)(a7), VM_CALL_END)
+#define VM_Call_8(vm, callNum, a1, a2, a3, a4, a5, a6, a7, a8) VM_CallFunc(vm, callNum, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), (intptr_t)(a7), (intptr_t)(a8), VM_CALL_END)
+#define VM_Call_9(vm, callNum, a1, a2, a3, a4, a5, a6, a7, a8, a9) VM_CallFunc(vm, callNum, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), (intptr_t)(a7), (intptr_t)(a8), (intptr_t)(a9), VM_CALL_END)
+#define VM_Call_10(vm, callNum, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) VM_CallFunc(vm, callNum, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), (intptr_t)(a7), (intptr_t)(a8), (intptr_t)(a9), (intptr_t)(a10), VM_CALL_END)
+#define VM_Call_11(vm, callNum, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11) VM_CallFunc(vm, callNum, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), (intptr_t)(a7), (intptr_t)(a8), (intptr_t)(a9), (intptr_t)(a10), (intptr_t)(a11), VM_CALL_END)
+#define VM_Call_12(vm, callNum, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12) VM_CallFunc(vm, callNum, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), (intptr_t)(a7), (intptr_t)(a8), (intptr_t)(a9), (intptr_t)(a10), (intptr_t)(a11), (intptr_t)(a12), VM_CALL_END)
+
+#define VM_Call(...) EXPAND(GET_VM_MACRO(__VA_ARGS__, VM_Call_12, VM_Call_11, VM_Call_10, VM_Call_9, VM_Call_8, VM_Call_7, VM_Call_6, VM_Call_5, VM_Call_4, VM_Call_3, VM_Call_2, VM_Call_1, VM_Call_0)(__VA_ARGS__))
 intptr_t QDECL VM_CallFunc(vm_t *vm, int callNum, ...);
-#define VM_Call(...) VM_CallFunc(__VA_ARGS__, VM_CALL_END)
 
 void VM_Debug(int level);
 

--- a/src/qcommon/vm.c
+++ b/src/qcommon/vm.c
@@ -338,12 +338,12 @@ void VM_LoadSymbols(vm_t *vm)
  */
 intptr_t QDECL VM_DllSyscall(intptr_t arg, ...)
 {
-#if defined(__x86_64__) || defined (__llvm__) || defined(__ANDROID__) || defined(__aarch64__) || ((defined __linux__) && (defined __powerpc__))
+#if defined(__x86_64__) || defined (_WIN64) || defined (__llvm__) || defined(__ANDROID__) || defined(__aarch64__) || ((defined __linux__) && (defined __powerpc__))
 	// rcg010206 - see commentary above
 	intptr_t args[VM_SYSCALL_ARGS] = { 0 };
 	int      i;
 	va_list  ap;
-	size_t len = ARRAY_LEN(args);
+	size_t   len = ARRAY_LEN(args);
 
 	args[0] = arg;
 
@@ -422,10 +422,10 @@ vm_t *VM_Restart(vm_t *vm)
 	// round up to next power of 2 so all data operations can
 	// be mask protected
 	dataLength = header->dataLength + header->litLength + header->bssLength;
-	for (i = 0; dataLength > (1 << i); i++)
+	for (i = 0; dataLength > ((intptr_t)1 << i); i++)
 	{
 	}
-	dataLength = 1 << i;
+	dataLength = (intptr_t)1 << i;
 
 	// clear the data
 	Com_Memset(vm->dataBase, 0, dataLength);
@@ -454,9 +454,9 @@ vm_t *VM_Restart(vm_t *vm)
 void VM_Error(errorParm_t errorParm, const char *module, const char *filename)
 {
 #if ARCH_X86
-    Com_Error(errorParm, "%s", va("VM_Create on %s failed\n\nMake sure ^2%s ^*exists in the mod's folder you're trying to run.", module, filename));
+	Com_Error(errorParm, "%s", va("VM_Create on %s failed\n\nMake sure ^2%s ^*exists in the mod's folder you're trying to run.", module, filename));
 #else
-    Com_Error(errorParm, "%s", va("VM_Create on %s failed\n\nMake sure ^2%s ^*exists in the mod's folder you're trying to run and that the mod is compatible with your platform.", module, filename));
+	Com_Error(errorParm, "%s", va("VM_Create on %s failed\n\nMake sure ^2%s ^*exists in the mod's folder you're trying to run and that the mod is compatible with your platform.", module, filename));
 #endif
 }
 


### PR DESCRIPTION
Macro the shit out of `VM_Call` and `SystemCall` to correctly cast all arguments to `intptr_t` so we don't do undefined behavior on 64-bit platforms when passing 4-byte integers etc. to `VM_Call` and `VM_DllSyscall`.

Also fixes 64-bit Windows using incorrect path in `VM_DllSyscall` as `__x86_64__` isn't defined on Windows.

refs #1389, #157