### PR TITLE
game: Tweak 'give' command

### DIFF
--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -649,7 +649,6 @@ void Cmd_Give_f(gentity_t *ent, unsigned int dwCommand, int value)
 	int      cnum;
 	int      j;
 	int      amount       = 0;
-	qboolean hasAmount    = qfalse;
 	int      i            = 1;
 	qboolean validGiveCmd = qfalse;
 
@@ -695,7 +694,6 @@ void Cmd_Give_f(gentity_t *ent, unsigned int dwCommand, int value)
 	trap_Argv(++i, amt, sizeof(amt));
 	if (*amt != '\0')
 	{
-		hasAmount = qtrue;
 		amount    = Q_atoi(amt);
 	}
 
@@ -712,7 +710,7 @@ void Cmd_Give_f(gentity_t *ent, unsigned int dwCommand, int value)
 			return;
 		}
 
-		if (hasAmount) // skill number given
+		if (amount) // skill number given
 		{
 			skill = (skillType_t)amount; // Change amount to skill, so that we can use amount properly
 

--- a/src/game/g_items.c
+++ b/src/game/g_items.c
@@ -136,7 +136,7 @@ int Add_Ammo(gentity_t *ent, weapon_t weapon, int count, qboolean fillClip)
 	if ((GetWeaponTableData(ammoweap)->type & WEAPON_TYPE_GRENADE) || ammoweap == WP_DYNAMITE || ammoweap == WP_SATCHEL_DET) // make sure if he picks it up that he get's the "launcher" too
 	{
 		COM_BitSet(ent->client->ps.weapons, ammoweap);
-		fillClip = qtrue;   // always filter into the "clip"
+		fillClip = qtrue;  // always filter into the "clip"
 	}
 
 	if (fillClip)
@@ -144,21 +144,27 @@ int Add_Ammo(gentity_t *ent, weapon_t weapon, int count, qboolean fillClip)
 		Fill_Clip(&ent->client->ps, weapon);
 	}
 
-	ent->client->ps.ammo[ammoweap] += count;
-
-	if (!GetWeaponTableData(ammoweap)->useClip)
-	{
-		maxammo -= ent->client->ps.ammoclip[ammoweap];
-	}
-
-	if (ent->client->ps.ammo[ammoweap] > maxammo)
-	{
-		ent->client->ps.ammo[ammoweap] = maxammo;   // - ent->client->ps.ammoclip[BG_FindClipForWeapon(weapon)];
-	}
-
-	if (count >= 999)     // 'really, give /all/'
+	if (count >= 999)  // really, give **all** - force the count
 	{
 		ent->client->ps.ammo[ammoweap] = count;
+	}
+	else  // otherwise cap the count to maxammo / >0
+	{
+		ent->client->ps.ammo[ammoweap] += count;
+
+		if (!GetWeaponTableData(ammoweap)->useClip)
+		{
+			maxammo -= ent->client->ps.ammoclip[ammoweap];
+		}
+
+		if (ent->client->ps.ammo[ammoweap] > maxammo)
+		{
+			ent->client->ps.ammo[ammoweap] = maxammo;   // - ent->client->ps.ammoclip[BG_FindClipForWeapon(weapon)];
+		}
+		else if (ent->client->ps.ammo[ammoweap] < 0)
+		{
+			ent->client->ps.ammo[ammoweap] = 0;
+		}
 	}
 
 	return (ent->client->ps.ammo[ammoweap] > originalCount);


### PR DESCRIPTION
- added `give skill none` to reset skills
- added `give hp` as an alias for `give health`
- added `give health none` to damage a player`s health to 0
- added `give weapon` as an alias for `give weapons`
- added `give weapon <number>` to give only a specific weapon instead of all
---
- changed `give all` to give up to 'maxammo' for each weapon, previously gave forced 9999 ammo for each weapon
---
- changed `give ammo` now only giving up to 'maxammo' for each weapon, previously gave forced 9999 ammo for each weapon
- changed `give ammo -9999` now caps the ammo at 0 instead of setting player ammo to negative values
- added   `give ammo all` to force 9999 ammo for each weapon
- added   `give ammo clip` to give a clip worth of ammo to each weapon
- added   `give ammo none` to remove all ammo and empty all clips from each weapon
---
- made plain `give` to show most available combinations