### PR TITLE
mod: change the way /scores server command works, refs #229

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2712,6 +2712,8 @@ typedef struct cgs_s
 	int sv_fps;                 // FPS server wants to send
 	sampledStat_t sampledStat;  // fps client sample data
 
+	int scoresCount;
+	char scores[MAX_SCORES_CMDS][MAX_STRING_CHARS];
 } cgs_t;
 
 //==============================================================================

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -108,6 +108,8 @@ extern vec3_t playerHeadProneMaxs;
 
 #define MAX_COMMANDMAP_LAYERS   16
 
+#define MAX_SCORES_CMDS 96
+
 // on fire effects
 #define FIRE_FLASH_TIME         2000
 #define FIRE_FLASH_FADEIN_TIME  1000

--- a/src/game/g_active.c
+++ b/src/game/g_active.c
@@ -1231,6 +1231,8 @@ void ClientThink_real(gentity_t *ent)
 		                    client->pers.pmoveMsec) * client->pers.pmoveMsec;
 	}
 
+	G_SendMatchInfo(ent);
+
 	if (client->wantsscore)
 	{
 		G_SendScore(ent);

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1047,6 +1047,10 @@ struct gclient_s
 	qboolean activateHeld;                  ///< client is holding down +activate
 
 	int lastRevivePushTime;
+
+	int scoresIndex;
+	int scoresCount;
+	char scores[MAX_SCORES_CMDS][MAX_STRING_CHARS];
 };
 
 /**
@@ -2525,6 +2529,7 @@ void G_initMatch(void);
 void G_loadMatchGame(void);
 void G_matchInfoDump(unsigned int dwDumpType);
 void G_printMatchInfo(gentity_t *ent);
+void G_SendMatchInfo(gentity_t *ent);
 void G_parseStatsJson(void *object);
 void G_printFull(const char *str, gentity_t *ent);
 void G_resetModeState(void);

--- a/src/tvgame/tvg_active.c
+++ b/src/tvgame/tvg_active.c
@@ -313,6 +313,8 @@ void TVG_ClientThink_real(gclient_t *client)
 		return;
 	}
 
+	TVG_SendMatchInfo(client);
+
 	// check for inactivity timer, but never drop the local client of a non-dedicated server
 	// moved here to allow for spec inactivity checks as well
 	if (!TVG_ClientInactivityTimer(client))

--- a/src/tvgame/tvg_cmds.c
+++ b/src/tvgame/tvg_cmds.c
@@ -1463,13 +1463,26 @@ static void TVG_ClientCommandPassThrough(char *cmd)
 	case WEAPONSTATS_HASH:                // "WeaponStats"
 		return;
 	case SC_HASH:                         // "sc" = /scores
-		if (level.cmds.scoresTime != level.time || level.cmds.scoresEndIndex > 99)
+	{
+		int count;
+		token = strtok(NULL, " ");
+
+		if (count = Q_atoi(token))
 		{
-			level.cmds.scoresEndIndex = 0;
+			level.cmds.scoresIndex = 0;
+			level.cmds.scoresCount = count < MAX_SCORES_CMDS ? count : MAX_SCORES_CMDS;
 		}
-		Q_strncpyz(level.cmds.scores[level.cmds.scoresEndIndex++], cmd, sizeof(level.cmds.scores[0]));
-		level.cmds.scoresTime = level.time;
+
+		if (level.cmds.scoresIndex <= level.cmds.scoresCount)
+		{
+			Q_strncpyz(level.cmds.scores[level.cmds.scoresIndex++], cmd, sizeof(level.cmds.scores[0]));
+		}
+		else
+		{
+			G_DPrintf(S_COLOR_YELLOW "WARNING: Scores index overflow, dropping command\n");
+		}
 		return;
+	}
 	case CPM_HASH:                        // "cpm"
 		trap_SendServerCommand(-1, cmd);
 		return;

--- a/src/tvgame/tvg_cmds_ext.c
+++ b/src/tvgame/tvg_cmds_ext.c
@@ -51,12 +51,12 @@ const char *lock_status[2] = { "unlock", "lock" };
 static tvcmd_reference_t tvCommandInfo[] =
 {
 	// keep "say" command on top for optimisation purpose, they are the most used command
-	{ "say",          CMD_USAGE_ANY_TIME,                        0,          NOCD,       0, qtrue,  0,          TVG_say_cmd,                             " <msg>:^7 Sends a chat message"                                                             },
-	{ "say_team",     CMD_USAGE_ANY_TIME,                        0,          NOCD,       0, qtrue,  0,          TVG_say_cmd,                             " <msg>:^7 Sends a chat message"                                                             },
-	{ "say_buddy",    CMD_USAGE_ANY_TIME,                        0,          NOCD,       0, qtrue,  0,          TVG_say_cmd,                             " <msg>:^7 Sends a buddy chat message"                                                       },
-	{ "say_teamnl",   CMD_USAGE_ANY_TIME,                        0,          NOCD,       0, qtrue,  0,          TVG_say_cmd,                             " <msg>:^7 Sends a team chat message without location info"                                  },
+	{ "say",          CMD_USAGE_ANY_TIME,                        0,          NOCD,       0, qtrue,  0,                      TVG_say_cmd,                             " <msg>:^7 Sends a chat message"                                                             },
+	{ "say_team",     CMD_USAGE_ANY_TIME,                        0,          NOCD,       0, qtrue,  0,                      TVG_say_cmd,                             " <msg>:^7 Sends a chat message"                                                             },
+	{ "say_buddy",    CMD_USAGE_ANY_TIME,                        0,          NOCD,       0, qtrue,  0,                      TVG_say_cmd,                             " <msg>:^7 Sends a buddy chat message"                                                       },
+	{ "say_teamnl",   CMD_USAGE_ANY_TIME,                        0,          NOCD,       0, qtrue,  0,                      TVG_say_cmd,                             " <msg>:^7 Sends a team chat message without location info"                                  },
 
-	{ "tvchat",       CMD_USAGE_ANY_TIME,                        0,          NOCD,       0, qtrue,  0,          TVG_tvchat_cmd,                          ":^7 Turns tvchat on/off"                                                                    },
+	{ "tvchat",       CMD_USAGE_ANY_TIME,                        0,          NOCD,       0, qtrue,  0,                      TVG_tvchat_cmd,                          ":^7 Turns tvchat on/off"                                                                    },
 	//{ "ignore",         CMD_USAGE_ANY_TIME,          qtrue,       qfalse, TVCmd_Ignore_f,                      " <clientname>:^7 Ignore a player from chat"                                                 },
 	//{ "unignore",       CMD_USAGE_ANY_TIME,          qtrue,       qfalse, TVCmd_UnIgnore_f,                    " <clientname>:^7 Unignore a player from chat"                                               },
 
@@ -65,47 +65,47 @@ static tvcmd_reference_t tvCommandInfo[] =
 	//{ "commands",       CMD_USAGE_ANY_TIME,          qtrue,       qtrue,  G_commands_cmd,                      ":^7 Gives a list of commands"                                                               },
 	//{ "help",           CMD_USAGE_ANY_TIME,          qtrue,       qtrue,  G_commands_cmd,                      ":^7 Gives a list of commands"                                                               },
 
-	{ "bottomshots",  CMD_USAGE_ANY_TIME | CMD_USAGE_AUTOUPDATE, 0,          MEDIUMCD,   0, qfalse, ETJUMP_MOD, TVG_weaponRankings_cmd,                  ":^7 Shows WORST player for each weapon. Add ^3<weapon_ID>^7 to show all stats for a weapon" },
-	{ "callvote",     CMD_USAGE_NO_INTERMISSION,                 0,          NOCD,       0, qtrue,  0,          TVG_Cmd_CallVote_f,                      " <params>:^7 Calls a vote"                                                                  },
+	{ "bottomshots",  CMD_USAGE_ANY_TIME | CMD_USAGE_AUTOUPDATE, 0,          MEDIUMCD,   0, qfalse, ETJUMP_MOD,             TVG_weaponRankings_cmd,                  ":^7 Shows WORST player for each weapon. Add ^3<weapon_ID>^7 to show all stats for a weapon" },
+	{ "callvote",     CMD_USAGE_NO_INTERMISSION,                 0,          NOCD,       0, qtrue,  0,                      TVG_Cmd_CallVote_f,                      " <params>:^7 Calls a vote"                                                                  },
 
-	{ "follow",       CMD_USAGE_NO_INTERMISSION,                 0,          NOCD,       0, qfalse, 0,          TVG_Cmd_Follow_f,                        " <player_ID|allies|axis>:^7 Spectates a particular player or team"                          },
-	{ "follownext",   CMD_USAGE_NO_INTERMISSION,                 0,          NOCD,       0, qfalse, 0,          TVG_Cmd_FollowNext_f,                    ":^7 Follow next player in list"                                                             },
-	{ "followprev",   CMD_USAGE_NO_INTERMISSION,                 0,          NOCD,       0, qfalse, 0,          TVG_Cmd_FollowPrevious_f,                ":^7 Follow previous player in list"                                                         },
+	{ "follow",       CMD_USAGE_NO_INTERMISSION,                 0,          NOCD,       0, qfalse, 0,                      TVG_Cmd_Follow_f,                        " <player_ID|allies|axis>:^7 Spectates a particular player or team"                          },
+	{ "follownext",   CMD_USAGE_NO_INTERMISSION,                 0,          NOCD,       0, qfalse, 0,                      TVG_Cmd_FollowNext_f,                    ":^7 Follow next player in list"                                                             },
+	{ "followprev",   CMD_USAGE_NO_INTERMISSION,                 0,          NOCD,       0, qfalse, 0,                      TVG_Cmd_FollowPrevious_f,                ":^7 Follow previous player in list"                                                         },
 
-	{ "imvotetally",  CMD_USAGE_INTERMISSION_ONLY,               0,          NOCD,       0, qfalse, 0,          TVG_IntermissionVoteTally,               ""                                                                                           },
-	{ "immaplist",    CMD_USAGE_INTERMISSION_ONLY,               0,          NOCD,       0, qfalse, 0,          TVG_IntermissionMapList,                 ""                                                                                           },
-	{ "immaphistory", CMD_USAGE_INTERMISSION_ONLY,               0,          NOCD,       0, qfalse, 0,          TVG_IntermissionMapHistory,              ""                                                                                           },
+	{ "imvotetally",  CMD_USAGE_INTERMISSION_ONLY,               0,          NOCD,       0, qfalse, 0,                      TVG_IntermissionVoteTally,               ""                                                                                           },
+	{ "immaplist",    CMD_USAGE_INTERMISSION_ONLY,               0,          NOCD,       0, qfalse, 0,                      TVG_IntermissionMapList,                 ""                                                                                           },
+	{ "immaphistory", CMD_USAGE_INTERMISSION_ONLY,               0,          NOCD,       0, qfalse, 0,                      TVG_IntermissionMapHistory,              ""                                                                                           },
 
-	{ "impkd",        CMD_USAGE_INTERMISSION_ONLY,               0,          NOCD,       0, qfalse, 0,          TVG_Cmd_IntermissionPlayerKillsDeaths_f, ""                                                                                           },
-	{ "impr",         CMD_USAGE_INTERMISSION_ONLY,               0,          NOCD,       0, qfalse, 0,          TVG_Cmd_IntermissionPrestige_f,          ""                                                                                           },
-	{ "impt",         CMD_USAGE_INTERMISSION_ONLY,               0,          NOCD,       0, qfalse, 0,          TVG_Cmd_IntermissionPlayerTime_f,        ""                                                                                           },
-	{ "imsr",         CMD_USAGE_INTERMISSION_ONLY,               0,          NOCD,       0, qfalse, 0,          TVG_Cmd_IntermissionSkillRating_f,       ""                                                                                           },
-	{ "imwa",         CMD_USAGE_INTERMISSION_ONLY,               0,          NOCD,       0, qfalse, 0,          TVG_Cmd_IntermissionWeaponAccuracies_f,  ""                                                                                           },
-	{ "imws",         CMD_USAGE_INTERMISSION_ONLY,               0,          NOCD,       0, qfalse, 0,          TVG_Cmd_IntermissionWeaponStats_f,       ""                                                                                           },
+	{ "impkd",        CMD_USAGE_INTERMISSION_ONLY,               0,          NOCD,       0, qfalse, 0,                      TVG_Cmd_IntermissionPlayerKillsDeaths_f, ""                                                                                           },
+	{ "impr",         CMD_USAGE_INTERMISSION_ONLY,               0,          NOCD,       0, qfalse, 0,                      TVG_Cmd_IntermissionPrestige_f,          ""                                                                                           },
+	{ "impt",         CMD_USAGE_INTERMISSION_ONLY,               0,          NOCD,       0, qfalse, 0,                      TVG_Cmd_IntermissionPlayerTime_f,        ""                                                                                           },
+	{ "imsr",         CMD_USAGE_INTERMISSION_ONLY,               0,          NOCD,       0, qfalse, 0,                      TVG_Cmd_IntermissionSkillRating_f,       ""                                                                                           },
+	{ "imwa",         CMD_USAGE_INTERMISSION_ONLY,               0,          NOCD,       0, qfalse, 0,                      TVG_Cmd_IntermissionWeaponAccuracies_f,  ""                                                                                           },
+	{ "imws",         CMD_USAGE_INTERMISSION_ONLY,               0,          NOCD,       0, qfalse, 0,                      TVG_Cmd_IntermissionWeaponStats_f,       ""                                                                                           },
 
-	{ "players",      CMD_USAGE_ANY_TIME,                        0,          SHORTCD,    0, qtrue,  0,          TVG_players_cmd,                         ":^7 Lists all active players and their IDs"                                                 },
-	{ "viewers",      CMD_USAGE_ANY_TIME,                        0,          SHORTCD,    0, qtrue,  0,          TVG_viewers_cmd,                         ":^7 Lists all viewers and their IDs"                                                        },
-	{ "rconAuth",     CMD_USAGE_ANY_TIME,                        0,          SHORTCD,    0, qfalse, 0,          TVG_Cmd_AuthRcon_f,                      ":^7 Client authentication"                                                                  },
+	{ "players",      CMD_USAGE_ANY_TIME,                        0,          SHORTCD,    0, qtrue,  0,                      TVG_players_cmd,                         ":^7 Lists all active players and their IDs"                                                 },
+	{ "viewers",      CMD_USAGE_ANY_TIME,                        0,          SHORTCD,    0, qtrue,  0,                      TVG_viewers_cmd,                         ":^7 Lists all viewers and their IDs"                                                        },
+	{ "rconAuth",     CMD_USAGE_ANY_TIME,                        0,          SHORTCD,    0, qfalse, 0,                      TVG_Cmd_AuthRcon_f,                      ":^7 Client authentication"                                                                  },
 
-	{ "ref",          CMD_USAGE_ANY_TIME,                        0,          SHORTCD,    0, qtrue,  0,          TVG_ref_cmd,                             " <password>:^7 Become a referee (admin access)"                                             },
+	{ "ref",          CMD_USAGE_ANY_TIME,                        0,          SHORTCD,    0, qtrue,  0,                      TVG_ref_cmd,                             " <password>:^7 Become a referee (admin access)"                                             },
 
-	{ "score",        CMD_USAGE_ANY_TIME | CMD_USAGE_AUTOUPDATE, qtrue,      SHORTCD,    0, qfalse, 0,          TVG_Cmd_Score_f,                         ":^7 Request current scoreboard information"                                                 },
-	{ "scores",       CMD_USAGE_ANY_TIME | CMD_USAGE_AUTOUPDATE, qtrue,      MEDIUMCD,   0, qfalse, ETJUMP_MOD, TVG_scores_cmd,                          ":^7 Displays current match stat info"                                                       },
+	{ "score",        CMD_USAGE_ANY_TIME | CMD_USAGE_AUTOUPDATE, qtrue,      SHORTCD,    0, qfalse, 0,                      TVG_Cmd_Score_f,                         ":^7 Request current scoreboard information"                                                 },
+	{ "scores",       CMD_USAGE_ANY_TIME | CMD_USAGE_AUTOUPDATE, qtrue,      MEDIUMCD,   0, qfalse, ETJUMP_MOD | ETPRO_MOD, TVG_scores_cmd,                          ":^7 Displays current match stat info"                                                       },
 
-	{ "sgstats",      CMD_USAGE_ANY_TIME,                        SHORTCD,    NOCD,       0, qtrue,  0,          TVG_Cmd_sgStats_f,                       ""                                                                                           },
-	{ "wstats",       CMD_USAGE_ANY_TIME,                        SHORTCD,    NOCD,       0, qtrue,  0,          TVG_Cmd_wStats_f,                        ""                                                                                           },
-	{ "weaponstats",  CMD_USAGE_ANY_TIME,                        SHORTCD,    NOCD,       0, qtrue,  0,          TVG_weaponStats_cmd,                     " [player_ID]:^7 Shows weapon accuracy stats for a player"                                   },
+	{ "sgstats",      CMD_USAGE_ANY_TIME,                        SHORTCD,    NOCD,       0, qtrue,  0,                      TVG_Cmd_sgStats_f,                       ""                                                                                           },
+	{ "wstats",       CMD_USAGE_ANY_TIME,                        SHORTCD,    NOCD,       0, qtrue,  0,                      TVG_Cmd_wStats_f,                        ""                                                                                           },
+	{ "weaponstats",  CMD_USAGE_ANY_TIME,                        SHORTCD,    NOCD,       0, qtrue,  0,                      TVG_weaponStats_cmd,                     " [player_ID]:^7 Shows weapon accuracy stats for a player"                                   },
 
-	{ "statsall",     CMD_USAGE_ANY_TIME | CMD_USAGE_AUTOUPDATE, VERYLONGCD, NOCD,       0, qtrue,  ETJUMP_MOD, TVG_statsall_cmd,                        ":^7 Shows weapon accuracy stats for all players"                                            },
-	{ "stshots",      CMD_USAGE_ANY_TIME | CMD_USAGE_AUTOUPDATE, MEDIUMCD,   VERYLONGCD, 0, qfalse, ETJUMP_MOD, TVG_Cmd_WeaponStatsLeaders_f,            ""                                                                                           },
-	{ "topshots",     CMD_USAGE_ANY_TIME | CMD_USAGE_AUTOUPDATE, qtrue,      MEDIUMCD,   0, qfalse, ETJUMP_MOD, TVG_weaponRankings_cmd,                  ":^7 Shows BEST player for each weapon. Add ^3<weapon_ID>^7 to show all stats for a weapon"  },
-	{ "ws",           CMD_USAGE_ANY_TIME,                        qtrue,      MEDIUMCD,   0, qtrue,  0,          TVG_Cmd_WeaponStat_f,                    ":^7 Shows weapon stats"                                                                     },
+	{ "statsall",     CMD_USAGE_ANY_TIME | CMD_USAGE_AUTOUPDATE, VERYLONGCD, NOCD,       0, qtrue,  ETJUMP_MOD,             TVG_statsall_cmd,                        ":^7 Shows weapon accuracy stats for all players"                                            },
+	{ "stshots",      CMD_USAGE_ANY_TIME | CMD_USAGE_AUTOUPDATE, MEDIUMCD,   VERYLONGCD, 0, qfalse, ETJUMP_MOD,             TVG_Cmd_WeaponStatsLeaders_f,            ""                                                                                           },
+	{ "topshots",     CMD_USAGE_ANY_TIME | CMD_USAGE_AUTOUPDATE, qtrue,      MEDIUMCD,   0, qfalse, ETJUMP_MOD,             TVG_weaponRankings_cmd,                  ":^7 Shows BEST player for each weapon. Add ^3<weapon_ID>^7 to show all stats for a weapon"  },
+	{ "ws",           CMD_USAGE_ANY_TIME,                        qtrue,      MEDIUMCD,   0, qtrue,  0,                      TVG_Cmd_WeaponStat_f,                    ":^7 Shows weapon stats"                                                                     },
 
-	{ "setviewpos",   CMD_USAGE_NO_INTERMISSION,                 qtrue,      MEDIUMCD,   0, qfalse, 0,          TVG_Cmd_SetViewpos_f,                    " x y z pitch yaw roll useViewHeight(0/1):^7 Set the current player position and view angle" },
-	{ "noclip",       CMD_USAGE_NO_INTERMISSION,                 qtrue,      NOCD,       0, qfalse, 0,          TVG_Cmd_Noclip_f,                        ":^7 No clip"                                                                                },
+	{ "setviewpos",   CMD_USAGE_NO_INTERMISSION,                 qtrue,      MEDIUMCD,   0, qfalse, 0,                      TVG_Cmd_SetViewpos_f,                    " x y z pitch yaw roll useViewHeight(0/1):^7 Set the current player position and view angle" },
+	{ "noclip",       CMD_USAGE_NO_INTERMISSION,                 qtrue,      NOCD,       0, qfalse, 0,                      TVG_Cmd_Noclip_f,                        ":^7 No clip"                                                                                },
 
-	{ "obj",          CMD_USAGE_NO_INTERMISSION,                 qtrue,      NOCD,       0, qfalse, 0,          TVG_Cmd_SelectedObjective_f,             " <val>:^7 Selected Objective"                                                               },
-	{ NULL,           CMD_USAGE_ANY_TIME,                        qtrue,      NOCD,       0, qfalse, 0,          NULL,                                    ""                                                                                           }
+	{ "obj",          CMD_USAGE_NO_INTERMISSION,                 qtrue,      NOCD,       0, qfalse, 0,                      TVG_Cmd_SelectedObjective_f,             " <val>:^7 Selected Objective"                                                               },
+	{ NULL,           CMD_USAGE_ANY_TIME,                        qtrue,      NOCD,       0, qfalse, 0,                      NULL,                                    ""                                                                                           }
 };
 
 /**
@@ -493,32 +493,56 @@ qboolean TVG_tvchat_cmd(gclient_t *client, tvcmd_reference_t *self)
 }
 
 /**
- * @brief Sends match stats to the requesting client.
+ * @brief TVG_SendMatchInfo Sends match stats to the requesting client.
+ * @param[in] client
+ */
+void TVG_SendMatchInfo(gclient_t *client)
+{
+	if (!client->wantsScores)
+	{
+		return;
+	}
+
+	// wait for all commands before sending
+	if (level.cmds.scoresIndex - 1 != level.cmds.scoresCount)
+	{
+		// if update came during sending to client then start from scratch,
+		// client will discard all the previously sent commands
+		client->scoresIndex = 0;
+		return;
+	}
+
+	if (client->scoresIndex <= level.cmds.scoresCount)
+	{
+		trap_SendServerCommand(client - level.clients, level.cmds.scores[client->scoresIndex++]);
+		return;
+	}
+
+	client->wantsScores = qfalse;
+	client->scoresIndex = 0;
+}
+
+/**
+ * @brief TVG_scores_cmd
  * @param[in] client
  * @param[in] self
  */
 qboolean TVG_scores_cmd(gclient_t *client, tvcmd_reference_t *self)
 {
-	return qfalse;
+	if (!client)
+	{
+		if (TVG_CommandsAutoUpdate(self))
+		{
+			return qtrue;
+		}
 
-	//int i;
+		return qfalse;
+	}
 
-	//if (!client)
-	//{
-	//	if (TVG_CommandsAutoUpdate(self))
-	//	{
-	//		return qtrue;
-	//	}
-	//
-	//	return qfalse;
-	//}
+	client->wantsScores = qtrue;
+	client->scoresIndex = 0;
 
-	//for (i = 0; i < level.cmds.scoresEndIndex; i++)
-	//{
-	//	trap_SendServerCommand(client - level.clients, level.cmds.scores[i]);
-	//}
-
-	//return qtrue;
+	return qtrue;
 }
 
 /**

--- a/src/tvgame/tvg_local.h
+++ b/src/tvgame/tvg_local.h
@@ -343,6 +343,9 @@ struct gclient_s
 	pmoveExt_t pmext;
 
 	wantsPlayerInfoStats_t wantsInfoStats[INFO_NUM];
+
+	int scoresIndex;
+	qboolean wantsScores;
 };
 
 // this structure is cleared as each map is entered
@@ -370,9 +373,9 @@ typedef struct tvgamecommands_s
 	qboolean prValid;
 	char pr[MAX_STRING_CHARS];
 
-	int scoresTime;
-	int scoresEndIndex;
-	char scores[100][MAX_STRING_CHARS];
+	int scoresIndex;
+	int scoresCount;
+	char scores[MAX_SCORES_CMDS][MAX_STRING_CHARS];
 
 	// "topshots"-related commands
 	char astats[MAX_STRING_CHARS];
@@ -875,6 +878,8 @@ qboolean TVG_statsall_cmd(gclient_t *client, tvcmd_reference_t *self);
 qboolean TVG_weaponRankings_cmd(gclient_t *client, tvcmd_reference_t *self);
 qboolean TVG_weaponStats_cmd(gclient_t *client, tvcmd_reference_t *self);
 qboolean TVG_weaponStatsLeaders_cmd(gclient_t *client, qboolean doTop, qboolean doWindow);
+
+void TVG_SendMatchInfo(gclient_t *client);
 
 // tvg_referee.c
 qboolean TVG_Cmd_AuthRcon_f(gclient_t *client, tvcmd_reference_t *self);


### PR DESCRIPTION
- add back /scores and auto updates to scores in tvgame
- does not break old demos

Note:

/scores command causes lag client side, because it is really big it fragments the packet (mtu is 1300) if sent all at once (just 10 players can cause the packet to be split even 3 times). This causes the player to get rate limited which in turn means delayed packets which means players has nothing to interpolate to.

Instead of sending everything at once the strings are saved per player basis in qagame and added to snapshot one per clientthink, this still can be too much on some settings (com_maxfps and sv_fps) and with many players on server. Command is displayed on client only after receving all strings. The downside to this is there will be more delay when the scores commands appears on client.

Pretty much the only reason I would like to add it is to be able to do automatic updates of scores for etltv (only legacy mod) without causing server lag every X seconds (etltv server is also a client that gets it's packets fragmented).

refs #229