### PR TITLE
game: init s.solid to 0, refs #1886

### DIFF
--- a/src/game/g_utils.c
+++ b/src/game/g_utils.c
@@ -784,6 +784,7 @@ void G_InitGentity(gentity_t *e)
 	e->r.ownerNum = ENTITYNUM_NONE;
 	e->nextthink  = 0;
 	e->free       = NULL;
+	e->s.solid    = 0;
 
 	// init scripting
 	e->scriptStatus.scriptEventIndex = -1;


### PR DESCRIPTION
- s.solid like many other fields are retained for client entities. If you connect to a slot where previous player had that field set (was in a team) then you have that field set because it is only set by server in trap_LinkEntity and spectators are never linked.
- This is VET bug and can be reproduced in other mods (ETMain, ETPro, ETJump), it's not as obvious there because legacy has different WolfReviveBbox function (which causes the floating), but you can reproduce the stuck print with developer 1. 
- It only happens on spectator spawn point because r.currentOrigin is not updated for spectators. 
- I wouldn't be surprised if there were more hidden issues like this because the gentity struct is not fully cleared for player entities.

refs #1886