### PR TITLE
cgame: Use ':' instead of '|' to separate akimbo ammo

### DIFF
--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -1204,7 +1204,7 @@ void CG_DrawAmmoCount(hudComponent_t *comp)
 	// .25f
 	if (value3 >= 0)
 	{
-		Com_sprintf(buffer, sizeof(buffer), "%i|%i/%i", value3, value, value2);
+		Com_sprintf(buffer, sizeof(buffer), "%i:%i/%i", value3, value, value2);
 	}
 	else if (value2 >= 0)
 	{


### PR DESCRIPTION
Vbar '|' causes vertical layouting boo boo's when using akimbo pistols compared to normal ammo display.

':' arguably also just fits better as '/' is already used to separate reserve ammo count.