### PR TITLE
game: Make medic's passive heal deterministic

### DIFF
--- a/src/game/g_active.c
+++ b/src/game/g_active.c
@@ -838,6 +838,17 @@ void ClientTimerActions(gentity_t *ent, int msec)
 {
 	gclient_t *client = ent->client;
 
+   // reset and pause client timer when we've reached maxhealth, such that once
+   // we take damage again, it will take a full second every time to re-heal
+	if (ent->health == client->ps.stats[STAT_MAX_HEALTH])
+	{
+		if (client->timeResidual != 0)
+		{
+			client->timeResidual = 0;
+		}
+		return;
+	}
+
 	client->timeResidual += msec;
 
 	while (client->timeResidual >= 1000)

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -972,7 +972,7 @@ struct gclient_s
 	int lastKillTime;                       ///< for multiple kill rewards FIXME: implement this/make available to Lua
 
 	// timeResidual is used to handle events that happen every second
-	// like health / armor countdowns and regeneration
+	// like health countdowns and regeneration
 	int timeResidual;
 
 	float currentAimSpreadScale;


### PR DESCRIPTION
Medic's currently heal every second via 'ClientTimerActions', which loops continuously in the background.

This means that in case a Medic takes damage, the timer could be anywhere between 0.1 and 0.9 seconds off the next passive heal, effectively making it random in a way that neither the player nor the opponent can control.

This commit alleviates the issue by resetting and pausing the timer once the player has reached MAX_HEALTH, making the passive heal deterministic.