### PR TITLE
cgame: Trim last 2 flame sprites

### DIFF
--- a/src/cgame/cg_flamethrower.c
+++ b/src/cgame/cg_flamethrower.c
@@ -737,6 +737,10 @@ void CG_AddFlameSpriteToScene(flameChunk_t *f, float lifeFrac, float alpha)
 	rST[1]    = radius * 1.0f / 1.481f;
 	alphaChar = (unsigned char)(255.0f * alpha);
 
+	// TODO: The 2 frame sprites fade out the flame sprite 
+	// This however leads to situations where you think the flame chunk 
+	// just disappeared but it is actually still there
+	// rework flame sprites one day so we could sort out those extra sprites
 	frameNum = (int)floor((double)(lifeFrac * (NUM_FLAME_SPRITES-2)));
 	if (frameNum < 0)
 	{

--- a/src/cgame/cg_flamethrower.c
+++ b/src/cgame/cg_flamethrower.c
@@ -737,7 +737,7 @@ void CG_AddFlameSpriteToScene(flameChunk_t *f, float lifeFrac, float alpha)
 	rST[1]    = radius * 1.0f / 1.481f;
 	alphaChar = (unsigned char)(255.0f * alpha);
 
-	frameNum = (int)floor((double)(lifeFrac * NUM_FLAME_SPRITES));
+	frameNum = (int)floor((double)(lifeFrac * (NUM_FLAME_SPRITES-2)));
 	if (frameNum < 0)
 	{
 		frameNum = 0;


### PR DESCRIPTION
The 2 frame sprites fade out the flame sprite (additionally to the alpha channel whichis already being faded out in code).

This however leads to situations where you think the flame chunk just disappeared but it is actually still there.

This is significantly reduced by trimming the 2 last frames of a flame chunk sprite, which spreads the remaining frames out over the same duration.