### PR TITLE
game: Fix pack diagonal throw

### DIFF
--- a/src/game/bg_misc.c
+++ b/src/game/bg_misc.c
@@ -2532,18 +2532,7 @@ qboolean BG_PlayerTouchesItem(playerState_t *ps, entityState_t *item, int atTime
 
 	BG_EvaluateTrajectory(&item->pos, atTime, origin, qfalse, item->effect2Time);
 
-	// we are ignoring ducked differences here
-	if (ps->origin[0] - origin[0] > 36
-	    || ps->origin[0] - origin[0] < -36
-	    || ps->origin[1] - origin[1] > 36
-	    || ps->origin[1] - origin[1] < -36
-	    || ps->origin[2] - origin[2] > 36
-	    || ps->origin[2] - origin[2] < -36)
-	{
-		return qfalse;
-	}
-
-	return qtrue;
+	return (vec3_distance(ps->origin, origin) < 36);
 }
 
 /**


### PR DESCRIPTION
When standing and throwing an ammo/medpick, you'd pick it up at a 45° YAW angle.

Addressed by properly comparing vector distances.

Fixes https://github.com/etlegacy/etlegacy/issues/2269