### PR TITLE
client: improve timedemo output and add benchmark command

### DIFF
--- a/src/client/cl_cgame.c
+++ b/src/client/cl_cgame.c
@@ -1510,9 +1510,9 @@ void CL_FirstSnapshot(void)
 	cls.state = CA_ACTIVE;
 
 	// set the timedelta so we are exactly on this first frame
-	cl.baselineDelta      = cl.serverTimeDelta = cl.snap.serverTime - cls.realtime;
-	cl.oldServerTime      = cl.snap.serverTime;
-	clc.demo.timeBaseTime = cl.snap.serverTime;
+	cl.baselineDelta               = cl.serverTimeDelta = cl.snap.serverTime - cls.realtime;
+	cl.oldServerTime               = cl.snap.serverTime;
+	clc.demo.timedemo.timeBaseTime = cl.snap.serverTime;
 
 	// if this is the first frame of active play,
 	// execute the contents of activeAction now

--- a/src/client/cl_demo.c
+++ b/src/client/cl_demo.c
@@ -1193,6 +1193,7 @@ static void CL_TimedemoResults(void)
 	int      onePercentIdx, pointOnePercentIdx;
 	float    fps, minFps, maxFps;
 	char     onePercent[8], pointOnePercent[8];
+	int      desiredFrametime, numOptimalFrames;
 
 	time = Sys_Milliseconds() - clc.demo.timedemo.timeStart;
 
@@ -1242,15 +1243,27 @@ static void CL_TimedemoResults(void)
 		Com_sprintf(pointOnePercent, sizeof(pointOnePercent), "%3.2f", 1000.0f / sortedFrametimes[numFrames - 1 - pointOnePercentIdx]);
 	}
 
+	desiredFrametime = 1000 / Cvar_VariableIntegerValue("com_maxfps");
+	numOptimalFrames = 0;
+
+	for (i = 0; i < numFrames; i++)
+	{
+		if (sortedFrametimes[i] <= desiredFrametime)
+		{
+			numOptimalFrames++;
+		}
+	}
+
 	Com_FuncPrinf("\n----- Benchmark results -----\n");
-	Com_Printf("\n%-18s %3.2f sec\n%-18s %i\n%-18s %3.2f\n%-18s %3.2f\n%-18s %3.2f\n%-18s %s\n%-18s %s\n",
+	Com_Printf("\n%-18s %3.2f sec\n%-18s %i\n%-18s %3.2f\n%-18s %3.2f\n%-18s %3.2f\n%-18s %s\n%-18s %s\n%-18s %3.2f pct\n",
 	           "Time elapsed:", time / 1000.0f,
 	           "Total frames:", numFrames,
 	           "Minimum fps:", minFps,
 	           "Maximum fps:", maxFps,
 	           "Average fps:", fps,
 	           "99th pct. min:", onePercentIdx ? onePercent : "--",
-	           "99.9th pct. min:", pointOnePercentIdx ? pointOnePercent : "--");
+	           "99.9th pct. min:", pointOnePercentIdx ? pointOnePercent : "--",
+	           "Stability:", (float)numOptimalFrames / (float)numFrames * 100.0f);
 	Com_Printf("\n-----------------------------\n\n");
 }
 

--- a/src/client/cl_demo.c
+++ b/src/client/cl_demo.c
@@ -1174,10 +1174,10 @@ static int CL_CompareFrametimes(const void *a, const void *b)
  */
 static void CL_TimedemoResults(void)
 {
-	int     time;
+	int     i, time;
 	uint8_t sortedFrametimes[MAX_TIMEDEMO_FRAMES];
 	int     onePercentIdx, pointOnePercentIdx;
-	float   fps;
+	float   fps, minFps, maxFps;
 	char    onePercent[8], pointOnePercent[8];
 
 	time = Sys_Milliseconds() - clc.demo.timedemo.timeStart;
@@ -1191,6 +1191,19 @@ static void CL_TimedemoResults(void)
 
 	Com_Memcpy(sortedFrametimes, clc.demo.timedemo.frametime, clc.demo.timedemo.timeFrames * sizeof(uint8_t));
 	qsort(sortedFrametimes, clc.demo.timedemo.timeFrames, sizeof(uint8_t), CL_CompareFrametimes);
+
+	minFps = 1000.0f / sortedFrametimes[clc.demo.timedemo.timeFrames - 1];
+	maxFps = 0;
+
+	// filter out 0ms anomalies for maxfps
+	for (i = 0; i < clc.demo.timedemo.timeFrames; i++)
+	{
+		if (sortedFrametimes[i] != 0)
+		{
+			maxFps = 1000.0f / sortedFrametimes[i];
+			break;
+		}
+	}
 
 	onePercentIdx = (int)(0.01f * clc.demo.timedemo.timeFrames);
 
@@ -1209,9 +1222,11 @@ static void CL_TimedemoResults(void)
 	}
 
 	Com_FuncPrinf("\n----- Benchmark results -----\n");
-	Com_Printf("\n%-18s %3.2f sec\n%-18s %i\n%-18s %3.2f\n%-18s %s\n%-18s %s\n",
+	Com_Printf("\n%-18s %3.2f sec\n%-18s %i\n%-18s %3.2f\n%-18s %3.2f\n%-18s %3.2f\n%-18s %s\n%-18s %s\n",
 	           "Time elapsed:", time / 1000.0f,
 	           "Total frames:", clc.demo.timedemo.timeFrames,
+	           "Minimum fps:", minFps,
+	           "Maximum fps:", maxFps,
 	           "Average fps:", fps,
 	           "99th pct. min:", onePercentIdx ? onePercent : "--",
 	           "99.9th pct. min:", pointOnePercentIdx ? pointOnePercent : "--");

--- a/src/client/cl_demo.c
+++ b/src/client/cl_demo.c
@@ -1166,7 +1166,7 @@ void CL_DemoCleanUp(void)
  */
 static int CL_CompareFrametimes(const void *a, const void *b)
 {
-	return (*(uint8_t *)a - *(uint8_t *)b);
+	return (*(const uint16_t *)a - *(const uint16_t *)b);
 }
 
 /**

--- a/src/client/cl_demo.c
+++ b/src/client/cl_demo.c
@@ -1248,10 +1248,12 @@ static void CL_TimedemoResults(void)
 
 	for (i = 0; i < numFrames; i++)
 	{
-		if (sortedFrametimes[i] <= desiredFrametime)
+		if (sortedFrametimes[i] > desiredFrametime)
 		{
-			numOptimalFrames++;
+			break;
 		}
+
+		numOptimalFrames++;
 	}
 
 	Com_FuncPrinf("\n----- Benchmark results -----\n");

--- a/src/client/cl_demo.c
+++ b/src/client/cl_demo.c
@@ -1166,7 +1166,21 @@ void CL_DemoCleanUp(void)
  */
 static int CL_CompareFrametimes(const void *a, const void *b)
 {
-	return (*(const uint16_t *)a - *(const uint16_t *)b);
+	const uint16_t arg1 = *(uint16_t *)a;
+	const uint16_t arg2 = *(uint16_t *)b;
+
+	if (arg1 > arg2)
+	{
+		return 1;
+	}
+	else if (arg2 > arg1)
+	{
+		return -1;
+	}
+	else
+	{
+		return 0;
+	}
 }
 
 /**

--- a/src/client/cl_demo.c
+++ b/src/client/cl_demo.c
@@ -1166,8 +1166,8 @@ void CL_DemoCleanUp(void)
  */
 static int CL_CompareFrametimes(const void *a, const void *b)
 {
-	const uint16_t arg1 = *(uint16_t *)a;
-	const uint16_t arg2 = *(uint16_t *)b;
+	const uint16_t arg1 = *(const uint16_t *)a;
+	const uint16_t arg2 = *(const uint16_t *)b;
 
 	if (arg1 > arg2)
 	{

--- a/src/client/cl_demo.c
+++ b/src/client/cl_demo.c
@@ -1174,11 +1174,11 @@ static int CL_CompareFrametimes(const void *a, const void *b)
  */
 static void CL_TimedemoResults(void)
 {
-	int     i, time;
-	uint8_t sortedFrametimes[MAX_TIMEDEMO_FRAMES];
-	int     onePercentIdx, pointOnePercentIdx;
-	float   fps, minFps, maxFps;
-	char    onePercent[8], pointOnePercent[8];
+	int      i, time;
+	uint16_t sortedFrametimes[MAX_TIMEDEMO_FRAMES];
+	int      onePercentIdx, pointOnePercentIdx;
+	float    fps, minFps, maxFps;
+	char     onePercent[8], pointOnePercent[8];
 
 	time = Sys_Milliseconds() - clc.demo.timedemo.timeStart;
 
@@ -1189,8 +1189,8 @@ static void CL_TimedemoResults(void)
 
 	fps = clc.demo.timedemo.timeFrames * 1000.0f / time;
 
-	Com_Memcpy(sortedFrametimes, clc.demo.timedemo.frametime, clc.demo.timedemo.timeFrames * sizeof(uint8_t));
-	qsort(sortedFrametimes, clc.demo.timedemo.timeFrames, sizeof(uint8_t), CL_CompareFrametimes);
+	Com_Memcpy(sortedFrametimes, clc.demo.timedemo.frametime, clc.demo.timedemo.timeFrames * sizeof(uint16_t));
+	qsort(sortedFrametimes, clc.demo.timedemo.timeFrames, sizeof(uint16_t), CL_CompareFrametimes);
 
 	minFps = 1000.0f / sortedFrametimes[clc.demo.timedemo.timeFrames - 1];
 	maxFps = 0;

--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -2675,7 +2675,7 @@ void CL_Frame(int msec)
 		// if this happens, it just means that we don't get the frametimes of the entire demo,
 		// we just drop the frametimes from the start and take average towards the end
 		// - 1 because timeFrames has already been incremented at this point in CL_SetCGameTime
-		clc.demo.timedemo.frametime[clc.demo.timedemo.timeFrames % MAX_TIMEDEMO_FRAMES] = Sys_Milliseconds() - frameStart;
+		clc.demo.timedemo.frametime[(clc.demo.timedemo.timeFrames - 1) % MAX_TIMEDEMO_FRAMES] = Sys_Milliseconds() - frameStart;
 	}
 }
 

--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -2596,6 +2596,8 @@ static void CL_FrameHandleVideo(int *msec)
  */
 void CL_Frame(int msec)
 {
+	int frameStart;
+
 	if (!com_cl_running->integer)
 	{
 		return;
@@ -2607,6 +2609,11 @@ void CL_Frame(int msec)
 		// if disconnected, bring up the menu
 		S_StopAllSounds();
 		VM_Call(uivm, UI_SET_ACTIVE_MENU, UIMENU_MAIN);
+	}
+
+	if (clc.demo.playing && cl_timedemo && cl_timedemo->integer)
+	{
+		frameStart = Sys_Milliseconds();
 	}
 
 	CL_FrameHandleVideo(&msec);
@@ -2658,6 +2665,18 @@ void CL_Frame(int msec)
 	Con_RunConsole();
 
 	cls.framecount++;
+
+	// make sure we have a valid timedemo frame before storing the frametime,
+	// as the first frame of demo is skipped
+	if (clc.demo.playing && clc.demo.timedemo.timeFrames && cl_timedemo && cl_timedemo->integer)
+	{
+		// use circular buffer to store the frametimes - this might exceed the total number of frames
+		// on a *really* long demo (something like 3h+) but realistically that doesn't matter
+		// if this happens, it just means that we don't get the frametimes of the entire demo,
+		// we just drop the frametimes from the start and take average towards the end
+		// - 1 because timeFrames has already been incremented at this point in CL_SetCGameTime
+		clc.demo.timedemo.frametime[clc.demo.timedemo.timeFrames % MAX_TIMEDEMO_FRAMES] = Sys_Milliseconds() - frameStart;
+	}
 }
 
 //============================================================================

--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -2596,7 +2596,7 @@ static void CL_FrameHandleVideo(int *msec)
  */
 void CL_Frame(int msec)
 {
-	int frameStart;
+	int frameStart = 0;
 
 	if (!com_cl_running->integer)
 	{

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -435,6 +435,9 @@ typedef struct
 	clipboardCapture_t clipboard;
 
 	int cinematicHandle;
+
+	qboolean benchmarking;
+	qboolean resetTimedemoCvar;
 } clientStatic_t;
 
 extern clientStatic_t cls;

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -195,6 +195,23 @@ extern clientActive_t cl;
 
 //==================================================================
 
+#define MAX_TIMEDEMO_FRAMES 262140
+
+/**
+ * @struct timedemo_t
+ * @brief Timedemo information
+ */
+typedef struct
+{
+	uint8_t frametime[MAX_TIMEDEMO_FRAMES];    ///< integer since frametimes aren't fractional
+	                                           ///< this should be a really low number always so unit8_t is more than enough,
+	                                           ///< if it isn't, your benchmark really isn't valid anyway
+
+	int timeFrames;                            ///< counter of rendered frames
+	int timeStart;                             ///< cls.realtime before first frame
+	int timeBaseTime;                          ///< each frame will be at this time + frameNum * 50
+} timedemo_t;
+
 /**
  * @struct demo_t
  * @brief Client demo information
@@ -209,9 +226,7 @@ typedef struct
 	qboolean firstFrameSkipped;
 	fileHandle_t file;
 
-	int timeFrames;                         ///< counter of rendered frames
-	int timeStart;                          ///< cls.realtime before first frame
-	int timeBaseTime;                       ///< each frame will be at this time + frameNum * 50
+	timedemo_t timedemo;
 } demo_t;
 
 /**

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -203,10 +203,7 @@ extern clientActive_t cl;
  */
 typedef struct
 {
-	uint8_t frametime[MAX_TIMEDEMO_FRAMES];    ///< integer since frametimes aren't fractional
-	                                           ///< this should be a really low number always so unit8_t is more than enough,
-	                                           ///< if it isn't, your benchmark really isn't valid anyway
-
+	uint16_t frametime[MAX_TIMEDEMO_FRAMES];   ///< integer since frametimes aren't fractional
 	int timeFrames;                            ///< counter of rendered frames
 	int timeStart;                             ///< cls.realtime before first frame
 	int timeBaseTime;                          ///< each frame will be at this time + frameNum * 50


### PR DESCRIPTION
* Add min, max, 99th percentile and 99.9th percentile minimum framerate to `timedemo` output
* Make it look prettier and improve the readability
* Add `benchmark` command - wrapper command that executes `timedemo 1; demo <demoname>`

The frametime storage should be enough for ~3h of demo playback from my calculations. It uses a circular buffer, so if it ever gets filled, it will simply start overwriting from the start, meaning that the start of the demo will be excluded from 99th/99.9th percentile framerates.

![image](https://github.com/user-attachments/assets/231c03bb-68c3-4010-990c-1f4624c8383c)


refs #2655 
