### PR TITLE
game: normalize flamethrower damage to default sv_fps

### DIFF
--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -178,6 +178,9 @@ extern vec3_t playerHeadProneMaxs;
 #define SVF_SELF_PORTAL             0x00008000  ///< use self->origin2 as portal
 #define SVF_SELF_PORTAL_EXCLUSIVE   0x00010000  ///< use self->origin2 as portal and DONT add self->origin PVS ents
 
+// default server frametime at sv_fps 20, for framerate independent timings
+#define DEFAULT_SV_FRAMETIME 50
+
 /**
  * @struct svCvar_s
  * @typedef svCvar_t
@@ -654,7 +657,7 @@ typedef struct
 } pmove_t;
 
 // if a full pmove isn't done on the client, you can just update the angles
-void PM_UpdateViewAngles(playerState_t * ps, pmoveExt_t * pmext, usercmd_t * cmd, void(trace) (trace_t * results, const vec3_t start, const vec3_t mins, const vec3_t maxs, const vec3_t end, int passEntityNum, int contentMask), int tracemask);
+void PM_UpdateViewAngles(playerState_t * ps, pmoveExt_t * pmext, usercmd_t * cmd, void(trace) (trace_t *results, const vec3_t start, const vec3_t mins, const vec3_t maxs, const vec3_t end, int passEntityNum, int contentMask), int tracemask);
 int Pmove(pmove_t *pmove);
 void PmovePredict(pmove_t *pmove, float frametime);
 
@@ -766,7 +769,7 @@ typedef enum
 #define EF_MOVER_STOP       0x10000000                         ///< will push otherwise	///< moved down to make space for one more client flag
 #define EF_MOVER_BLOCKED    0x20000000                         ///< mover was blocked dont lerp on the client///< moved down to make space for client flag
 
-#define BG_PlayerMounted(eFlags) ((eFlags &EF_MG42_ACTIVE) || (eFlags &EF_MOUNTEDTANK) || (eFlags &EF_AAGUN_ACTIVE))
+#define BG_PlayerMounted(eFlags) ((eFlags & EF_MG42_ACTIVE) || (eFlags & EF_MOUNTEDTANK) || (eFlags & EF_AAGUN_ACTIVE))
 #define BG_IsSkillAvailable(skill, skillType, requiredlvl) (GetSkillTableData(skillType)->skillLevels[requiredlvl] > -1 && skill[skillType] >= requiredlvl)
 
 /**
@@ -3058,8 +3061,8 @@ typedef enum popupMessageXPGainType_e
 #define HITBOXBIT_LEGS   2048
 #define HITBOXBIT_CLIENT 4096
 
-void PM_TraceLegs(trace_t * trace, float *legsOffset, vec3_t start, vec3_t end, trace_t * bodytrace, vec3_t viewangles, void(tracefunc)(trace_t * results, const vec3_t start, const vec3_t mins, const vec3_t maxs, const vec3_t end, int passEntityNum, int contentMask), int ignoreent, int tracemask);
-void PM_TraceHead(trace_t * trace, vec3_t start, vec3_t end, trace_t * bodytrace, vec3_t viewangles, void(tracefunc)(trace_t * results, const vec3_t start, const vec3_t mins, const vec3_t maxs, const vec3_t end, int passEntityNum, int contentMask), int ignoreent, int tracemask);
+void PM_TraceLegs(trace_t * trace, float *legsOffset, vec3_t start, vec3_t end, trace_t * bodytrace, vec3_t viewangles, void(tracefunc)(trace_t *results, const vec3_t start, const vec3_t mins, const vec3_t maxs, const vec3_t end, int passEntityNum, int contentMask), int ignoreent, int tracemask);
+void PM_TraceHead(trace_t * trace, vec3_t start, vec3_t end, trace_t * bodytrace, vec3_t viewangles, void(tracefunc)(trace_t *results, const vec3_t start, const vec3_t mins, const vec3_t maxs, const vec3_t end, int passEntityNum, int contentMask), int ignoreent, int tracemask);
 void PM_TraceAllParts(trace_t *trace, float *legsOffset, vec3_t start, vec3_t end);
 void PM_TraceAll(trace_t *trace, vec3_t start, vec3_t end);
 

--- a/src/game/g_combat.c
+++ b/src/game/g_combat.c
@@ -1469,7 +1469,7 @@ void G_DamageExt(gentity_t *targ, gentity_t *inflictor, gentity_t *attacker, vec
 		BG_UpdateConditionValue(targ->client->ps.clientNum, ANIM_COND_ENEMY_WEAPON, attacker->client->ps.weapon, qtrue);
 	}
 
-    take = MAX(damage, 0);
+	take = MAX(damage, 0);
 
 	// adrenaline junkie!
 	if (targ->client && targ->client->ps.powerups[PW_ADRENALINE])
@@ -1902,7 +1902,7 @@ void G_RailTrail(vec_t *start, vec_t *end, vec_t *color)
  * @param[in] color
  * @param[in] index
  */
-void G_RailBox(vec_t *origin, vec_t *mins, vec_t *maxs, vec_t *color, int index)
+void G_RailBox(const vec_t *origin, const vec_t *mins, const vec_t *maxs, const vec_t *color, int index)
 {
 	vec3_t    b1;
 	vec3_t    b2;

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -488,7 +488,7 @@ struct gentity_s
 	int lastHintCheckTime;
 	int voiceChatSquelch;
 	int voiceChatPreviousTime;
-	int lastBurnedFrameNumber;          ///< to fix FT instant-kill exploit
+	int lastBurnedFrameTime;          ///< last burn damage timestamp
 
 	entState_t entstate;
 	char *constages;
@@ -1739,7 +1739,7 @@ void Svcmd_ShuffleTeamsSR_f(qboolean restart);
 
 // g_weapon.c
 void FireWeapon(gentity_t *ent);
-void G_BurnMeGood(gentity_t *self, gentity_t *body, gentity_t *chunk);
+void G_BurnMeGood(gentity_t *self, gentity_t *body, gentity_t *chunk, qboolean directhit);
 
 void MoveClientToIntermission(gentity_t *ent, qboolean hasVoted);
 void G_SendScore(gentity_t *ent);
@@ -2927,7 +2927,7 @@ void G_MapVoteInfoRead(void);
 #define VOTEF_DISP_CALLER           4   ///< append "(called by name)" in vote string
 
 void G_RailTrail(vec_t *start, vec_t *end, vec_t *color);
-void G_RailBox(vec_t *origin, vec_t *mins, vec_t *maxs, vec_t *color, int index);
+void G_RailBox(const vec_t *origin, const vec_t *mins, const vec_t *maxs, const vec_t *color, int index);
 
 /**
  * @struct weapFireTable_s

--- a/src/game/g_svcmds.c
+++ b/src/game/g_svcmds.c
@@ -1591,7 +1591,7 @@ static void Svcmd_Burn(void)
 			}
 
 			// FIXME: add mod param? mod_unknown instead of flamer
-			G_BurnMeGood(vic, vic, NULL);
+			G_BurnMeGood(vic, vic, NULL, qtrue);
 			count++;
 		}
 
@@ -1624,10 +1624,9 @@ static void Svcmd_Burn(void)
 	}
 
 	// FIXME: add mod param? mod_unknown instead of flamer
-	G_BurnMeGood(vic, vic, NULL);
+	G_BurnMeGood(vic, vic, NULL, qtrue);
 
 	CPx(-1, va("cp \"^7%s^7 is burned.\"", vic->client->pers.netname));
-	return;
 }
 
 /**


### PR DESCRIPTION
* Fix flamethrower dealing direct damage on every frame, which increased direct damage dps on high `sv_fps` values - now applied only every 50ms
* Fix tap firing potentially increasing flamer DPS due to flamechunk burn timestamps no longer aligning to 100ms intervals - tap firing no longer has potentially higher dps from chunk damage (potential dps grew higher with high `sv_fps` values)
* Fix flamechunks growing in size too fast on high `sv_fps` values

refs #1637 