### PR TITLE
ui: fix replay menu path resetting when re-opening the menu

### DIFF
--- a/src/ui/ui_main.c
+++ b/src/ui/ui_main.c
@@ -4870,8 +4870,6 @@ void UI_RunMenuScript(char **args)
 		}
 		else if (Q_stricmp(name, "LoadDemos") == 0)
 		{
-			// Reset the path
-			uiInfo.demos.path[0] = '\0';
 			UI_LoadDemos();
 		}
 		else if (Q_stricmp(name, "LoadMovies") == 0)


### PR DESCRIPTION
The first byte of `uiInfo.demos.path` was getting reset whenever `LoadDemos` was called, which caused the current display path to always be blank when opening replay menu. This caused the list to appear blank if the list was scrolled to an entry which was not visible on screen at the time the menu was exited. The current path is now always remembered correctly, and the replay menu will open back to the folder with previous entry selected when re-opening.

It seems this was the intended behavior when the folder support was created, as there's code in `UI_LoadDemos` which suggests that it was designed to remember the last opened path. Whether this is desired or if the menu should always reset back to the root `demos` folder is up to discussion I guess.

https://github.com/etlegacy/etlegacy/blob/609fdcad2e082a1b62817f55d043b928c3789931/src/ui/ui_main.c#L4383-L4392

Fixes #2525 