### PR TITLE
sdl: fix r_mode -2 resolution detection on non-primary display

### DIFF
--- a/src/sdl/sdl_glimp.c
+++ b/src/sdl/sdl_glimp.c
@@ -747,6 +747,20 @@ static int GLimp_SetMode(glconfig_t *glConfig, int mode, qboolean fullscreen, qb
 	{
 		display = SDL_GetWindowDisplayIndex(main_window);
 	}
+	// try to determine display from last known window location
+	else if (r_windowLocation->string && r_windowLocation->string[0])
+	{
+		// the format for r_windowLocation is normally "displayIndex,x,y", so unless the user manually
+		// sets this to some weird value, this resolves just to the displayIndex value
+		display = Q_atoi(r_windowLocation->string);
+
+		// bogus value for r_windowLocation, default to display 0
+		if (display < 0 || display >= SDL_GetNumVideoDisplays())
+		{
+			Com_Printf("Cannot determine display to start on, falling back to default\n");
+			display = 0;
+		}
+	}
 
 	if (SDL_GetDesktopDisplayMode(display, &desktopMode) == 0)
 	{


### PR DESCRIPTION
`r_mode -2` was never detecting the actual display that the game window was started/currently on, instead it always took the properties from display 0. This works fine if:

* Your operating system assigns display 0 as your primary monitor
* You only ever want to run the game on your primary monitor

However if someone wants to run the game on their non-primary display, or their display 0 is not the primary monitor (can often be the case on Linux) and the display that they try to run on has a different resolution than their primary monitor, this will apply wrong mode, and potentially wrong refresh rate.

Instead use `r_windowLocation` to determine the last known display that the window was on, to detect the native resolution of the display. `r_windowLocation` is automatically saved whenever the game window is moved or destroyed, so unless a user manually sets the cvar value to something bogus, or their monitor setup changes between game launches, this will always resolve to a valid monitor. Upon fail, it will just fallback to display 0.

fixes #2708 