### PR TITLE
renderer: set uploadWidth/Height for internal images

### DIFF
--- a/src/renderer/tr_image.c
+++ b/src/renderer/tr_image.c
@@ -970,6 +970,9 @@ image_t *R_CreateImage(const char *name, const byte *pic, int width, int height,
 	else
 	{
 		image->internalFormat = GL_RGBA;
+		image->uploadWidth    = image->width;
+		image->uploadHeight   = image->height;
+
 		glTexImage2D(GL_TEXTURE_2D, 0, image->internalFormat, image->width, image->height, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
 		if (mipmap)

--- a/src/renderer_vk/tr_image.c
+++ b/src/renderer_vk/tr_image.c
@@ -970,6 +970,9 @@ image_t *R_CreateImage(const char *name, const byte *pic, int width, int height,
 	else
 	{
 		image->internalFormat = GL_RGBA;
+		image->uploadWidth    = image->width;
+		image->uploadHeight   = image->height;
+
 		glTexImage2D(GL_TEXTURE_2D, 0, image->internalFormat, image->width, image->height, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 
 		if (mipmap)


### PR DESCRIPTION
`image->uploadWidth/Height` were not set for internal images, which caused `imagelist` command to report incorrect texel cound and possibly over/underflow. This happened on every renderer init with the call to `R_CreateImage` from `R_InitGamma`, which caused there to always be an image in the list with unset `uploadWidth/Height` (unless `r_ignorehwgamma` was set).

fixes #2250 