### PR TITLE
qcommon: don't try to sort NULL directories

### DIFF
--- a/src/qcommon/files.c
+++ b/src/qcommon/files.c
@@ -3894,7 +3894,10 @@ void FS_AddGameDirectory(const char *path, const char *dir, qboolean addBase)
 		// Get top level directories (we'll filter them later since the Sys_ListFiles filtering is terrible)
 		pakdirs = Sys_ListFiles(curpath, "/", NULL, &numdirs, qfalse);
 
-		qsort(pakdirs, numdirs, sizeof(char *), paksort);
+		if (pakdirs)
+		{
+			qsort(pakdirs, numdirs, sizeof(char *), paksort);
+		}
 	}
 
 	pakfilesi = 0;


### PR DESCRIPTION
The code made an assumption that both `etmain/fs_game` directories were present in both base and homepath, which is not necessarily valid, especially for 3rd party mods.