### PR TITLE
engine: pass netadr_t structs as pointers rather than values

### DIFF
--- a/src/client/cl_input.c
+++ b/src/client/cl_input.c
@@ -1236,7 +1236,7 @@ qboolean CL_ReadyToSendPacket(void)
 	}
 
 	// send every frame for LAN
-	if (Sys_IsLANAddress(clc.netchan.remoteAddress))
+	if (Sys_IsLANAddress(&clc.netchan.remoteAddress))
 	{
 		return qtrue;
 	}

--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -1935,9 +1935,9 @@ static unsigned int CL_ParseResponseServers(const netadr_t *from, msg_t *msg, ne
 
 static void CL_MarkBlockedServers()
 {
-	int          count = 0, i, j;
-	serverInfo_t *server;
-	netadr_t     *addr;
+	int            count = 0, i, j;
+	serverInfo_t   *server;
+	const netadr_t *addr;
 
 	// if the arrays are considered in a "reset" state then just skip
 	if (cls.numglobalservers == -1)

--- a/src/client/cl_ui.c
+++ b/src/client/cl_ui.c
@@ -166,7 +166,7 @@ void LAN_SaveServersToFile(void)
 	for (i = 0; i < cls.numfavoriteservers; i++)
 	{
 		serverObj = cJSON_CreateObject();
-		cJSON_AddStringToObject(serverObj, "address", NET_AdrToString(cls.favoriteServers[i].adr));
+		cJSON_AddStringToObject(serverObj, "address", NET_AdrToString(&cls.favoriteServers[i].adr));
 		cJSON_AddStringToObject(serverObj, "name", cls.favoriteServers[i].hostName);
 		cJSON_AddStringToObject(serverObj, "game", cls.favoriteServers[i].game);
 
@@ -273,7 +273,7 @@ int LAN_AddServer(int source, const char *name, const char *address)
 		NET_StringToAdr(address, &adr, NA_UNSPEC);
 		for (i = 0; i < *count; i++)
 		{
-			if (NET_CompareAdr(servers[i].adr, adr))
+			if (NET_CompareAdr(&servers[i].adr, &adr))
 			{
 				break;
 			}
@@ -342,7 +342,7 @@ static void LAN_RemoveServer(int source, const char *addr)
 			NET_StringToAdr(addr, &comp, NA_UNSPEC);
 			for (i = 0; i < *count; i++)
 			{
-				if (NET_CompareAdr(comp, servers[i].adr))
+				if (NET_CompareAdr(&comp, &servers[i].adr))
 				{
 					j = i;
 
@@ -450,21 +450,21 @@ static void LAN_GetServerAddressString(int source, int n, char *buf, size_t bufl
 	case AS_LOCAL:
 		if (n >= 0 && n < MAX_OTHER_SERVERS)
 		{
-			Q_strncpyz(buf, NET_AdrToString(cls.localServers[n].adr), buflen);
+			Q_strncpyz(buf, NET_AdrToString(&cls.localServers[n].adr), buflen);
 			return;
 		}
 		break;
 	case AS_GLOBAL:
 		if (n >= 0 && n < MAX_GLOBAL_SERVERS)
 		{
-			Q_strncpyz(buf, NET_AdrToString(cls.globalServers[n].adr), buflen);
+			Q_strncpyz(buf, NET_AdrToString(&cls.globalServers[n].adr), buflen);
 			return;
 		}
 		break;
 	case AS_FAVORITES:
 		if (n >= 0 && n < MAX_FAVOURITE_SERVERS)
 		{
-			Q_strncpyz(buf, NET_AdrToString(cls.favoriteServers[n].adr), buflen);
+			Q_strncpyz(buf, NET_AdrToString(&cls.favoriteServers[n].adr), buflen);
 			return;
 		}
 		break;
@@ -529,7 +529,7 @@ static void LAN_GetServerInfo(int source, int n, char *buf, size_t buflen)
 		Info_SetValueForKey(info, "game", server->game);
 		Info_SetValueForKey(info, "gametype", va("%i", server->gameType));
 		Info_SetValueForKey(info, "nettype", va("%i", server->netType));
-		Info_SetValueForKey(info, "addr", NET_AdrToString(server->adr));
+		Info_SetValueForKey(info, "addr", NET_AdrToString(&server->adr));
 		Info_SetValueForKey(info, "friendlyFire", va("%i", server->friendlyFire));
 		Info_SetValueForKey(info, "maxlives", va("%i", server->maxlives));
 		Info_SetValueForKey(info, "needpass", va("%i", server->needpass));
@@ -934,7 +934,7 @@ qboolean LAN_ServerIsInFavoriteList(int source, int n)
 
 	for (i = 0; i < cls.numfavoriteservers; i++)
 	{
-		if (NET_CompareAdr(cls.favoriteServers[i].adr, server->adr))
+		if (NET_CompareAdr(&cls.favoriteServers[i].adr, &server->adr))
 		{
 			return qtrue;
 		}

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -680,8 +680,8 @@ void CL_ParseServerMessage(msg_t *msg);
 
 //====================================================================
 
-void CL_ServerInfoPacket(netadr_t from, msg_t *msg);
-void CL_ServerInfoPacketCheck(netadr_t from, msg_t *msg);
+void CL_ServerInfoPacket(const netadr_t *from, msg_t *msg);
+void CL_ServerInfoPacketCheck(const netadr_t *from, msg_t *msg);
 void CL_LocalServers_f(void);
 void CL_GlobalServers_f(void);
 void CL_GlobalBlockedServers_f(void);
@@ -903,7 +903,7 @@ void DB_DeleteFavorite(const char *profile, const char *address);
 void DB_UpdateFavorite(const char *profile, const char *address);
 void DB_LoadFavorites(const char *profile);
 
-void CL_InitServerInfo(serverInfo_t *server, netadr_t *address);
+void CL_InitServerInfo(serverInfo_t *server, const netadr_t *address);
 #endif
 
 #endif // #ifndef INCLUDE_CLIENT_H

--- a/src/qcommon/common.c
+++ b/src/qcommon/common.c
@@ -2484,7 +2484,7 @@ sysEvent_t Com_GetEvent(void)
  * @param[in] evFrom
  * @param[in] buf
  */
-void Com_RunAndTimeServerPacket(netadr_t *evFrom, msg_t *buf)
+void Com_RunAndTimeServerPacket(const netadr_t *evFrom, msg_t *buf)
 {
 	int t1 = 0;
 
@@ -2493,7 +2493,7 @@ void Com_RunAndTimeServerPacket(netadr_t *evFrom, msg_t *buf)
 		t1 = Sys_Milliseconds();
 	}
 
-	SV_PacketEvent(*evFrom, buf);
+	SV_PacketEvent(evFrom, buf);
 
 	if (com_speeds->integer)
 	{
@@ -2533,7 +2533,7 @@ int Com_EventLoop(void)
 			// manually send packet events for the loopback channel
 			while (NET_GetLoopPacket(NS_CLIENT, &evFrom, &buf))
 			{
-				CL_PacketEvent(evFrom, &buf);
+				CL_PacketEvent(&evFrom, &buf);
 			}
 
 			while (NET_GetLoopPacket(NS_SERVER, &evFrom, &buf))

--- a/src/qcommon/net_ip.c
+++ b/src/qcommon/net_ip.c
@@ -512,9 +512,10 @@ qboolean Sys_StringToAdr(const char *s, netadr_t *a, netadrtype_t family)
  */
 qboolean NET_CompareBaseAdrMask(const netadr_t *a, const netadr_t *b, int netmask)
 {
-	qboolean differed;
-	byte     cmpmask, *addra, *addrb;
-	int      curbyte;
+	qboolean   differed;
+	byte       cmpmask;
+	const byte *addra, *addrb;
+	int        curbyte;
 
 	if (a->type != b->type)
 	{
@@ -527,8 +528,8 @@ qboolean NET_CompareBaseAdrMask(const netadr_t *a, const netadr_t *b, int netmas
 		return qtrue;
 	case NA_IP:
 	{
-		addra = (byte *) &a->ip;
-		addrb = (byte *) &b->ip;
+		addra = (const byte *) &a->ip;
+		addrb = (const byte *) &b->ip;
 
 		if (netmask < 0 || netmask > 32)
 		{
@@ -539,8 +540,8 @@ qboolean NET_CompareBaseAdrMask(const netadr_t *a, const netadr_t *b, int netmas
 #ifdef FEATURE_IPV6
 	case NA_IP6:
 	{
-		addra = (byte *) &a->ip6;
-		addrb = (byte *) &b->ip6;
+		addra = (const byte *) &a->ip6;
+		addrb = (const byte *) &b->ip6;
 
 		if (netmask < 0 || netmask > 128)
 		{

--- a/src/qcommon/net_ip.c
+++ b/src/qcommon/net_ip.c
@@ -239,7 +239,7 @@ char *NET_ErrorString(void)
  * @param[in] a
  * @param[out] s
  */
-static void NetadrToSockadr(netadr_t *a, struct sockaddr *s)
+static void NetadrToSockadr(const netadr_t *a, struct sockaddr *s)
 {
 	switch (a->type)
 	{
@@ -510,25 +510,25 @@ qboolean Sys_StringToAdr(const char *s, netadr_t *a, netadrtype_t family)
  * @param[in] netmask
  * @return
  */
-qboolean NET_CompareBaseAdrMask(netadr_t a, netadr_t b, int netmask)
+qboolean NET_CompareBaseAdrMask(const netadr_t *a, const netadr_t *b, int netmask)
 {
 	qboolean differed;
 	byte     cmpmask, *addra, *addrb;
 	int      curbyte;
 
-	if (a.type != b.type)
+	if (a->type != b->type)
 	{
 		return qfalse;
 	}
 
-	switch (a.type)
+	switch (a->type)
 	{
 	case NA_LOOPBACK:
 		return qtrue;
 	case NA_IP:
 	{
-		addra = (byte *) &a.ip;
-		addrb = (byte *) &b.ip;
+		addra = (byte *) &a->ip;
+		addrb = (byte *) &b->ip;
 
 		if (netmask < 0 || netmask > 32)
 		{
@@ -539,8 +539,8 @@ qboolean NET_CompareBaseAdrMask(netadr_t a, netadr_t b, int netmask)
 #ifdef FEATURE_IPV6
 	case NA_IP6:
 	{
-		addra = (byte *) &a.ip6;
-		addrb = (byte *) &b.ip6;
+		addra = (byte *) &a->ip6;
+		addrb = (byte *) &b->ip6;
 
 		if (netmask < 0 || netmask > 128)
 		{
@@ -550,7 +550,7 @@ qboolean NET_CompareBaseAdrMask(netadr_t a, netadr_t b, int netmask)
 	break;
 #endif
 	default:
-		Com_Printf("NET_CompareBaseAdrMask: bad address type a: %i (b: %i, netmask: %i)\n", a.type, b.type, netmask);
+		Com_Printf("NET_CompareBaseAdrMask: bad address type a: %i (b: %i, netmask: %i)\n", a->type, b->type, netmask);
 		return qfalse;
 	}
 
@@ -598,7 +598,7 @@ qboolean NET_CompareBaseAdrMask(netadr_t a, netadr_t b, int netmask)
  * @param[in] b
  * @return
  */
-qboolean NET_CompareBaseAdr(netadr_t a, netadr_t b)
+qboolean NET_CompareBaseAdr(const netadr_t *a, const netadr_t *b)
 {
 	return NET_CompareBaseAdrMask(a, b, -1);
 }
@@ -608,11 +608,11 @@ qboolean NET_CompareBaseAdr(netadr_t a, netadr_t b)
  * @param[in] a
  * @return
  */
-const char *NET_AdrToStringNoPort(netadr_t a)
+const char *NET_AdrToStringNoPort(const netadr_t *a)
 {
 	static char s[NET_ADDRSTRMAXLEN];
 
-	switch (a.type)
+	switch (a->type)
 	{
 	case NA_LOOPBACK:
 		Com_sprintf(s, sizeof(s), "loopback");
@@ -621,7 +621,7 @@ const char *NET_AdrToStringNoPort(netadr_t a)
 		Com_sprintf(s, sizeof(s), "bot");
 		break;
 	case NA_IP:
-		Com_sprintf(s, sizeof(s), "%u.%u.%u.%u", a.ip[0], a.ip[1], a.ip[2], a.ip[3]);
+		Com_sprintf(s, sizeof(s), "%u.%u.%u.%u", a->ip[0], a->ip[1], a->ip[2], a->ip[3]);
 		break;
 #ifdef FEATURE_IPV6
 	case NA_IP6:
@@ -629,7 +629,7 @@ const char *NET_AdrToStringNoPort(netadr_t a)
 		struct sockaddr_storage sadr;
 
 		Com_Memset(&sadr, 0, sizeof(sadr));
-		NetadrToSockadr(&a, (struct sockaddr *) &sadr);
+		NetadrToSockadr(a, (struct sockaddr *) &sadr);
 		Sys_SockaddrToString(s, sizeof(s), (struct sockaddr *) &sadr);
 		break;
 	}
@@ -640,7 +640,7 @@ const char *NET_AdrToStringNoPort(netadr_t a)
 		Com_sprintf(s, sizeof(s), "invalid");
 		break;
 	default:
-		Com_Printf("NET_AdrToStringNoPort: Unknown address type: %i\n", a.type);
+		Com_Printf("NET_AdrToStringNoPort: Unknown address type: %i\n", a->type);
 		Com_sprintf(s, sizeof(s), "unknown");
 		break;
 	}
@@ -653,11 +653,11 @@ const char *NET_AdrToStringNoPort(netadr_t a)
  * @param[in] a
  * @return
  */
-const char *NET_AdrToString(netadr_t a)
+const char *NET_AdrToString(const netadr_t *a)
 {
 	static char s[NET_ADDRSTRMAXLEN_EXT];
 
-	switch (a.type)
+	switch (a->type)
 	{
 	case NA_LOOPBACK:
 		Com_sprintf(s, sizeof(s), "loopback");
@@ -666,11 +666,11 @@ const char *NET_AdrToString(netadr_t a)
 		Com_sprintf(s, sizeof(s), "bot");
 		break;
 	case NA_IP:
-		Com_sprintf(s, sizeof(s), "%u.%u.%u.%u:%hu", a.ip[0], a.ip[1], a.ip[2], a.ip[3], BigShort(a.port));
+		Com_sprintf(s, sizeof(s), "%u.%u.%u.%u:%hu", a->ip[0], a->ip[1], a->ip[2], a->ip[3], BigShort(a->port));
 		break;
 #ifdef FEATURE_IPV6
 	case NA_IP6:
-		Com_sprintf(s, sizeof(s), "[%s]:%hu", NET_AdrToStringNoPort(a), ntohs(a.port));
+		Com_sprintf(s, sizeof(s), "[%s]:%hu", NET_AdrToStringNoPort(a), ntohs(a->port));
 		break;
 #endif
 	case NA_BAD: // Invalid, unknown or non-applicable address type
@@ -678,7 +678,7 @@ const char *NET_AdrToString(netadr_t a)
 		Com_sprintf(s, sizeof(s), "invalid");
 		break;
 	default:
-		Com_Printf("NET_AdrToString: Unknown address type: %i\n", a.type);
+		Com_Printf("NET_AdrToString: Unknown address type: %i\n", a->type);
 		Com_sprintf(s, sizeof(s), "unknown");
 		break;
 	}
@@ -692,20 +692,20 @@ const char *NET_AdrToString(netadr_t a)
  * @param[in] b
  * @return
  */
-qboolean NET_CompareAdr(netadr_t a, netadr_t b)
+qboolean NET_CompareAdr(const netadr_t *a, const netadr_t *b)
 {
 	if (!NET_CompareBaseAdr(a, b))
 	{
 		return qfalse;
 	}
 
-	if (a.type == NA_IP
+	if (a->type == NA_IP
 #ifdef FEATURE_IPV6
-	    || a.type == NA_IP6
+	    || a->type == NA_IP6
 #endif
 	    )
 	{
-		if (a.port == b.port)
+		if (a->port == b->port)
 		{
 			return qtrue;
 		}
@@ -723,9 +723,9 @@ qboolean NET_CompareAdr(netadr_t a, netadr_t b)
  * @param[in] adr
  * @return
  */
-qboolean NET_IsLocalAddress(netadr_t adr)
+qboolean NET_IsLocalAddress(const netadr_t *adr)
 {
-	return adr.type == NA_LOOPBACK;
+	return adr->type == NA_LOOPBACK;
 }
 
 /**
@@ -795,7 +795,7 @@ qboolean NET_GetPacket(netadr_t *net_from, msg_t *net_message, fd_set *fdr)
 
 			if (ret >= net_message->maxsize)
 			{
-				Com_Printf("Oversize packet from %s\n", NET_AdrToString(*net_from));
+				Com_Printf("Oversize packet from %s\n", NET_AdrToString(net_from));
 				return qfalse;
 			}
 
@@ -826,7 +826,7 @@ qboolean NET_GetPacket(netadr_t *net_from, msg_t *net_message, fd_set *fdr)
 
 			if (ret >= net_message->maxsize)
 			{
-				Com_Printf("Oversize packet from %s\n", NET_AdrToString(*net_from));
+				Com_Printf("Oversize packet from %s\n", NET_AdrToString(net_from));
 				return qfalse;
 			}
 
@@ -856,7 +856,7 @@ qboolean NET_GetPacket(netadr_t *net_from, msg_t *net_message, fd_set *fdr)
 
 			if (ret >= net_message->maxsize)
 			{
-				Com_Printf("Oversize packet from %s\n", NET_AdrToString(*net_from));
+				Com_Printf("Oversize packet from %s\n", NET_AdrToString(net_from));
 				return qfalse;
 			}
 
@@ -879,43 +879,43 @@ static char socksBuf[4096];
  * @param[in] data
  * @param[in] to
  */
-void Sys_SendPacket(int length, const void *data, netadr_t to)
+void Sys_SendPacket(int length, const void *data, const netadr_t *to)
 {
 	int                     ret = SOCKET_ERROR;
 	struct sockaddr_storage addr;
 
-	if (to.type != NA_BROADCAST && to.type != NA_IP
+	if (to->type != NA_BROADCAST && to->type != NA_IP
 #ifdef FEATURE_IPV6
-	    && to.type != NA_IP6 && to.type != NA_MULTICAST6
+	    && to->type != NA_IP6 && to->type != NA_MULTICAST6
 #endif
 	    )
 	{
 		Com_Error(ERR_FATAL, "Sys_SendPacket: bad address type");
 	}
 
-	if ((ip_socket == INVALID_SOCKET && to.type == NA_IP) ||
-	    (ip_socket == INVALID_SOCKET && to.type == NA_BROADCAST))
+	if ((ip_socket == INVALID_SOCKET && to->type == NA_IP) ||
+	    (ip_socket == INVALID_SOCKET && to->type == NA_BROADCAST))
 	{
 		return;
 	}
 
 #ifdef FEATURE_IPV6
-	if ((ip6_socket == INVALID_SOCKET && to.type == NA_IP6) ||
-	    (ip6_socket == INVALID_SOCKET && to.type == NA_MULTICAST6))
+	if ((ip6_socket == INVALID_SOCKET && to->type == NA_IP6) ||
+	    (ip6_socket == INVALID_SOCKET && to->type == NA_MULTICAST6))
 	{
 		return;
 	}
 
-	if (to.type == NA_MULTICAST6 && (net_enabled->integer & NET_DISABLEMCAST))
+	if (to->type == NA_MULTICAST6 && (net_enabled->integer & NET_DISABLEMCAST))
 	{
 		return;
 	}
 #endif
 
 	Com_Memset(&addr, 0, sizeof(addr));
-	NetadrToSockadr(&to, (struct sockaddr *) &addr);
+	NetadrToSockadr(to, (struct sockaddr *) &addr);
 
-	if (usingSocks && to.type == NA_IP)
+	if (usingSocks && to->type == NA_IP)
 	{
 		socksBuf[0]            = 0; // reserved
 		socksBuf[1]            = 0;
@@ -950,7 +950,7 @@ void Sys_SendPacket(int length, const void *data, netadr_t to)
 		}
 
 		// some PPP links do not allow broadcasts and return an error
-		if ((err == EADDRNOTAVAIL) && ((to.type == NA_BROADCAST)))
+		if ((err == EADDRNOTAVAIL) && ((to->type == NA_BROADCAST)))
 		{
 			return;
 		}
@@ -980,43 +980,43 @@ void Sys_SendPacket(int length, const void *data, netadr_t to)
  *
  * @todo docu IPv6
  */
-qboolean Sys_IsLANAddress(netadr_t adr)
+qboolean Sys_IsLANAddress(const netadr_t *adr)
 {
-	int      index, run, addrsize = 0;
-	qboolean differed;
-	byte     *compareadr = NULL, *comparemask = NULL, *compareip = NULL;
+	int        index, run, addrsize = 0;
+	qboolean   differed;
+	const byte *compareadr = NULL, *comparemask = NULL, *compareip = NULL;
 
-	switch (adr.type)
+	switch (adr->type)
 	{
 	case NA_LOOPBACK:
 		return qtrue;
 	case NA_IP:
 		// RFC1918:
-		if (adr.ip[0] == 10)
+		if (adr->ip[0] == 10)
 		{
 			return qtrue;
 		}
-		if (adr.ip[0] == 172 && (adr.ip[1] & 0xf0) == 16)
+		if (adr->ip[0] == 172 && (adr->ip[1] & 0xf0) == 16)
 		{
 			return qtrue;
 		}
-		if (adr.ip[0] == 192 && adr.ip[1] == 168)
+		if (adr->ip[0] == 192 && adr->ip[1] == 168)
 		{
 			return qtrue;
 		}
 
-		if (adr.ip[0] == 127)
+		if (adr->ip[0] == 127)
 		{
 			return qtrue;
 		}
 		break;
 	case NA_IP6:
 #ifdef FEATURE_IPV6
-		if (adr.ip6[0] == 0xfe && (adr.ip6[1] & 0xc0) == 0x80)
+		if (adr->ip6[0] == 0xfe && (adr->ip6[1] & 0xc0) == 0x80)
 		{
 			return qtrue;
 		}
-		if ((adr.ip6[0] & 0xfe) == 0xfc)
+		if ((adr->ip6[0] & 0xfe) == 0xfc)
 		{
 			return qtrue;
 		}
@@ -1031,15 +1031,15 @@ qboolean Sys_IsLANAddress(netadr_t adr)
 	// Now compare against the networks this computer is member of.
 	for (index = 0; index < numIP; index++)
 	{
-		if (localIP[index].type == adr.type)
+		if (localIP[index].type == adr->type)
 		{
-			if (adr.type == NA_IP)
+			if (adr->type == NA_IP)
 			{
 				compareip   = (byte *) &((struct sockaddr_in *) &localIP[index].addr)->sin_addr.s_addr;
 				comparemask = (byte *) &((struct sockaddr_in *) &localIP[index].netmask)->sin_addr.s_addr;
-				compareadr  = adr.ip;
+				compareadr  = adr->ip;
 
-				addrsize = sizeof(adr.ip);
+				addrsize = sizeof(adr->ip);
 			}
 			else
 			{
@@ -1048,9 +1048,9 @@ qboolean Sys_IsLANAddress(netadr_t adr)
 
 				compareip   = (byte *) &((struct sockaddr_in6 *) &localIP[index].addr)->sin6_addr;
 				comparemask = (byte *) &((struct sockaddr_in6 *) &localIP[index].netmask)->sin6_addr;
-				compareadr  = adr.ip6;
+				compareadr  = adr->ip6;
 
-				addrsize = sizeof(adr.ip6);
+				addrsize = sizeof(adr->ip6);
 #endif
 			}
 
@@ -2118,7 +2118,7 @@ void NET_Event(fd_set *fdr)
 			}
 			else
 			{
-				CL_PacketEvent(from, &netmsg);
+				CL_PacketEvent(&from, &netmsg);
 			}
 		}
 		else

--- a/src/qcommon/qcommon.h
+++ b/src/qcommon/qcommon.h
@@ -220,17 +220,17 @@ void NET_Shutdown(void);
 void NET_Restart_f(void);
 //void NET_Config(qboolean enableNetworking);
 
-void NET_SendPacket(netsrc_t sock, int length, const void *data, netadr_t to);
-void QDECL NET_OutOfBandPrint(netsrc_t sock, netadr_t adr, const char *format, ...);
-void QDECL NET_OutOfBandData(netsrc_t sock, netadr_t adr, const char *format, int len);
+void NET_SendPacket(netsrc_t sock, int length, const void *data, const netadr_t *to);
+void QDECL NET_OutOfBandPrint(netsrc_t sock, const netadr_t *adr, const char *format, ...);
+void QDECL NET_OutOfBandData(netsrc_t sock, const netadr_t *adr, const char *format, int len);
 
-qboolean NET_CompareAdr(netadr_t a, netadr_t b);
-qboolean NET_CompareBaseAdr(netadr_t a, netadr_t b);
-qboolean NET_IsLocalAddress(netadr_t adr);
+qboolean NET_CompareAdr(const netadr_t *a, const netadr_t *b);
+qboolean NET_CompareBaseAdr(const netadr_t *a, const netadr_t *b);
+qboolean NET_IsLocalAddress(const netadr_t *adr);
 qboolean NET_IsLocalAddressString(const char *address);
 qboolean NET_IsIPXAddress(const char *buf);
-const char *NET_AdrToString(netadr_t a);
-const char *NET_AdrToStringNoPort(netadr_t a);
+const char *NET_AdrToString(const netadr_t *a);
+const char *NET_AdrToStringNoPort(const netadr_t *a);
 int NET_StringToAdr(const char *s, netadr_t *a, netadrtype_t family);
 qboolean NET_GetLoopPacket(netsrc_t sock, netadr_t *net_from, msg_t *net_message);
 void NET_Sleep(int msec);
@@ -294,7 +294,7 @@ typedef struct
 } netchan_t;
 
 void Netchan_Init(int port);
-void Netchan_Setup(netsrc_t sock, netchan_t *chan, netadr_t adr, int qport);
+void Netchan_Setup(netsrc_t sock, netchan_t *chan, const netadr_t *adr, int qport);
 
 void Netchan_Transmit(netchan_t *chan, int length, const byte *data);
 void Netchan_TransmitNextFragment(netchan_t *chan);
@@ -1222,7 +1222,7 @@ void CL_MouseEvent(int dx, int dy, int time);
 
 void CL_JoystickEvent(int axis, int value, int time);
 
-void CL_PacketEvent(netadr_t from, msg_t *msg);
+void CL_PacketEvent(const netadr_t *from, msg_t *msg);
 
 void CL_ConsolePrint(char *txt);
 
@@ -1269,8 +1269,8 @@ void Com_CheckAutoUpdate(void);
 void Com_GetAutoUpdate(void);
 qboolean Com_CheckUpdateDownloads(void);
 qboolean Com_InitUpdateDownloads(void);
-qboolean Com_UpdatePacketEvent(netadr_t from);
-void Com_UpdateInfoPacket(netadr_t from);
+qboolean Com_UpdatePacketEvent(const netadr_t *from);
+void Com_UpdateInfoPacket(const netadr_t *from);
 void Com_CheckUpdateStarted(void);
 void Com_UpdateVarsClean(int flags);
 void Com_Update_f(void);
@@ -1311,7 +1311,7 @@ void SCR_DebugGraph(float value);     // FIXME: move logging to common?
 void SV_Init(void);
 void SV_Shutdown(const char *finalmsg);
 void SV_Frame(int msec);
-void SV_PacketEvent(netadr_t from, msg_t *msg);
+void SV_PacketEvent(const netadr_t *from, msg_t *msg);
 qboolean SV_GameCommand(void);
 int SV_FrameMsec();
 int SV_SendQueuedPackets();
@@ -1361,7 +1361,7 @@ typedef struct
 void Com_QueueEvent(int time, sysEventType_t type, int value, int value2, int ptrLength, void *ptr);
 int Com_EventLoop(void);
 sysEvent_t Com_GetSystemEvent(void);
-void Com_RunAndTimeServerPacket(netadr_t *evFrom, msg_t *buf);
+void Com_RunAndTimeServerPacket(const netadr_t *evFrom, msg_t *buf);
 
 void Sys_Init(void);
 qboolean IN_IsNumLockDown(void);
@@ -1406,12 +1406,12 @@ void Sys_SnapVector(float *v);
 // the system console is shown when a dedicated server is running
 void Sys_DisplaySystemConsole(qboolean show);
 
-void Sys_SendPacket(int length, const void *data, netadr_t to);
+void Sys_SendPacket(int length, const void *data, const netadr_t *to);
 
 qboolean Sys_StringToAdr(const char *s, netadr_t *a, netadrtype_t family);
 //Does NOT parse port numbers, only base addresses.
 
-qboolean Sys_IsLANAddress(netadr_t adr);
+qboolean Sys_IsLANAddress(const netadr_t *adr);
 void Sys_ShowIP(void);
 
 qboolean Sys_CheckCD(void);

--- a/src/qcommon/update.c
+++ b/src/qcommon/update.c
@@ -79,7 +79,7 @@ void Com_CheckAutoUpdate(void)
 
 		if (res)
 		{
-			Com_Printf("resolved to %s\n", NET_AdrToString(autoupdate.autoupdateServer));
+			Com_Printf("resolved to %s\n", NET_AdrToString(&autoupdate.autoupdateServer));
 		}
 		else
 		{
@@ -106,7 +106,7 @@ void Com_CheckAutoUpdate(void)
 #else
 		NS_CLIENT
 #endif  // DEDICATED
-		, autoupdate.autoupdateServer, "getUpdateInfo \"%s\"", info);
+		, &autoupdate.autoupdateServer, "getUpdateInfo \"%s\"", info);
 
 	autoupdate.updateChecked = qtrue;
 
@@ -188,7 +188,7 @@ void Com_GetAutoUpdate(void)
 	Com_Memcpy(&clc.serverAddress, &autoupdate.autoupdateServer, sizeof(netadr_t));
 
 	Com_DPrintf("%s resolved to %s\n", cls.servername,
-	            NET_AdrToString(clc.serverAddress));
+	            NET_AdrToString(&clc.serverAddress));
 
 	cls.state = CA_DISCONNECTED;
 	Cvar_Set("ui_connecting", "1");
@@ -363,7 +363,7 @@ qboolean Com_InitUpdateDownloads(void)
 #ifdef FEATURE_AUTOUPDATE
 	if (autoupdate.updateStarted
 #ifndef DEDICATED
-	    && NET_CompareAdr(autoupdate.autoupdateServer, clc.serverAddress)
+	    && NET_CompareAdr(&autoupdate.autoupdateServer, &clc.serverAddress)
 #endif
 	    )
 	{
@@ -440,12 +440,12 @@ qboolean Com_InitUpdateDownloads(void)
  * @param[in] from
  * @return
  */
-qboolean Com_UpdatePacketEvent(netadr_t from)
+qboolean Com_UpdatePacketEvent(const netadr_t *from)
 {
 #ifdef FEATURE_AUTOUPDATE
 	static qboolean autoupdateRedirected = qfalse;
 	// Update server doesn't understand netchan packets
-	if (NET_CompareAdr(autoupdate.autoupdateServer, from))
+	if (NET_CompareAdr(&autoupdate.autoupdateServer, from))
 	{
 		if (autoupdate.updateStarted && !autoupdateRedirected)
 		{
@@ -463,7 +463,7 @@ qboolean Com_UpdatePacketEvent(netadr_t from)
  * @brief Com_UpdateInfoPacket
  * @param[in] from
  */
-void Com_UpdateInfoPacket(netadr_t from)
+void Com_UpdateInfoPacket(const netadr_t *from)
 {
 	if (autoupdate.autoupdateServer.type == NA_BAD)
 	{
@@ -472,15 +472,15 @@ void Com_UpdateInfoPacket(netadr_t from)
 	}
 
 	Com_DPrintf("Update server resolved to %s\n",
-	            NET_AdrToString(autoupdate.autoupdateServer));
+	            NET_AdrToString(&autoupdate.autoupdateServer));
 
-	if (!NET_CompareAdr(from, autoupdate.autoupdateServer))
+	if (!NET_CompareAdr(from, &autoupdate.autoupdateServer))
 	{
 #ifdef DEDICATED
 		SV_WriteAttackLog(va("bad update info packet from %s\n", NET_AdrToString(from)));
 #else
 		Com_DPrintf("Com_UpdateInfoPacket: Ignoring packet from %s, because the update server is located at %s\n",
-		            NET_AdrToString(from), NET_AdrToString(autoupdate.autoupdateServer));
+		            NET_AdrToString(from), NET_AdrToString(&autoupdate.autoupdateServer));
 #endif
 		return;
 	}
@@ -531,7 +531,7 @@ void Com_CheckUpdateStarted(void)
 	// If we have completed a connection to the Auto-Update server...
 	if (autoupdate.updateChecked
 #ifndef DEDICATED
-	    && NET_CompareAdr(autoupdate.autoupdateServer, clc.serverAddress)
+	    && NET_CompareAdr(&autoupdate.autoupdateServer, &clc.serverAddress)
 #endif
 	    )
 	{

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -569,7 +569,7 @@ struct leakyBucket_s
 #define MAX_HASHES          1024
 
 qboolean SVC_RateLimit(leakyBucket_t *bucket, int burst, int period);
-qboolean SVC_RateLimitAddress(netadr_t from, int burst, int period);
+qboolean SVC_RateLimitAddress(const netadr_t *from, int burst, int period);
 extern leakyBucket_t outboundLeakyBucket;
 
 // sv_init.c
@@ -590,9 +590,9 @@ void SV_WriteAttackLog(const char *log);
 #endif
 
 // sv_client.c
-void SV_GetChallenge(netadr_t from);
-qboolean SV_CheckChallenge(netadr_t from);
-void SV_DirectConnect(netadr_t from);
+void SV_GetChallenge(const netadr_t *from);
+qboolean SV_CheckChallenge(const netadr_t *from);
+void SV_DirectConnect(const netadr_t *from);
 void SV_ExecuteClientMessage(client_t *cl, msg_t *msg);
 void SV_UserinfoChanged(client_t *cl);
 void SV_UpdateUserinfo_f(client_t *cl);
@@ -606,7 +606,7 @@ int SV_SendQueuedMessages(void);
 
 // sv_ccmds.c
 void SV_Heartbeat_f(void);
-qboolean SV_TempBanIsBanned(netadr_t address, char *guid);
+qboolean SV_TempBanIsBanned(const netadr_t *address, char *guid);
 void SV_TempBan(client_t *client, int length);
 void SV_UptimeReset(void);
 
@@ -987,10 +987,10 @@ int SV_CL_GetPlayerstate(int clientNum, playerState_t *ps);
 void SV_CL_Frame(int frameMsec);
 void SV_CL_RunFrame(void);
 
-void SV_CL_ConnectionlessPacket(netadr_t from, msg_t *msg);
-void SV_CL_ServerInfoPacketCheck(netadr_t from, msg_t *msg);
-void SV_CL_ServerInfoPacket(netadr_t from, msg_t *msg);
-void SV_CL_DisconnectPacket(netadr_t from);
+void SV_CL_ConnectionlessPacket(const netadr_t *from, msg_t *msg);
+void SV_CL_ServerInfoPacketCheck(const netadr_t *from, msg_t *msg);
+void SV_CL_ServerInfoPacket(const netadr_t *from, msg_t *msg);
+void SV_CL_DisconnectPacket(const netadr_t *from);
 
 // sv_cl_net_chan.c
 void SV_CL_Netchan_Transmit(netchan_t *chan, msg_t *msg);

--- a/src/server/sv_ccmds.c
+++ b/src/server/sv_ccmds.c
@@ -452,7 +452,7 @@ void SV_TempBan(client_t *client, int length)
  * @param[in] guid
  * @return
  */
-qboolean SV_TempBanIsBanned(netadr_t address, char *guid)
+qboolean SV_TempBanIsBanned(const netadr_t *address, char *guid)
 {
 	int i;
 
@@ -460,7 +460,7 @@ qboolean SV_TempBanIsBanned(netadr_t address, char *guid)
 	{
 		if (svs.tempBans[i].endtime && svs.tempBans[i].endtime > svs.time)
 		{
-			if (NET_CompareBaseAdr(address, svs.tempBans[i].adr))
+			if (NET_CompareBaseAdr(address, &svs.tempBans[i].adr))
 			{
 				return qtrue;
 			}
@@ -545,7 +545,7 @@ static void SV_Status_f(void)
 			Com_Printf("%4i ", ping);
 		}
 
-		s = NET_AdrToString(cl->netchan.remoteAddress);
+		s = NET_AdrToString(&cl->netchan.remoteAddress);
 
 		// extend the name length by couting extra color characters to keep well formated output
 		maxNameLength = sizeof(cl->name) + (strlen(cl->name) - Q_PrintStrlen(cl->name)) + 1;

--- a/src/server/sv_client.c
+++ b/src/server/sv_client.c
@@ -53,7 +53,7 @@ static void SV_CloseDownload(client_t *cl);
  * the server with invalid connection IPs. With a challenge,
  * they must give a valid IP address.
  */
-void SV_GetChallenge(netadr_t from)
+void SV_GetChallenge(const netadr_t *from)
 {
 	int         i;
 	int         oldest;
@@ -92,7 +92,7 @@ void SV_GetChallenge(netadr_t from)
 	challenge = &svs.challenges[0];
 	for (i = 0 ; i < MAX_CHALLENGES ; i++, challenge++)
 	{
-		if (!challenge->connected && NET_CompareAdr(from, challenge->adr))
+		if (!challenge->connected && NET_CompareAdr(from, &challenge->adr))
 		{
 			break;
 		}
@@ -109,7 +109,7 @@ void SV_GetChallenge(netadr_t from)
 		challenge = &svs.challenges[oldest];
 
 		Com_RandomBytes(&challenge->challenge, sizeof(int32_t));
-		challenge->adr       = from;
+		challenge->adr       = *from;
 		challenge->firstTime = svs.time;
 		challenge->firstPing = 0;
 		challenge->time      = svs.time;
@@ -138,7 +138,7 @@ void SV_GetChallenge(netadr_t from)
  * So we let localhost connect since bots don't connect from SV_DirectConnect
  * where SV_isClientIPValidToConnect is done.
  */
-static qboolean SV_isClientIPValidToConnect(netadr_t from)
+static qboolean SV_isClientIPValidToConnect(const netadr_t *from)
 {
 	client_t *clientTmp;
 	int      count = 1;       // we count as the first one
@@ -170,7 +170,7 @@ static qboolean SV_isClientIPValidToConnect(netadr_t from)
 		}
 
 		// Don't compare the port - just the IP
-		if (NET_CompareBaseAdr(from, clientTmp->netchan.remoteAddress))
+		if (NET_CompareBaseAdr(from, &clientTmp->netchan.remoteAddress))
 		{
 			++count;
 			if (count > max)
@@ -192,7 +192,7 @@ static qboolean SV_isClientIPValidToConnect(netadr_t from)
  * @param[in] from
  * @param[in] userinfo
  */
-static qboolean SV_IsValidUserinfo(netadr_t from, const char *userinfo)
+static qboolean SV_IsValidUserinfo(const netadr_t *from, const char *userinfo)
 {
 	// FIXME: add some logging in for admins? we only do developer prints when a client is filtered
 	int version;
@@ -265,7 +265,7 @@ static qboolean SV_IsValidUserinfo(netadr_t from, const char *userinfo)
  * @param[in] from
  * @param[in] userinfo
  */
-static qboolean SV_isValidClient(netadr_t from, const char *userinfo)
+static qboolean SV_isValidClient(const netadr_t *from, const char *userinfo)
 {
 	char *guid;
 
@@ -278,7 +278,7 @@ static qboolean SV_isValidClient(netadr_t from, const char *userinfo)
 	}
 
 	// server bots are always valid (with valid userinfo)
-	if (from.type == NA_BOT)
+	if (from->type == NA_BOT)
 	{
 		return qtrue;
 	}
@@ -316,7 +316,7 @@ static qboolean SV_isValidClient(netadr_t from, const char *userinfo)
 	return qtrue;
 }
 
-qboolean SV_CheckChallenge(netadr_t from)
+qboolean SV_CheckChallenge(const netadr_t *from)
 {
 	int i, challenge;
 
@@ -332,7 +332,7 @@ qboolean SV_CheckChallenge(netadr_t from)
 	{
 		for (i = 0; i < MAX_CHALLENGES; i++)
 		{
-			if (NET_CompareAdr(from, svs.challenges[i].adr))
+			if (NET_CompareAdr(from, &svs.challenges[i].adr))
 			{
 				if (challenge == svs.challenges[i].challenge && !svs.challenges[i].connected)
 				{
@@ -354,7 +354,7 @@ qboolean SV_CheckChallenge(netadr_t from)
  *
  * @param[in] from
  */
-void SV_DirectConnect(netadr_t from)
+void SV_DirectConnect(const netadr_t *from)
 {
 	char     userinfo[MAX_INFO_STRING];
 	int      i, count = 0;
@@ -411,8 +411,8 @@ void SV_DirectConnect(netadr_t from)
 		//continue;
 		//}
 
-		if (NET_CompareBaseAdr(from, cl->netchan.remoteAddress)
-		    && (cl->netchan.qport == qport || from.port == cl->netchan.remoteAddress.port))
+		if (NET_CompareBaseAdr(from, &cl->netchan.remoteAddress)
+		    && (cl->netchan.qport == qport || from->port == cl->netchan.remoteAddress.port))
 		{
 			if ((svs.time - cl->lastConnectTime) < sv_reconnectlimit->integer * 1000)
 			{
@@ -433,7 +433,7 @@ void SV_DirectConnect(netadr_t from)
 
 		for (i = 0 ; i < MAX_CHALLENGES ; i++)
 		{
-			if (NET_CompareAdr(from, svs.challenges[i].adr))
+			if (NET_CompareAdr(from, &svs.challenges[i].adr))
 			{
 				if (challenge == svs.challenges[i].challenge)
 				{
@@ -495,9 +495,9 @@ void SV_DirectConnect(netadr_t from)
 		{
 			continue;
 		}
-		if (NET_CompareBaseAdr(from, cl->netchan.remoteAddress)
+		if (NET_CompareBaseAdr(from, &cl->netchan.remoteAddress)
 		    && (cl->netchan.qport == qport
-		        || from.port == cl->netchan.remoteAddress.port)
+		        || from->port == cl->netchan.remoteAddress.port)
 		    && !cl->demoClient)
 		{
 			Com_Printf("%s:reconnect\n", NET_AdrToString(from));
@@ -767,7 +767,7 @@ void SV_DropClient(client_t *drop, const char *reason)
 
 		for (i = 0 ; i < MAX_CHALLENGES ; i++, challenge++)
 		{
-			if (NET_CompareAdr(drop->netchan.remoteAddress, challenge->adr))
+			if (NET_CompareAdr(&drop->netchan.remoteAddress, &challenge->adr))
 			{
 				challenge->connected = qfalse;
 				break;
@@ -1960,7 +1960,7 @@ void SV_UserinfoChanged(client_t *cl)
 
 	// if the client is on the same subnet as the server and we aren't running an
 	// internet public server, assume they don't need a rate choke
-	if (Sys_IsLANAddress(cl->netchan.remoteAddress) && com_dedicated->integer != 2 && sv_lanForceRate->integer == 1)
+	if (Sys_IsLANAddress(&cl->netchan.remoteAddress) && com_dedicated->integer != 2 && sv_lanForceRate->integer == 1)
 	{
 		cl->rate = 99999;   // lans should not rate limit
 	}
@@ -2032,9 +2032,9 @@ void SV_UserinfoChanged(client_t *cl)
 	// - modified to always keep this consistent, instead of only
 	// when "ip" is 0-length, so users can't supply their own IP
 	//Com_DPrintf("Maintain IP in userinfo for '%s'\n", cl->name);
-	if (!NET_IsLocalAddress(cl->netchan.remoteAddress))
+	if (!NET_IsLocalAddress(&cl->netchan.remoteAddress))
 	{
-		Info_SetValueForKey(cl->userinfo, "ip", NET_AdrToString(cl->netchan.remoteAddress));
+		Info_SetValueForKey(cl->userinfo, "ip", NET_AdrToString(&cl->netchan.remoteAddress));
 	}
 	else
 	{

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -1122,9 +1122,8 @@ static qboolean SV_CheckDRDoS(netadr_t from)
  * Shift down the remaining args. Redirect all printfs.
  *
  * @param[in] from
- * @param msg - unused
  */
-static void SVC_RemoteCommand(const netadr_t *from, msg_t *msg)
+static void SVC_RemoteCommand(const netadr_t *from)
 {
 	qboolean valid;
 	char     remaining[1024];
@@ -1282,7 +1281,7 @@ static void SV_ConnectionlessPacket(const netadr_t *from, msg_t *msg)
 	}
 	else if (!Q_stricmp(c, "rcon"))
 	{
-		SVC_RemoteCommand(from, msg);
+		SVC_RemoteCommand(from);
 	}
 	else if (!Q_stricmp(c, "disconnect"))
 	{

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -599,11 +599,11 @@ static long SVC_HashForAddress(const netadr_t *address)
 	{
 	case NA_IP:
 		ip   = address->ip;
-		size = 4;
+		size = sizeof(address->ip);
 		break;
 	case NA_IP6:
 		ip   = address->ip6;
-		size = 16;
+		size = sizeof(address->ip6);
 		break;
 	default:
 		break;

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -140,7 +140,7 @@ cvar_t *sv_etltv_delay;
 cvar_t *sv_etltv_shownet;
 cvar_t *sv_etltv_queue_ms;
 
-static void SVC_Status(netadr_t from, qboolean force);
+static void SVC_Status(const netadr_t *from, qboolean force);
 
 /*
 =============================================================================
@@ -375,7 +375,7 @@ void SV_MasterHeartbeat(const char *msg)
 
 				if (res)
 				{
-					Com_Printf("%s resolved to %s\n", master, NET_AdrToString(adr[i][0]));
+					Com_Printf("%s resolved to %s\n", master, NET_AdrToString(&adr[i][0]));
 				}
 				else
 				{
@@ -400,7 +400,7 @@ void SV_MasterHeartbeat(const char *msg)
 
 				if (res)
 				{
-					Com_Printf("%s resolved to %s\n", master, NET_AdrToString(adr[i][1]));
+					Com_Printf("%s resolved to %s\n", master, NET_AdrToString(&adr[i][1]));
 				}
 				else
 				{
@@ -427,13 +427,13 @@ void SV_MasterHeartbeat(const char *msg)
 
 		if ((netenabled & NET_ENABLEV4) && adr[i][0].type != NA_BAD)
 		{
-			NET_OutOfBandPrint(NS_SERVER, adr[i][0], "heartbeat %s\n", msg);
+			NET_OutOfBandPrint(NS_SERVER, &adr[i][0], "heartbeat %s\n", msg);
 		}
 
 #ifdef FEATURE_IPV6
 		if (netenabled & NET_ENABLEV6 && adr[i][1].type != NA_BAD)
 		{
-			NET_OutOfBandPrint(NS_SERVER, adr[i][1], "heartbeat %s\n", msg);
+			NET_OutOfBandPrint(NS_SERVER, &adr[i][1], "heartbeat %s\n", msg);
 		}
 #endif
 	}
@@ -493,7 +493,7 @@ void SV_MasterGameCompleteStatus()
 
 				if (res)
 				{
-					Com_Printf("%s resolved to %s\n", master, NET_AdrToString(adr[i][0]));
+					Com_Printf("%s resolved to %s\n", master, NET_AdrToString(&adr[i][0]));
 				}
 				else
 				{
@@ -518,7 +518,7 @@ void SV_MasterGameCompleteStatus()
 
 				if (res)
 				{
-					Com_Printf("%s resolved to %s\n", master, NET_AdrToString(adr[i][1]));
+					Com_Printf("%s resolved to %s\n", master, NET_AdrToString(&adr[i][1]));
 				}
 				else
 				{
@@ -545,13 +545,13 @@ void SV_MasterGameCompleteStatus()
 
 		if ((netenabled & NET_ENABLEV4) && adr[i][0].type != NA_BAD)
 		{
-			SVC_Status(adr[i][0], qtrue);
+			SVC_Status(&adr[i][0], qtrue);
 		}
 
 #ifdef FEATURE_IPV6
 		if (netenabled & NET_ENABLEV6 && adr[i][1].type != NA_BAD)
 		{
-			SVC_Status(adr[i][1], qtrue);
+			SVC_Status(&adr[i][1], qtrue);
 		}
 #endif
 	}
@@ -588,18 +588,22 @@ leakyBucket_t        outboundLeakyBucket;
  * @param[in] address
  * @return
  */
-static long SVC_HashForAddress(netadr_t address)
+static long SVC_HashForAddress(const netadr_t *address)
 {
-	byte         *ip  = NULL;
+	const byte   *ip  = NULL;
 	size_t       size = 0;
 	unsigned int i;
 	long         hash = 0;
 
-	switch (address.type)
+	switch (address->type)
 	{
-	case NA_IP:  ip = address.ip;  size = 4;
+	case NA_IP:
+		ip   = address->ip;
+		size = 4;
 		break;
-	case NA_IP6: ip = address.ip6; size = 16;
+	case NA_IP6:
+		ip   = address->ip6;
+		size = 16;
 		break;
 	default:
 		break;
@@ -629,7 +633,7 @@ static long SVC_HashForAddress(netadr_t address)
  * @param[in] period
  * @return
  */
-static leakyBucket_t *SVC_BucketForAddress(netadr_t address, int burst, int period)
+static leakyBucket_t *SVC_BucketForAddress(const netadr_t *address, int burst, int period)
 {
 	leakyBucket_t *bucket = NULL;
 	int           i;
@@ -641,13 +645,13 @@ static leakyBucket_t *SVC_BucketForAddress(netadr_t address, int burst, int peri
 		switch (bucket->type)
 		{
 		case NA_IP:
-			if (memcmp(bucket->ipv._4, address.ip, 4) == 0)
+			if (memcmp(bucket->ipv._4, address->ip, sizeof(address->ip)) == 0)
 			{
 				return bucket;
 			}
 			break;
 		case NA_IP6:
-			if (memcmp(bucket->ipv._6, address.ip6, 16) == 0)
+			if (memcmp(bucket->ipv._6, address->ip6, sizeof(address->ip6)) == 0)
 			{
 				return bucket;
 			}
@@ -689,12 +693,14 @@ static leakyBucket_t *SVC_BucketForAddress(netadr_t address, int burst, int peri
 
 		if (bucket->type == NA_BAD)
 		{
-			bucket->type = address.type;
-			switch (address.type)
+			bucket->type = address->type;
+			switch (address->type)
 			{
-			case NA_IP:  Com_Memcpy(bucket->ipv._4, address.ip, 4);
+			case NA_IP:
+				Com_Memcpy(bucket->ipv._4, address->ip, sizeof(address->ip));
 				break;
-			case NA_IP6: Com_Memcpy(bucket->ipv._6, address.ip6, 16);
+			case NA_IP6:
+				Com_Memcpy(bucket->ipv._6, address->ip6, sizeof(address->ip6));
 				break;
 			default:
 				break;
@@ -777,7 +783,7 @@ qboolean SVC_RateLimit(leakyBucket_t *bucket, int burst, int period)
  *
  * @note  Don't call if sv_protect 1 (SVP_IOQ3) flag is not set!
  */
-qboolean SVC_RateLimitAddress(netadr_t from, int burst, int period)
+qboolean SVC_RateLimitAddress(const netadr_t *from, int burst, int period)
 {
 	leakyBucket_t *bucket = SVC_BucketForAddress(from, burst, period);
 
@@ -793,7 +799,7 @@ qboolean SVC_RateLimitAddress(netadr_t from, int burst, int period)
  * @param[in] from
  * @param[in] force toggle rate limit checks
  */
-static void SVC_Status(netadr_t from, qboolean force)
+static void SVC_Status(const netadr_t *from, qboolean force)
 {
 	char          player[1024];
 	char          status[MAX_MSGLEN];
@@ -868,7 +874,7 @@ static void SVC_Status(netadr_t from, qboolean force)
  *
  * @param[in] from
  */
-void SVC_Info(netadr_t from)
+static void SVC_Info(const netadr_t *from)
 {
 	int  i, clients = 0, humans = 0;
 	char *tmpString;
@@ -986,7 +992,7 @@ void SVC_Info(netadr_t from)
  */
 static void SV_FlushRedirect(char *outputbuf)
 {
-	NET_OutOfBandPrint(NS_SERVER, svs.redirectAddress, "print\n%s", outputbuf);
+	NET_OutOfBandPrint(NS_SERVER, &svs.redirectAddress, "print\n%s", outputbuf);
 }
 
 /**
@@ -1000,7 +1006,7 @@ static void SV_FlushRedirect(char *outputbuf)
  *
  * @note Don't call this if sv_protect 2 flag is not set!
  */
-qboolean SV_CheckDRDoS(netadr_t from)
+static qboolean SV_CheckDRDoS(netadr_t from)
 {
 	int        i;
 	int        globalCount;
@@ -1017,7 +1023,7 @@ qboolean SV_CheckDRDoS(netadr_t from)
 	// with a source address being a spoofed LAN address.  Even if that's not
 	// the case, sending packets to other hosts in the LAN is not a big deal.
 	// NA_LOOPBACK qualifies as a LAN address.
-	if (Sys_IsLANAddress(from))
+	if (Sys_IsLANAddress(&from))
 	{
 		return qfalse;
 	}
@@ -1070,7 +1076,7 @@ qboolean SV_CheckDRDoS(netadr_t from)
 				// first frame of a server's life.
 				globalCount++;
 			}
-			if (NET_CompareBaseAdr(from, receipt->adr))
+			if (NET_CompareBaseAdr(&from, &receipt->adr))
 			{
 				specificCount++;
 			}
@@ -1097,7 +1103,7 @@ qboolean SV_CheckDRDoS(netadr_t from)
 		if (lastSpecificLogTime + 1000 <= timeNow)   // Limit one log every second.
 		{
 			SV_WriteAttackLog(va("Possible DRDoS attack to address %s, ignoring getinfo/getstatus connectionless packet\n",
-			                     NET_AdrToString(exactFrom)));
+			                     NET_AdrToString(&exactFrom)));
 			lastSpecificLogTime = timeNow;
 		}
 
@@ -1118,7 +1124,7 @@ qboolean SV_CheckDRDoS(netadr_t from)
  * @param[in] from
  * @param msg - unused
  */
-static void SVC_RemoteCommand(netadr_t from, msg_t *msg)
+static void SVC_RemoteCommand(const netadr_t *from, msg_t *msg)
 {
 	qboolean valid;
 	char     remaining[1024];
@@ -1161,7 +1167,7 @@ static void SVC_RemoteCommand(netadr_t from, msg_t *msg)
 	}
 
 	// start redirecting all print outputs to the packet
-	svs.redirectAddress = from;
+	svs.redirectAddress = *from;
 	/* FIXME: our rcon redirection could be improved. Big rcon commands such as status
 	          lead to sending out of band packets on every single call to Com_Printf
 	          which leads to client overflows (also a Q3 issue)
@@ -1209,7 +1215,7 @@ static void SVC_RemoteCommand(netadr_t from, msg_t *msg)
  * @param[in] from
  * @param[in] msg
  */
-static void SV_ConnectionlessPacket(netadr_t from, msg_t *msg)
+static void SV_ConnectionlessPacket(const netadr_t *from, msg_t *msg)
 {
 	char *s;
 	char *c;
@@ -1240,7 +1246,7 @@ static void SV_ConnectionlessPacket(netadr_t from, msg_t *msg)
 			return;
 		}
 
-		if ((sv_protect->integer & SVP_OWOLF) && SV_CheckDRDoS(from))
+		if ((sv_protect->integer & SVP_OWOLF) && SV_CheckDRDoS(*from))
 		{
 			return;
 		}
@@ -1255,7 +1261,7 @@ static void SV_ConnectionlessPacket(netadr_t from, msg_t *msg)
 			return;
 		}
 
-		if ((sv_protect->integer & SVP_OWOLF) && SV_CheckDRDoS(from))
+		if ((sv_protect->integer & SVP_OWOLF) && SV_CheckDRDoS(*from))
 		{
 			return;
 		}
@@ -1263,7 +1269,7 @@ static void SV_ConnectionlessPacket(netadr_t from, msg_t *msg)
 	}
 	else if (!Q_stricmp(c, "getchallenge"))
 	{
-		if ((sv_protect->integer & SVP_OWOLF) && SV_CheckDRDoS(from))
+		if ((sv_protect->integer & SVP_OWOLF) && SV_CheckDRDoS(*from))
 		{
 			return;
 		}
@@ -1301,14 +1307,14 @@ static void SV_ConnectionlessPacket(netadr_t from, msg_t *msg)
  * @param[in] from
  * @param[in] msg
  */
-void SV_PacketEvent(netadr_t from, msg_t *msg)
+void SV_PacketEvent(const netadr_t *from, msg_t *msg)
 {
 	int      i;
 	client_t *cl;
 	int      qport;
 
 #ifdef DEDICATED
-	if (NET_CompareAdr(from, svclc.serverAddress))
+	if (NET_CompareAdr(from, &svclc.serverAddress))
 	{
 		CL_PacketEvent(from, msg);
 		return;
@@ -1340,7 +1346,7 @@ void SV_PacketEvent(netadr_t from, msg_t *msg)
 		{
 			continue;
 		}
-		if (!NET_CompareBaseAdr(from, cl->netchan.remoteAddress))
+		if (!NET_CompareBaseAdr(from, &cl->netchan.remoteAddress))
 		{
 			continue;
 		}
@@ -1354,10 +1360,10 @@ void SV_PacketEvent(netadr_t from, msg_t *msg)
 		// the IP port can't be used to differentiate them, because
 		// some address translating routers periodically change UDP
 		// port assignments
-		if (cl->netchan.remoteAddress.port != from.port)
+		if (cl->netchan.remoteAddress.port != from->port)
 		{
 			Com_Printf("SV_PacketEvent: fixing up a translated port\n");
-			cl->netchan.remoteAddress.port = from.port;
+			cl->netchan.remoteAddress.port = from->port;
 		}
 
 		// make sure it is a valid, in sequence packet

--- a/src/server/sv_snapshot.c
+++ b/src/server/sv_snapshot.c
@@ -1154,7 +1154,7 @@ void SV_SendClientMessages(void)
 		}
 
 		if (!(c->netchan.remoteAddress.type == NA_LOOPBACK ||
-		      (sv_lanForceRate->integer && Sys_IsLANAddress(c->netchan.remoteAddress))))
+		      (sv_lanForceRate->integer && Sys_IsLANAddress(&c->netchan.remoteAddress))))
 		{
 			// rate control for clients not on LAN
 			if (SV_RateMsec(c) > 0)

--- a/src/server/sv_tracker.c
+++ b/src/server/sv_tracker.c
@@ -73,7 +73,7 @@ void Tracker_Send(char *format, ...)
 	Q_vsnprintf(msg, sizeof(msg), format, argptr);
 	va_end(argptr);
 
-	NET_OutOfBandPrint(NS_SERVER, addr, "%s", msg);
+	NET_OutOfBandPrint(NS_SERVER, &addr, "%s", msg);
 }
 
 /**


### PR DESCRIPTION
There's almost no cases where pass by value is required for these, most uses can be pointer to const.