### PR TITLE
etmain: actually add missing shader for orange vchat sprite

### DIFF
--- a/etmain/scripts/legacy_sprites.shader
+++ b/etmain/scripts/legacy_sprites.shader
@@ -115,6 +115,18 @@ sprites/redcross
 		rgbGen vertex
 	}
 }
+
+sprites/voicechat_orange
+{
+	nocompress
+	nopicmip
+	{
+		map sprites/voicechat_orange.tga
+		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
+		rgbGen vertex
+	}
+}
+
 //========================================//
 
 


### PR DESCRIPTION
Previous commit (13faba99d30015f3f3e86d1ba3a30d7518a7b21a) added it to wrong file (presumably some r2-specific material file)

refs #2293