### PR TITLE
qcommon: ensure Q_LCG never overflows

### DIFF
--- a/src/qcommon/q_math.h
+++ b/src/qcommon/q_math.h
@@ -457,7 +457,7 @@ float Q_acos(float c);
  */
 static inline int Q_LCG(int x)
 {
-	return (int)(69069U * x + 1U);
+	return (int)((69069U * x + 1U) & 0x7FFFFFFF);
 }
 
 int Q_RandomInt(int *seed);


### PR DESCRIPTION
If a big seed was passed into the function, the results could sometimes overflow and return a negative number. This makes it more in line with what rand() would produce.

If a negative number was returned from this function, it caused out of bounds read in smoke sprite rendering, where it tried to access a negative index of `bytedirs` array.

https://github.com/etlegacy/etlegacy/blob/72bc2b615a60c188c06beaef7c51fab18b41bf5c/src/cgame/cg_effects.c#L1053

refs #2622