### PR TITLE
cgame: fix smoke sprites not fading out correctly

### DIFF
--- a/src/cgame/cg_effects.c
+++ b/src/cgame/cg_effects.c
@@ -1285,7 +1285,7 @@ void CG_AddSmokeSprites(void)
 		// fadeout
 		if (smokesprite->dist > (radius * .5f * .8f))
 		{
-			color[3] = (byte)(smokesprite->colour[3] - smokesprite->colour[3] * ((smokesprite->dist - (radius * .5f * .8f)) / ((radius * .5f) - (radius * .5f * .8f)))) * 0xff;
+			color[3] = (byte)((smokesprite->colour[3] - smokesprite->colour[3] * ((smokesprite->dist - (radius * .5f * .8f)) / ((radius * .5f) - (radius * .5f * .8f)))) * 0xff);
 		}
 		else
 		{


### PR DESCRIPTION
Cast to byte was done incorrectly, the last multiplication was left out.