### PR TITLE
cgame: fix some particle effects with MissileCam

### DIFF
--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -4697,7 +4697,7 @@ void CG_DrawMissileCamera(hudComponent_t *comp)
 		CG_AddPacketEntities();
 		CG_AddMarks();
 		CG_AddParticles();
-		CG_AddLocalEntities();
+		CG_AddLocalEntities(qfalse);
 		CG_AddSmokeSprites();
 		CG_AddAtmosphericEffects();
 		CG_AddFlameChunks();

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -3372,7 +3372,7 @@ void CG_UpdateFlamethrowerSounds(void);
 void CG_InitLocalEntities(void);
 localEntity_t *CG_AllocLocalEntity(void);
 localEntity_t *CG_FindLocalEntity(int index, int sideNum);
-void CG_AddLocalEntities(void);
+void CG_AddLocalEntities(qboolean master);
 void CG_DemoRewindFixLocalEntities(void);
 
 // cg_locations.c

--- a/src/cgame/cg_localents.c
+++ b/src/cgame/cg_localents.c
@@ -1142,8 +1142,9 @@ void CG_AddConstRGB(localEntity_t *le)
 /**
  * @brief CG_AddMoveScaleFade
  * @param[in] le
+ * @param[in] master - if local entities are allowed to be mutated (e.g. freed)
  */
-static void CG_AddMoveScaleFade(localEntity_t *le)
+static void CG_AddMoveScaleFade(localEntity_t *le, qboolean master)
 {
 	refEntity_t *re = &le->refEntity;
 	float       c;
@@ -1175,13 +1176,15 @@ static void CG_AddMoveScaleFade(localEntity_t *le)
 
 	BG_EvaluateTrajectory(&le->pos, cg.time, re->origin, qfalse, -1);
 
-	// if the view would be "inside" the sprite, kill the sprite
-	// so it doesn't add too much overdraw
-	len = VectorDistance(re->origin, cg.refdef_current->vieworg);
-	if (len < le->radius)
-	{
-		CG_FreeLocalEntity(le);
-		return;
+	if (master) {
+		// if the view would be "inside" the sprite, kill the sprite
+		// so it doesn't add too much overdraw
+		len = VectorDistance(re->origin, cg.refdef_current->vieworg);
+		if (len < le->radius)
+		{
+			CG_FreeLocalEntity(le);
+			return;
+		}
 	}
 
 	trap_R_AddRefEntityToScene(re);
@@ -1193,8 +1196,9 @@ static void CG_AddMoveScaleFade(localEntity_t *le)
  * removed if the view passes through them.
  * There are often many of these, so it needs to be simple.
  * @param[in] le
+ * @param[in] master - if local entities are allowed to be mutated (e.g. freed)
  */
-static void CG_AddScaleFade(localEntity_t *le)
+static void CG_AddScaleFade(localEntity_t *le, qboolean master)
 {
 	refEntity_t *re = &le->refEntity;
 	float       c   = (le->endTime - cg.time) * le->lifeRate; // fade / grow time
@@ -1206,13 +1210,15 @@ static void CG_AddScaleFade(localEntity_t *le)
 		re->radius = le->radius * (1.0f - c) + 8;
 	}
 
-	// if the view would be "inside" the sprite, kill the sprite
-	// so it doesn't add too much overdraw
-	len = VectorDistance(re->origin, cg.refdef_current->vieworg);
-	if (len < le->radius)
-	{
-		CG_FreeLocalEntity(le);
-		return;
+	if (master) {
+		// if the view would be "inside" the sprite, kill the sprite
+		// so it doesn't add too much overdraw
+		len = VectorDistance(re->origin, cg.refdef_current->vieworg);
+		if (len < le->radius)
+		{
+			CG_FreeLocalEntity(le);
+			return;
+		}
 	}
 
 	trap_R_AddRefEntityToScene(re);
@@ -1225,8 +1231,9 @@ static void CG_AddScaleFade(localEntity_t *le)
  * removed if the view passes through them.
  * There are often 100+ of these, so it needs to be simple.
  * @param[in] le
+ * @param[in] master - if local entities are allowed to be mutated (e.g. freed)
  */
-static void CG_AddFallScaleFade(localEntity_t *le)
+static void CG_AddFallScaleFade(localEntity_t *le, qboolean master)
 {
 	refEntity_t *re = &le->refEntity;
 	float       c   = (le->endTime - cg.time) * le->lifeRate; // fade time
@@ -1238,13 +1245,15 @@ static void CG_AddFallScaleFade(localEntity_t *le)
 
 	re->radius = le->radius * (1.0f - c) + 16;
 
-	// if the view would be "inside" the sprite, kill the sprite
-	// so it doesn't add too much overdraw
-	len = VectorDistance(re->origin, cg.refdef_current->vieworg);
-	if (len < le->radius)
-	{
-		CG_FreeLocalEntity(le);
-		return;
+	if (master) {
+		// if the view would be "inside" the sprite, kill the sprite
+		// so it doesn't add too much overdraw
+		len = VectorDistance(re->origin, cg.refdef_current->vieworg);
+		if (len < le->radius)
+		{
+			CG_FreeLocalEntity(le);
+			return;
+		}
 	}
 
 	trap_R_AddRefEntityToScene(re);
@@ -1337,8 +1346,9 @@ static void CG_AddSpriteExplosion(localEntity_t *le)
 
 /**
  * @brief CG_AddLocalEntities
+ * @param[in] master - if local entities are allowed to be mutated (e.g. freed)
  */
-void CG_AddLocalEntities(void)
+void CG_AddLocalEntities(qboolean master)
 {
 	localEntity_t *le, *next;
 
@@ -1407,7 +1417,7 @@ void CG_AddLocalEntities(void)
 			CG_AddFragment(le);
 			break;
 		case LE_MOVE_SCALE_FADE:        // water bubbles
-			CG_AddMoveScaleFade(le);
+			CG_AddMoveScaleFade(le, master);
 			break;
 		case LE_FADE_RGB:               // teleporters, railtrails
 			CG_AddFadeRGB(le);
@@ -1416,10 +1426,10 @@ void CG_AddLocalEntities(void)
 			CG_AddConstRGB(le);         // debug lines
 			break;
 		case LE_FALL_SCALE_FADE:        // gib blood trails
-			CG_AddFallScaleFade(le);
+			CG_AddFallScaleFade(le, master);
 			break;
 		case LE_SCALE_FADE:             // rocket trails
-			CG_AddScaleFade(le);
+			CG_AddScaleFade(le, master);
 			break;
 		case LE_EMITTER:
 			CG_AddEmitter(le);

--- a/src/cgame/cg_multiview.c
+++ b/src/cgame/cg_multiview.c
@@ -729,7 +729,7 @@ void CG_mvDraw(cg_window_t *sw)
 		CG_AddPacketEntities();
 		CG_AddMarks();
 		CG_AddParticles();
-		CG_AddLocalEntities();
+		CG_AddLocalEntities(qfalse);
 
 		CG_AddSmokeSprites();
 		CG_AddAtmosphericEffects();

--- a/src/cgame/cg_view.c
+++ b/src/cgame/cg_view.c
@@ -2540,7 +2540,7 @@ void CG_DrawActiveFrame(int serverTime, qboolean demoPlayback)
 
 			DEBUGTIME
 
-			CG_AddLocalEntities();
+			CG_AddLocalEntities(qtrue);
 
 			DEBUGTIME
 


### PR DESCRIPTION
Both 'CG_DrawMissileCamera' and 'CG_DrawActiveFrame' (which renders the "main" camera) were adding particle effects like the smoke of a WP_SMOKE_MARKER (the field ops smoke grenade) to their respective scene graphs via 'CG_AddLocalEntities'.

However, some of the consequent 'CG_Add*' calls entail checks to not-render and actually remove entities if they are close to the camera. (Note, remove the entity itself, not merely removing it from the respective scene graph).

Because both the MissileCam and the "Main"Cam would call these functions, a particle entity close to the MissileCam would actually be removed altogether and subsequently disappear also for the "Main"Cam.

This is circumvented by removing the delete calls (`CG_FreeLocalEntity`) and returning early before adding the entity to the scene graph.