### PR TITLE
mod: allow obj command during intermission

### DIFF
--- a/src/game/g_cmds_ext.c
+++ b/src/game/g_cmds_ext.c
@@ -137,7 +137,7 @@ static const cmd_reference_t aCommandInfo[] =
 	{ "nostamina",      CMD_USAGE_NO_INTERMISSION,   qtrue,       qfalse, Cmd_Nostamina_f,                     ":^7 Infinite stamina / charge power"                                                        },
 	{ "notarget",       CMD_USAGE_NO_INTERMISSION,   qtrue,       qfalse, Cmd_Notarget_f,                      ":^7 ???"                                                                                    },
 	{ "notready",       CMD_USAGE_ANY_TIME,          qfalse,      qtrue,  G_ready_cmd,                         ":^7 Sets your status to ^5not ready^7 to start a match"                                     },
-	{ "obj",            CMD_USAGE_NO_INTERMISSION,   qtrue,       qfalse, Cmd_SelectedObjective_f,             " <val>:^7 Selected Objective"                                                               },
+	{ "obj",            CMD_USAGE_ANY_TIME,          qtrue,       qfalse, Cmd_SelectedObjective_f,             " <val>:^7 Selected Objective"                                                               },
 	{ "pause",          CMD_USAGE_NO_INTERMISSION,   qtrue,       qfalse, G_pause_cmd,                         ":^7 Allows a team to pause a match"                                                         },
 	{ "players",        CMD_USAGE_ANY_TIME,          qtrue,       qtrue,  G_players_cmd,                       ":^7 Lists all active players and their IDs/information"                                     },
 	{ "rconAuth",       CMD_USAGE_ANY_TIME,          qtrue,       qfalse, Cmd_AuthRcon_f,                      ":^7 Client authentication"                                                                  },

--- a/src/tvgame/tvg_cmds_ext.c
+++ b/src/tvgame/tvg_cmds_ext.c
@@ -101,7 +101,7 @@ static tvcmd_reference_t tvCommandInfo[] =
 	{ "setviewpos",   CMD_USAGE_NO_INTERMISSION,                 0,     MEDIUMCD,   0, qfalse, TVG_Cmd_SetViewpos_f,                    ALL,            " x y z pitch yaw roll useViewHeight(0/1):^7 Set the current player position and view angle" },
 	{ "noclip",       CMD_USAGE_NO_INTERMISSION,                 0,     NOCD,       0, qfalse, TVG_Cmd_Noclip_f,                        ALL,            ":^7 No clip"                                                                                },
 
-	{ "obj",          CMD_USAGE_NO_INTERMISSION,                 0,     NOCD,       0, qfalse, TVG_Cmd_SelectedObjective_f,             ALL,            " <val>:^7 Selected Objective"                                                               },
+	{ "obj",          CMD_USAGE_ANY_TIME,                        0,     NOCD,       0, qfalse, TVG_Cmd_SelectedObjective_f,             ALL,            " <val>:^7 Selected Objective"                                                               },
 
 	{ NULL,           CMD_USAGE_ANY_TIME,                        0,     NOCD,       0, qfalse, NULL,                                    0,              ""                                                                                           }
 };


### PR DESCRIPTION
When a player switches team during intermission (or shoutcast status changes), the limbo panel setup runs, which executes `obj -1` to reset the limbo cam objective to default. This should be allowed always as you can open limbo menu during intermission anyway. VET also allows this during intermission.

If the command isn't allowed during intermission, every team switch or shoutcast status change would print `obj not allowed during intermission.`