### PR TITLE
etmain: tweak 1P rifles

### DIFF
--- a/etmain/models/multiplayer/kar98/weapon.cfg
+++ b/etmain/models/multiplayer/kar98/weapon.cfg
@@ -17,19 +17,19 @@ newfmt
 ///   /   /   /   /   /   ______________________________/
 //   /   /   /   /   /   /
 
-0	1	20	1	0	0	0	// IDLE1 (for kar98)
-125	1	20	1	0	0	0	// IDLE2 (for gpg40)
+0	1	20	1	0	0	0	// IDLE1
+125	1	20	1	0	0	0	// IDLE2 (GPG40/RG)
 
-1	10	20	0	0	0	0	// ATTACK1 (for kar98)
-72	5	10	0	0	0	0	// ATTACK2 (for gpg40)
-16	11	20	0	0	0	0	// ATTACK_LASTSHOT (for kar98)
+2	4	18	0	0	0	0	// ATTACK1
+74	5	11	0	0	0	0	// ATTACK2 (GPG40/RG)
+2	4	18	0	0	0	0	// ATTACK_LASTSHOT
 
-29	5	20	0	0	0	0	// DROP (for kar98)
-34	7	20	0	0	0	0	// RAISE (for kar98)
-41	23	14	1	0	0	0	// RELOAD1 (for kar98)
-2	47	30	1	0	0	0	// RELOAD2 (for gpg40)
-131	5	20	1	0	0	0	// RAISE (for gpg40)
+30	4	30	0	0	0	0	// DROP
+36	5	40	0	0	0	0	// RAISE
+40	24	18	0	0	0	0	// RELOAD1
+0	0	0	0	0	0	0	// RELOAD2 notused
+0	0	0	0	0	0	0	// RELOAD3 notused
 
-78	47	20	0	0	0	0	// equipping grenade (for gpg40)
-147	28	20	0	0	0	0	// un-equipping grenade
-128	4	20	0	0	0	0	// DROP2 (for gpg40)
+79	46	19	0	0	0	0	// ALTSWITCHFROM equipping grenade
+147	28	23	0	0	0	0	// ALTSWITCHTO   un-equipping grenade
+0	0	0	0	0	0	0	// DROP2 notused

--- a/etmain/models/multiplayer/kar98/weapon2.cfg
+++ b/etmain/models/multiplayer/kar98/weapon2.cfg
@@ -7,30 +7,30 @@
 newfmt
 // config file for weapon animations
 
-//                                             	 barrel                     	 barrel
-//    first     length      fps      looping  	anim bits      animated weap   	draw bits
-//     /      ___/          /         /          /               /                  /
-//    /      /       ______/         /          /               /              	   /
-//   /      /       /       ________/          /               /              	  /
-//  /      /   	   /   	   /  	   ___________/               /              	 /
-// /   	  /   	  /   	  /   	  /   	  ___________________/              	/
-///   	 /   	 /   	 /   	 /   	 /   	 ______________________________/
-//   	/   	/   	/   	/   	/   	/
+//                                 barrel                     barrel
+//    first  length  fps  looping  anim bits  animated weap   draw bits
+//     /   ___/      /     /      /           /              /
+//    /   /   ______/     /      /           /              /
+//   /   /   /   ________/      /           /              /
+//  /   /   /   /   ___________/           /              /
+// /   /   /   /   /   ___________________/              /
+///   /   /   /   /   /   ______________________________/
+//   /   /   /   /   /   /
 
-0	1	20	1	0	0	0	// IDLE1 (for kar98)
-128	1	20	1	0	0	0	// IDLE2 (for gpg40)
+0	1	20	1	0	0	0	// IDLE1
+0	0	0	0	0	0	0	// IDLE2 notused
 
-1	10	20	0	0	0	0	// ATTACK1 (for kar98)
-130 5   10	0   0   0   0   // ATTACK2 (for gpg40)
-16	11	20	0	0	0	0	// ATTACK_LASTSHOT (for kar98)
+2	4	18	0	0	0	0	// ATTACK1
+0	0	0	0	0	0	0	// ATTACK2 notused
+2	4	18	0	0	0	0	// ATTACK_LASTSHOT
 
-29	5	20	0	0	0	0	// DROP (for kar98)
-34	7	20	0	0	0	0	// RAISE (for kar98)
-41	23	14	1	0	0	0	// RELOAD1 (for kar98)
-136	46	20	1	0	0	0	// RELOAD2 (for gpg40)
-190	5	20	1	0	0	0	// RAISE (for gpg40)
+30	4	30	0	0	0	0	// DROP
+36	5	40	0	0	0	0	// RAISE
+40	24	18	0	0	0	0	// RELOAD1
+0	0	0	0	0	0	0	// RELOAD2 notused
+0	0	0	0	0	0	0	// RELOAD3 notused
 
-29	5	20	0	0	0	0	// zooming in
-34	7	20	0	0	0	0	// zooming out
+0	1	0	0	0	0	0	// ALTSWITCHFROM (zoom in)
+0	1	0	0	0	0	0	// ALTSWITCHTO   (zoom out)
 
-185	5	20	0	0	0	0	// DROP (for gpg40)
+0	0	0	0	0	0	0	// DROP2 notused

--- a/etmain/models/multiplayer/m1_garand/weapon.cfg
+++ b/etmain/models/multiplayer/m1_garand/weapon.cfg
@@ -17,19 +17,19 @@ newfmt
 ///   /   /   /   /   /   ______________________________/
 //   /   /   /   /   /   /
 
-0	1	20	1	0	0	0	// IDLE1
-135	1	20	1	0	0	0	// IDLE2
+0	1	20	0	0	0	0	// IDLE1
+135	1	20	0	0	0	0	// IDLE2 (M7/RG)
 
-1	5	25	0	0	0	0	// ATTACK1
-76	9	20	0	0	0	0	// ATTACK2
-40	5	20	0	0	0	0	// ATTACK_LASTSHOT (for M1-garand)
+2	4	18	0	0	0	0	// ATTACK1
+76	9	24	0	0	0	0	// ATTACK2 (M7/RG)
+2	4	18	0	0	0	0	// ATTACK_LASTSHOT
 
-29	5	20	0	0	0	0	// DROP (for M1-garand)
-34	7	20	0	0	0	0	// RAISE
-44	20	14	1	0	0	0	// RELOAD1
-130	49	20	1	0	0	0	// RELOAD2
-173	5	20	1	0	0	0	// RAISE (for M7)
+29	4	30	0	0	0	0	// DROP
+36	5	42	0	0	0	0	// RAISE
+46	20	12	0	0	0	0	// RELOAD1
+0	0	0	0	0	0	0	// RELOAD2 notused
+0	0	0	0	0	0	0	// RELOAD3 notused
 
-85	52	20	0	0	0	0	// ALTSWITCHFROM equipping grenade
-135	29	20	0	0	0	0	// ALTSWITCHTO   un-equipping grenade
-164	5	20	0	0	0	0	// DROP2 (for M7)
+85	50	21	0	0	0	0	// ALTSWITCHFROM equipping grenade
+136	28	23	0	0	0	0	// ALTSWITCHTO   un-equipping grenade
+0	0	0	0	0	0	0	// DROP2 notused

--- a/etmain/models/multiplayer/m1_garand/weapon2.cfg
+++ b/etmain/models/multiplayer/m1_garand/weapon2.cfg
@@ -7,30 +7,29 @@
 newfmt
 // config file for weapon animations
 
-//                                             	 barrel                     	 barrel
-//    first     length      fps      looping  	anim bits      animated weap   	draw bits
-//     /      ___/          /         /          /               /                  /
-//    /      /       ______/         /          /               /              	   /
-//   /      /       /       ________/          /               /              	  /
-//  /      /   	   /   	   /  	   ___________/               /              	 /
-// /   	  /   	  /   	  /   	  /   	  ___________________/              	/
-///   	 /   	 /   	 /   	 /   	 /   	 ______________________________/
-//   	/   	/   	/   	/   	/   	/
+//                                 barrel                     barrel
+//    first  length  fps  looping  anim bits  animated weap   draw bits
+//     /   ___/      /     /      /           /              /
+//    /   /   ______/     /      /           /              /
+//   /   /   /   ________/      /           /              /
+//  /   /   /   /   ___________/           /              /
+// /   /   /   /   /   ___________________/              /
+///   /   /   /   /   /   ______________________________/
+//   /   /   /   /   /   /
 
-0	1	20	1	0	0	0	// IDLE1
-179	1	20	1	0	0	0	// IDLE2
+0	1	20	0	0	0	0	// IDLE1
+179	1	20	0	0	0	0	// IDLE2 notused
 
-1	5	25	0	0	0	0	// ATTACK1
-121 9   20	0   0   0   0   // ATTACK2 (for M7)
-40	5	20	0	0	0	0	// ATTACK_LASTSHOT (for M1-garand)
+2	4	18	0	0	0	0	// ATTACK1
+121 9	20	0	0	0	0	// ATTACK2
+2	4	18	0	0	0	0	// ATTACK_LASTSHOT
 
-29	5	20	0	0	0	0	// DROP (for M1-garand)
-34	7	20	0	0	0	0	// RAISE
-44	20	14	1	0	0	0	// RELOAD1
-130	49	20	1	0	0	0	// RELOAD2
-210	7	20	1	0	0	0	// RAISE (for M7)
+30	4	30	0	0	0	0	// DROP
+36	5	42	0	0	0	0	// RAISE
+45	19	14	0	0	0	0	// RELOAD1
+0	0	0	0	0	0	0	// RELOAD2 notused
+0	0	0	0	0	0	0	// RELOAD3 notused
 
-29	5	20	0	0	0	0	// Zooming in.
-34	7	20	0	0	0	0	// Zooming out.
-
-205	5	20	0	0	0	0	// DROP2 (for M7)
+0	1	0	0	0	0	0	// ALTSWITCHFROM (zoom in)
+0	1	0	0	0	0	0	// ALTSWITCHTO   (zoom out)
+0	0	0	0	0	0	0	// DROP2 notused


### PR DESCRIPTION
1. Reframe covi/engi rifles for smoother animation.

2. Fix Flash offsets for both rifles.

3. Fix covi rifles disappearing for a brief time right after de-scoping.

4. Offset the normal kar98 axis engi rifle brass ejection, as it has a
   high tendency to eject brass into the playerview in an obscuring way
   via the default 'tag_brass' tag.

5. Offset the scoped kar98 silencer, as it's misaligned by default
