### PR TITLE
etmain: reframe 1P SMGs

### DIFF
--- a/etmain/models/weapons2/mp40/weapon.cfg
+++ b/etmain/models/weapons2/mp40/weapon.cfg
@@ -18,18 +18,18 @@ newfmt
 //   /   /   /   /   /   /
 
 0	1	20	1	0	0	0	// IDLE1
-0	1	20	1	0	0	0	// IDLE2
+0	0	0	0	0	0	0	// IDLE2 notused
 
-1	3	20	2	0	0	0	// ATTACK1
-1	3	20	2	0	0	0	// ATTACK2
-1	3	20	2	0	0	0	// ATTACK3
+2	2	18	3	0	0	0	// ATTACK1
+0	0	0	0	0	0	0	// ATTACK2 notused
+2	2	16	0	0	0	0	// ATTACK_LASTSHOT
 
-7	5	20	0	0	0	0	// DROP
-12	4	16	0	0	0	0	// RAISE
-17	48	20	1	0	0	0	// RELOAD1
-17	48	30	1	0	0	0	// RELOAD2
-17	48	20	1	0	0	0	// RELOAD3
+8	5	14	0	0	0	0	// DROP
+13	5	14	0	0	0	0	// RAISE
+17	48	20	0	0	0	0	// RELOAD1
+19	48	29	0	0	0	0	// RELOAD2
+0	0	0	0	0	0	0	// RELOAD3 notused
 
-0	1	20	1	0	0	0	// ALTSWITCH
-0	1	20	1	0	0	0	// ALTSWITCH
-0	1	20	1	0	0	0	// DROP2
+0	0	0	0	0	0	0	// ALTSWITCH notused
+0	0	0	0	0	0	0	// ALTSWITCH notused
+0	0	0	0	0	0	0	// DROP2 notused

--- a/etmain/models/weapons2/thompson/weapon.cfg
+++ b/etmain/models/weapons2/thompson/weapon.cfg
@@ -18,18 +18,18 @@ newfmt
 //   /   /   /   /   /   /
 
 0	1	20	1	0	0	0	// IDLE1
-0	1	20	1	0	0	0	// IDLE2
+0	0	0	0	0	0	0	// IDLE2 notused
 
-1	3	20	2	0	0	0	// ATTACK1
-1	3	20	2	0	0	0	// ATTACK2
-1	3	20	2	0	0	0	// ATTACK3
+2	3	18	2	0	0	0	// ATTACK1
+0	0	0	0	0	0	0	// ATTACK2 notused
+3	2	14	0	0	0	0	// ATTACK_LASTSHOT
 
-7	5	20	0	0	0	0	// DROP
-12	4	16	0	0	0	0	// RAISE
-16	49	20	1	0	0	0	// RELOAD1  was at 20 fps
-16	49	32	1	0	0	0	// RELOAD2
-16	49	20	1	0	0	0	// RELOAD3
+8	4	15	0	0	0	0	// DROP
+13	5	18	0	0	0	0	// RAISE
+17	48	20	0	0	0	0	// RELOAD1
+19	48	29	0	0	0	0	// RELOAD2
+0	0	0	0	0	0	0	// RELOAD3 notused
 
-0	1	20	1	0	0	0	// ALTSWITCH
-0	1	20	1	0	0	0	// ALTSWITCH
-0	1	20	1	0	0	0	// DROP2
+0	0	0	0	0	0	0	// ALTSWITCH notused
+0	0	0	0	0	0	0	// ALTSWITCH notused
+0	0	0	0	0	0	0	// DROP2 notused


### PR DESCRIPTION
Adjust both MP40 and Thompson 1P animations along the following lines:

Both RELOAD (slow & fast) and RAISE animations transition more smoothly into ATTACK, such that the muzzle flash of the 1st and 2nd shot doesn't jump noticably.

ATTACK loops are slightly adjusted to match the rhythm of the firing rate visuals a tad better.

DROP is slightly adjusted to smooth weapon transitions.