### PR TITLE
etmain: Skip 3P reload animations for PF/Flamer

### DIFF
--- a/etmain/animations/scripts/human_base.script
+++ b/etmain/animations/scripts/human_base.script
@@ -2729,11 +2729,15 @@ reload
 	}
 	weapons bazooka
 	{
-		torso reload_rifle
+		NOOP
 	}
 	weapons panzerfaust
 	{
-		torso reload_panzer
+		NOOP
+	}
+	weapons flamethrower
+	{
+		NOOP
 	}
 	weapons pistols, movetype idlecr
 	{

--- a/src/game/bg_animation.c
+++ b/src/game/bg_animation.c
@@ -809,6 +809,11 @@ static void BG_ParseCommands(char **input, animScriptItem_t *scriptItem, animMod
 			Com_Memset(command, 0, sizeof(*command));
 		}
 
+      // skip adding NOOP commands altogether
+		if (!Q_stricmp(token, "NOOP")) {
+			continue;
+		}
+
 		command->bodyPart[partIndex] = BG_IndexForString(token, animBodyPartsStr, qtrue);
 		if (command->bodyPart[partIndex] > 0)
 		{


### PR DESCRIPTION
These are triggered sometimes (e.g. directly upon respawning), but they
make no sense as these weapons are instantly "reloaded" and all have no
1st person reload animation as well.