### PR TITLE
Prioritize 3P torso reload anim when jumping

### DIFF
--- a/etmain/animations/scripts/human_base.script
+++ b/etmain/animations/scripts/human_base.script
@@ -2807,109 +2807,37 @@ reload
 
 jump
 {
+	weapons none, movetype run, reloading
+	{
+		legs jump_1step_1h
+	}
 	weapons none, movetype run
 	{
 		both jump_1step_1h
+	}
+	weapons none, reloading
+	{
+		legs jump_nostep_1h
 	}
 	weapons none
 	{
 		both jump_nostep_1h
 	}
+	weapons one_handed_weapons, movetype run, reloading
+	{
+		legs jump_1step_1h
+	}
 	weapons one_handed_weapons, movetype run
 	{
 		both jump_1step_1h
 	}
+	weapons one_handed_weapons, reloading
+	{
+		legs jump_nostep_1h
+	}
 	weapons one_handed_weapons
 	{
 		both jump_nostep_1h
-	}
-//	weapons rifles, movetype run
-//	{
-//		legs jump_1step_2h torso stand_rifle
-//	}
-//	weapons rifles
-//	{
-//		legs jump_nostep_1h torso stand_rifle
-//	}
-	weapons Scoped M1 Garand, movetype run
-	{
-		legs jump_1step_2h
-	}
-	weapons Scoped M1 Garand
-	{
-		legs jump_nostep_1h
-	}
-	weapons FG 42 Paratroop Rifle, movetype run
-	{
-		legs jump_1step_2h
-	}
-	weapons FG 42 Paratroop Rifle
-	{
-		legs jump_nostep_1h
-	}
-	weapons K43 Rifle, movetype run
-	{
-		legs jump_1step_2h
-	}
-	weapons K43 Rifle
-	{
-		legs jump_nostep_1h
-	}
-	weapons gpg40, movetype run
-	{
-		legs jump_1step_2h
-	}
-	weapons gpg40
-	{
-		legs jump_nostep_1h
-	}
-	weapons M7, movetype run
-	{
-		legs jump_1step_2h
-	}
-	weapons M7
-	{
-		legs jump_nostep_1h
-	}
-	weapons m1 garand, movetype run
-	{
-		legs jump_1step_2h
-	}
-	weapons m1 garand
-	{
-		legs jump_nostep_1h
-	}
-	weapons Scoped K43 Rifle, movetype run
-	{
-		legs jump_1step_2h
-	}
-	weapons Scoped K43 Rifle
-	{
-		legs jump_nostep_1h
-	}
-	weapons K43 Rifle Scope, movetype run
-	{
-		legs jump_1step_2h torso stand_rifle
-	}
-	weapons K43 Rifle Scope
-	{
-		legs jump_nostep_1h torso stand_rifle
-	}
-	weapons M1 Garand Scope, movetype run
-	{
-		legs jump_1step_2h torso stand_rifle
-	}
-	weapons M1 Garand Scope
-	{
-		legs jump_nostep_1h torso stand_rifle
-	}
-	weapons FG 42 Paratroop Rifle Scope, movetype run
-	{
-		legs jump_1step_2h torso stand_rifle
-	}
-	weapons FG 42 Paratroop Rifle Scope
-	{
-		legs jump_nostep_1h torso stand_rifle
 	}
 	weapons bazooka, movetype run
 	{
@@ -2927,9 +2855,17 @@ jump
 	{
 		legs jump_nostep_1h torso stand_panzer
 	}
+	weapons two_handed_weapons, movetype run, reloading
+	{
+		legs jump_1step_2h
+	}
 	weapons two_handed_weapons, movetype run
 	{
 		both jump_1step_2h
+	}
+	weapons two_handed_weapons, reloading
+	{
+		legs jump_nostep_1h
 	}
 	weapons two_handed_weapons
 	{
@@ -2943,101 +2879,21 @@ jump
 
 jumpbk
 {
+	weapons one_handed_weapons, movetype run, reloading
+	{
+		legs jump_1step_1h
+	}
 	weapons one_handed_weapons, movetype run
 	{
 		both jump_1step_1h
 	}
+	weapons one_handed_weapons, reloading
+	{
+		legs jump_nostep_1h
+	}
 	weapons one_handed_weapons
 	{
 		both jump_nostep_1h
-	}
-//	weapons rifles, movetype run
-//	{
-//		legs jump_1step_2h torso stand_rifle
-//	}
-//	weapons rifles
-//	{
-//		legs jump_nostep_1h torso stand_rifle
-//	}
-	weapons Scoped M1 Garand, movetype run
-	{
-		legs jump_1step_2h
-	}
-	weapons Scoped M1 Garand
-	{
-		legs jump_nostep_1h
-	}
-	weapons FG 42 Paratroop Rifle, movetype run
-	{
-		legs jump_1step_2h
-	}
-	weapons FG 42 Paratroop Rifle
-	{
-		legs jump_nostep_1h
-	}
-	weapons K43 Rifle, movetype run
-	{
-		legs jump_1step_2h
-	}
-	weapons K43 Rifle
-	{
-		legs jump_nostep_1h
-	}
-	weapons gpg40, movetype run
-	{
-		legs jump_1step_2h
-	}
-	weapons gpg40
-	{
-		legs jump_nostep_1h
-	}
-	weapons M7, movetype run
-	{
-		legs jump_1step_2h
-	}
-	weapons M7
-	{
-		legs jump_nostep_1h
-	}
-	weapons m1 garand, movetype run
-	{
-		legs jump_1step_2h
-	}
-	weapons m1 garand
-	{
-		legs jump_nostep_1h
-	}
-	weapons Scoped K43 Rifle, movetype run
-	{
-		legs jump_1step_2h
-	}
-	weapons Scoped K43 Rifle
-	{
-		legs jump_nostep_1h
-	}
-	weapons K43 Rifle Scope, movetype run
-	{
-		legs jump_1step_2h torso stand_rifle
-	}
-	weapons K43 Rifle Scope
-	{
-		legs jump_nostep_1h torso stand_rifle
-	}
-	weapons M1 Garand Scope, movetype run
-	{
-		legs jump_1step_2h torso stand_rifle
-	}
-	weapons M1 Garand Scope
-	{
-		legs jump_nostep_1h torso stand_rifle
-	}
-	weapons FG 42 Paratroop Rifle Scope, movetype run
-	{
-		legs jump_1step_2h torso stand_rifle
-	}
-	weapons FG 42 Paratroop Rifle Scope
-	{
-		legs jump_nostep_1h torso stand_rifle
 	}
 	weapons bazooka, movetype run
 	{
@@ -3055,9 +2911,17 @@ jumpbk
 	{
 		legs jump_nostep_1h torso stand_panzer
 	}
+	weapons two_handed_weapons, movetype run, reloading
+	{
+		legs jump_1step_2h
+	}
 	weapons two_handed_weapons, movetype run
 	{
 		both jump_1step_2h
+	}
+	weapons two_handed_weapons, reloading
+	{
+		legs jump_nostep_1h
 	}
 	weapons two_handed_weapons
 	{

--- a/src/game/bg_animation.c
+++ b/src/game/bg_animation.c
@@ -281,6 +281,7 @@ static animStringItem_t animConditionsStr[NUM_ANIM_CONDITIONS + 1] =
 	{ "GEN_BITFLAG",    -1 },
 	{ "AISTATE",        -1 },
 	{ "SUICIDE",        -1 },
+	{ "RELOADING",      -1 },
 
 	{ NULL,             -1 },
 };
@@ -308,6 +309,7 @@ static animConditionTable_t animConditionsTable[NUM_ANIM_CONDITIONS] =
 	{ ANIM_CONDTYPE_VALUE,    animFlailTypeStr             },
 	{ ANIM_CONDTYPE_BITFLAGS, animGenBitFlagStr            },
 	{ ANIM_CONDTYPE_VALUE,    animAIStateStr               },
+	{ ANIM_CONDTYPE_VALUE,    NULL                         },
 	{ ANIM_CONDTYPE_VALUE,    NULL                         },
 };
 
@@ -1973,14 +1975,8 @@ void BG_AnimUpdatePlayerStateConditions(pmove_t *pmove)
 		ps->eFlags &= ~EF_CROUCHING;
 	}
 
-	if (pmove->cmd.buttons & BUTTON_ATTACK)
-	{
-		BG_UpdateConditionValue(ps->clientNum, ANIM_COND_FIRING, qtrue, qtrue);
-	}
-	else
-	{
-		BG_UpdateConditionValue(ps->clientNum, ANIM_COND_FIRING, qfalse, qtrue);
-	}
+	BG_UpdateConditionValue(ps->clientNum, ANIM_COND_FIRING, (pmove->cmd.buttons & BUTTON_ATTACK), qtrue);
+	BG_UpdateConditionValue(ps->clientNum, ANIM_COND_RELOADING, (pmove->ps->weaponstate == WEAPON_RELOADING), qtrue);
 
 	if (ps->pm_flags & PMF_FLAILING)
 	{

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -2319,6 +2319,7 @@ typedef enum
 	ANIM_COND_GEN_BITFLAG,     ///< general bit flags (to save some space)
 	ANIM_COND_AISTATE,         ///< our current ai state (sometimes more convenient than creating a separate section)
 	ANIM_COND_SUICIDE,
+	ANIM_COND_RELOADING,
 
 	NUM_ANIM_CONDITIONS
 } scriptAnimConditions_t;


### PR DESCRIPTION
Some weapons (like SMGs or Pistols) had their torso reload animation overriden by jumping.
    
This commit ensures that reloading torso animations are always shown when jumping during reload.

Also cleans up unneeded 'jump' and 'jumpbk' rules.
