### PR TITLE
etmain: Tweak 3P 'jump_nostep_1h'

### DIFF
--- a/etmain/animations/human/base/body.aninc
+++ b/etmain/animations/human/base/body.aninc
@@ -125,7 +125,7 @@
 
 		jump_1step_2h		3111	11	0	20	0	0	0
 		jump_1step_1h		3131	11	0	20	0	0	0
-		jump_nostep_1h		3152	16	0	16	0	0	0
+		jump_nostep_1h		3154	7	0	12	0	0	0
 
 		swim_2h				3169	30	30	20	0	0	0
 		swim_1h				3200	33	33	20	0	0	0


### PR DESCRIPTION
The 'jump_nostep_1h' jump animation does not only animate jumping off the ground, but also include animations for landing on the ground again.

This has the following downsides:

- If the jump distance is longer, then the animation plays the included "landing on the ground" part mid-air.

- As the jump animations take priority over anything else, if the distance is too small, the player will "hover"/"glide" as the "landing on the ground" part is still playing.

In practice this means that this animation causes a lot of "hovering"/"gliding".

This is addressed by simply trimming the "landing on the ground" part from it.