### PR TITLE
etmain: Show 3P grenade priming torso anim while jumping

### DIFF
--- a/etmain/animations/scripts/human_base.script
+++ b/etmain/animations/scripts/human_base.script
@@ -2871,6 +2871,14 @@ jump
 	{
 		both jump_nostep_1h
 	}
+	weapons dynamite weapon
+	{
+		both jump_1step_1h
+	}
+	firing
+	{
+		legs jump_1step_1h
+	}
 	default
 	{
 		both jump_1step_1h
@@ -2926,6 +2934,14 @@ jumpbk
 	weapons two_handed_weapons
 	{
 		both jump_nostep_1h
+	}
+	weapons dynamite weapon
+	{
+		both jump_1step_1h
+	}
+	firing
+	{
+		legs jump_1step_1h
 	}
 	default
 	{


### PR DESCRIPTION
There is a custom torso animation for priming a grenade (holding down +attack), whereby the player holds the grenade close to their chest.

The jump animation however overrides it.

This commit ensures that grenade priming is prioritized over jumping.

Dynamite is an exception that is taken care of.