### PR TITLE
game: fix crash if et.G_Damage is called with a weapon MOD

### DIFF
--- a/src/game/g_combat.c
+++ b/src/game/g_combat.c
@@ -984,7 +984,7 @@ qboolean IsHeadShot(gentity_t *targ, const vec3_t dir, const vec3_t point, means
 	gentity_t *traceEnt;
 
 	// can happen if et.G_Damage lua is called with a MOD that is an actual weapon
-	if (!point)
+	if (!point || !dir)
 	{
 		return qfalse;
 	}
@@ -1063,7 +1063,7 @@ qboolean IsLegShot(gentity_t *targ, const vec3_t dir, const vec3_t point, meansO
 	gentity_t *leg;
 
 	// can happen if et.G_Damage lua is called with a MOD that is an actual weapon
-	if (!point)
+	if (!point || !dir)
 	{
 		return qfalse;
 	}

--- a/src/game/g_combat.c
+++ b/src/game/g_combat.c
@@ -976,12 +976,18 @@ gentity_t *G_BuildLeg(gentity_t *ent, grefEntity_t *refent, qboolean newRefent)
  * @param[in] newRefent
  * @return
  */
-qboolean IsHeadShot(gentity_t *targ, vec3_t dir, vec3_t point, meansOfDeath_t mod, grefEntity_t *refent, qboolean newRefent)
+qboolean IsHeadShot(gentity_t *targ, const vec3_t dir, const vec3_t point, meansOfDeath_t mod, grefEntity_t *refent, qboolean newRefent)
 {
 	gentity_t *head;
 	trace_t   tr;
 	vec3_t    start, end;
 	gentity_t *traceEnt;
+
+	// can happen if et.G_Damage lua is called with a MOD that is an actual weapon
+	if (!point)
+	{
+		return qfalse;
+	}
 
 	// not a player or critter so bail
 	if (!(targ->client))
@@ -1052,9 +1058,15 @@ qboolean IsHeadShot(gentity_t *targ, vec3_t dir, vec3_t point, meansOfDeath_t mo
  * @param[in] newRefent
  * @return
  */
-qboolean IsLegShot(gentity_t *targ, vec3_t dir, vec3_t point, meansOfDeath_t mod, grefEntity_t *refent, qboolean newRefent)
+qboolean IsLegShot(gentity_t *targ, const vec3_t dir, const vec3_t point, meansOfDeath_t mod, grefEntity_t *refent, qboolean newRefent)
 {
 	gentity_t *leg;
+
+	// can happen if et.G_Damage lua is called with a MOD that is an actual weapon
+	if (!point)
+	{
+		return qfalse;
+	}
 
 	if (!(targ->client))
 	{
@@ -1141,10 +1153,16 @@ qboolean IsLegShot(gentity_t *targ, vec3_t dir, vec3_t point, meansOfDeath_t mod
  * @param[in] mod
  * @return
  */
-qboolean IsArmShot(gentity_t *targ, gentity_t *ent, vec3_t point, meansOfDeath_t mod)
+qboolean IsArmShot(gentity_t *targ, gentity_t *ent, const vec3_t point, meansOfDeath_t mod)
 {
 	vec3_t path, view;
 	vec_t  dot;
+
+	// can happen if et.G_Damage lua is called with a MOD that is an actual weapon
+	if (!point)
+	{
+		return qfalse;
+	}
 
 	if (!(targ->client))
 	{


### PR DESCRIPTION
Hit region detection gets a nullptr vector when this happens, which crashes the server.

fixes #2749 