### PR TITLE
cgame: turn off "Force colors" popup message flag for default Shoutcaster HUD

### DIFF
--- a/etmain/ui/huds.hud
+++ b/etmain/ui/huds.hud
@@ -1102,7 +1102,7 @@
 						"w":	422,
 						"h":	96
 					},
-					"style":	352,
+					"style":	96,
 					"anchor":	3,
 					"parent":	{
 						"anchor":	8,


### PR DESCRIPTION
It should be disabled because in competitive games teams usually have colorful tags that distinguish players in teams. On top of that changing forced colors is unintuitive from user perspective and the colors are not set in this HUD which makes popups just gray.