### PR TITLE
etmain: Fix 3P proned zooming binoc anim

### DIFF
--- a/etmain/animations/scripts/human_base.script
+++ b/etmain/animations/scripts/human_base.script
@@ -1564,13 +1564,13 @@ STATE COMBAT
 		{
 			legs prone_legs torso prone_mg_idle
 		}
-		weapons binoculars
-		{
-			legs prone_legs torso e_prone_binocs_idle
-		}
 		weapons binoculars, gen_bitflag zooming
 		{
 			legs prone_legs torso e_prone_binocs_lie
+		}
+		weapons binoculars
+		{
+			legs prone_legs torso e_prone_binocs_idle
 		}
 		weapons smokeGrenade
 		{


### PR DESCRIPTION
Evaluation order of 'idleprone' was messed up for binocs, such that the animation for actually holding the binocs to your eyes was never played when proned.