### PR TITLE
server: add possibility to watch tv_84 demos on client (listen server), refs #229

### DIFF
--- a/src/null/null_client.c
+++ b/src/null/null_client.c
@@ -86,12 +86,21 @@ void CL_CharEvent(int key)
 {
 }
 
+extern void SV_CL_Disconnect(void);
+extern void SV_CL_FlushMemory(void);
+
 /**
  * @brief CL_Disconnect
  * @param showMainMenu - unused
  */
 void CL_Disconnect(qboolean showMainMenu)
 {
+	SV_CL_Disconnect();
+}
+
+void CL_FlushMemory(void)
+{
+	SV_CL_FlushMemory();
 }
 
 /**

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -712,7 +712,6 @@ qboolean SV_Netchan_Process(client_t *client, msg_t *msg);
 
 #define MAX_PARSE_ENTITIES  2048
 
-#ifdef DEDICATED
 
 #define SV_CL_MAXPACKETS 40
 
@@ -976,6 +975,7 @@ void SV_CL_AddReliableCommand(const char *cmd);
 void SV_CL_WritePacket(void);
 qboolean SV_CL_ReadyToSendPacket(void);
 void SV_CL_ClearState(void);
+void SV_CL_FlushMemory(void);
 void SV_CL_DownloadsComplete(void);
 void SV_CL_SendPureChecksums(int serverId);
 void SV_CL_InitTVGame(void);
@@ -993,9 +993,11 @@ void SV_CL_ServerInfoPacket(const netadr_t *from, msg_t *msg);
 void SV_CL_DisconnectPacket(const netadr_t *from);
 
 // sv_cl_net_chan.c
+#ifdef DEDICATED
 void SV_CL_Netchan_Transmit(netchan_t *chan, msg_t *msg);
 void SV_CL_Netchan_TransmitNextFragment(netchan_t *chan);
 qboolean SV_CL_Netchan_Process(netchan_t *chan, msg_t *msg);
+#endif
 
 // sv_cl_parse.c
 void SV_CL_ParseServerMessage(msg_t *msg, int headerBytes);
@@ -1018,13 +1020,14 @@ void SV_CL_ParseGamestateQueue(msg_t *msg);
 void SV_CL_DemoInit(void);
 void SV_CL_Record(const char *name);
 void SV_CL_StopRecord_f(void);
+void SV_CL_PlayDemo_f(void);
+void SV_CL_FastForward_f(void);
 void SV_CL_WriteDemoMessage(msg_t *msg, int headerBytes);
 void SV_CL_ReadDemoMessage(void);
 void SV_CL_DemoCompleted(void);
 void SV_CL_DemoCleanUp(void);
 void SV_CL_NextDemo(void);
 
-#endif // DEDICATED
 
 //============================================================
 

--- a/src/server/sv_ccmds.c
+++ b/src/server/sv_ccmds.c
@@ -267,12 +267,10 @@ static void SV_MapRestart_f(void)
 		return;
 	}
 
-#ifdef DEDICATED
 	if (svclc.demo.playing)
 	{
 		svclc.demo.fastForwardTime = 0;
 	}
-#endif // DEDICATED
 
 	if (Cmd_Argc() > 1)
 	{
@@ -753,9 +751,7 @@ void SV_AddOperatorCommands(void)
 	Cmd_AddCommand("killserver", SV_KillServer_f, "Kills the server.");
 	Cmd_AddCommand("cleartempbans", SV_TempBanClear_f, "Clears the temporary ban list.");
 
-#ifdef DEDICATED
 	Cmd_AddCommand("tv", SV_CL_Commands_f, "tv commands.");
-#endif
 
 	if (com_dedicated->integer)
 	{
@@ -774,7 +770,7 @@ void SV_AddOperatorCommands(void)
 
 #ifdef DEDICATED
 	SV_CL_DemoInit();
-#endif
+#endif // DEDICATED
 }
 
 /**

--- a/src/server/sv_cl_demo.c
+++ b/src/server/sv_cl_demo.c
@@ -34,8 +34,6 @@
 
 #include "server.h"
 
-#ifdef DEDICATED
-
 /**
   * @brief Dumps the current net message, prefixed by the length
   * @param[in] msg
@@ -272,6 +270,7 @@ void SV_CL_NextDemo(void)
 	Com_Printf("SV_CL_NextDemo: %s\n", v);
 	if (!v[0])
 	{
+		Cvar_SetValue("sv_killserver", 1);
 		return;
 	}
 
@@ -385,7 +384,7 @@ void SV_CL_FastForward_f(void)
 {
 	int time;
 
-	if (Cmd_Argc() != 2)
+	if (Cmd_Argc() != 2 && Cmd_Argc() != 3)
 	{
 		Com_Printf("ff <seconds>\n");
 		return;
@@ -411,7 +410,7 @@ void SV_CL_PlayDemo_f(void)
 	char *demoFile;
 	int  nextDemoNo;
 
-	if (Cmd_Argc() != 2)
+	if (Cmd_Argc() != 2 && Cmd_Argc() != 3)
 	{
 		Com_Printf("demo <demoname>\n");
 		return;
@@ -462,6 +461,8 @@ void SV_CL_PlayDemo_f(void)
 
 	sv.time = svcl.serverTime;
 }
+
+#ifdef DEDICATED
 
 /**
  * @brief SV_CL_CompleteDemoName

--- a/src/server/sv_cl_main.c
+++ b/src/server/sv_cl_main.c
@@ -711,7 +711,7 @@ rescan:
 		// propagate disconnect message to chained tv server(s) and their client(s)
 		if (Cmd_Argc() >= 2)
 		{
-			SV_Shutdown(Cmd_Argv(1));
+			SV_Shutdown(va("Server Disconnected - %s", Cmd_Argv(1)));
 		}
 		else
 		{

--- a/src/server/sv_cl_main.c
+++ b/src/server/sv_cl_main.c
@@ -139,7 +139,7 @@ void SV_CL_Commands_f(void)
 
 	if (argc < 2)
 	{
-		Com_Printf("usage: tv <connect|disconnect> [-4|-6] server masterpassword privatepassword\n");
+		Com_Printf("usage: tv <connect|disconnect>\n");
 		return;
 	}
 
@@ -153,11 +153,35 @@ void SV_CL_Commands_f(void)
 	{
 		SV_CL_Disconnect();
 	}
-	else
+}
+#else
+/**
+* @brief SV_CL_Commands_f
+*/
+void SV_CL_Commands_f(void)
+{
+	char *cmd;
+	int  argc = Cmd_Argc();
+
+	if (argc < 2)
 	{
-		Com_Printf("usage: tv <connect|disconnect> [-4|-6] server masterpassword privatepassword\n");
+		Com_Printf("usage: tv <demo|ff>\n");
+		return;
+	}
+
+	cmd = Cmd_Argv(1);
+
+	if (!Q_stricmp(cmd, "demo"))
+	{
+		SV_CL_PlayDemo_f();
+	}
+	else if (!Q_stricmp(cmd, "ff"))
+	{
+		SV_CL_FastForward_f();
 	}
 }
+
+#endif // DEDICATED
 
 #define RETRANSMIT_TIMEOUT  3000
 
@@ -390,6 +414,7 @@ qboolean SV_CL_ReadyToSendPacket(void)
  */
 void SV_CL_WritePacket(void)
 {
+#ifdef DEDICATED
 	msg_t     buf;
 	byte      data[MAX_MSGLEN];
 	int       i;
@@ -473,6 +498,7 @@ void SV_CL_WritePacket(void)
 	{
 		SV_CL_Netchan_TransmitNextFragment(&svclc.netchan);
 	}
+#endif
 }
 
 /**
@@ -681,9 +707,18 @@ rescan:
 
 	if (!strcmp(cmd, "disconnect"))
 	{
-		// allow server to indicate why they were disconnected
-		Cbuf_AddText("tv disconnect\n");
-		return qtrue;
+		// this is a bit hacky solution (same code invoked twice) to properly
+		// propagate disconnect message to chained tv server(s) and their client(s)
+		if (Cmd_Argc() >= 2)
+		{
+			SV_Shutdown(Cmd_Argv(1));
+		}
+		else
+		{
+			SV_Shutdown("Server disconnected");
+		}
+
+		Com_Error(ERR_SERVERDISCONNECT, "Server disconnected");
 	}
 
 	if (!strcmp(cmd, "bcs0"))
@@ -801,7 +836,7 @@ void SV_CL_DownloadsComplete(void)
 	// this will also (re)load the UI
 	// if this is a local client then only the client part of the hunk
 	// will be cleared, note that this is done after the hunk mark has been set
-	CL_FlushMemory();
+	SV_CL_FlushMemory();
 
 	SV_CL_InitTVGame();
 
@@ -1247,6 +1282,8 @@ void SV_CL_ConnectionlessPacket(const netadr_t *from, msg_t *msg)
 	Com_DPrintf("Unknown connectionless packet command.\n");
 }
 
+#ifdef  DEDICATED
+
 /**
  * @brief A packet has arrived from the main event loop
  *
@@ -1333,12 +1370,12 @@ void CL_PacketEvent(const netadr_t *from, msg_t *msg)
 	}
 }
 
+#endif //  DEDICATED
+
 /**
- * @brief Called by CL_MapLoading, CL_Connect_f, CL_PlayDemo_f, and CL_ParseGamestate the only
- * ways a client gets into a game
- * Also called by Com_Error
+ * @brief SV_CL_FlushMemory
  */
-void CL_FlushMemory(void)
+void SV_CL_FlushMemory(void)
 {
 	if (svclc.demo.recording)
 	{
@@ -1596,5 +1633,3 @@ void SV_CL_Frame(int frameMsec)
 	// check user info buffer thingy
 	SV_CheckClientUserinfoTimer();
 }
-
-#endif // DEDICATED

--- a/src/server/sv_cl_parse.c
+++ b/src/server/sv_cl_parse.c
@@ -34,9 +34,7 @@
 
 #include "server.h"
 
-#ifdef DEDICATED
-
-const char *svc_strings[32] =
+const char *sv_cl_strings[32] =
 {
 	"svc_bad",
 
@@ -1077,19 +1075,19 @@ void SV_CL_ParseServerMessage(msg_t *msg, int headerBytes)
 
 		if (sv_etltv_shownet->integer >= 2)
 		{
-			if (cmd < 0 || cmd > svc_ettv_currentstate) // MSG_ReadByte might return -1 and we can't access our svc_strings array ...
+			if (cmd < 0 || cmd > svc_ettv_currentstate) // MSG_ReadByte might return -1 and we can't access our sv_cl_strings array ...
 			{
 				Com_Printf("%3i:BAD BYTE %i\n", msg->readcount - 1, cmd); // -> ERR_DROP
 			}
 			else
 			{
-				if (!svc_strings[cmd])
+				if (!sv_cl_strings[cmd])
 				{
 					Com_Printf("%3i:BAD CMD %i\n", msg->readcount - 1, cmd);
 				}
 				else
 				{
-					SV_CL_SHOWNET(msg, svc_strings[cmd]);
+					SV_CL_SHOWNET(msg, sv_cl_strings[cmd]);
 				}
 			}
 		}
@@ -1370,5 +1368,3 @@ void SV_CL_ParseServerMessageIntoQueue(msg_t *msg, int headerBytes)
 
 	SV_CL_CopyMsg(&currentMessage->msg, msg, lastReadCount, lastReadBit);
 }
-
-#endif // DEDICATED

--- a/src/server/sv_client.c
+++ b/src/server/sv_client.c
@@ -598,9 +598,7 @@ gotnewcl:
 	*newcl    = temp;
 	clientNum = newcl - svs.clients;
 
-#ifdef DEDICATED
 	if (!svcls.isTVGame)
-#endif // DEDICATED
 	{
 		newcl->gentity            = SV_GentityNum(clientNum);
 		newcl->gentity->r.svFlags = 0; // clear client flags on new connection.
@@ -679,12 +677,10 @@ gotnewcl:
 	{
 		int clients = sv_maxclients->integer;
 
-#ifdef DEDICATED
 		if (svcls.isTVGame)
 		{
 			clients = MAX_CLIENTS;
 		}
-#endif // DEDICATED
 
 		newcl->ettvClientFrame = Com_Allocate(sizeof(ettvClientSnapshot_t *) * PACKET_BACKUP);
 
@@ -917,13 +913,11 @@ void SV_SendClientGameState(client_t *client)
 
 	MSG_WriteByte(&msg, svc_EOF);
 
-#ifdef DEDICATED
 	if (svcls.isTVGame)
 	{
 		MSG_WriteLong(&msg, svclc.clientNum);
 	}
 	else
-#endif // DEDICATED
 	{
 		MSG_WriteLong(&msg, client - svs.clients);
 	}

--- a/src/server/sv_client.c
+++ b/src/server/sv_client.c
@@ -209,6 +209,13 @@ static qboolean SV_IsValidUserinfo(const netadr_t *from, const char *userinfo)
 			return qfalse;
 		}
 
+		if (!com_dedicated->integer)
+		{
+			NET_OutOfBandPrint(NS_SERVER, from, "print\n[err_dialog]Master must be a dedicated server.\n");
+			Com_DPrintf("    rejected ettv slave connection from %s because server is not dedicated.\n", NET_AdrToString(from));
+			return qfalse;
+		}
+
 		if (sv_etltv_maxslaves->integer <= 0)
 		{
 			NET_OutOfBandPrint(NS_SERVER, from, "print\n[err_dialog]Master must reserve slots with sv_etltv_maxslaves.\n");

--- a/src/server/sv_game.c
+++ b/src/server/sv_game.c
@@ -133,13 +133,11 @@ void SV_GameSendServerCommand(int clientNum, const char *text)
 		SV_DemoWriteGameCommand(clientNum, text);
 	}
 
-#ifdef DEDICATED
 	if (clientNum == -2)
 	{
 		SV_CL_AddReliableCommand(text);
 		return;
 	}
-#endif // DEDICATED
 
 	if (clientNum == -1)
 	{
@@ -699,11 +697,7 @@ intptr_t SV_GameSystemCalls(intptr_t *args)
 		return SV_BinaryMessageStatus(args[1]);
 
 	case G_ETLTV_GETPLAYERSTATE:
-#ifdef DEDICATED
 		return SV_CL_GetPlayerstate(args[1], VMA(2));
-#else
-		return 0;
-#endif // DEDICATED
 
 	case G_DEMOSUPPORT:
 		SV_DemoSupport(VMA(1));
@@ -739,9 +733,7 @@ void SV_ShutdownGameProgs(void)
 	VM_Free(gvm);
 	gvm = NULL;
 
-#ifdef DEDICATED
 	svcls.isTVGame = qfalse;
-#endif // DEDICATED
 }
 
 /**
@@ -803,7 +795,6 @@ void SV_InitGameProgs(void)
 	sv.num_tagheaders = 0;
 	sv.num_tags       = 0;
 
-#ifdef DEDICATED
 	// load the dll
 	if (svcls.state >= CA_AUTHORIZING)
 	{
@@ -811,7 +802,6 @@ void SV_InitGameProgs(void)
 		svcls.isTVGame = gvm != NULL;
 	}
 	else
-#endif // DEDICATED
 	{
 		gvm = VM_Create("qagame", qfalse, SV_GameSystemCalls, VMI_NATIVE);
 	}

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -98,13 +98,11 @@ void SV_SetConfigstring(int index, const char *val)
 	sv.configstrings[index]         = CopyString(val);
 	sv.configstringsmodified[index] = qtrue;
 
-#ifdef DEDICATED
 	if (svcls.isTVGame && svcls.state != CA_LOADING &&
 	    (index == CS_SERVERINFO || index == CS_WOLFINFO))
 	{
 		SV_CL_ConfigstringInfoChanged(index);
 	}
-#endif // DEDICATED
 
 	// save config strings to demo
 	if (sv.demoState == DS_RECORDING)
@@ -308,7 +306,6 @@ void SV_CreateBaseline(void)
 	sharedEntity_t *svent;
 	int            entnum;
 
-#ifdef DEDICATED
 	if (svcls.isTVGame)
 	{
 		for (entnum = 0; entnum < MAX_GENTITIES; entnum++)
@@ -323,7 +320,6 @@ void SV_CreateBaseline(void)
 			}
 		}
 	}
-#endif // DEDICATED
 
 	for (entnum = 1; entnum < sv.num_entities ; entnum++)
 	{
@@ -357,10 +353,8 @@ void SV_BoundMaxClients(int minimum)
 		Cvar_Set("sv_maxclients", va("%i", minimum));
 	}
 	else if (sv_maxclients->integer > MAX_CLIENTS
-#ifdef DEDICATED
 	         // no limit for etltv slave server
 	         && svcls.state <= CA_DISCONNECTED
-#endif // DEDICATED
 	         )
 	{
 		Cvar_Set("sv_maxclients", va("%i", MAX_CLIENTS));
@@ -872,9 +866,7 @@ void SV_SpawnServer(const char *server)
 
 					client        = &svs.clients[i];
 					client->state = CS_ACTIVE;
-#ifdef DEDICATED
 					if (!svcls.isTVGame)
-#endif // DEDICATED
 					{
 						ent             = SV_GentityNum(i);
 						ent->s.number   = i;
@@ -1312,12 +1304,10 @@ void SV_Shutdown(const char *finalmsg)
 		return;
 	}
 
-#ifdef DEDICATED
 	if (!svclc.demo.playing)
 	{
 		SV_CL_Disconnect();
 	}
-#endif
 
 #if defined(FEATURE_IRC_SERVER) && defined(DEDICATED)
 	Cmd_RemoveCommand("irc_connect");

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -38,15 +38,13 @@
 #include "sv_tracker.h"
 #endif
 
-serverStatic_t svs;                   // persistant server info
-server_t       sv;                    // local server
-#ifdef DEDICATED
+serverStatic_t       svs;             // persistant server info
+server_t             sv;              // local server
 svclientActive_t     svcl;
 svclientConnection_t svclc;
 svclientStatic_t     svcls;
 serverMessageQueue_t *svMsgQueueHead, *svMsgQueueTail;
-#endif // DEDICATED
-vm_t *gvm = NULL;                     // game virtual machine
+vm_t                 *gvm = NULL;     // game virtual machine
 
 cvar_t *sv_fps = NULL;          // time rate for running non-clients
 cvar_t *sv_timeout;             // seconds without any message
@@ -1596,12 +1594,10 @@ static qboolean SV_CheckPaused(void)
  */
 int SV_FrameMsec()
 {
-#ifdef DEDICATED
 	if (svcls.isTVGame)
 	{
 		return 8;
 	}
-#endif // DEDICATED
 
 	if (sv_fps)
 	{
@@ -1732,9 +1728,7 @@ void SV_Frame(int msec)
 	start           = Sys_Milliseconds();
 	svs.stats.idle += ( double )(start - end) / 1000;
 
-#ifdef DEDICATED
 	svcls.realtime += msec;
-#endif // DEDICATED
 
 	// the menu kills the server with this cvar
 	if (sv_killserver->integer)
@@ -1821,13 +1815,11 @@ void SV_Frame(int msec)
 		return;
 	}
 
-#ifdef DEDICATED
 	if (svcls.isTVGame)
 	{
 		SV_CL_Frame(frameMsec);
 	}
 	else
-#endif // DEDICATED
 	{
 		SV_Frame_Ext(frameMsec);
 	}

--- a/src/server/sv_world.c
+++ b/src/server/sv_world.c
@@ -231,18 +231,14 @@ void SV_LinkEntity(sharedEntity_t *gEnt)
 
 	ent = SV_SvEntityForGentity(gEnt);
 
-#ifdef DEDICATED
 	if (svcls.isTVGame && gEnt->s.solid == SOLID_BMODEL)
 	{
 		gEnt->r.bmodel = qtrue;
 	}
-#endif // DEDICATED
 
 	// sanity check for possible currentOrigin being reset bug
 	if (!gEnt->r.bmodel && vec3_compare(gEnt->r.currentOrigin, vec3_origin)
-#ifdef DEDICATED
 	    && !svcls.isTVGame
-#endif // DEDICATED
 	    )
 	{
 		// I've seen this warning a lot - let map makers know which entity is affected.


### PR DESCRIPTION
- add tv demo <demoname> console command (client only) to play demo
- add tv ff <seconds> console command (client only) to fast-forward demo by <seconds>
- still cannot connect listen server as tv server although a lot of the tv server code is now compiled into client (too lazy to add DEDICATED guards and splitting a lot of the places with them is not something I like). This is also very unlikely to ever change because by design the connected tv server should be a spectator and preferably never move too.
- connecting tv server to a listen server is not recommended (looks buggy), other clients should be fine
- fix tv server(s) and their client(s) not properly disconnecting when master server shuts down (imported ettv bug)
- fix improper server shutdown on demo end if there are no more demos to play next (imported ettv bug)

refs #229