### PR TITLE
mod: fix scores cmd not showing all strings if guid starts with number, refs #2768, #2681, #229

### DIFF
--- a/src/cgame/cg_servercmds.c
+++ b/src/cgame/cg_servercmds.c
@@ -2912,7 +2912,7 @@ static void CG_scores_cmd(void)
 
 	// if this is start of cmd reset the counter
 	// in case a player requested scores again before receiving end marker
-	if (Q_atoi(str))
+	if (Q_ParseInt(str, &i))
 	{
 		cgs.scoresCount = 0;
 		return;

--- a/src/qcommon/q_shared.c
+++ b/src/qcommon/q_shared.c
@@ -3145,3 +3145,17 @@ float Q_IntToFloat(int32_t i)
 	fi.i = i;
 	return fi.f;
 }
+
+/**
+ * @brief Q_ParseInt Parse string to int and check if the string was numeric
+ * @param[in] src String to parse
+ * @param[in,out] out Parsed int
+ * @return qtrue if the src string is numeric
+ */
+qboolean Q_ParseInt(const char *src, int *out)
+{
+	char *end;
+
+	*out = (int)strtol(src, &end, 10);
+	return !*end;
+}

--- a/src/qcommon/q_shared.h
+++ b/src/qcommon/q_shared.h
@@ -1606,8 +1606,8 @@ typedef struct entityState_s
 	int otherEntityNum2;
 
 	int groundEntityNum;    ///< ENTITYNUM_NONE when in air - otherwise the
-							///entity number of the entity it is atop, also see
-							///ENTITYNUM_WORLD
+	                        ///entity number of the entity it is atop, also see
+	                        ///ENTITYNUM_WORLD
 
 	int constantLight;      ///< r + (g<<8) + (b<<16) + (intensity<<24)
 	int dl_intensity;       ///< used for coronas
@@ -2089,6 +2089,7 @@ int ExtractInt(const char *src);
 
 int32_t Q_FloatToInt(float f);
 float Q_IntToFloat(int32_t i);
+qboolean Q_ParseInt(const char *src, int *out);
 
 #define PASSFLOAT(f) Q_FloatToInt((f))
 

--- a/src/tvgame/tvg_cmds.c
+++ b/src/tvgame/tvg_cmds.c
@@ -1466,9 +1466,8 @@ static void TVG_ClientCommandPassThrough(char *cmd)
 	{
 		int count;
 		token = strtok(NULL, " ");
-		count = Q_atoi(token);
 
-		if (count)
+		if (Q_ParseInt(token, &count))
 		{
 			level.cmds.scoresIndex = 0;
 			level.cmds.scoresCount = count < MAX_SCORES_CMDS ? count : MAX_SCORES_CMDS;


### PR DESCRIPTION
refs #2768, #2681, #229