### PR TITLE
qcommon: fix potential buffer overflow in Com_Printf

### DIFF
--- a/src/qcommon/common.c
+++ b/src/qcommon/common.c
@@ -249,7 +249,7 @@ void QDECL Com_Printf(const char *fmt, ...)
 	msg = buffer + Com_sprintf(buffer, sizeof(buffer), "%8i ", timestamp);
 
 	va_start(argptr, fmt);
-	bufferEnd = msg + Q_vsnprintf(msg, sizeof(buffer), fmt, argptr);
+	bufferEnd = msg + Q_vsnprintf(msg, sizeof(buffer) - (msg - buffer), fmt, argptr);
 	va_end(argptr);
 
 	if (rd_buffer)


### PR DESCRIPTION
`Q_vsnprintf` was writing to buffer with the assumption that it had the entire buffer to itself, while in reality the message timestamp was already written to the buffer. Because of this, `msg` was not pointing to the start of the buffer, so writing a message with `MAX_PRINT_MSG` size would cause a buffer overflow.

refs #830 