### PR TITLE
etmain: Fix 3P attaching/detaching rifle grenades

### DIFF
--- a/etmain/animations/human/base/body.aninc
+++ b/etmain/animations/human/base/body.aninc
@@ -227,11 +227,11 @@
 		detach_silencer			4280	20	0	14	0	0	1	13
 
 		// GRENADE LAUNCER
-		reload_grenlauncher		4302	20	0	17	0	0	0	20  // also used for attaching
+		attach_grenlauncher		4303	19	0	9	0	0	0	20
 		stand_grenlauncher		4323	20	20	12	0	0	0	0
 		firing_grenlauncher		4344	5	0	20	0	0	0	15
 		raise_grenlauncher		4349	8	0	15	0	0	0	10
-		detach_grenlauncher		4302	20	0	17	0	0	1	13
+		detach_grenlauncher		4302	20	0	21	0	0	1	20
 
 		// MOBILE MG 42
 		stand_mobilemg42		4361	19	19	10	0	0	0	0

--- a/etmain/animations/scripts/human_base.script
+++ b/etmain/animations/scripts/human_base.script
@@ -2833,11 +2833,11 @@ reload
 	}
 	weapons gpg40
 	{
-		torso reload_grenlauncher
+		NOOP
 	}
 	weapons M7
 	{
-		torso reload_grenlauncher
+		NOOP
 	}
 	weapons m1 garand
 	{
@@ -3182,19 +3182,19 @@ do_alt_weapon_mode
 {
 	weapons K43 Rifle
 	{
-		torso reload_grenlauncher
+		torso attach_grenlauncher
 	}
 	weapons m1 garand
 	{
-		torso reload_grenlauncher
+		torso attach_grenlauncher
 	}
 	weapons gpg40
 	{
-		torso reload_grenlauncher
+		torso attach_grenlauncher
 	}
 	weapons M7
 	{
-		torso reload_grenlauncher
+		torso attach_grenlauncher
 	}
 	weapons Luger
 	{


### PR DESCRIPTION
- Fixes playing the attach animation twice (it was also referenced as reload, which would cause it to happen 2x in a row)

- Reframe attach/detach anim to smooth to consequent fire