### PR TITLE
etmain: Remove 3P 'climb_start' animation

### DIFF
--- a/etmain/animations/human/base/body.aninc
+++ b/etmain/animations/human/base/body.aninc
@@ -148,7 +148,7 @@
 
 		climb_up				2981	21	21	10	-1	0	0	8
 		climb_dis				3004	7	0	40	0	0	0	0
-		climb_start				2981	1	0	100	-1	1	0	8  // effectively disable
+		//climb_start				3035	46	0	20	0	0	0	8
 		climb_down				3082	28	28	12	-1	0	0	8
 
 		jump_1step_2h			3111	11	0	20	0	0	0	3

--- a/etmain/animations/scripts/human_base.script
+++ b/etmain/animations/scripts/human_base.script
@@ -3005,14 +3005,6 @@ jumpbk
 	}
 }
 
-climbmount
-{
-	default
-	{
-		both climb_start
-	}
-}
-
 climbdismount
 {
 	default


### PR DESCRIPTION
'climb_start' was "effectively disabled", yet forced a one frame animation transition that would cancel reload animations, circumventing the animation priority system.

Fixed by simply commenting out the animation altogether and removing it's 'climbmount' entry.