### PR TITLE
game: Don't play 'nopower' animation when proned

### DIFF
--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -3675,7 +3675,7 @@ static void PM_Weapon(void)
 			// check if there is enough charge to fire
 			if (pm->cmd.serverTime - pm->ps->classWeaponTime < chargeTime * coeff)
 			{
-				if ((pm->ps->weapon == WP_MEDKIT || pm->ps->weapon == WP_AMMO) && (pm->cmd.buttons & BUTTON_ATTACK))
+				if ((pm->ps->weapon == WP_MEDKIT || pm->ps->weapon == WP_AMMO) && (pm->cmd.buttons & BUTTON_ATTACK) && !(pm->ps->eFlags & EF_PRONE))
 				{
 					BG_AnimScriptEvent(pm->ps, pm->character->animModelInfo, ANIM_ET_NOPOWER, qtrue, qfalse);
 				}


### PR DESCRIPTION
When trying to throw a medpack without the required power while proned,
the torso would still play the 'e_no_juice' animation, which would make
the character deform into a snake of sorts.
