### PR TITLE
etmain: Reframe 1&3P Syringe

### DIFF
--- a/etmain/animations/human/base/body.aninc
+++ b/etmain/animations/human/base/body.aninc
@@ -174,7 +174,7 @@
 
 		//raise_binoculars		3525	10	0	20	0	0	0	10
 		firing_pliers			3540	19	19	20	0	50	0	20
-		firing_syringe			3565	20	0	20	0	0	0	20
+		firing_syringe			3570	15	0	60	0	0	0	20
 		raise_medpack			3590	10	0	20	0	0	0	10
 		stand_medpack			3605	30	30	20	0	0	0	0
 
@@ -307,6 +307,8 @@
 		prone_knife_switch		4662	10	0	18	0	0	0	10
 		prone_knife_attack		4689	10	0	25	0	0	0	20
 		prone_knife_idle		4672	1	0	20	0	0	0	0
+
+		prone_syringe_attack	4691	8	0	35	0	0	0	20
 
 		// Prone Death
 		prone_die1				4573    10	0	20	0	0	0	0

--- a/etmain/animations/scripts/human_base.script
+++ b/etmain/animations/scripts/human_base.script
@@ -1659,7 +1659,7 @@ EVENTS
 fireweapon
 {
 // ADRENALINE SYRINGE
-	weapons Adrenaline Syringe, movetype walk AND turnleft AND turnright AND idlecr AND idle AND crouching AND run AND swim AND backstep AND swimbk
+	weapons Adrenaline Syringe
 	{
 		torso self_inject
 	}
@@ -2195,9 +2195,13 @@ fireweaponprone
 	{
 		torso prone_poke_fire
 	}
-	weapons Syringe AND Adrenaline Syringe
+	weapons Syringe
 	{
-		torso prone_poke_fire
+		torso prone_syringe_attack
+	}
+	weapons Adrenaline Syringe
+	{
+		torso self_inject
 	}
 	weapons bazooka
 	{
@@ -2431,10 +2435,6 @@ reloadprone
 	{
 		torso prone_poke_switch
 	}
-	weapons Syringe AND Adrenaline Syringe
-	{
-		torso prone_poke_switch
-	}
 	weapons throwables AND throwables_underhand
 	{
 		torso prone_grenade_switch
@@ -2521,7 +2521,7 @@ raiseweapon
 	}
 	weapons Syringe AND Adrenaline Syringe
 	{
-		torso raise_knife
+		NOOP
 	}
 	weapons Ammo Pack
 	{

--- a/etmain/models/multiplayer/syringe/weapon.cfg
+++ b/etmain/models/multiplayer/syringe/weapon.cfg
@@ -18,19 +18,18 @@ newfmt
 //   /   /   /   /   /   /
 
 0	1	15	0	0	0	0	// IDLE1
-0	1	15	0	0	0	0	// IDLE2
+0	0	0	0	0	0	0	// IDLE2 notused
 
-1	13	15	0	0	0	0	// ATTACK1
-0	1	15	0	0	0	0	// ATTACK2
-1	13	15	0	0	0	0	// ATTACKLASTSHOT
+0	0	0	0	0	0	0	// ATTACK1 notused
+0	0	0	0	0	0	0	// ATTACK2 notused
+1	13	40	0	0	0	0	// ATTACK_LASTSHOT
 
-14	5	15	0	0	0	0	// DROP
-21	4	15	0	0	0	0	// RAISE
-0	1	15	0	0	0	0	// RELOAD1
-0	1	15	0	0	0	0	// RELOAD2
-0	1	15	0	0	0	0	// RELOAD3
+14	5	16	0	0	0	0	// DROP
+21	4	11	0	0	0	0	// RAISE
+0	0	0	0	0	0	0	// RELOAD1 notused
+0	0	0	0	0	0	0	// RELOAD2 notused
+0	0	0	0	0	0	0	// RELOAD3 notused
 
-0	1	15	0	0	0	0	// WEAP_ALTSWITCHFROM
-0	1	15	0	0	0	0	// WEAP_ALTSWITCHTO
-
-0	1	15	0	0	0	0	// WEAP_DROP2
+0	0	0	0	0	0	0	// ALTSWITCH notused
+0	0	0	0	0	0	0	// ALTSWITCH notused
+0	0	0	0	0	0	0	// DROP2 notused


### PR DESCRIPTION
Fit 1P 'ATTACK_LASTSHOT' / 3P 'firing_syringe' animation to gameplay hit check.

NOOP 3P 'raiseweapon', as drawing and firing syringe is too quick for both to play and it lerps unconsistently otherwise.

3P 'self_inject' already fits.