### PR TITLE
client: add cvar cl_interpolation, refs #1637

### DIFF
--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -130,6 +130,8 @@ cvar_t *cl_packetdelay;
 
 cvar_t *cl_consoleKeys;
 
+cvar_t *cl_interpolation;
+
 clientActive_t     cl;
 clientConnection_t clc;
 clientStatic_t     cls;
@@ -3358,6 +3360,10 @@ void CL_Init(void)
 
 	// ~ and `, as keys and characters
 	cl_consoleKeys = Cvar_Get("cl_consoleKeys", "~ ` 0x7e 0x60", CVAR_ARCHIVE);
+
+	cl_interpolation = Cvar_GetAndDescribe("cl_interpolation", "0", CVAR_ARCHIVE,
+	                                       "Buffering server packets to smooth over packetloss/ping instability.\nValues 0-4 depending on 'sv_fps' and 'snaps'.\nSet to 0 for most responsive gameplay.");
+	Cvar_CheckRange(cl_interpolation, 0, 4, qtrue);
 
 	Cvar_Get("cg_drawNotifyText", "1", CVAR_ARCHIVE);
 	Cvar_Get("cg_quickMessageAlt", "1", CVAR_ARCHIVE);

--- a/src/client/cl_parse.c
+++ b/src/client/cl_parse.c
@@ -581,6 +581,8 @@ void CL_ParseSnapshot(msg_t *msg)
 	}
 
 	cl.newSnapshots = qtrue;
+
+	CL_SetSnapshotLerp();
 }
 
 //=====================================================================

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -125,6 +125,7 @@ typedef struct
 	                                        ///< to disconnect, preventing debugging breaks from
 	                                        ///< causing immediate disconnects on continue
 	clSnapshot_t snap;                      ///< latest received from server
+	clSnapshot_t snapLerp;                  ///< snap interpolated from
 
 	int serverTime;                         ///< may be paused during play
 	int oldServerTime;                      ///< to prevent time from flowing bakcwards
@@ -517,6 +518,8 @@ extern cvar_t *cl_defaultProfile;
 
 extern cvar_t *cl_consoleKeys;
 
+extern cvar_t *cl_interpolation;
+
 extern cvar_t *con_scale;
 
 //=================================================
@@ -881,6 +884,7 @@ qboolean CL_GetSnapshot(int snapshotNumber, snapshot_t *snapshot);
 qboolean CL_GetServerCommand(int serverCommandNumber);
 int CL_FindIncrementThreshold(void);
 void CL_AdjustTimeDelta(void);
+void CL_SetSnapshotLerp(void);
 
 // cl_ui.c
 

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -897,7 +897,7 @@ typedef struct
 	qboolean legsPitching;
 } clientMarker_t;
 
-#define MAX_CLIENT_MARKERS 17
+#define MAX_CLIENT_MARKERS 40
 
 #define FIELDOPS_SPECIAL_PICKUP_MOD 3   ///< Number of times (minus one for modulo) field ops must drop ammo before scoring a point
 #define MEDIC_SPECIAL_PICKUP_MOD    4   ///< Same thing for medic


### PR DESCRIPTION
- increase MAX_CLIENT_MARKERS from 17 to 40 (antilag buffer, supports 400ms ping (from 170ms) on sv_fps 100)

Note about cl_interpolation:
Buffers server packets to smooth over packetloss/ping instability. Values 0-4 depending on 'sv_fps' and 'snaps' (scales off the smaller value of the two). Set to 0 for most responsive gameplay.

Similiar to other engines the cvar allows to change the intepolation amount to smoother out the gameplay at the cost of responsivnes. Interpolation in ET engine by default is tied to sv_fps/snaps, meaning at sv_fps 20 interpolation is locked to 50ms, at sv_fps 100 interpolation is locked to 10ms.

I believe this turned out to be a problem few years ago when I tried to push for sv_fps 100 as some players reported that everyone is laggy. While I didn't have any information past that my assumption was and is that interpolation is just too small. sv_fps 100 means that a client expects new snapshot every 10ms. If a player uses com_maxfps 125 (8 ms frametime) that means that it basically expects a new snapshot every frame which could be very unreliable when not in a LAN setting but over internet. 

cl_interpolation is meant to help with that, by buffering additional snapshot(s) before rendering them and extending the window where a delayed/missing snapshot becomes an issue. Because as far as I know noone ever played ET on sv_fps 10, the default max interpolation is still 50ms, meaning on sv_fps 20 the cvar has no effect. 

On sv_fps 40 only allowed values are 0 or 1, which means that at most one additional snapshot can be buffered, the result of that is it will feel as if playing on sv_fps 20 (in terms of noticing a respones for example a hitsound). 

sv_fps 100 supports values from 0 to 4, 4 would mean as if playing on sv_fps 20, value 1 would mean intepolation of 20ms so faster than sv_fps 40 by 5ms, while not much it could be good enough for people that internet connection would not allow for enjoyable experience on sv_fps 100 with default 10ms interpolation.

cl_interpolation 0 sv_fps 40 sv_packetloss 50: https://youtu.be/XfKe-RfBras
cl_interpolation 1 sv_fps 40 sv_packetloss 50: https://youtu.be/SAoQUwAHsiQ
cl_interpolation 0 sv_fps 100 sv_packetloss 50: https://youtu.be/Fc9CWcaHZpU
cl_interpolation 1 sv_fps 100 sv_packetloss 50: https://youtu.be/ndITp2PHjVs
cl_interpolation 4 sv_fps 100 sv_packetloss 50: https://youtu.be/qGXXIo6VgGA

refs #1637