### PR TITLE
etmain: Reframe 3P Panzerfaust & Bazooka

### DIFF
--- a/etmain/animations/human/base/body.aninc
+++ b/etmain/animations/human/base/body.aninc
@@ -167,10 +167,13 @@
 		//eng_hammer_firing		3380	13	13	15	0	0	0	20
 		//eng_construction		3395	11	11	15	0	0	0	0
 
-		raise_panzer			3420	13	0	20	0	0	0	10
+		raise_panzer			3425	8	0	20	0	0	0	10
 		stand_panzer			3434	31	31	20	0	0	0	0
-		firing_panzer			3469	17	17	20	0	0	0	20
+		firing_panzer			3470	16	0	22	0	0	0	20
 		//reload_panzer			3487	33	0	20	0	0	0	20
+
+		raise_bazooka			2243	10	0	20	0	0	0	10
+		firing_bazooka			2640	18	0	14	0	0	0	20
 
 		//raise_binoculars		3525	10	0	20	0	0	0	10
 		firing_pliers			3540	19	19	20	0	50	0	20

--- a/etmain/animations/scripts/human_base.script
+++ b/etmain/animations/scripts/human_base.script
@@ -1727,7 +1727,7 @@ fireweapon
 // BAZOOKA
 	weapons bazooka
 	{
-		torso stand_rifle
+		torso firing_bazooka
 	}
 // PANZERFAUST
 	weapons panzerfaust, movetype walk AND turnleft AND turnright AND idlecr AND idle
@@ -2545,7 +2545,7 @@ raiseweapon
 	}
 	weapons bazooka
 	{
-		torso raise_machinegun
+		torso raise_bazooka
 	}
 	weapons panzerfaust
 	{


### PR DESCRIPTION
- Add a missing firing animation for Bazooka (previously no knockback).

- Reframe both RAISE animations for PF and Bazooka to have less weapon clipping through the body and a smoother transition towards idle/fire.

- Shave off a delay for Panzerfaust firing before the kickback hits.

- Prone animations remain untouched.