### PR TITLE
cgame: Reset weapon smoke upon respawning

### DIFF
--- a/src/cgame/cg_playerstate.c
+++ b/src/cgame/cg_playerstate.c
@@ -155,8 +155,9 @@ void CG_Respawn(qboolean revived)
 	VectorClear(cg.predictedError);
 
 	// need to reset client-side weapon animations
-	cg.predictedPlayerState.weapAnim    = ((cg.predictedPlayerState.weapAnim & ANIM_TOGGLEBIT) ^ ANIM_TOGGLEBIT) | WEAP_IDLE1;      // reset weapon animations
-	cg.predictedPlayerState.weaponstate = WEAPON_READY; // hmm, set this?  what to?
+	cg.predictedPlayerState.weapAnim         = ((cg.predictedPlayerState.weapAnim & ANIM_TOGGLEBIT) ^ ANIM_TOGGLEBIT) | WEAP_IDLE1; // reset weapon animations
+	cg.predictedPlayerState.weaponstate      = WEAPON_READY; // hmm, set this?  what to?
+	cg.predictedPlayerEntity.muzzleFlashTime = 0;  // reset weapon smoke
 
 	// display weapons available
 	cg.weaponSelectTime = cg.time;


### PR DESCRIPTION
Currently 'muzzleFlashTime', which determines the time that smoke generated from the muzzle after firing any weapon will not reset via respawning.

Fixed by resetting it on respawn.