### PR TITLE
cgame: Fix MG42 bipod

### DIFF
--- a/src/cgame/cg_weapons.c
+++ b/src/cgame/cg_weapons.c
@@ -1822,7 +1822,7 @@ void CG_AddPlayerWeapon(refEntity_t *parent, playerState_t *ps, centity_t *cent)
 		else if (GetWeaponTableData(weaponNum)->type & WEAPON_TYPE_MG)
 		{
 			barrel.hModel = weapon->modModels[0];
-			barrel.frame  = GetWeaponTableData(weaponNum)->type & WEAPON_TYPE_SETTABLE;
+			barrel.frame = (GetWeaponTableData(weaponNum)->type & WEAPON_TYPE_SET) ? 0 : 1;
 			CG_PositionEntityOnTag(&barrel, &gun, "tag_bipod", 0, NULL);
 			CG_AddWeaponWithPowerups(&barrel, cent->currentState.powerups, ps, cent);
 		}


### PR DESCRIPTION
The MG42 bipod is currently broken and always appears expanded, when it ought to appear only when MG42 is deployed in prone.

This is fixed, which also addresses the following error line that would appear when wielding an MG42 in 3P:

R_AddMD3Surfaces: no such frame 0 to 4096 for 'models/multiplayer/mg42/mg42_3rd_bipod.md3' (2)