### PR TITLE
cgame: cap crosshair entity writing + reduce the array size

### DIFF
--- a/src/cgame/cg_ents.c
+++ b/src/cgame/cg_ents.c
@@ -371,6 +371,12 @@ static void CG_EntityEffects(centity_t *cent)
  */
 static void CG_AddEntToCrosshairScanList(centity_t *cent)
 {
+	if (cg.crosshairEntsToScanCount > MAX_ENTITIES_IN_SNAPSHOT - 1)
+	{
+		CG_Printf(S_COLOR_YELLOW "%s: max crosshair entities reached!\n", __FUNCTION__);
+		return;
+	}
+
 	cg.crosshairEntsToScan[cg.crosshairEntsToScanCount++] = cent;
 }
 

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1273,7 +1273,7 @@ typedef struct
 	int lastKillTime;
 
 	// crosshair
-	centity_t *crosshairEntsToScan[MAX_ENTITIES];
+	centity_t *crosshairEntsToScan[MAX_ENTITIES_IN_SNAPSHOT];
 	int crosshairEntsToScanCount;
 	int crosshairEntNum;
 	int crosshairEntTime;
@@ -4311,7 +4311,7 @@ typedef struct hudStructure_s
 	hudComponent_t hudhead;
 
 	hudComponent_t cursorhints;
-    hudComponent_t cursorhintsbar; // 20
+	hudComponent_t cursorhintsbar; // 20
 	hudComponent_t cursorhintstext;
 	hudComponent_t weaponstability;
 	hudComponent_t livesleft;
@@ -4324,7 +4324,7 @@ typedef struct hudStructure_s
 	hudComponent_t votetext;
 	hudComponent_t spectatortext;
 	hudComponent_t limbotext;   // 30
-	hudComponent_t followtext;  
+	hudComponent_t followtext;
 	hudComponent_t demotext;
 
 	hudComponent_t missilecamera;
@@ -4336,7 +4336,7 @@ typedef struct hudStructure_s
 	hudComponent_t snapshot;
 	hudComponent_t ping;
 	hudComponent_t speed;   // 40
-	hudComponent_t lagometer;       
+	hudComponent_t lagometer;
 	hudComponent_t disconnect;
 	hudComponent_t chat;
 	hudComponent_t spectatorstatus;
@@ -4346,7 +4346,7 @@ typedef struct hudStructure_s
 	hudComponent_t objectivetext;
 	hudComponent_t centerprint;
 	hudComponent_t banner;  // 50
-	hudComponent_t crosshair;       
+	hudComponent_t crosshair;
 	hudComponent_t crosshairtext;
 	hudComponent_t crosshairbar;
 	hudComponent_t stats;


### PR DESCRIPTION
Cap the adding of new entities since `[index++]` array write is always a bit scary, and halve the array size since there's never a valid scenario for more entities to be added than `MAX_ENTITIES_IN_SNAPSHOT`.

refs b8bbe8e888426c538ebe736ba9a764ee5f435cf8