### PR TITLE
cgame: fix crosshair health bar trace distance + minor tweaks

### DIFF
--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -2362,9 +2362,25 @@ void CG_DrawCrosshairNames(hudComponent_t *comp)
 			case ET_MISSILE:
 				if (comp->style & 2 && VectorDistance(cg.refdef_current->vieworg, es->origin) < 512)
 				{
-					s = va(CG_TranslateString("%s^*\'s %s"),
-					       CG_GetCrosshairNameString(comp, es->otherEntityNum),
-					       !Q_stricmp(BG_GetItem(GetWeaponTableData(es->weapon)->item)->classname, "weapon_dynamite") ? "Dynamite" : "Landmine");
+					const char *weaponText;
+
+					switch (es->weapon)
+					{
+					case WP_DYNAMITE:
+						weaponText = "Dynamite";
+						break;
+					case WP_LANDMINE:
+						weaponText = "Landmine";
+						break;
+					case WP_SATCHEL:
+						weaponText = "Satchel Charge";
+						break;
+					default:
+						weaponText = "Unknown weapon";
+						break;
+					}
+
+					s = va(CG_TranslateString("%s^*\'s %s"), CG_GetCrosshairNameString(comp, es->otherEntityNum), weaponText);
 				}
 				break;
 			default:

--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -1890,7 +1890,7 @@ static void CG_ScanForCrosshairEntity()
 		return;
 	}
 
-	VectorMA(cg.refdef.vieworg, 512, cg.refdef.viewaxis[0], end);
+	VectorMA(cg.refdef.vieworg, MAX_TRACE, cg.refdef.viewaxis[0], end);
 
 	CG_Trace(&trace, cg.refdef.vieworg, NULL, NULL, end, cg.snap->ps.clientNum, CONTENTS_SOLID | CONTENTS_BODY | CONTENTS_ITEM);
 
@@ -2346,10 +2346,12 @@ void CG_DrawCrosshairNames(hudComponent_t *comp)
 	{
 		if (cgs.clientinfo[cg.snap->ps.clientNum].team != TEAM_SPECTATOR || cgs.clientinfo[cg.clientNum].shoutcaster)
 		{
-			switch (cg_entities[cg.crosshairEntNum].currentState.eType)
+			entityState_t *es = &cg_entities[cg.crosshairEntNum].currentState;
+
+			switch (es->eType)
 			{
 			case ET_MOVER:
-				if (cg_entities[cg.crosshairEntNum].currentState.effect1Time)
+				if (es->effect1Time)
 				{
 					s = Info_ValueForKey(CG_ConfigString(CS_SCRIPT_MOVER_NAMES), va("%i", cg.crosshairEntNum));
 				}
@@ -2358,11 +2360,11 @@ void CG_DrawCrosshairNames(hudComponent_t *comp)
 				s = Info_ValueForKey(CG_ConfigString(CS_CONSTRUCTION_NAMES), va("%i", cg.crosshairEntNum));
 				break;
 			case ET_MISSILE:
-				if (comp->style & 2)
+				if (comp->style & 2 && VectorDistance(cg.refdef_current->vieworg, es->origin) < 512)
 				{
 					s = va(CG_TranslateString("%s^*\'s %s"),
-					       CG_GetCrosshairNameString(comp, cg_entities[cg.crosshairEntNum].currentState.otherEntityNum),
-					       BG_GetItem(GetWeaponTableData(cg_entities[cg.crosshairEntNum].currentState.weapon)->item)->pickup_name);
+					       CG_GetCrosshairNameString(comp, es->otherEntityNum),
+					       !Q_stricmp(BG_GetItem(GetWeaponTableData(es->weapon)->item)->classname, "weapon_dynamite") ? "Dynamite" : "Landmine");
 				}
 				break;
 			default:

--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -65,9 +65,9 @@ const hudComponentFields_t hudComponentFields[] =
 	{ HUDF(powerups),           CG_DrawPowerUps,                  0.19f,  { 0 } },
 	{ HUDF(objectives),         CG_DrawObjectiveStatus,           0.19f,  { 0 } },
 	{ HUDF(hudhead),            CG_DrawPlayerStatusHead,          0.19f,  { 0 } },
-	{ HUDF(cursorhints),        CG_DrawCursorhint,                0.19f,  { "Size Pulse",    "Strobe Pulse", "Alpha Pulse" } }, // FIXME: outside cg_draw_hud
+	{ HUDF(cursorhints),        CG_DrawCursorhint,                0.19f,  { "Size Pulse",    "Strobe Pulse", "Alpha Pulse" } },// FIXME: outside cg_draw_hud
 	{ HUDF(cursorhintsbar),     CG_DrawCursorHintBar,             0.19f,  { "Left",          "Center",       "Vertical",       "No Alpha", "Bar Bckgrnd", "X0 Y5", "X0 Y0", "Lerp Color", "Bar Border", "Border Tiny", "Decor", "Icon"} },  // FIXME: outside cg_draw_hud
-	{ HUDF(cursorhintstext),    CG_DrawCursorHintText,            0.19f,  { "Draw Suffix" } },  // FIXME: outside cg_draw_hud
+	{ HUDF(cursorhintstext),    CG_DrawCursorHintText,            0.19f,  { "Draw Suffix" } },// FIXME: outside cg_draw_hud
 	{ HUDF(weaponstability),    CG_DrawWeapStability,             0.19f,  { "Always",        "Left",         "Center",         "Vertical", "No Alpha", "Bar Bckgrnd", "X0 Y5", "X0 Y0", "Lerp Color", "Bar Border", "Border Tiny", "Decor", "Icon"} }, // FIXME: outside cg_draw_hud
 	{ HUDF(livesleft),          CG_DrawLivesLeft,                 0.19f,  { 0 } },
 	{ HUDF(roundtimer),         CG_DrawRoundTimer,                0.19f,  { "Simple" } },
@@ -97,7 +97,7 @@ const hudComponentFields_t hudComponentFields[] =
 	{ HUDF(objectivetext),      CG_DrawObjectiveInfo,             0.22f,  { 0 } },           // FIXME: outside cg_draw_hud
 	{ HUDF(centerprint),        CG_DrawCenterString,              0.22f,  { 0 } },           // FIXME: outside cg_draw_hud
 	{ HUDF(banner),             CG_DrawBannerPrint,               0.23f,  { 0 } },           // FIXME: outside cg_draw_hud
-	{ HUDF(crosshairtext),      CG_DrawCrosshairNames,            0.25f,  { "Full Color",    "Explosif Owner" } },// FIXME: outside cg_draw_hud
+	{ HUDF(crosshairtext),      CG_DrawCrosshairNames,            0.25f,  { "Full Color",    "Explosive Owner" } },// FIXME: outside cg_draw_hud
 	{ HUDF(crosshairbar),       CG_DrawCrosshairHealthBar,        0.25f,  { "Class",         "Rank",         "Prestige",       "Left", "Center", "Vertical", "No Alpha", "Bar Bckgrnd", "X0 Y5", "X0 Y0", "Lerp Color", "Bar Border", "Border Tiny", "Decor", "Icon", "Dynamic Color"} }, // FIXME: outside cg_draw_hud
 	{ HUDF(stats),              CG_DrawShoutcastPlayerStatus,     0.19f,  { 0 } },           // FIXME: outside cg_draw_hud
 	{ HUDF(xpgain),             CG_DrawPMItemsXPGain,             0.22f,  { "Scroll Down",   "No Reason" } },// FIXME: outside cg_draw_hud


### PR DESCRIPTION
* Restore `8192` as trace distance for crosshair entity scanning so teammate healthbars are drawn properly at long distances
* Don't draw landmine/dynamite crosshair text unless the entity is `< 512` from vieworg (old `g_misc 8/16` behavior)
* Don't use pickup name for drawing missile hint text, as the pickup text for dynamite is "Dynamite Weapon", rather check the weapon and just use an explicit string
* Fix grammar in HUD editor

refs b8bbe8e888426c538ebe736ba9a764ee5f435cf8