### PR TITLE
etmain: Tweak M1 Garand 1P RELOAD anim

### DIFF
--- a/etmain/models/multiplayer/m1_garand/weapon.cfg
+++ b/etmain/models/multiplayer/m1_garand/weapon.cfg
@@ -17,19 +17,19 @@ newfmt
 ///   /   /   /   /   /   ______________________________/
 //   /   /   /   /   /   /
 
-0	1	20	0	0	0	0	// IDLE1
-135	1	20	0	0	0	0	// IDLE2 (M7/RG)
+0	1	20		0	0	0	0	// IDLE1
+135	1	20		0	0	0	0	// IDLE2 (M7/RG)
 
-2	4	18	0	0	0	0	// ATTACK1
-76	9	24	0	0	0	0	// ATTACK2 (M7/RG)
-2	4	18	0	0	0	0	// ATTACK_LASTSHOT
+2	4	18		0	0	0	0	// ATTACK1
+76	9	24		0	0	0	0	// ATTACK2 (M7/RG)
+2	4	18		0	0	0	0	// ATTACK_LASTSHOT
 
-29	4	30	0	0	0	0	// DROP
-36	5	42	0	0	0	0	// RAISE
-46	20	12	0	0	0	0	// RELOAD1
-0	0	0	0	0	0	0	// RELOAD2 notused
-0	0	0	0	0	0	0	// RELOAD3 notused
+29	4	30		0	0	0	0	// DROP
+36	5	42		0	0	0	0	// RAISE
+45	20	12.4	0	0	0	0	// RELOAD1
+0	0	0		0	0	0	0	// RELOAD2 notused
+0	0	0		0	0	0	0	// RELOAD3 notused
 
-85	50	21	0	0	0	0	// ALTSWITCHFROM equipping grenade
-136	28	23	0	0	0	0	// ALTSWITCHTO   un-equipping grenade
-0	0	0	0	0	0	0	// DROP2 notused
+85	50	21		0	0	0	0	// ALTSWITCHFROM equipping grenade
+136	28	23		0	0	0	0	// ALTSWITCHTO   un-equipping grenade
+0	0	0		0	0	0	0	// DROP2 notused


### PR DESCRIPTION
Turns out that 'fps' is actually parsed via 'strtof', so we can finally float this to not have to make an always suboptimal choice between either trimming too much or leaving too much space at the end.