### PR TITLE
mod: fix satchel det adding unnecessary EV_NOAMMO events

### DIFF
--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -2878,7 +2878,7 @@ void PM_CheckForReload(weapon_t weapon)
 static void PM_SwitchIfEmpty(void)
 {
 	// weapon here are explosives or syringe/adrenaline, if they are not --> return
-	if (!(GetWeaponTableData(pm->ps->weapon)->firingMode & (WEAPON_FIRING_MODE_ONE_SHOT | WEAPON_FIRING_MODE_THROWABLE)))
+	if (!(GetWeaponTableData(pm->ps->weapon)->firingMode & (WEAPON_FIRING_MODE_ONE_SHOT | WEAPON_FIRING_MODE_THROWABLE)) || pm->ps->weapon == WP_SATCHEL_DET)
 	{
 		return;
 	}


### PR DESCRIPTION
The checks done here in vanilla would filter out satchel detonator, but the refactored weapon table stuff doesn't filter it out because satchel detonator has `firingMode WEAPON_FIRING_MODE_ONE_SHOT`.