### PR TITLE
cgame: Default to icons following heads when downed

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2804,6 +2804,7 @@ extern vmCvar_t pmove_msec;
 
 extern vmCvar_t cg_timescale;
 
+extern vmCvar_t cg_spritesFollowHeads;
 extern vmCvar_t cg_voiceSpriteTime;
 
 extern vmCvar_t cg_gameType;

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -207,6 +207,7 @@ vmCvar_t cg_messageType;
 
 vmCvar_t cg_timescale;
 
+vmCvar_t cg_spritesFollowHeads;
 vmCvar_t cg_voiceSpriteTime;
 
 vmCvar_t cg_drawNotifyText;
@@ -464,6 +465,7 @@ static cvarTable_t cvarTable[] =
 	{ &pmove_fixed,                 "pmove_fixed",                 "0",           CVAR_SYSTEMINFO,              0 },
 	{ &pmove_msec,                  "pmove_msec",                  "8",           CVAR_SYSTEMINFO,              0 },
 
+	{ &cg_spritesFollowHeads,       "cg_spritesFollowHeads",       "1",           CVAR_ARCHIVE,                 0 },
 	{ &cg_voiceSpriteTime,          "cg_voiceSpriteTime",          "6000",        CVAR_ARCHIVE,                 0 },
 
 	{ &cg_teamChatsOnly,            "cg_teamChatsOnly",            "0",           CVAR_ARCHIVE,                 0 },

--- a/src/cgame/cg_players.c
+++ b/src/cgame/cg_players.c
@@ -2001,24 +2001,35 @@ static void CG_PlayerFloatSprite(centity_t *cent, qhandle_t shader, int height, 
 	ent.origin[2] += vPos[off];
 	VectorMA(ent.origin, hPos[off], right, ent.origin) ;
 
-	// Account for ducking
-	// FIXME: adjust origin for others
-	if (cent->currentState.clientNum == cg.snap->ps.clientNum)
+	if ((cent->currentState.eFlags & EF_DEAD) && (cg_spritesFollowHeads.integer > 0))
 	{
-		if (cent->currentState.eFlags & EF_CROUCHING)
-		{
-			ent.origin[2] -= 18;
-		}
-		else if (cent->currentState.eFlags & EF_PRONE)
-		{
-			ent.origin[2] -= 45;
-		}
+		// "new-way" - trash any previously set Z coord and instead reset to a player's head
+		// as long as we're not dead
+		ent.origin[2] = cent->pe.headRefEnt.origin[2] + 20;
 	}
 	else
 	{
-		if (cent->currentState.animMovetype)
+		// "old-way" - use hardcoded Z coord dependent on player state
+
+		// Account for ducking
+		// FIXME: adjust origin for others
+		if (cent->currentState.clientNum == cg.snap->ps.clientNum)
 		{
-			ent.origin[2] -= 18;
+			if (cent->currentState.eFlags & EF_CROUCHING)
+			{
+				ent.origin[2] -= 18;
+			}
+			else if (cent->currentState.eFlags & EF_PRONE)
+			{
+				ent.origin[2] -= 45;
+			}
+		}
+		else
+		{
+			if (cent->currentState.animMovetype)
+			{
+				ent.origin[2] -= 18;
+			}
 		}
 	}
 


### PR DESCRIPTION
Adds a new CVAR 'cg_spritesFollowHeads' that defaults to 1, which makes player icons (revive icon etc.) to follow player heads when they are downed.

This prevents any death animation from blocking the revive icon and thereby to quicker determine if a fellow player has suicided/given-up or not.