### PR TITLE
game: Add 'g_debugEvents' to log server events

### DIFF
--- a/src/cgame/cg_event.c
+++ b/src/cgame/cg_event.c
@@ -2015,7 +2015,7 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 
 	if (cg_debugEvents.integer)
 	{
-		CG_Printf("time:%i ent:%3i  event:%3i ", cg.time, es->number, event);
+		CG_Printf("CEV: RECV time:%7i ent:%15i event:%3i eventParm:%3i ", cg.time, es->number, event, es->eventParm);
 
 		if (event < EV_NONE || event >= EV_MAX_EVENTS)
 		{
@@ -2023,7 +2023,7 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 		}
 		else
 		{
-			CG_Printf("%s\n", eventnames[event]);
+			Com_Printf("%s C(%d)\n", eventnames[event], (es->clientNum < 0 || es->clientNum >= MAX_CLIENTS) ? -1 : es->clientNum);
 		}
 	}
 

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -2233,6 +2233,7 @@ extern vmCvar_t g_stickyCharge;
 extern vmCvar_t g_xpSaver;
 
 extern vmCvar_t g_debugForSingleClient;
+extern vmCvar_t g_debugEvents;
 
 #define G_InactivityValue (g_inactivity.integer ? g_inactivity.integer : 60)
 #define G_SpectatorInactivityValue (g_spectatorInactivity.integer ? g_spectatorInactivity.integer : 60)

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -373,6 +373,7 @@ vmCvar_t g_stickyCharge;
 vmCvar_t g_xpSaver;
 
 vmCvar_t g_debugForSingleClient;
+vmCvar_t g_debugEvents;
 
 vmCvar_t g_suddenDeath;
 
@@ -661,6 +662,7 @@ cvarTable_t gameCvarTable[] =
 	{ &g_debugHitboxes,                   "g_debugHitboxes",                   "0",                          CVAR_CHEAT,                                      0, qfalse, qfalse },
 	{ &g_debugPlayerHitboxes,             "g_debugPlayerHitboxes",             "0",                          0,                                               0, qfalse, qfalse },     // no need to make this CVAR_CHEAT
 	{ &g_debugForSingleClient,            "g_debugForSingleClient",            "-1",                         0,                                               0, qfalse, qfalse },     // no need to make this CVAR_CHEAT
+	{ &g_debugEvents,                     "g_debugevents",                     "0",                         0,                                               0, qfalse, qfalse },
 
 	{ &g_corpses,                         "g_corpses",                         "0",                          CVAR_LATCH | CVAR_ARCHIVE,                       0, qfalse, qfalse },
 	{ &g_realHead,                        "g_realHead",                        "1",                          0,                                               0, qfalse, qfalse },

--- a/src/game/g_utils.c
+++ b/src/game/g_utils.c
@@ -1036,6 +1036,27 @@ gentity_t *G_PopupMessage(popupMessageType_t type)
 
 //==============================================================================
 
+static void G_debugPrintEvent(gentity_t *ent, int event, int eventParm)
+{
+	// try to warn when an event got dropped
+	// TODO : add 'ent->s.oldEventSequence' so we can do the same for 'ent->s' ?
+	if (ent->client && (ent->client->ps.eventSequence >= (ent->client->ps.oldEventSequence + 3)))
+	{
+		Com_Printf("SEV: ^1DROP ^7time:%7i ent:%15p\n", level.time, ent);
+	}
+
+	Com_Printf("SEV: ADD  time:%7i ent:%15p event:%3i eventParm:%3i ", level.time, ent, event, eventParm);
+
+	if (event < EV_NONE || event >= EV_MAX_EVENTS)
+	{
+		Com_Printf("UNKNOWN\n");
+	}
+	else
+	{
+		Com_Printf("%s C(%d)\n", eventnames[event], (!ent->client) ? -1 : ent->client->ps.clientNum);
+	}
+}
+
 /**
  * @brief Use for non-pmove events that would also be predicted on the
  * client side: jumppads and item pickups
@@ -1050,6 +1071,10 @@ void G_AddPredictableEvent(gentity_t *ent, int event, int eventParm)
 	if (!ent->client)
 	{
 		return;
+	}
+	if (g_debugEvents.integer > 0)
+	{
+		G_debugPrintEvent(ent, event, eventParm);
 	}
 	BG_AddPredictableEventToPlayerstate(event, eventParm, &ent->client->ps);
 }
@@ -1068,6 +1093,10 @@ void G_AddEvent(gentity_t *ent, int event, int eventParm)
 		return;
 	}
 
+	if (g_debugEvents.integer > 0)
+	{
+		G_debugPrintEvent(ent, event, eventParm);
+	}
 	// use the sequential event list
 	if (ent->client)
 	{


### PR DESCRIPTION
There's currently 'cg_debugEvents' to log client events. This commit adds a new CVAR 'g_debugEvents' to also log some server events.