### PR TITLE
cgame: allow missile camera in demo playback

### DIFF
--- a/src/cgame/cg_ents.c
+++ b/src/cgame/cg_ents.c
@@ -1432,7 +1432,7 @@ static void CG_Missile(centity_t *cent)
 		}
 	}
 
-	if ((cgs.sv_cheats || !cg.demoPlayback) && cent->currentState.clientNum == cg.predictedPlayerState.clientNum)
+	if ((cgs.sv_cheats || cg.demoPlayback) && cent->currentState.clientNum == cg.predictedPlayerState.clientNum)
 	{
 		if (cent->currentState.pos.trType != TR_STATIONARY)
 		{

--- a/src/cgame/cg_ents.c
+++ b/src/cgame/cg_ents.c
@@ -1432,7 +1432,7 @@ static void CG_Missile(centity_t *cent)
 		}
 	}
 
-	if (cgs.sv_cheats && cent->currentState.clientNum == cg.predictedPlayerState.clientNum)
+	if ((cgs.sv_cheats || !cg.demoPlayback) && cent->currentState.clientNum == cg.predictedPlayerState.clientNum)
 	{
 		if (cent->currentState.pos.trType != TR_STATIONARY)
 		{


### PR DESCRIPTION
useful for reviewing demos after game or making videos