### PR TITLE
client: add possibility to pause sounds, refs #760

### DIFF
--- a/src/cgame/cg_event.c
+++ b/src/cgame/cg_event.c
@@ -2271,11 +2271,11 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 		// IS_VALID_WEAPON(es->weapon) ?
 		if (BG_IsSkillAvailable(cgs.clientinfo[clientNum].skill, SK_LIGHT_WEAPONS, SK_LIGHT_WEAPONS_FASTER_RELOAD) && (GetWeaponTableData(es->weapon)->attributes & WEAPON_ATTRIBUT_FAST_RELOAD) && cg_weapons[es->weapon].reloadFastSound)
 		{
-			trap_S_StartSound(NULL, es->number, CHAN_WEAPON, cg_weapons[es->weapon].reloadFastSound);
+			trap_S_StartSoundEx(NULL, es->number, CHAN_WEAPON, cg_weapons[es->weapon].reloadFastSound, SND_PAUSABLE);
 		}
 		else if (cg_weapons[es->weapon].reloadSound)
 		{
-			trap_S_StartSound(NULL, es->number, CHAN_WEAPON, cg_weapons[es->weapon].reloadSound);     // following sherman's SP fix, should allow killing reload sound when player dies
+			trap_S_StartSoundEx(NULL, es->number, CHAN_WEAPON, cg_weapons[es->weapon].reloadSound, SND_PAUSABLE);     // following sherman's SP fix, should allow killing reload sound when player dies
 		}
 		break;
 	case EV_MG42_FIXED:

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -3798,10 +3798,12 @@ qboolean trap_GetValue(char *value, int valueSize, const char *key);
 void trap_SysFlashWindow(int state);
 void trap_CommandComplete(const char *value);
 void trap_CmdBackup_Ext(void);
+void trap_MatchPaused(qboolean matchPaused);
 extern int dll_com_trapGetValue;
 extern int dll_trap_SysFlashWindow;
 extern int dll_trap_CommandComplete;
 extern int dll_trap_CmdBackup_Ext;
+extern int dll_trap_MatchPaused;
 
 bg_playerclass_t *CG_PlayerClassForClientinfo(clientInfo_t *ci, centity_t *cent);
 

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -47,6 +47,7 @@ int dll_com_trapGetValue;
 int dll_trap_SysFlashWindow;
 int dll_trap_CommandComplete;
 int dll_trap_CmdBackup_Ext;
+int dll_trap_MatchPaused;
 
 /**
  * @brief This is the only way control passes into the module.
@@ -2736,6 +2737,7 @@ static ID_INLINE void CG_SetupExtensions(void)
 		CG_SetupExtensionTrap(value, MAX_CVAR_VALUE_STRING, &dll_trap_SysFlashWindow, "trap_SysFlashWindow_Legacy");
 		CG_SetupExtensionTrap(value, MAX_CVAR_VALUE_STRING, &dll_trap_CommandComplete, "trap_CommandComplete_Legacy");
 		CG_SetupExtensionTrap(value, MAX_CVAR_VALUE_STRING, &dll_trap_CmdBackup_Ext, "trap_CmdBackup_Ext_Legacy");
+		CG_SetupExtensionTrap(value, MAX_CVAR_VALUE_STRING, &dll_trap_MatchPaused, "trap_MatchPaused_Legacy");
 	}
 }
 

--- a/src/cgame/cg_public.h
+++ b/src/cgame/cg_public.h
@@ -288,6 +288,7 @@ typedef enum
 	CG_COMMAND_COMPLETE,
 
 	CG_CMDBACKUP_EXT,
+	CG_MATCHPAUSED,
 
 } cgameImport_t;
 

--- a/src/cgame/cg_servercmds.c
+++ b/src/cgame/cg_servercmds.c
@@ -613,6 +613,8 @@ void CG_ParseServerToggles(void)
 	value = Q_atoi(info);
 
 	cgs.matchPaused = (value & CV_SVS_PAUSE) ? qtrue : qfalse;
+
+	trap_MatchPaused(cgs.matchPaused);
 }
 
 /**

--- a/src/cgame/cg_syscalls.c
+++ b/src/cgame/cg_syscalls.c
@@ -1972,3 +1972,14 @@ void trap_CmdBackup_Ext(void)
 		cg.cmdMask   = CMD_MASK;
 	}
 }
+
+/**
+ * @brief Extension for letting engine know if match is paused
+ */
+void trap_MatchPaused(qboolean matchPaused)
+{
+	if (dll_trap_MatchPaused)
+	{
+		SystemCall(dll_trap_MatchPaused, matchPaused);
+	}
+}

--- a/src/client/cl_cgame.c
+++ b/src/client/cl_cgame.c
@@ -1126,7 +1126,7 @@ intptr_t CL_CgameSystemCalls(intptr_t *args)
 		cl.cmdMask   = CMD_MASK_ETL;
 		return 0;
 	case CG_MATCHPAUSED:
-		S_SoundsPause(args[1]);
+		S_PauseSounds(args[1]);
 		return 0;
 
 	default:

--- a/src/client/cl_cgame.c
+++ b/src/client/cl_cgame.c
@@ -45,6 +45,7 @@ static ext_trap_keys_t cg_extensionTraps[] =
 	{ "trap_SysFlashWindow_Legacy",  CG_SYS_FLASH_WINDOW, qfalse },
 	{ "trap_CommandComplete_Legacy", CG_COMMAND_COMPLETE, qfalse },
 	{ "trap_CmdBackup_Ext_Legacy",   CG_CMDBACKUP_EXT,    qfalse },
+	{ "trap_MatchPaused_Legacy",     CG_MATCHPAUSED,      qfalse },
 	{ NULL,                          -1,                  qfalse }
 };
 
@@ -1123,6 +1124,9 @@ intptr_t CL_CgameSystemCalls(intptr_t *args)
 	case CG_CMDBACKUP_EXT:
 		cl.cmdBackup = CMD_BACKUP_ETL;
 		cl.cmdMask   = CMD_MASK_ETL;
+		return 0;
+	case CG_MATCHPAUSED:
+		S_SoundsPause(args[1]);
 		return 0;
 
 	default:

--- a/src/client/snd_dma.c
+++ b/src/client/snd_dma.c
@@ -1515,6 +1515,10 @@ static qboolean S_ScanChannelStarts(void)
 			ch->startSample = s_paintedtime - ch->pauseOffset;
 			continue;
 		}
+		else
+		{
+			ch->pauseOffset = -1;
+		}
 
 		// if it is completely finished by now, clear it
 		if (ch->startSample + (ch->thesfx->soundLength) <= s_paintedtime)

--- a/src/client/snd_dma.c
+++ b/src/client/snd_dma.c
@@ -91,7 +91,6 @@ cvar_t *s_show;
 cvar_t *s_mixahead;
 cvar_t *s_mixOffset;
 cvar_t *s_debugStreams;
-cvar_t *s_debugPause;
 
 static loopSound_t loopSounds[MAX_LOOP_SOUNDS];
 static vec3_t      entityPositions[MAX_GENTITIES];

--- a/src/client/snd_dma.c
+++ b/src/client/snd_dma.c
@@ -2376,7 +2376,6 @@ qboolean S_Base_Init(soundInterface_t *si)
 	s_show         = Cvar_Get("s_show", "0", CVAR_CHEAT);
 	s_testsound    = Cvar_Get("s_testsound", "0", CVAR_CHEAT);
 	s_debugStreams = Cvar_Get("s_debugStreams", "0", CVAR_TEMP);
-	s_debugPause   = Cvar_Get("s_debugPause", "0", CVAR_CHEAT);
 
 	r = SNDDMA_Init();
 

--- a/src/client/snd_dma.c
+++ b/src/client/snd_dma.c
@@ -59,7 +59,7 @@ int       numLoopChannels;
 
 static int      s_soundStarted;
 static qboolean s_soundMuted;
-static qboolean s_soundsPause;
+static qboolean s_soundsPaused;
 
 // sound fading
 static float    s_volStart, s_volTarget;
@@ -1472,9 +1472,9 @@ void S_Base_Respatialize(int entnum, const vec3_t head, vec3_t axis[3], int inwa
  * @brief S_SoundsPaused
  * @return qtrue if sounds should be paused
  */
-static qboolean S_SoundsPaused(void)
+static ID_INLINE qboolean S_SoundsPaused(void)
 {
-	return (s_soundsPause || s_debugPause->integer);
+	return (s_soundsPaused || s_debugPause->integer);
 }
 
 /**
@@ -2290,12 +2290,12 @@ int S_Base_GetCurrentSoundTime(void)
 }
 
 /**
- * @brief S_Base_SoundsPause For sound pausing
+ * @brief S_Base_PauseSounds For sounds pausing
  * @param[in] pause
  */
-void S_Base_SoundsPause(qboolean pause)
+void S_Base_PauseSounds(qboolean pause)
 {
-	s_soundsPause = pause;
+	s_soundsPaused = pause;
 }
 
 /**
@@ -2428,7 +2428,7 @@ qboolean S_Base_Init(soundInterface_t *si)
 	si->GetVoiceAmplitude     = S_Base_GetVoiceAmplitude;
 	si->GetSoundLength        = S_Base_GetSoundLength;
 	si->GetCurrentSoundTime   = S_Base_GetCurrentSoundTime;
-	si->SoundsPause           = S_Base_SoundsPause;
+	si->PauseSounds           = S_Base_PauseSounds;
 
 #ifdef USE_VOIP
 	si->StartCapture            = S_Base_StartCapture;

--- a/src/client/snd_local.h
+++ b/src/client/snd_local.h
@@ -218,7 +218,7 @@ typedef struct
 	int (*GetVoiceAmplitude)(int entityNum);
 	int (*GetSoundLength)(sfxHandle_t sfxHandle);
 	int (*GetCurrentSoundTime)(void);
-	void (*SoundsPause)(qboolean pause);
+	void (*PauseSounds)(qboolean pause);
 #ifdef USE_VOIP
 	void (*StartCapture)(void);
 	int (*AvailableCaptureSamples)(void);

--- a/src/client/snd_local.h
+++ b/src/client/snd_local.h
@@ -296,6 +296,7 @@ extern cvar_t *s_volume;
 extern cvar_t *s_musicVolume;
 extern cvar_t *s_muted;
 extern cvar_t *s_doppler;
+extern cvar_t *s_debugPause;
 
 extern cvar_t *s_testsound;
 extern cvar_t *s_debugStreams;

--- a/src/client/snd_local.h
+++ b/src/client/snd_local.h
@@ -162,6 +162,9 @@ typedef struct
 	sfx_t *thesfx;              ///< sfx structure
 	qboolean doppler;
 	int flags;
+
+	qboolean paused;            ///< is the sound paused
+	int pauseOffset;            ///< length of played sound untill paused, for calculating new startSample
 } channel_t;
 
 #define WAV_FORMAT_PCM      1
@@ -215,6 +218,7 @@ typedef struct
 	int (*GetVoiceAmplitude)(int entityNum);
 	int (*GetSoundLength)(sfxHandle_t sfxHandle);
 	int (*GetCurrentSoundTime)(void);
+	void (*SoundsPause)(qboolean pause);
 #ifdef USE_VOIP
 	void (*StartCapture)(void);
 	int (*AvailableCaptureSamples)(void);

--- a/src/client/snd_main.c
+++ b/src/client/snd_main.c
@@ -44,6 +44,7 @@ cvar_t *s_doppler;
 cvar_t *s_backend;
 cvar_t *s_muteWhenMinimized;
 cvar_t *s_muteWhenUnfocused;
+cvar_t *s_debugPause;
 
 static soundInterface_t si;
 

--- a/src/client/snd_main.c
+++ b/src/client/snd_main.c
@@ -837,7 +837,7 @@ void S_Init(void)
 	s_backend           = Cvar_Get("s_backend", "", CVAR_ROM);
 	s_muteWhenMinimized = Cvar_Get("s_muteWhenMinimized", "1", CVAR_ARCHIVE);
 	s_muteWhenUnfocused = Cvar_Get("s_muteWhenUnfocused", "0", CVAR_ARCHIVE);
-	s_debugPause        = Cvar_Get("s_debugPause", "0", CVAR_ARCHIVE);
+	s_debugPause        = Cvar_Get("s_debugPause", "0", CVAR_CHEAT);
 
 	Cvar_CheckRange(s_volume, 0.0f, 1.0f, qfalse);
 	Cvar_CheckRange(s_musicVolume, 0.0f, 1.0f, qfalse);

--- a/src/client/snd_main.c
+++ b/src/client/snd_main.c
@@ -170,6 +170,10 @@ static qboolean S_ValidSoundInterface(soundInterface_t *si)
 	{
 		return qfalse;
 	}
+	if (!si->SoundsPause)
+	{
+		return qfalse;
+	}
 #ifdef USE_VOIP
 	if (!si->StartCapture)
 	{
@@ -604,6 +608,18 @@ int S_GetCurrentSoundTime(void)
 	else
 	{
 		return 0;
+	}
+}
+
+/**
+ * @brief S_SoundsPause Let sound system know to pause sounds
+ * @param[in] pause
+ */
+void S_SoundsPause(qboolean pause)
+{
+	if (si.SoundsPause)
+	{
+		si.SoundsPause(pause);
 	}
 }
 

--- a/src/client/snd_main.c
+++ b/src/client/snd_main.c
@@ -837,6 +837,7 @@ void S_Init(void)
 	s_backend           = Cvar_Get("s_backend", "", CVAR_ROM);
 	s_muteWhenMinimized = Cvar_Get("s_muteWhenMinimized", "1", CVAR_ARCHIVE);
 	s_muteWhenUnfocused = Cvar_Get("s_muteWhenUnfocused", "0", CVAR_ARCHIVE);
+	s_debugPause        = Cvar_Get("s_debugPause", "0", CVAR_ARCHIVE);
 
 	Cvar_CheckRange(s_volume, 0.0f, 1.0f, qfalse);
 	Cvar_CheckRange(s_musicVolume, 0.0f, 1.0f, qfalse);

--- a/src/client/snd_main.c
+++ b/src/client/snd_main.c
@@ -170,7 +170,7 @@ static qboolean S_ValidSoundInterface(soundInterface_t *si)
 	{
 		return qfalse;
 	}
-	if (!si->SoundsPause)
+	if (!si->PauseSounds)
 	{
 		return qfalse;
 	}
@@ -612,14 +612,14 @@ int S_GetCurrentSoundTime(void)
 }
 
 /**
- * @brief S_SoundsPause Let sound system know to pause sounds
+ * @brief S_PauseSounds Let sound system know to pause sounds
  * @param[in] pause
  */
-void S_SoundsPause(qboolean pause)
+void S_PauseSounds(qboolean pause)
 {
-	if (si.SoundsPause)
+	if (si.PauseSounds)
 	{
-		si.SoundsPause(pause);
+		si.PauseSounds(pause);
 	}
 }
 

--- a/src/client/snd_mix.c
+++ b/src/client/snd_mix.c
@@ -367,9 +367,9 @@ static void S_PaintChannelFrom16_altivec(channel_t *ch, const sfx_t *sc, int cou
 				vector signed int    merge0, merge1;
 				vector signed int    d0, d1, d2, d3;
 				vector unsigned char samplePermute0 =
-				    VECCONST_UINT8(0, 1, 4, 5, 0, 1, 4, 5, 2, 3, 6, 7, 2, 3, 6, 7);
+					VECCONST_UINT8(0, 1, 4, 5, 0, 1, 4, 5, 2, 3, 6, 7, 2, 3, 6, 7);
 				vector unsigned char samplePermute1 =
-				    VECCONST_UINT8(8, 9, 12, 13, 8, 9, 12, 13, 10, 11, 14, 15, 10, 11, 14, 15);
+					VECCONST_UINT8(8, 9, 12, 13, 8, 9, 12, 13, 10, 11, 14, 15, 10, 11, 14, 15);
 				vector unsigned char loadPermute0, loadPermute1;
 
 				// Rather than permute the vectors after we load them to do the sample
@@ -846,7 +846,7 @@ void S_PaintChannels(int endtime)
 		ch = s_channels;
 		for (i = 0; i < MAX_CHANNELS ; i++, ch++)
 		{
-			if (!ch->thesfx || (!ch->leftvol && !ch->rightvol))
+			if (!ch->thesfx || (!ch->leftvol && !ch->rightvol) || ch->paused)
 			{
 				continue;
 			}

--- a/src/client/snd_openal.c
+++ b/src/client/snd_openal.c
@@ -231,6 +231,15 @@ int S_AL_GetCurrentSoundTime(void)
 }
 
 /**
+ * @brief S_AL_SoundsPause For sound pausing
+ * @param[in] pause
+ */
+void S_AL_SoundsPause(qboolean pause)
+{
+
+}
+
+/**
  * @brief Find a free handle
  * @return
  */
@@ -3585,6 +3594,7 @@ qboolean S_AL_Init(soundInterface_t *si)
 	si->GetVoiceAmplitude     = S_AL_GetVoiceAmplitude;
 	si->GetSoundLength        = S_AL_GetSoundLength;
 	si->GetCurrentSoundTime   = S_AL_GetCurrentSoundTime;
+	si->SoundsPause           = S_AL_SoundsPause;
 
 #ifdef USE_VOIP
 	si->StartCapture            = S_AL_StartCapture;

--- a/src/client/snd_openal.c
+++ b/src/client/snd_openal.c
@@ -56,8 +56,6 @@ cvar_t *s_alDevice;
 cvar_t *s_alAvailableDevices;
 //cvar_t *s_alAvailableInputDevices;
 
-cvar_t *s_debugPause;
-
 static qboolean enumeration_ext     = qfalse;
 static qboolean enumeration_all_ext = qfalse;
 

--- a/src/client/snd_openal.c
+++ b/src/client/snd_openal.c
@@ -231,10 +231,10 @@ int S_AL_GetCurrentSoundTime(void)
 }
 
 /**
- * @brief S_AL_SoundsPause For sound pausing
+ * @brief S_AL_PauseSounds For sound pausing
  * @param[in] pause
  */
-void S_AL_SoundsPause(qboolean pause)
+void S_AL_PauseSounds(qboolean pause)
 {
 
 }
@@ -3594,7 +3594,7 @@ qboolean S_AL_Init(soundInterface_t *si)
 	si->GetVoiceAmplitude     = S_AL_GetVoiceAmplitude;
 	si->GetSoundLength        = S_AL_GetSoundLength;
 	si->GetCurrentSoundTime   = S_AL_GetCurrentSoundTime;
-	si->SoundsPause           = S_AL_SoundsPause;
+	si->PauseSounds           = S_AL_PauseSounds;
 
 #ifdef USE_VOIP
 	si->StartCapture            = S_AL_StartCapture;

--- a/src/client/snd_public.h
+++ b/src/client/snd_public.h
@@ -100,6 +100,8 @@ int S_GetVoiceAmplitude(int entNum);
 int S_GetSoundLength(sfxHandle_t sfxHandle);
 int S_GetCurrentSoundTime(void);
 
+void S_SoundsPause(qboolean matchPaused);
+
 #ifdef USE_VOIP
 void S_StartCapture(void);
 int S_AvailableCaptureSamples(void);

--- a/src/client/snd_public.h
+++ b/src/client/snd_public.h
@@ -100,7 +100,7 @@ int S_GetVoiceAmplitude(int entNum);
 int S_GetSoundLength(sfxHandle_t sfxHandle);
 int S_GetCurrentSoundTime(void);
 
-void S_SoundsPause(qboolean matchPaused);
+void S_SoundsPause(qboolean pause);
 
 #ifdef USE_VOIP
 void S_StartCapture(void);

--- a/src/client/snd_public.h
+++ b/src/client/snd_public.h
@@ -100,7 +100,7 @@ int S_GetVoiceAmplitude(int entNum);
 int S_GetSoundLength(sfxHandle_t sfxHandle);
 int S_GetCurrentSoundTime(void);
 
-void S_SoundsPause(qboolean pause);
+void S_PauseSounds(qboolean pause);
 
 #ifdef USE_VOIP
 void S_StartCapture(void);

--- a/src/qcommon/q_shared.h
+++ b/src/qcommon/q_shared.h
@@ -401,12 +401,13 @@ typedef int clipHandle_t;
 #define EXPAND(x) x
 
 //#define   SND_NORMAL          0x000   ///< (default) Allow sound to be cut off only by the same sound on this channel
-#define     SND_OKTOCUT         0x001   ///< Allow sound to be cut off by any following sounds on this channel
-#define     SND_REQUESTCUT      0x002   ///< Allow sound to be cut off by following sounds on this channel only for sounds who request cutoff
-#define     SND_CUTOFF          0x004   ///< Cut off sounds on this channel that are marked 'SND_REQUESTCUT'
-#define     SND_CUTOFF_ALL      0x008   ///< Cut off all sounds on this channel
-#define     SND_NOCUT           0x010   ///< Don't cut off.  Always let finish (overridden by SND_CUTOFF_ALL)
-#define     SND_NO_ATTENUATION  0x020   ///< don't attenuate (even though the sound is in voice channel, for example)
+#define     SND_OKTOCUT         BIT(0)   ///< Allow sound to be cut off by any following sounds on this channel
+#define     SND_REQUESTCUT      BIT(1)   ///< Allow sound to be cut off by following sounds on this channel only for sounds who request cutoff
+#define     SND_CUTOFF          BIT(2)   ///< Cut off sounds on this channel that are marked 'SND_REQUESTCUT'
+#define     SND_CUTOFF_ALL      BIT(3)   ///< Cut off all sounds on this channel
+#define     SND_NOCUT           BIT(4)   ///< Don't cut off.  Always let finish (overridden by SND_CUTOFF_ALL)
+#define     SND_NO_ATTENUATION  BIT(5)   ///< don't attenuate (even though the sound is in voice channel, for example)
+#define     SND_PAUSABLE        BIT(6)   ///< Allow sound to be paused
 
 #ifndef NULL
 #define NULL ((void *)0)


### PR DESCRIPTION
- add engine extension `CG_MATCHPAUSED` to let engine know when match is paused
- add `PauseSounds` function to `soundInterface_t` which is called on `CG_MATCHPAUSED`
- add reload sound as pausable sound (maybe more in the future)
- add cvar `s_debugPause` (`CVAR_CHEAT`) for easier debugging

Note:
Adding pausable sounds is possible during the time when sounds are paused, which makes them play only after they are unpaused. This could be changed in cgame to not allow adding such sounds (by for example removing the flag before starting the sound), right now the developer needs to be aware of it and not add them. Looping sounds and some other sounds not supported because some engine calls don't support setting sound flags.

https://www.youtube.com/watch?v=h8TwN6dwN6A

refs #760