### PR TITLE
cgame: Tweak Sten/MP34

### DIFF
--- a/src/cgame/cg_weapons.c
+++ b/src/cgame/cg_weapons.c
@@ -2061,7 +2061,11 @@ void CG_AddPlayerWeapon(refEntity_t *parent, playerState_t *ps, centity_t *cent)
 		{
 			if (cg_muzzleFlash.integer && cg.time - cent->firedTime < 100)
 			{
-				CG_ParticleImpactSmokePuffExtended(cgs.media.smokeParticleShader, flash.origin, 500, 8, 20, 30, 0.25f, 8.f);
+				if (ps) {
+					CG_ParticleImpactSmokePuffExtended(cgs.media.smokeParticleShader, flash.origin, 500, 8, 20, 30, 0.13f, 7.f);
+				} else {
+					CG_ParticleImpactSmokePuffExtended(cgs.media.smokeParticleShader, flash.origin, 500, 8, 20, 30, 0.11f, 5.f);
+				}
 			}
 		}
 	}
@@ -5445,7 +5449,10 @@ void CG_Bullet(int weapon, vec3_t end, int sourceEntityNum, int targetEntityNum)
 				}
 				else        // (not flesh)
 				{
-					CG_DrawBulletTracer(start, end, sourceEntityNum);
+					if (weapon != WP_STEN && weapon != WP_MP34)
+					{
+						CG_DrawBulletTracer(start, end, sourceEntityNum);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
- Sten/MP34 now do not produce bullet tracers

  This gives them a unique characteristic and buffs them by not automatically giving away the player's position.

  (This matters especially in smoke bomb fights, where now neither their muzzle smoke nor their shots give away any information about a player's position on the other side of a smoke bomb).

- Slightly reduce muzzle smoke (size and transparency) upon firing.