### PR TITLE
cgame: Add 'cg_muzzleFlash 2' for hiding 1P only

### DIFF
--- a/src/cgame/cg_weapons.c
+++ b/src/cgame/cg_weapons.c
@@ -1389,7 +1389,10 @@ void CG_AddPlayerWeapon(refEntity_t *parent, playerState_t *ps, centity_t *cent)
 			VectorCopy(cg_entities[cg_entities[cent->currentState.number].tagParent].mountedMG42Flash.origin, flash.origin);
 			AxisCopy(cg_entities[cg_entities[cent->currentState.number].tagParent].mountedMG42Flash.axis, flash.axis);
 
-			trap_R_AddRefEntityToScene(&flash);
+			if (!(cg_muzzleFlash.integer == 2 && ps && isFirstPerson))
+			{
+				trap_R_AddRefEntityToScene(&flash);
+			}
 
 			// add dynamic light
 			trap_R_AddLightToScene(flash.origin, 320, 1.25f + (rand() & 31) / 128.0f, 1.0f, 0.6f, 0.23f, 0, 0);
@@ -1402,7 +1405,10 @@ void CG_AddPlayerWeapon(refEntity_t *parent, playerState_t *ps, centity_t *cent)
 	{
 		if (cg_muzzleFlash.integer && cg.time - cent->firedTime < MUZZLE_FLASH_TIME)
 		{
-			CG_MG42EFX(cent);
+			if (!(cg_muzzleFlash.integer == 2 && ps && isFirstPerson))
+			{
+				CG_MG42EFX(cent);
+			}
 		}
 		return;
 	}
@@ -1503,7 +1509,7 @@ void CG_AddPlayerWeapon(refEntity_t *parent, playerState_t *ps, centity_t *cent)
 		// rotate
 		AxisToAngles(gun.axis, angles);
 
-		angles[YAW] += 270;
+		angles[YAW]   += 270;
 		angles[PITCH] -= 20;
 
 		// translate
@@ -2046,12 +2052,15 @@ void CG_AddPlayerWeapon(refEntity_t *parent, playerState_t *ps, centity_t *cent)
 				const int smoketime = (weaponNum == WP_BAZOOKA) ? 1910 : 1000;
 				if (cg_muzzleFlash.integer && cg.time - cent->firedTime < smoketime)
 				{
-					if (!(rand() % 5))
+					if (!(cg_muzzleFlash.integer == 2 && ps && isFirstPerson))
 					{
-						float alpha = 1.0f - ((float)(cg.time - cent->firedTime) / (float)smoketime);     // what fraction of smoketime are we at
+						if (!(rand() % 5))
+						{
+							float alpha = 1.0f - ((float)(cg.time - cent->firedTime) / (float)smoketime); // what fraction of smoketime are we at
 
-						alpha *= 0.25f;     // .25 max alpha
-						CG_ParticleImpactSmokePuffExtended(cgs.media.smokeParticleShader, flash.origin, 1000, 8, 20, 30, alpha, 8.f);
+							alpha *= 0.25f; // .25 max alpha
+							CG_ParticleImpactSmokePuffExtended(cgs.media.smokeParticleShader, flash.origin, 1000, 8, 20, 30, alpha, 8.f);
+						}
 					}
 				}
 			}
@@ -2061,7 +2070,10 @@ void CG_AddPlayerWeapon(refEntity_t *parent, playerState_t *ps, centity_t *cent)
 		{
 			if (ps && !cg.renderingThirdPerson && cg_muzzleFlash.integer && cg.time - cent->firedTime < 800)
 			{
-				CG_ParticleImpactSmokePuffExtended(cgs.media.smokeParticleShader, flash.origin, 700, 16, 20, 30, .12f, 4.f);
+				if (!(cg_muzzleFlash.integer == 2 && ps && isFirstPerson))
+				{
+					CG_ParticleImpactSmokePuffExtended(cgs.media.smokeParticleShader, flash.origin, 700, 16, 20, 30, .12f, 4.f);
+				}
 			}
 		}
 
@@ -2083,10 +2095,16 @@ void CG_AddPlayerWeapon(refEntity_t *parent, playerState_t *ps, centity_t *cent)
 		{
 			if (cg_muzzleFlash.integer && cg.time - cent->firedTime < 100)
 			{
-				if (ps) {
-					CG_ParticleImpactSmokePuffExtended(cgs.media.smokeParticleShader, flash.origin, 500, 8, 20, 30, 0.13f, 7.f);
-				} else {
-					CG_ParticleImpactSmokePuffExtended(cgs.media.smokeParticleShader, flash.origin, 500, 8, 20, 30, 0.11f, 5.f);
+				if (!(cg_muzzleFlash.integer == 2 && ps && isFirstPerson))
+				{
+					if (ps)
+					{
+						CG_ParticleImpactSmokePuffExtended(cgs.media.smokeParticleShader, flash.origin, 500, 8, 20, 30, 0.13f, 7.f);
+					}
+					else
+					{
+						CG_ParticleImpactSmokePuffExtended(cgs.media.smokeParticleShader, flash.origin, 500, 8, 20, 30, 0.11f, 5.f);
+					}
 				}
 			}
 		}
@@ -2103,8 +2121,10 @@ void CG_AddPlayerWeapon(refEntity_t *parent, playerState_t *ps, centity_t *cent)
 		// changed this so the muzzle flash stays onscreen for long enough to be seen
 		if (cg_muzzleFlash.integer && cg.time - cent->firedTime < MUZZLE_FLASH_TIME)
 		{
-			//if (firing) { // Ridah
-			trap_R_AddRefEntityToScene(&flash);
+			if (!(cg_muzzleFlash.integer == 2 && ps && isFirstPerson))
+			{
+				trap_R_AddRefEntityToScene(&flash);
+			}
 		}
 	}
 
@@ -2341,7 +2361,10 @@ void CG_AddViewWeapon(playerState_t *ps)
 
 		if (cg_muzzleFlash.integer && cg.time - cg.predictedPlayerEntity.firedTime < MUZZLE_FLASH_TIME)
 		{
-			trap_R_AddRefEntityToScene(&flash);
+			if (!(cg_muzzleFlash.integer == 2 && ps))
+			{
+				trap_R_AddRefEntityToScene(&flash);
+			}
 		}
 
 		return;


### PR DESCRIPTION
Setting 'cg_muzzleFlash' to '2' now hides muzzle flashes only for
yourself (1P) and not for others (3P).