### PR TITLE
game: Retain old 'BG_PlayerTouchesItem' for CTF flags

### DIFF
--- a/src/game/bg_misc.c
+++ b/src/game/bg_misc.c
@@ -2519,8 +2519,32 @@ gitem_t *BG_FindItemForClassName(const char *className)
 }
 
 /**
+ * @brief Old Version of 'BG_PlayerTouchesItem' retained for intersect checking Objectives.
+ * @param[in] ps
+ * @param[in] item
+ * @param[in] atTime
+ * @return
+ */
+qboolean BG_PlayerTouchesObjective(playerState_t *ps, entityState_t *item, int atTime)
+{
+	vec3_t origin;
+
+	BG_EvaluateTrajectory(&item->pos, atTime, origin, qfalse, item->effect2Time);
+
+	// we are ignoring ducked differences here
+	return (ps->origin[0] - origin[0] > 36
+	        || ps->origin[0] - origin[0] < -36
+	        || ps->origin[1] - origin[1] > 36
+	        || ps->origin[1] - origin[1] < -36
+	        || ps->origin[2] - origin[2] > 36
+	        || ps->origin[2] - origin[2] < -36);
+}
+
+/**
  * @brief Items can be picked up without actually touching their physical bounds to make
- *        grabbing them easier
+ *        grabbing them easier.
+ *
+ *        New Version that checks in a cylinder instead of a box.
  * @param[in] ps
  * @param[in] item
  * @param[in] atTime
@@ -3776,7 +3800,7 @@ void BG_PlayerStateToEntityState(playerState_t *ps, entityState_t *s, int time, 
  * [0]  = names      - rank name
  * [1]  = miniNames  - mini rank name
  * [2]  = soundNames - sound to play on rank promotion
- * 
+ *
  * @todo cgame only. move ?
  */
 ranktable_t rankTable[2][NUM_EXPERIENCE_LEVELS] =

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -2128,6 +2128,7 @@ void BG_AddPredictableEventToPlayerstate(int newEvent, int eventParm, playerStat
 
 void BG_PlayerStateToEntityState(playerState_t *ps, entityState_t *s, int time, qboolean snap);
 
+qboolean BG_PlayerTouchesObjective(playerState_t *ps, entityState_t *item, int atTime);
 qboolean BG_PlayerTouchesItem(playerState_t *ps, entityState_t *item, int atTime);
 qboolean BG_PlayerSeesItem(playerState_t *ps, entityState_t *item, int atTime);
 qboolean BG_AddMagicAmmo(playerState_t *ps, int *skill, team_t teamNum, int numOfClips);

--- a/src/game/g_active.c
+++ b/src/game/g_active.c
@@ -475,9 +475,19 @@ void G_TouchTriggers(gentity_t *ent)
 		// so you don't have to actually contact its bounding box
 		if (hit->s.eType == ET_ITEM)
 		{
-			if (!BG_PlayerTouchesItem(&ent->client->ps, &hit->s, level.time))
+			if (hit->item && hit->item->giType == IT_TEAM)  // is a CTF flag / objective
 			{
-				continue;
+				if (!BG_PlayerTouchesObjective(&ent->client->ps, &hit->s, level.time))
+				{
+					continue;
+				}
+			}
+			else
+			{
+				if (!BG_PlayerTouchesItem(&ent->client->ps, &hit->s, level.time))
+				{
+					continue;
+				}
 			}
 		}
 		else
@@ -838,8 +848,8 @@ void ClientTimerActions(gentity_t *ent, int msec)
 {
 	gclient_t *client = ent->client;
 
-   // reset and pause client timer when we've reached maxhealth, such that once
-   // we take damage again, it will take a full second every time to re-heal
+	// reset and pause client timer when we've reached maxhealth, such that once
+	// we take damage again, it will take a full second every time to re-heal
 	if (ent->health == client->ps.stats[STAT_MAX_HEALTH])
 	{
 		if (client->timeResidual != 0)


### PR DESCRIPTION
The newly introduced 'BG_PlayerTouchesItem' is working fine and dandy for medi/ammo packs, however it also affected mission objectives (CTF flags) in existing maps and ways that messed with player expectations.

This commit readds the old 'BG_PlayerTouchesItem' logic in 'BG_PlayerTouchesItemOld' and uses it whenever we are to intersect with CTF flag entities.

Fixes https://github.com/etlegacy/etlegacy/issues/2827