### PR TITLE
game: fix oob write to dmgReceivedSts when attacker wasn't a client

### DIFF
--- a/src/game/g_combat.c
+++ b/src/game/g_combat.c
@@ -1730,10 +1730,14 @@ void G_DamageExt(gentity_t *targ, gentity_t *inflictor, gentity_t *attacker, vec
 	{
 		if (attacker)
 		{
-			targ->client->ps.persistant[PERS_ATTACKER]                       = attacker->s.number;
-			targ->client->dmgReceivedSts[attacker->s.number].damageReceived += take;
-			targ->client->dmgReceivedSts[attacker->s.number].mods            = mod;
-			targ->client->dmgReceivedSts[attacker->s.number].lastHitTime     = level.time;
+			targ->client->ps.persistant[PERS_ATTACKER] = attacker->s.number;
+
+			if (attacker->client)
+			{
+				targ->client->dmgReceivedSts[attacker->s.number].damageReceived += take;
+				targ->client->dmgReceivedSts[attacker->s.number].mods            = mod;
+				targ->client->dmgReceivedSts[attacker->s.number].lastHitTime     = level.time;
+			}
 		}
 		else
 		{


### PR DESCRIPTION
`attacker->s.number` can be any entity in the map, which meant that this could easily cause an out of bounds write. This would manifest into this write getting written into the next `gclient_t` struct in `gentity_t` struct, which wrote garbage data to the next players playerstate most likely (as that's the first field in `gclient_t` struct).

fixes #2797
fixes #2828
refs #2535 