### PR TITLE
game: Fixup jump-crouch- and swim-hitbox

### DIFF
--- a/src/cgame/cg_predict.c
+++ b/src/cgame/cg_predict.c
@@ -157,7 +157,12 @@ float CG_ClientHitboxMaxZ(entityState_t *hitEnt, float def)
 		maxs = origin[2] - cent->lerpOrigin[2] - 6;
 		return (maxs < PRONE_BODYHEIGHT) ? PRONE_BODYHEIGHT : maxs;
 	}
-	else if (hitEnt->eFlags & EF_CROUCHING)
+	else if (
+		// crouching on the ground
+		(hitEnt->eFlags & EF_CROUCHING && hitEnt->groundEntityNum != ENTITYNUM_NONE)
+		// or is swimming
+		|| (cgs.clientinfo[hitEnt->clientNum].character->animModelInfo->animations[hitEnt->legsAnim & ~ANIM_TOGGLEBIT]->movetype & ((1 << ANIM_MT_SWIM) | (1 << ANIM_MT_SWIMBK)))
+		)
 	{
 		VectorCopy(cent->pe.headRefEnt.origin, origin);
 		VectorMA(origin, 6.5f, cent->pe.headRefEnt.axis[2], origin); // up

--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -3649,7 +3649,12 @@ float ClientHitboxMaxZ(gentity_t *hitEnt)
 
 		return PRONE_BODYHEIGHT;
 	}
-	else if (hitEnt->client->ps.eFlags & EF_CROUCHING)
+	else if (
+		// crouching on the ground
+		(hitEnt->client->ps.eFlags & EF_CROUCHING && hitEnt->client->ps.groundEntityNum != ENTITYNUM_NONE)
+		// or is swimming
+		|| (hitEnt->legsFrame.animation->movetype & ((1 << ANIM_MT_SWIM) | (1 << ANIM_MT_SWIMBK)))
+		)
 	{
 		// Crouched hitbox height is calculated with head computed from G_BuildHead to stay right under head
 		if (hitEnt->client->tempHead)


### PR DESCRIPTION
'ClientHitboxMaxZ' and 'CG_ClientHitboxMaxZ' both are used to determine the hitbox of a player server and client side respectively.

In the case of holding crouch while in the air jumping, 'CG_ClientHitboxMaxZ' erroneously set the hitbox height to shoulder level. This is corrected by checking for not being in the air when the crouch flag is set.

In the case of swimming, crouching while swimming would also set the hitbox height to shoulder level.

Instead of removing this, it is made the default - as the swimming hitbox was comically tall anyhow and it is not expected to have a huge impact towards gameplay.