### PR TITLE
game: Derive 'classnameHash' for entities

### DIFF
--- a/src/game/bg_misc.c
+++ b/src/game/bg_misc.c
@@ -2519,8 +2519,32 @@ gitem_t *BG_FindItemForClassName(const char *className)
 }
 
 /**
+ * @brief Old Version of 'BG_PlayerTouchesItem' retained for intersect checking Objectives.
+ * @param[in] ps
+ * @param[in] item
+ * @param[in] atTime
+ * @return
+ */
+qboolean BG_PlayerTouchesObjective(playerState_t *ps, entityState_t *item, int atTime)
+{
+	vec3_t origin;
+
+	BG_EvaluateTrajectory(&item->pos, atTime, origin, qfalse, item->effect2Time);
+
+	// we are ignoring ducked differences here
+	return (ps->origin[0] - origin[0] > 36
+	        || ps->origin[0] - origin[0] < -36
+	        || ps->origin[1] - origin[1] > 36
+	        || ps->origin[1] - origin[1] < -36
+	        || ps->origin[2] - origin[2] > 36
+	        || ps->origin[2] - origin[2] < -36);
+}
+
+/**
  * @brief Items can be picked up without actually touching their physical bounds to make
- *        grabbing them easier
+ *        grabbing them easier.
+ *
+ *        New Version that checks in a cylinder instead of a box.
  * @param[in] ps
  * @param[in] item
  * @param[in] atTime
@@ -3776,7 +3800,7 @@ void BG_PlayerStateToEntityState(playerState_t *ps, entityState_t *s, int time, 
  * [0]  = names      - rank name
  * [1]  = miniNames  - mini rank name
  * [2]  = soundNames - sound to play on rank promotion
- * 
+ *
  * @todo cgame only. move ?
  */
 ranktable_t rankTable[2][NUM_EXPERIENCE_LEVELS] =

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -2128,6 +2128,7 @@ void BG_AddPredictableEventToPlayerstate(int newEvent, int eventParm, playerStat
 
 void BG_PlayerStateToEntityState(playerState_t *ps, entityState_t *s, int time, qboolean snap);
 
+qboolean BG_PlayerTouchesObjective(playerState_t *ps, entityState_t *item, int atTime);
 qboolean BG_PlayerTouchesItem(playerState_t *ps, entityState_t *item, int atTime);
 qboolean BG_PlayerSeesItem(playerState_t *ps, entityState_t *item, int atTime);
 qboolean BG_AddMagicAmmo(playerState_t *ps, int *skill, team_t teamNum, int numOfClips);

--- a/src/game/g_active.c
+++ b/src/game/g_active.c
@@ -475,7 +475,7 @@ void G_TouchTriggers(gentity_t *ent)
 		// so you don't have to actually contact its bounding box
 		if (hit->s.eType == ET_ITEM)
 		{
-			if (!Q_stricmp(hit->classname, "team_ctf_redflag") || !Q_stricmp(hit->classname, "team_ctf_blueflag"))
+			if (hit->classnameHash == CLASSNAME_HASH_TEAM_CTF_REDFLAG || hit->classnameHash == CLASSNAME_HASH_TEAM_CTF_BLUEFLAG)
 			{
 				if (!BG_PlayerTouchesObjective(&ent->client->ps, &hit->s, level.time))
 				{

--- a/src/game/g_active.c
+++ b/src/game/g_active.c
@@ -475,9 +475,19 @@ void G_TouchTriggers(gentity_t *ent)
 		// so you don't have to actually contact its bounding box
 		if (hit->s.eType == ET_ITEM)
 		{
-			if (!BG_PlayerTouchesItem(&ent->client->ps, &hit->s, level.time))
+			if (!Q_stricmp(hit->classname, "team_ctf_redflag") || !Q_stricmp(hit->classname, "team_ctf_blueflag"))
 			{
-				continue;
+				if (!BG_PlayerTouchesObjective(&ent->client->ps, &hit->s, level.time))
+				{
+					continue;
+				}
+			}
+			else
+			{
+				if (!BG_PlayerTouchesItem(&ent->client->ps, &hit->s, level.time))
+				{
+					continue;
+				}
 			}
 		}
 		else
@@ -838,8 +848,8 @@ void ClientTimerActions(gentity_t *ent, int msec)
 {
 	gclient_t *client = ent->client;
 
-   // reset and pause client timer when we've reached maxhealth, such that once
-   // we take damage again, it will take a full second every time to re-heal
+	// reset and pause client timer when we've reached maxhealth, such that once
+	// we take damage again, it will take a full second every time to re-heal
 	if (ent->health == client->ps.stats[STAT_MAX_HEALTH])
 	{
 		if (client->timeResidual != 0)

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -307,6 +307,7 @@ struct gentity_s
 	vec3_t instantVelocity;         ///< per entity instantaneous velocity, set per frame
 
 	const char *classname;          ///< set in QuakeEd
+	long classnameHash;             ///< derived from classname
 	int spawnflags;                 ///< set in QuakeEd
 
 	qboolean neverFree;             ///< if true, FreeEntity will only unlink
@@ -2809,6 +2810,10 @@ void G_TempTraceIgnoreEntities(gentity_t *ent);
 qboolean G_CanPickupWeapon(weapon_t weapon, gentity_t *ent);
 
 qboolean G_LandmineSnapshotCallback(int entityNum, int clientNum);
+
+// ClassnameHashes
+#define CLASSNAME_HASH_TEAM_CTF_REDFLAG  209279
+#define CLASSNAME_HASH_TEAM_CTF_BLUEFLAG 223985
 
 // Spawnflags
 

--- a/src/game/g_spawn.c
+++ b/src/game/g_spawn.c
@@ -801,6 +801,8 @@ gentity_t *G_SpawnGEntityFromSpawnVars(void)
 		G_ParseField(level.spawnVars[i][0], level.spawnVars[i][1], ent);
 	}
 
+	ent->classnameHash =  BG_StringHashValue(ent->classname);
+
 	// check for "notteam" / "notfree" flags
 	G_SpawnInt("notteam", "0", &i);
 	if (i)


### PR DESCRIPTION
Derived from https://github.com/etlegacy/etlegacy/pull/2831
WIP - if done could/should be expanded to other `classname` strcmps as well.
Or abandoned as strcmp's on Release builds seem to be fast anyhow.