### PR TITLE
game: Support 'g_forcerespawn' == -1 to respawn instantly

### DIFF
--- a/src/game/g_active.c
+++ b/src/game/g_active.c
@@ -838,8 +838,8 @@ void ClientTimerActions(gentity_t *ent, int msec)
 {
 	gclient_t *client = ent->client;
 
-   // reset and pause client timer when we've reached maxhealth, such that once
-   // we take damage again, it will take a full second every time to re-heal
+	// reset and pause client timer when we've reached maxhealth, such that once
+	// we take damage again, it will take a full second every time to re-heal
 	if (ent->health == client->ps.stats[STAT_MAX_HEALTH])
 	{
 		if (client->timeResidual != 0)
@@ -1750,11 +1750,25 @@ void SpectatorClientEndFrame(gentity_t *ent)
 		gclient_t *cl;
 		qboolean  do_respawn = qfalse;
 
-		// Players can respawn quickly in warmup
-		if (g_gamestate.integer != GS_PLAYING && ent->client->respawnTime <= level.timeCurrent &&
-		    ent->client->sess.sessionTeam != TEAM_SPECTATOR)
+		if (
+			// Players can instantly respawn when 'g_forcerespawn == -1'
+			(g_forcerespawn.integer == -1 && ent->client->sess.sessionTeam != TEAM_SPECTATOR)
+			// Players can instantly respawn in warmup
+			|| (g_gamestate.integer != GS_PLAYING && ent->client->respawnTime <= level.timeCurrent &&
+			    ent->client->sess.sessionTeam != TEAM_SPECTATOR)
+			)
 		{
-			do_respawn = qtrue;
+			// XXX : delay respawn onto the next frame - this circumvents
+			// specific issues that currently occur when player die and respawn
+			// on the same server frame
+			if (ent->client->instantRespawnDelayTime == 0)
+			{
+				ent->client->instantRespawnDelayTime = level.time;
+			}
+			else if (level.time > ent->client->instantRespawnDelayTime)
+			{
+				do_respawn = qtrue;
+			}
 		}
 		else if (ent->client->sess.sessionTeam == TEAM_AXIS)
 		{

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -976,6 +976,7 @@ struct gclient_s
 	int lasthurt_time;                      ///< level.time of last damage
 
 	// timers
+	int instantRespawnDelayTime;            ///< used to prevent dying and respawning all within the same server frame
 	int respawnTime;                        ///< can respawn when time > this, force after g_forcerespwan
 	int inactivityTime;                     ///< kick players when time > this
 	qboolean inactivityWarning;             ///< qtrue if the five seoond warning has been given

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -461,7 +461,7 @@ cvarTable_t gameCvarTable[] =
 
 	{ &g_needpass,                        "g_needpass",                        "0",                          CVAR_SERVERINFO | CVAR_ROM,                      0, qtrue,  qfalse },
 	{ &g_balancedteams,                   "g_balancedteams",                   "0",                          CVAR_SERVERINFO | CVAR_ROM,                      0, qtrue,  qfalse },
-	{ &g_forcerespawn,                    "g_forcerespawn",                    "0",                          0,                                               0, qtrue,  qfalse },
+	{ &g_forcerespawn,                    "g_forcerespawn",                    "0",                          CVAR_ARCHIVE,                                    0, qtrue,  qfalse },
 	{ &g_inactivity,                      "g_inactivity",                      "0",                          0,                                               0, qtrue,  qfalse },
 	{ &g_debugMove,                       "g_debugMove",                       "0",                          0,                                               0, qfalse, qfalse },
 	{ &g_debugDamage,                     "g_debugDamage",                     "0",                          CVAR_CHEAT,                                      0, qfalse, qfalse },


### PR DESCRIPTION
Also fix 'warmup' respawning to occur on the next server frame instead of the same as the player died to circumvent a set of issues that would otherwise occur.