### PR TITLE
cgame: Stop Class Limbo Selection take effect immediately by default

### DIFF
--- a/src/cgame/cg_limbopanel.c
+++ b/src/cgame/cg_limbopanel.c
@@ -1687,8 +1687,18 @@ qboolean CG_LimboPanel_ClassButton_KeyDown(panel_button_t *button, int key)
 
 			CG_LimboPanel_RequestWeaponStats();
 
-			cgs.ccManuallySetSecondaryWeapon = qfalse;
-			CG_LimboPanel_SendSetupMsg(qfalse);
+			// NOTE : It used to be the case that by default selecting a class
+			// automatically makes it take effect - this however means that you
+			// can't look up via limbo menu e.g. if a Soldier weapon is
+			// currently available without also switching to the Soldier class.
+			//
+			// This is by default now taken out, but can be re-enabled via
+			// 'cg_limboClassClickConfirm'.
+			if (cg_limboClassClickConfirm.integer)
+			{
+				cgs.ccManuallySetSecondaryWeapon = qfalse;
+				CG_LimboPanel_SendSetupMsg(qfalse);
+			}
 		}
 
 		return qtrue;

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2839,6 +2839,8 @@ extern vmCvar_t cg_skybox;
 extern vmCvar_t cg_redlimbotime;
 extern vmCvar_t cg_bluelimbotime;
 
+extern vmCvar_t cg_limboClassClickConfirm;
+
 extern vmCvar_t cg_movespeed;
 
 extern vmCvar_t cg_drawNotifyText;

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -222,6 +222,8 @@ vmCvar_t cg_quickMessageAlt;
 vmCvar_t cg_redlimbotime;
 vmCvar_t cg_bluelimbotime;
 
+vmCvar_t cg_limboClassClickConfirm;
+
 vmCvar_t cg_antilag;
 
 vmCvar_t developer;
@@ -505,6 +507,7 @@ static cvarTable_t cvarTable[] =
 	{ &cg_gameType,                 "g_gametype",                  "0",           0,                            0 }, // communicated by systeminfo
 	{ &cg_bluelimbotime,            "",                            "30000",       0,                            0 }, // communicated by systeminfo
 	{ &cg_redlimbotime,             "",                            "30000",       0,                            0 }, // communicated by systeminfo
+	{ &cg_limboClassClickConfirm,   "cg_limboClassClickConfirm",   "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_drawNotifyText,           "cg_drawNotifyText",           "1",           CVAR_ARCHIVE,                 0 },
 	{ &cg_quickMessageAlt,          "cg_quickMessageAlt",          "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_antilag,                  "g_antilag",                   "1",           0,                            0 },


### PR DESCRIPTION
It used to be the case that by default selecting a class automatically
makes it take effect - this however means that you can't look up via
limbo menu e.g. if a Soldier weapon is currently available without also
switching to the Soldier class.

This is by default now taken out, but can be re-enabled via
'cg_limboClassClickConfirm'.

---

Also add 'z' Accelerator as another way to confirm Limbo selection.
