### PR TITLE
cgame: Change 'cg_centertime' default from 5 to 3

### DIFF
--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -412,7 +412,7 @@ static cvarTable_t cvarTable[] =
 	{ &cg_gun_x,                    "cg_gunX",                     "0",           CVAR_TEMP,                    0 },
 	{ &cg_gun_y,                    "cg_gunY",                     "0",           CVAR_TEMP,                    0 },
 	{ &cg_gun_z,                    "cg_gunZ",                     "0",           CVAR_TEMP,                    0 },
-	{ &cg_centertime,               "cg_centertime",               "5",           CVAR_ARCHIVE,                 0 }, // changed from 3 to 5
+	{ &cg_centertime,               "cg_centertime",               "3",           CVAR_ARCHIVE,                 0 },
 	{ &cg_bobbing,                  "cg_bobbing",                  "0.0",         CVAR_ARCHIVE,                 0 },
 	{ &cg_drawEnvAwareness,         "cg_drawEnvAwareness",         "7",           CVAR_ARCHIVE,                 0 },
 	{ &cg_drawEnvAwarenessScale,    "cg_drawEnvAwarenessScale",    "0.80",        CVAR_ARCHIVE,                 0 },


### PR DESCRIPTION
5 was way too high, note that this value * 2 = the amount of seconds any centerprint message is shown.

i.e. 3 amounts to 6 seconds