### PR TITLE
client: fix clip command, add autocomplete to it

### DIFF
--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -1405,7 +1405,7 @@ void CL_Clip_f(void)
 
 	if (Cmd_Argc() < 2)
 	{
-		Com_Printf("Nothing to be put to the clipboard.");
+		Com_Printf("Nothing to be put to the clipboard.\n");
 		return;
 	}
 
@@ -1444,7 +1444,7 @@ void CL_Clip_f(void)
 		}
 
 		Com_Memset(cmdBuffer[i], 0, MAX_QPATH * sizeof(char));
-		Q_strncpyz(cmdBuffer[i], Cmd_Argv(i + 1), sizeof(cmdBuffer[i]));
+		Q_strncpyz(cmdBuffer[i], Cmd_Argv(i + 1), MAX_QPATH);
 	}
 
 	// Execute the command parts
@@ -3453,7 +3453,7 @@ void CL_Init(void)
 	//Cmd_AddCommand("add_fav", CL_AddFavServer_f, "Adds the current connected server to favorites.");
 
 	Cmd_AddCommand("open_homepath", CL_OpenHomePath_f, "Open the home path in a system file explorer.");
-	Cmd_AddCommand("clip", CL_Clip_f, "Put command output to clipboard.");
+	Cmd_AddCommand("clip", CL_Clip_f, "Put command output to clipboard.", CL_CompleteRcon);
 
 	Cmd_AddCommand("rebaseDrift", CL_RebaseDrift_f, "Resets the baselineDelta used for calculating drift.");
 


### PR DESCRIPTION
- fixing incorrect Q_strncpyz size that used sizeof char pointer
- add auto-complete to `clip` - re-uses rcon auto-complete
- add missing new line to printf

I have investigated a bit if there was some other bad usage of sizeof and found possible issues in renderer2 code:
https://github.com/etlegacy/etlegacy/blob/23df72370d60632c898b9a5e67f7547aa1afdf7c/src/renderer2/tr_shader.c#L6305
https://github.com/etlegacy/etlegacy/blob/23df72370d60632c898b9a5e67f7547aa1afdf7c/src/renderer2/tr_shader.c#L6321

and

https://github.com/etlegacy/etlegacy/blob/23df72370d60632c898b9a5e67f7547aa1afdf7c/src/renderer2/tr_shader_r1.c#L1039-L1041
https://github.com/etlegacy/etlegacy/blob/23df72370d60632c898b9a5e67f7547aa1afdf7c/src/renderer2/tr_shader_r1.c#L1051-L1052

I don't want to touch these as renderer2 is abandoned and I don't know how to test it.
