### PR TITLE
mod: fixes to "create", fix CONTENTS_PLAYERCLIP fakebrushes

### DIFF
--- a/src/cgame/cg_predict.c
+++ b/src/cgame/cg_predict.c
@@ -221,7 +221,10 @@ static void CG_ClipMoveToEntities(const vec3_t start, const vec3_t mins, const v
 		}
 		else
 		{
-			if (ent->eFlags & EF_FAKEBMODEL)
+			// dmgFlags are set to r.contents if the fakebrush is playerclip,
+			// so only grab mins/maxs if we're doing a player trace (capsule), or if dmgFlags are not set (regular CONTENTS_SOLID),
+			// otherwise stuff like bullets and flame particles appear to collide with playerclip fakebrushes
+			if (ent->eFlags & EF_FAKEBMODEL && (capsule || !ent->dmgFlags))
 			{
 				// repurposed origin2 and angles2 to receive mins and maxs of func_fakebrush
 				VectorCopy(ent->origin2, bmins);

--- a/src/game/g_lua.c
+++ b/src/game/g_lua.c
@@ -1303,10 +1303,9 @@ static void _et_gentity_getweaponstat(lua_State *L, weapon_stat_t *ws)
 
 gentity_t *G_Lua_CreateEntity(char *params)
 {
-	gentity_t *create;
-	char      *token;
-	char      *p = params;
-	char      key[MAX_TOKEN_CHARS], value[MAX_TOKEN_CHARS];
+	char *token;
+	char *p = params;
+	char key[MAX_TOKEN_CHARS], value[MAX_TOKEN_CHARS];
 
 	level.numSpawnVars     = 0;
 	level.numSpawnVarChars = 0;
@@ -1349,17 +1348,8 @@ gentity_t *G_Lua_CreateEntity(char *params)
 
 		level.numSpawnVars++;
 	}
-	create = G_SpawnGEntityFromSpawnVars();
 
-	//create->classname = "lua_spawn"; // make additional param?
-
-	if (!create)  // don't link NULL ents
-	{
-		return NULL;
-	}
-
-	trap_LinkEntity(create);
-	return create;
+	return G_SpawnGEntityFromSpawnVars();
 }
 
 // entnum = _et_G_Lua_CreateEntity( params )
@@ -3895,8 +3885,8 @@ void G_LuaHook_SpawnEntitiesFromString()
  */
 const char *G_LuaHook_Chat(int sender, int receiver, const char *message, char *buffer, size_t bufsize)
 {
-	int      i;
-	lua_vm_t *vm;
+	int        i;
+	lua_vm_t   *vm;
 	const char *result, *newMessage;
 
 	newMessage = message;
@@ -3925,8 +3915,8 @@ const char *G_LuaHook_Chat(int sender, int receiver, const char *message, char *
 			}
 			// Return values
 			if (lua_isinteger(vm->L, -2) &&
-					lua_tointeger(vm->L, -2) != qfalse &&
-					lua_isstring(vm->L, -1))
+			    lua_tointeger(vm->L, -2) != qfalse &&
+			    lua_isstring(vm->L, -1))
 			{
 				result = luaL_checkstring(vm->L, -1);
 				Q_strncpyz(buffer, result, bufsize);

--- a/src/game/g_script_actions.c
+++ b/src/game/g_script_actions.c
@@ -5126,10 +5126,9 @@ qboolean G_ScriptAction_Delete(gentity_t *ent, char *params)
  */
 qboolean G_ScriptAction_Create(gentity_t *ent, char *params)
 {
-	gentity_t *create;
-	char      *token;
-	char      *p = params;
-	char      key[MAX_TOKEN_CHARS], value[MAX_TOKEN_CHARS];
+	char *token;
+	char *p = params;
+	char key[MAX_TOKEN_CHARS], value[MAX_TOKEN_CHARS];
 
 	level.numSpawnVars     = 0;
 	level.numSpawnVarChars = 0;
@@ -5169,13 +5168,7 @@ qboolean G_ScriptAction_Create(gentity_t *ent, char *params)
 
 		level.numSpawnVars++;
 	}
-	create = G_SpawnGEntityFromSpawnVars();
 
-	if (!create)
-	{
-		return qfalse; // don't link NULL ents
-	}
-
-	trap_LinkEntity(create);
+	G_SpawnGEntityFromSpawnVars();
 	return qtrue;
 }


### PR DESCRIPTION
* Removed implicit linking of entities created via `create` script action, or equivalent LUA hook. Entities should handle linking in their spawn function, if they require linking.
* `func_fakebrush` now handles prediction correctly if contents is set to `CONTENTS_PLAYERCLIP`, this allows creating fakebrushes that only block player movement but don't interfere with gameplay by blocking bullets and projectiles.
* `func_fakebrush` now requires `origin`, `mins`, `maxs` & `contents` to be set explicitly, to avoid unexpected default values to be used implicitly.

refs #180 