### PR TITLE
cgame: Add cg_muzzleFlashScale

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2766,6 +2766,7 @@ extern vmCvar_t cg_tracerSpeed;
 extern vmCvar_t cg_autoswitch;
 extern vmCvar_t cg_fov;
 extern vmCvar_t cg_muzzleFlash;
+extern vmCvar_t cg_muzzleFlashScale;
 extern vmCvar_t cg_drawEnvAwareness;
 extern vmCvar_t cg_drawEnvAwarenessScale;
 extern vmCvar_t cg_drawEnvAwarenessIconSize;

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -166,6 +166,7 @@ vmCvar_t cg_tracerSpeed;
 vmCvar_t cg_autoswitch;
 vmCvar_t cg_fov;
 vmCvar_t cg_muzzleFlash;
+vmCvar_t cg_muzzleFlashScale;
 vmCvar_t cg_zoomStepSniper;
 vmCvar_t cg_zoomDefaultSniper;
 vmCvar_t cg_thirdPerson;
@@ -389,6 +390,7 @@ static cvarTable_t cvarTable[] =
 	{ &cg_zoomStepSniper,           "cg_zoomStepSniper",           "2",           CVAR_ARCHIVE,                 0 },
 	{ &cg_fov,                      "cg_fov",                      "90",          CVAR_ARCHIVE,                 0 },
 	{ &cg_muzzleFlash,              "cg_muzzleFlash",              "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_muzzleFlashScale,         "cg_muzzleFlashScale",         "0.8",         CVAR_ARCHIVE,                 0 },
 	{ &cg_letterbox,                "cg_letterbox",                "0",           CVAR_TEMP,                    0 },
 	{ &cg_shadows,                  "cg_shadows",                  "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_gibs,                     "cg_gibs",                     "1",           CVAR_ARCHIVE,                 0 },

--- a/src/cgame/cg_weapons.c
+++ b/src/cgame/cg_weapons.c
@@ -2136,6 +2136,13 @@ void CG_AddPlayerWeapon(refEntity_t *parent, playerState_t *ps, centity_t *cent)
 		// changed this so the muzzle flash stays onscreen for long enough to be seen
 		if (shouldDrawMuzzleFlash && cg.time - cent->firedTime < MUZZLE_FLASH_TIME)
 		{
+			float scale = Com_Clamp(0.5f, 1.0f, cg_muzzleFlashScale.value);
+
+			// scale the muzzle flash
+			VectorScale(flash.axis[0], scale, flash.axis[0]);
+			VectorScale(flash.axis[1], scale, flash.axis[1]);
+			VectorScale(flash.axis[2], scale, flash.axis[2]);
+
 			trap_R_AddRefEntityToScene(&flash);
 		}
 	}


### PR DESCRIPTION
Muzzle Flashes are known to be a visibility problem for a long time, which is why 'cg_muzzleFlash' was added to disable them.

This decision however might've been overhasty, as gradual reduction of muzzle flash size seems to alleviate most of the problems without removing parts of the game altogether.

This commit adds a new 'cg_muzzleFlashScale' CVAR and after extensive experimentation, defaults it to '0.8', which provides a better visibility default, without a generally noticable shrink of muzzle flash size.