### PR TITLE
mod: fix mounted mg42 prediction, refs #2572

### DIFF
--- a/src/cgame/cg_predict.c
+++ b/src/cgame/cg_predict.c
@@ -1122,12 +1122,6 @@ void CG_PredictPlayerState(void)
 
 	current = trap_GetCurrentCmdNumber();
 
-	// let server handle mounted MG42 cooldown since client doesn't know
-	// the heat values of each individual mounted gun in the map
-	// otherwise we fire excess overheat events when client exits and re-enters
-	// the gun, as the correct heat value is never assigned client side
-	cg.pmext.weapHeat[WP_DUMMY_MG42] = 0.0f;
-
 	// fill in the current cmd with the latest prediction from
 	// cg.pmext (#166)
 	Com_Memcpy(&oldpmext[current & cg.cmdMask], &cg.pmext, sizeof(pmoveExt_t));

--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -2992,6 +2992,8 @@ void PM_CoolWeapons(void)
 {
 	weapon_t wp;
 
+	pm->pmext->weapHeat[WP_DUMMY_MG42] = (float)pm->ps->ammo[WP_DUMMY_MG42] + fmodf(pm->pmext->weapHeat[WP_DUMMY_MG42], 1);
+
 	for (wp = WP_KNIFE; wp < WP_NUM_WEAPONS; wp++)
 	{
 		// if the weapon can heat and you have the weapon
@@ -5344,6 +5346,7 @@ void PmoveSingle(pmove_t *pmove)
 	}
 
 	pm->ps->stats[STAT_SPRINTTIME] = pm->pmext->sprintTime;
+	pm->ps->ammo[WP_DUMMY_MG42]    = pm->pmext->weapHeat[WP_DUMMY_MG42];
 }
 
 /**

--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -4122,6 +4122,7 @@ qboolean Do_Activate_f(gentity_t *ent, gentity_t *traceEnt)
 		ent->backupWeaponTime                      = ent->client->ps.weaponTime;
 		ent->client->ps.weaponTime                 = traceEnt->backupWeaponTime;
 		ent->client->pmext.weapHeat[WP_DUMMY_MG42] = traceEnt->mg42weapHeat;
+		ent->client->ps.ammo[WP_DUMMY_MG42]        = traceEnt->mg42weapHeat;
 
 		ent->tankLink      = traceEnt;
 		traceEnt->tankLink = ent;
@@ -4161,6 +4162,7 @@ qboolean Do_Activate_f(gentity_t *ent, gentity_t *traceEnt)
 		ent->backupWeaponTime                      = ent->client->ps.weaponTime;
 		ent->client->ps.weaponTime                 = traceEnt->backupWeaponTime;
 		ent->client->pmext.weapHeat[WP_DUMMY_MG42] = traceEnt->mg42weapHeat;
+		ent->client->ps.ammo[WP_DUMMY_MG42]        = traceEnt->mg42weapHeat;
 
 		G_UseTargets(traceEnt, ent);     // added for Mike so mounting an MG42 can be a trigger event (let me know if there's any issues with this)
 	}

--- a/src/game/g_misc.c
+++ b/src/game/g_misc.c
@@ -1127,6 +1127,7 @@ void aagun_use(gentity_t *ent, gentity_t *other, gentity_t *activator)
 		owner->active                                  = qfalse;
 
 		other->client->pmext.weapHeat[WP_DUMMY_MG42] = ent->mg42weapHeat;
+		other->client->ps.ammo[WP_DUMMY_MG42]        = ent->mg42weapHeat;
 		ent->backupWeaponTime                        = owner->client->ps.weaponTime;
 		owner->backupWeaponTime                      = owner->client->ps.weaponTime;
 	}
@@ -1750,6 +1751,7 @@ void mg42_use(gentity_t *ent, gentity_t *other, gentity_t *activator)
 		owner->active                                  = qfalse;
 
 		other->client->pmext.weapHeat[WP_DUMMY_MG42] = ent->mg42weapHeat;
+		other->client->ps.ammo[WP_DUMMY_MG42]        = ent->mg42weapHeat;
 		ent->backupWeaponTime                        = owner->client->ps.weaponTime;
 		owner->backupWeaponTime                      = owner->client->ps.weaponTime;
 	}


### PR DESCRIPTION
Reuses `ps.ammo[WP_DUMMY_MG42]` field for weapon heat while still keeping it framerate independent.

refs #2572