### PR TITLE
sys: Add --strict-loading cmd line option

### DIFF
--- a/src/qcommon/q_shared.h
+++ b/src/qcommon/q_shared.h
@@ -466,6 +466,8 @@ typedef int clipHandle_t;
 
 #define DEFAULT_NAME "ETLegacyPlayer"
 
+extern char* GlobalGameTitle;
+
 /**
  * @enum messageStatus_t
  * @brief

--- a/src/sdl/sdl_glimp.c
+++ b/src/sdl/sdl_glimp.c
@@ -893,8 +893,8 @@ static int GLimp_SetMode(glconfig_t *glConfig, int mode, qboolean fullscreen, qb
 				{
 					depthBits = 8;
 				}
-            // fall through    
-			case 3: 
+			// fall through
+			case 3:
 				if (stencilBits == 24)
 				{
 					stencilBits = 16;
@@ -982,7 +982,7 @@ static int GLimp_SetMode(glconfig_t *glConfig, int mode, qboolean fullscreen, qb
 			SDL_GL_SetAttribute(SDL_GL_ACCELERATED_VISUAL, 1);
 		}
 
-		main_window = SDL_CreateWindow(CLIENT_WINDOW_TITLE, x, y, glConfig->vidWidth, glConfig->vidHeight, flags | SDL_WINDOW_SHOWN);
+		main_window = SDL_CreateWindow(GlobalGameTitle, x, y, glConfig->vidWidth, glConfig->vidHeight, flags | SDL_WINDOW_SHOWN);
 
 		if (!main_window)
 		{

--- a/src/sys/sys_win32_con.c
+++ b/src/sys/sys_win32_con.c
@@ -700,12 +700,14 @@ void Sys_CreateConsole(void)
 	RECT     rect;
 
 	const char *DEDCLASS = "ET: Legacy WinConsole";
+
+	char windowname[MAX_STRING_CHARS] = { 0 };
 #if defined (UPDATE_SERVER)
-	const char *WINDOWNAME = "ET: Legacy Update Server";
+	Q_strncpyz(windowname, "ET: Legacy Update Server", sizeof(windowname));
 #elif defined(DEDICATED)
-	const char *WINDOWNAME = "ET: Legacy Dedicated Server";
+	Q_strncpyz(windowname, "ET: Legacy Dedicated Server", sizeof(windowname));
 #else
-	const char *WINDOWNAME = "ET: Legacy Console";
+	Com_sprintf(windowname, sizeof(windowname), "%s Console", GlobalGameTitle);
 #endif
 
 	int nHeight;
@@ -746,7 +748,7 @@ void Sys_CreateConsole(void)
 
 	s_wcd.hWnd = CreateWindowEx(0,
 	                            DEDCLASS,
-	                            WINDOWNAME,
+	                            windowname,
 	                            DEDSTYLE,
 	                            (swidth - 600) / 2, (sheight - 450) / 2, rect.right - rect.left + 1, rect.bottom - rect.top + 1,
 	                            NULL,


### PR DESCRIPTION
By default loading errors (GameDLL etc.) do not cause the engine to
abort, but instead the engine prints a warning and fallbacks to loading
from SEARCHPATH2.

This however means when we do local development, it is hard to catch DLL
loading failures of our modified game DLL, as the engine likely falls
back to loading the game DLL from our `fs_homepath` instead (which
likely already exists) - which can cause a lot of confusion and is hard
to notice in practice.

This commit adds a '--strict-loading' cmd line option to disable this
implicit fallback behavior and make the engine abort printing the
specific loading error whenever a DLL loading failure happens.