### PR TITLE
cgame: Add 'cg_autoCmd' CVAR

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1153,6 +1153,7 @@ typedef struct
 	int etLegacyClient;                     ///< is either 0 (vanilla client) or a version integer from git_version.h
 	qboolean loading;                       ///< don't defer players at initial startup
 	qboolean intermissionStarted;           ///< don't draw disconnect icon/message because game will end shortly
+	qboolean autoCmdExecuted;				///< has 'cg_autoCmd' been executed yet
 
 	// there are only one or two snapshot_t that are relevent at a time
 	int latestSnapshotNum;                  ///< the number of snapshots the client system has received
@@ -2915,6 +2916,7 @@ extern vmCvar_t cg_weapaltMgAutoProne;
 extern vmCvar_t cg_sharetimerText;
 
 extern vmCvar_t cg_automapZoom;
+extern vmCvar_t cg_autoCmd;
 
 extern vmCvar_t cg_popupFadeTime;
 extern vmCvar_t cg_popupStayTime;

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -318,6 +318,7 @@ vmCvar_t cg_simpleItems;
 vmCvar_t cg_simpleItemsScale;
 
 vmCvar_t cg_automapZoom;
+vmCvar_t cg_autoCmd;
 
 vmCvar_t cg_popupFadeTime;
 vmCvar_t cg_popupStayTime;
@@ -590,6 +591,7 @@ static cvarTable_t cvarTable[] =
 	{ &cg_simpleItems,              "cg_simpleItems",              "0",           CVAR_ARCHIVE,                 0 }, // Bugged atm
 	{ &cg_simpleItemsScale,         "cg_simpleItemsScale",         "1.0",         CVAR_ARCHIVE,                 0 },
 	{ &cg_automapZoom,              "cg_automapZoom",              "5.159",       CVAR_ARCHIVE,                 0 },
+	{ &cg_autoCmd,                  "cg_autoCmd",                  "",            CVAR_TEMP,                    0 },
 	{ &cg_popupFadeTime,            "cg_popupFadeTime",            "2500",        CVAR_ARCHIVE,                 0 },
 	{ &cg_popupStayTime,            "cg_popupStayTime",            "2000",        CVAR_ARCHIVE,                 0 },
 	{ &cg_popupTime,                "cg_popupTime",                "0",           CVAR_ARCHIVE,                 0 },

--- a/src/cgame/cg_servercmds.c
+++ b/src/cgame/cg_servercmds.c
@@ -1406,6 +1406,7 @@ static void CG_MapRestart(void)
 
 	Com_Memset(&cg.lastWeapSelInBank[0], 0, MAX_WEAP_BANKS_MP * sizeof(int)); // clear weapon bank selections
 
+	cg.autoCmdExecuted         = qfalse;
 	cg.numbufferedSoundScripts = 0;
 
 	cg.centerPrintTime = 0; // reset centerprint counter so previous messages don't re-appear

--- a/src/cgame/cg_view.c
+++ b/src/cgame/cg_view.c
@@ -2635,4 +2635,12 @@ void CG_DrawActiveFrame(int serverTime, qboolean demoPlayback)
 
 	// let the client system know what our weapon, holdable item and zoom settings are
 	trap_SetUserCmdValue(cg.weaponSelect, cg.showGameView ? 0x01 : 0x00, cg.zoomSensitivity, cg.identifyClientRequest);
+
+	// execute 'cg_autoCmd'
+	if (cg_autoCmd.string[0] != '\0' && !cg.autoCmdExecuted)
+	{
+		Com_Printf("Executing cg_autoCmd: %s\n", cg_autoCmd.string);
+		trap_SendConsoleCommand(cg_autoCmd.string);
+		cg.autoCmdExecuted = qtrue;
+	}
 }


### PR DESCRIPTION
Allows setting a command that automatically gets executed when first snapshot was received.

Also executes for each `map_restart`.