### PR TITLE
tvgame: ignore svcvar configstring from master

### DIFF
--- a/src/server/sv_cl_main.c
+++ b/src/server/sv_cl_main.c
@@ -558,6 +558,10 @@ void SV_CL_ConfigstringModified(void)
 	int         len;
 
 	index = Q_atoi(Cmd_Argv(1));
+	if (svcls.isTVGame && index == CS_SVCVAR)
+	{
+		return;
+	}
 	if (index < 0 || index >= MAX_CONFIGSTRINGS)
 	{
 		Com_Error(ERR_DROP, "configstring < 0 or configstring >= MAX_CONFIGSTRINGS");

--- a/src/server/sv_cl_main.c
+++ b/src/server/sv_cl_main.c
@@ -523,7 +523,7 @@ void SV_CL_InitTVGame(void)
 
 	for (i = 0; i < MAX_CONFIGSTRINGS; i++)
 	{
-		if (!svcl.gameState.stringOffsets[i] || i == CS_SYSTEMINFO)
+		if (!svcl.gameState.stringOffsets[i] || i == CS_SYSTEMINFO || i == CS_SVCVAR)
 		{
 			continue;
 		}


### PR DESCRIPTION
To not force cvars from master to tv viewers.

To test:
- Make sure to re-build tvgame.
- run etlded: `./etlded +set sv_etltv_password tv +set sv_etltv_maxslaves 1 +set g_customConfig legacy6 +map radar`
- tv connect: `./etlded +tv connect localhost:27960 3ttv` 
- By running `csinfo CS_SVCVAR` in tv server console check that it's empty after connecting.
- Update some sv_cvar in master server: e.g `sv_cvar cg_autoaction IN 4 5`.
- Check again `csinfo CS_SVCVAR` in tv server console.

fixes: #2888
refs: #229