### PR TITLE
github-actions: Update macOS12 runner to macOS13

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -129,7 +129,7 @@ jobs:
         run: cpack
 
   osx:
-    runs-on: macos-12
+    runs-on: macos-13
     needs: [ version ]
     env:
       CI_ETL_DESCRIBE: ${{needs.version.outputs.describe}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,7 +146,7 @@ jobs:
           if-no-files-found: error
 
   osx-mod:
-    runs-on: macos-12
+    runs-on: macos-13
     needs: version
     steps:
       - uses: actions/checkout@v4
@@ -533,7 +533,7 @@ jobs:
           if-no-files-found: error
 
   osx:
-    runs-on: macos-12
+    runs-on: macos-13
     needs: [ version, mod-merger ]
     env:
       CI_ETL_DESCRIBE: ${{needs.version.outputs.describe}}


### PR DESCRIPTION
Soon deprecated according to:
https://github.com/actions/runner-images/issues/10721

See https://github.com/etlegacy/etlegacy/issues/2893