### PR TITLE
cgame: Limbo defaults to SMG if Soldier can

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2594,6 +2594,7 @@ typedef struct cgs_s
 	int ccSelectedClass;
 	weapon_t ccSelectedPrimaryWeapon;                   ///< Selected primary weapon from limbo panel
 	weapon_t ccSelectedSecondaryWeapon;                 ///< Selected secondary weapon from limbo panel
+	qboolean ccManuallySetSecondaryWeapon;
 	int ccWeaponShots;
 	int ccWeaponHits;
 	vec3_t ccPortalPos;


### PR DESCRIPTION
Currently the SMG will never be autoselected when switching to the Soldier class through Limbo menu.

The reason for that is that 'SetDefaultWeapon(SECONDARY_SLOT)' is called once the Class is changed and never thereafter - however, when the Class is changed, the default primary weapon is set to the SMG and the consequent 'SetDefaultWeapon(SECONDARY_SLOT)' call will reject the SMG, as it always rejects weapons that are already set in the primary slot.

To circumvent this we now track if a user ever switched the weapon panel to the secondary panel (which will reset if they change either class or team) and if they never have opened it, we call
'SetDefaultWeapon(SECONDARY_SLOT) **again** right before we actually place the `team` command in 'CG_LimboPanel_SendSetupMsg'.

The end effect is that just switching to Soldier and selecting a heavyweapon will now always prioritize the SMG as long as the SMG perk is available.