### PR TITLE
cgame: Disambiguate weapon bank collisions

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2761,6 +2761,7 @@ extern vmCvar_t cg_gun_y;
 extern vmCvar_t cg_gun_z;
 extern vmCvar_t cg_drawGun;
 extern vmCvar_t cg_weapAnims;
+extern vmCvar_t cg_weapBankCollisions;
 extern vmCvar_t cg_weapSwitchNoAmmoSounds;
 extern vmCvar_t cg_letterbox;
 extern vmCvar_t cg_tracerChance;

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -155,6 +155,7 @@ vmCvar_t cg_brassTime;
 vmCvar_t cg_letterbox;
 vmCvar_t cg_drawGun;
 vmCvar_t cg_weapAnims;
+vmCvar_t cg_weapBankCollisions;
 vmCvar_t cg_weapSwitchNoAmmoSounds;
 vmCvar_t cg_gun_frame;
 vmCvar_t cg_gun_x;
@@ -389,6 +390,7 @@ static cvarTable_t cvarTable[] =
 	{ &cg_autoswitch,               "cg_autoswitch",               "2",           CVAR_ARCHIVE,                 0 },
 	{ &cg_drawGun,                  "cg_drawGun",                  "1",           CVAR_ARCHIVE,                 0 },
 	{ &cg_weapAnims,                "cg_weapAnims",                "15",          CVAR_ARCHIVE,                 0 },
+	{ &cg_weapBankCollisions,       "cg_weapBankCollisions",       "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_weapSwitchNoAmmoSounds,   "cg_weapSwitchNoAmmoSounds",   "1",           CVAR_ARCHIVE,                 0 },
 	{ &cg_gun_frame,                "cg_gun_frame",                "0",           CVAR_TEMP,                    0 },
 	{ &cg_zoomDefaultSniper,        "cg_zoomDefaultSniper",        "20",          CVAR_ARCHIVE,                 0 }, // changed per atvi req

--- a/src/cgame/cg_weapons.c
+++ b/src/cgame/cg_weapons.c
@@ -3919,7 +3919,7 @@ void CG_WeaponBank_f(void)
 		return;
 	}
 
-	CG_WeaponIndex(cg.weaponSelect, &curbank, &curcycle);         // get bank/cycle of current weapon
+	CG_WeaponIndex(cg.weaponSelect, &curbank, &curcycle);  // get bank/cycle of current weapon
 
 	if (bank == curbank)
 	{
@@ -3933,6 +3933,88 @@ void CG_WeaponBank_f(void)
 		    (cg.snap->ps.weapAnim & ~ANIM_TOGGLEBIT) == WEAP_ALTSWITCHTO)
 		{
 			return;
+		}
+	}
+
+	// disambiguate weapon bank collisions, by just unrolling the possibilities
+	if (!cg_weapBankCollisions.integer && (bank == 2 || bank == 3) && (COM_BitCheck(cg.snap->ps.weapons, WP_MP40) || COM_BitCheck(cg.snap->ps.weapons, WP_THOMPSON)))
+	{
+		// CASE1 : for having 2 SMGs - bank 2 will be your team's, bank 3 the other
+		if (COM_BitCheck(cg.snap->ps.weapons, WP_MP40) && COM_BitCheck(cg.snap->ps.weapons, WP_THOMPSON))
+		{
+			if (bank == 2)
+			{
+				CG_FinishWeaponChange(cg.weaponSelect, (cgs.clientinfo[cg.snap->ps.clientNum].team == TEAM_AXIS) ? WP_MP40 : WP_THOMPSON);
+				return;
+			}
+			else if (bank == 3)
+			{
+				CG_FinishWeaponChange(cg.weaponSelect, (cgs.clientinfo[cg.snap->ps.clientNum].team == TEAM_AXIS) ? WP_THOMPSON : WP_MP40);
+				return;
+			}
+		}
+		// CASE2 : for soldier case with SMG that would otherwise collide with
+		// whatever heavy weapon the player has in bank 3 bank 2 is your smg, bank
+		// 3 the heavy weapon
+		else if (COM_BitCheck(cg.snap->ps.weapons, WP_MOBILE_MG42)
+		         || COM_BitCheck(cg.snap->ps.weapons, WP_MOBILE_BROWNING)
+		         || COM_BitCheck(cg.snap->ps.weapons, WP_FLAMETHROWER)
+		         || COM_BitCheck(cg.snap->ps.weapons, WP_PANZERFAUST)
+		         || COM_BitCheck(cg.snap->ps.weapons, WP_BAZOOKA)
+		         || COM_BitCheck(cg.snap->ps.weapons, WP_MORTAR2)
+		         || COM_BitCheck(cg.snap->ps.weapons, WP_MORTAR))
+		{
+			if (bank == 2)
+			{
+				if (CG_WeaponSelectable(WP_MP40, qfalse))
+				{
+					CG_FinishWeaponChange(cg.weaponSelect, WP_MP40);
+					return;
+				}
+				else if (CG_WeaponSelectable(WP_THOMPSON, qfalse))
+				{
+					CG_FinishWeaponChange(cg.weaponSelect, WP_THOMPSON);
+					return;
+				}
+			}
+			else if (bank == 3)
+			{
+				if (CG_WeaponSelectable(WP_MOBILE_MG42, qfalse))
+				{
+					CG_FinishWeaponChange(cg.weaponSelect, WP_MOBILE_MG42);
+					return;
+				}
+				else if (CG_WeaponSelectable(WP_MOBILE_BROWNING, qfalse))
+				{
+					CG_FinishWeaponChange(cg.weaponSelect, WP_MOBILE_BROWNING);
+					return;
+				}
+				else if (CG_WeaponSelectable(WP_FLAMETHROWER, qfalse))
+				{
+					CG_FinishWeaponChange(cg.weaponSelect, WP_FLAMETHROWER);
+					return;
+				}
+				else if (CG_WeaponSelectable(WP_PANZERFAUST, qfalse))
+				{
+					CG_FinishWeaponChange(cg.weaponSelect, WP_PANZERFAUST);
+					return;
+				}
+				else if (CG_WeaponSelectable(WP_BAZOOKA, qfalse))
+				{
+					CG_FinishWeaponChange(cg.weaponSelect, WP_BAZOOKA);
+					return;
+				}
+				else if (CG_WeaponSelectable(WP_MORTAR2, qfalse))
+				{
+					CG_FinishWeaponChange(cg.weaponSelect, WP_MORTAR2);
+					return;
+				}
+				else if (CG_WeaponSelectable(WP_MORTAR, qfalse))
+				{
+					CG_FinishWeaponChange(cg.weaponSelect, WP_MORTAR);
+					return;
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Related https://github.com/etlegacy/etlegacy/issues/1154

This PR addresses 2 cases:

- A Soldier with SMG Perk having 2 SMGs, which has become a possibilty
  after: https://github.com/etlegacy/etlegacy/issues/594.

  For such cases '2' will now select your team's SMG, '3' will select
  the other team's SMG

- A Soldier with SMG Perk having both an SMG and a heavy weapon.

  For such cases '2' will now select the SMG, '3' will select the
  heavy weapon.

Enables the above behavior when a newly introduced CVAR
'cg_weapBankCollisions' is set to it's default 0.