### PR TITLE
game: Allow callvote when warmup is about to end in stopwatch

### DIFF
--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -3344,7 +3344,9 @@ qboolean Cmd_CallVote_f(gentity_t *ent, unsigned int dwCommand, int fRefCommand)
 				CP("cp \"You cannot call a vote as a spectator.\"");
 				return qfalse;
 			}
-			else if (g_gamestate.integer == GS_WARMUP_COUNTDOWN && (level.warmupTime - level.time) < VOTE_TIME)
+			// unless it's a stopwatch game, we prevent callvoting when warmup
+			// is about to end - as it would likely fail on pub servers anyhow
+			else if (g_gametype.integer != GT_WOLF_STOPWATCH && g_gamestate.integer == GS_WARMUP_COUNTDOWN && (level.warmupTime - level.time) < VOTE_TIME)
 			{
 				CP("cp \"You cannot call a vote when warmup is about to end.\"");
 				return qfalse;
@@ -3431,9 +3433,13 @@ qboolean Cmd_CallVote_f(gentity_t *ent, unsigned int dwCommand, int fRefCommand)
 		G_globalSoundEnum(GAMESOUND_MISC_VOTE);
 	}
 
-	// shorter the vote timeout when map time is going to end
+	// for stopwatch games, shorter vote timeout when map time is going to end
 	// (e.g. surrendering a match in stopwatch)
-	if (g_gamestate.integer == GS_PLAYING && (level.startTime + (g_timelimit.value * 60000) - level.time < VOTE_TIME))
+	if (g_gametype.integer == GT_WOLF_STOPWATCH && g_gamestate.integer == GS_WARMUP_COUNTDOWN && (level.warmupTime - level.time) < VOTE_TIME)
+	{
+		level.voteInfo.voteTime = level.warmupTime - VOTE_TIME;
+	}
+	else if (g_gamestate.integer == GS_PLAYING && (level.startTime + (g_timelimit.value * 60000) - level.time < VOTE_TIME))
 	{
 		level.voteInfo.voteTime = level.startTime + (g_timelimit.value * 60000) - VOTE_TIME;
 	}


### PR DESCRIPTION
Upon request as a way to abort a running countdown for stopwatch games.

Followup to https://github.com/etlegacy/etlegacy/pull/2574