### PR TITLE
client: Increase 'con_openspeed' default from 3 → 5

### DIFF
--- a/src/client/cl_console.c
+++ b/src/client/cl_console.c
@@ -512,7 +512,7 @@ void Con_Init(void)
 	int i;
 
 	con_notifytime = Cvar_Get("con_notifytime", "7", 0);    // increased per id req for obits
-	con_openspeed  = Cvar_Get("con_openspeed", "3", 0);
+	con_openspeed  = Cvar_Get("con_openspeed", "5", 0);
 	con_autoclear  = Cvar_Get("con_autoclear", "1", CVAR_ARCHIVE_ND);
 	Cvar_Get("con_fontName", "JetBrainsMono-SemiBold", CVAR_LATCH | CVAR_ARCHIVE_ND);
 


### PR DESCRIPTION
A very good default compromise to get both a fast console open and still a smooth transition.