### PR TITLE
cgame: Move drawing airplane into new 'cg_drawAirplanes'

### DIFF
--- a/src/cgame/cg_ents.c
+++ b/src/cgame/cg_ents.c
@@ -1843,7 +1843,7 @@ void CG_MovePlane(centity_t *cent)
 	refEntity_t ent;
 
 	// allow the airstrike plane to be completely removed
-	if (!cg_visualEffects.integer || cent->currentState.time < 0)
+	if (!cg_drawAirstrikePlanes.integer || cent->currentState.time < 0)
 	{
 		return;
 	}

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2946,7 +2946,7 @@ extern vmCvar_t cg_quickchat;
 
 extern vmCvar_t cg_drawUnit;
 
-extern vmCvar_t cg_visualEffects;  ///< turn invisible (0) / visible (1) visual effect (i.e airstrike plane, debris ...)
+extern vmCvar_t cg_visualEffects;  ///< turn invisible (0) / visible (1) visual effect (e.g. smoke, debris, ...)
 extern vmCvar_t cg_bannerTime;
 
 extern vmCvar_t cg_shoutcastTeamNameRed;
@@ -2957,6 +2957,7 @@ extern vmCvar_t cg_shoutcastGrenadeTrail;
 extern vmCvar_t cg_activateLean;
 
 extern vmCvar_t cg_drawBreathPuffs;
+extern vmCvar_t cg_drawAirstrikePlanes;
 
 extern vmCvar_t cg_customFont1;
 extern vmCvar_t cg_customFont2;

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -356,6 +356,7 @@ vmCvar_t cg_shoutcastGrenadeTrail;
 vmCvar_t cg_activateLean;
 
 vmCvar_t cg_drawBreathPuffs;
+vmCvar_t cg_drawAirstrikePlanes;
 
 vmCvar_t cg_customFont1;
 vmCvar_t cg_customFont2;
@@ -618,7 +619,7 @@ static cvarTable_t cvarTable[] =
 
 	{ &cg_drawUnit,                 "cg_drawUnit",                 "0",           CVAR_ARCHIVE,                 0 },
 
-	{ &cg_visualEffects,            "cg_visualEffects",            "1",           CVAR_ARCHIVE,                 0 }, // Draw visual effects (i.e : airstrike plane, debris ...)
+	{ &cg_visualEffects,            "cg_visualEffects",            "1",           CVAR_ARCHIVE,                 0 }, // (e.g. : smoke, debris, ...)
 	{ &cg_bannerTime,               "cg_bannerTime",               "10000",       CVAR_ARCHIVE,                 0 },
 
 	{ &cg_shoutcastTeamNameRed,     "cg_shoutcastTeamNameRed",     "Axis",        CVAR_ARCHIVE,                 0 },
@@ -629,6 +630,7 @@ static cvarTable_t cvarTable[] =
 	{ &cg_activateLean,             "cg_activateLean",             "0",           CVAR_ARCHIVE,                 0 },
 
 	{ &cg_drawBreathPuffs,          "cg_drawBreathPuffs",          "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_drawAirstrikePlanes,      "cg_drawAirstrikePlanes",      "1",           CVAR_ARCHIVE,                 0 },
 
 	{ &cg_drawSpawnpoints,          "cg_drawSpawnpoints",          "0",           CVAR_ARCHIVE,                 0 },
 


### PR DESCRIPTION
Drawing airplanes used to be part of `cg_visualEffects`, which however has been forced off on many servers due to how visuall obtrusive and fps dependent/uneven especially smoke effects are.

Airplanes were added behind `cg_visualEffects` and got thus practically disabled by default.

However, as they are unobtrusive, practically free from a performance stnadpoint and even provide some historic info on where airstrikes previously happened, they are now split into a separate CVAR so that servers can decide to keep them while still getting rid of the particle effects of `cg_visualEffects`.