### PR TITLE
cgame: Debug draw Artillery on sv_cheats

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -3139,6 +3139,7 @@ const char *CG_TranslateString(const char *string);
 
 void CG_InitStatsDebug(void);
 void CG_StatsDebugAddText(const char *text);
+void CG_DrawDebugArtillery(centity_t * cent);
 
 void CG_AddLagometerFrameInfo(void);
 void CG_AddLagometerSnapshotInfo(snapshot_t *snap);
@@ -3171,6 +3172,7 @@ void CG_AddLineToScene(const vec3_t start, const vec3_t end, const vec4_t colour
 
 void CG_DrawRotateGizmo(const vec3_t origin, float radius, int numSegments, int activeAxis);
 void CG_DrawMoveGizmo(const vec3_t origin, float radius, int activeAxis);
+void CG_DrawSprite(const vec3_t origin, float radius, qhandle_t shader, byte color[4]);
 
 /**
  * @struct scrollText_s

--- a/src/cgame/cg_weapons.c
+++ b/src/cgame/cg_weapons.c
@@ -1294,6 +1294,13 @@ void CG_AddPlayerWeapon(refEntity_t *parent, playerState_t *ps, centity_t *cent)
 	// don't draw any weapons when the binocs are up
 	if (cent->currentState.eFlags & EF_ZOOMING)
 	{
+		// debug draw if artillery can be called in at the spot when self and
+		// using binocs as fops
+		if (cgs.sv_cheats && ps && isSelfFirstPerson && ps->stats[STAT_PLAYER_CLASS] == PC_FIELDOPS)
+		{
+			CG_DrawDebugArtillery(cent);
+		}
+
 		return;
 	}
 	// don't draw weapon stuff when looking through a scope


### PR DESCRIPTION
When using binocs as fops playing on an `sv_cheats 1` server, draw a sprite for where playerstate looks showing if artillery can be called in at the spot or not.