### PR TITLE
cgame: Fix `cg_drawGun 2` drawing tank mg

### DIFF
--- a/src/cgame/cg_weapons.c
+++ b/src/cgame/cg_weapons.c
@@ -2388,10 +2388,14 @@ void CG_AddViewWeapon(playerState_t *ps)
 	// draw all gun models (1)
 	// draw only melee weapon, syringe and pliers, and throwables (incl. grenades) (2)
 	if (!cg_drawGun.integer || (cg_drawGun.integer == 2
-	                            && GetWeaponTableData(ps->weapon)->type
-	                            && !(GetWeaponTableData(ps->weapon)->type & WEAPON_TYPE_GRENADE)
-	                            && !(GetWeaponTableData(ps->weapon)->type & WEAPON_TYPE_MELEE)
-	                            && !(GetWeaponTableData(ps->weapon)->type & WEAPON_TYPE_SYRINGUE)))
+	                            && (ps->eFlags & EF_MOUNTEDTANK
+	                                || (GetWeaponTableData(ps->weapon)->type
+	                                    && !(GetWeaponTableData(ps->weapon)->type & WEAPON_TYPE_GRENADE)
+	                                    && !(GetWeaponTableData(ps->weapon)->type & WEAPON_TYPE_MELEE)
+	                                    && !(GetWeaponTableData(ps->weapon)->type & WEAPON_TYPE_SYRINGUE))
+	                                )
+	                            )
+	    )
 	{
 		if (!BG_PlayerMounted(cg.predictedPlayerState.eFlags))
 		{


### PR DESCRIPTION
When holding either grenades, melee weapons or syringes, the mounted tank gun was suddenly being rendered in first person.

Fixes https://github.com/etlegacy/etlegacy/issues/2907