### PR TITLE
game: Always set 'PMF_BACKWARDS_JUMP' on OTG

### DIFF
--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -1909,13 +1909,20 @@ static void PM_GroundTrace(void)
 			if (pm->cmd.forwardmove >= 0)
 			{
 				BG_AnimScriptEvent(pm->ps, pm->character->animModelInfo, ANIM_ET_JUMP, qfalse);
-				pm->ps->pm_flags &= ~PMF_BACKWARDS_JUMP;
 			}
 			else
 			{
 				BG_AnimScriptEvent(pm->ps, pm->character->animModelInfo, ANIM_ET_JUMPBK, qfalse);
-				pm->ps->pm_flags |= PMF_BACKWARDS_JUMP;
 			}
+		}
+
+		if (pm->cmd.forwardmove >= 0)
+		{
+			pm->ps->pm_flags &= ~PMF_BACKWARDS_JUMP;
+		}
+		else
+		{
+			pm->ps->pm_flags |= PMF_BACKWARDS_JUMP;
 		}
 
 		pm->ps->groundEntityNum = ENTITYNUM_NONE;


### PR DESCRIPTION
To safeguard against unintended side-effects, always set the 'PMF_BACKWARDS_JUMP' flag - which was gated alongside with the animation via '35d5d4cbccbf73dcaabe56742a164a8fe5de9364' - however the intention in that commit was to only gate the animation.