### PR TITLE
game: Fix headshots causing double knockback

### DIFF
--- a/src/game/g_combat.c
+++ b/src/game/g_combat.c
@@ -1635,7 +1635,7 @@ void G_DamageExt(gentity_t *targ, gentity_t *inflictor, gentity_t *attacker, vec
 	}
 	else
 	{
-		knockback = MIN(take, 200);
+		knockback = MIN(damage, 200);
 
 		if (dflags & DAMAGE_HALF_KNOCKBACK)
 		{


### PR DESCRIPTION
revert to `VET` behavior