### PR TITLE
cgame: Fix noAmmoSound on weapNext/weapPrev

### DIFF
--- a/src/cgame/cg_weapons.c
+++ b/src/cgame/cg_weapons.c
@@ -3079,7 +3079,7 @@ void CG_FinishWeaponChange(int lastWeapon, int newWeapon)
 			}
 		}
 		// this fixes cg.switchbackWeapon=0 after very first spawn and switching weapon for the first time
-		else if (cg.switchbackWeapon == WP_NONE && CG_WeaponSelectable(lastWeapon, qtrue)) // ensure last weapon is available
+		else if (cg.switchbackWeapon == WP_NONE && CG_WeaponSelectable(lastWeapon, qfalse)) // ensure last weapon is available
 		{
 			if (!(GetWeaponTableData(lastWeapon)->type & WEAPON_TYPE_SCOPED))
 			{
@@ -3418,14 +3418,14 @@ void CG_NextWeap(qboolean switchBanks)
 				}
 			}
 
-			if (CG_WeaponSelectable(num, qtrue))
+			if (CG_WeaponSelectable(num, qfalse))
 			{
 				break;
 			}
 
 			if (GetWeaponTableData(num)->type & WEAPON_TYPE_RIFLE)
 			{
-				if (CG_WeaponSelectable(GetWeaponTableData(num)->weapAlts, qtrue))
+				if (CG_WeaponSelectable(GetWeaponTableData(num)->weapAlts, qfalse))
 				{
 					num = GetWeaponTableData(num)->weapAlts;
 					break;
@@ -3469,14 +3469,14 @@ void CG_NextWeap(qboolean switchBanks)
 			//  continue;
 			//}
 
-			if (CG_WeaponSelectable(num, qtrue))       // first entry in bank was selectable, no need to scan the bank
+			if (CG_WeaponSelectable(num, qfalse))       // first entry in bank was selectable, no need to scan the bank
 			{
 				break;
 			}
 
 			if (GetWeaponTableData(num)->type & WEAPON_TYPE_RIFLE)
 			{
-				if (CG_WeaponSelectable(GetWeaponTableData(num)->weapAlts, qtrue))
+				if (CG_WeaponSelectable(GetWeaponTableData(num)->weapAlts, qfalse))
 				{
 					num = GetWeaponTableData(num)->weapAlts;
 					break;
@@ -3493,14 +3493,14 @@ void CG_NextWeap(qboolean switchBanks)
 				// continue;
 				//}
 
-				if (CG_WeaponSelectable(num, qtrue))       // found selectable weapon
+				if (CG_WeaponSelectable(num, qfalse))       // found selectable weapon
 				{
 					break;
 				}
 
 				if (GetWeaponTableData(num)->type & WEAPON_TYPE_RIFLE)
 				{
-					if (CG_WeaponSelectable(GetWeaponTableData(num)->weapAlts, qtrue))
+					if (CG_WeaponSelectable(GetWeaponTableData(num)->weapAlts, qfalse))
 					{
 						num = GetWeaponTableData(num)->weapAlts;
 						break;
@@ -3573,14 +3573,14 @@ void CG_PrevWeap(qboolean switchBanks)
 			//  continue;
 			//}
 
-			if (CG_WeaponSelectable(num, qtrue))
+			if (CG_WeaponSelectable(num, qfalse))
 			{
 				break;
 			}
 
 			if (GetWeaponTableData(num)->type & WEAPON_TYPE_RIFLE)
 			{
-				if (CG_WeaponSelectable(GetWeaponTableData(num)->weapAlts, qtrue))
+				if (CG_WeaponSelectable(GetWeaponTableData(num)->weapAlts, qfalse))
 				{
 					num = GetWeaponTableData(num)->weapAlts;
 					break;
@@ -3618,14 +3618,14 @@ void CG_PrevWeap(qboolean switchBanks)
 				continue;
 			}
 
-			if (CG_WeaponSelectable(num, qtrue))       // first entry in bank was selectable, no need to scan the bank
+			if (CG_WeaponSelectable(num, qfalse))       // first entry in bank was selectable, no need to scan the bank
 			{
 				break;
 			}
 
 			if (GetWeaponTableData(num)->type & WEAPON_TYPE_RIFLE)
 			{
-				if (CG_WeaponSelectable(GetWeaponTableData(num)->weapAlts, qtrue))
+				if (CG_WeaponSelectable(GetWeaponTableData(num)->weapAlts, qfalse))
 				{
 					num = GetWeaponTableData(num)->weapAlts;
 					break;
@@ -3638,14 +3638,14 @@ void CG_PrevWeap(qboolean switchBanks)
 			{
 				num = getPrevWeapInBank(newbank, j);
 
-				if (CG_WeaponSelectable(num, qtrue))       // found selectable weapon
+				if (CG_WeaponSelectable(num, qfalse))       // found selectable weapon
 				{
 					break;
 				}
 
 				if (GetWeaponTableData(num)->type & WEAPON_TYPE_RIFLE)
 				{
-					if (CG_WeaponSelectable(GetWeaponTableData(num)->weapAlts, qtrue))
+					if (CG_WeaponSelectable(GetWeaponTableData(num)->weapAlts, qfalse))
 					{
 						num = GetWeaponTableData(num)->weapAlts;
 						break;
@@ -3778,7 +3778,7 @@ void CG_LastWeaponUsed_f(void)
 		return;
 	}
 
-	if (CG_WeaponSelectable(cg.switchbackWeapon, qtrue))
+	if (CG_WeaponSelectable(cg.switchbackWeapon, qfalse))
 	{
 		CG_FinishWeaponChange(cg.weaponSelect, cg.switchbackWeapon);
 	}


### PR DESCRIPTION
Regression after 'a683717d8838e0634a5102db2fd9321a52c38454' when using e.g. the mouse wheel to switch to grenade.