### PR TITLE
game: Add 1P brass eject offset .weap var

### DIFF
--- a/etmain/weapons/adrenaline.weap
+++ b/etmain/weapons/adrenaline.weap
@@ -42,7 +42,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		//ejectBrassOffset
 
 		adjustLean 1 1 1
 

--- a/etmain/weapons/akimbo_colt.weap
+++ b/etmain/weapons/akimbo_colt.weap
@@ -42,7 +42,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		ejectBrassFunc		"MachineGunEjectBrass"				// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		ejectBrassOffset    16 -4 24
 
 		adjustLean 1 1 1
 
@@ -113,6 +112,8 @@ weaponDef
 		thirdPerson {
 			model			"models/weapons2/colt/ss_colt.mdc"
 			flashmodel		"models/weapons2/colt/colt_flash.mdc"
+
+			ejectBrassOffset	16 -4 24
 		}
 	}
 }

--- a/etmain/weapons/akimbo_luger.weap
+++ b/etmain/weapons/akimbo_luger.weap
@@ -42,7 +42,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		ejectBrassFunc		"MachineGunEjectBrass"				// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		ejectBrassOffset	16 -4 24
 
 		adjustLean 1 1 1
 
@@ -113,6 +112,8 @@ weaponDef
 		thirdPerson {
 			model			"models/weapons2/luger/ss_luger.mdc"
 			flashmodel		"models/weapons2/luger/luger_flash.mdc"
+
+			ejectBrassOffset	16 -4 24
 		}
 	}
 }

--- a/etmain/weapons/akimbo_silenced_colt.weap
+++ b/etmain/weapons/akimbo_silenced_colt.weap
@@ -42,7 +42,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		ejectBrassFunc		"MachineGunEjectBrass"				// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		ejectBrassOffset    16 -4 24
 
 		adjustLean 1 1 1
 
@@ -123,6 +122,8 @@ weaponDef
 		thirdPerson {
 			model			"models/weapons2/colt/silenced.md3"
 			//flashmodel		"models/weapons2/colt/colt_flash.mdc"
+
+			ejectBrassOffset	16 -4 24
 		}
 	}
 }

--- a/etmain/weapons/akimbo_silenced_luger.weap
+++ b/etmain/weapons/akimbo_silenced_luger.weap
@@ -42,7 +42,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		ejectBrassFunc		"MachineGunEjectBrass"				// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		ejectBrassOffset    16 -4 24
 
 		adjustLean 1 1 1
 
@@ -123,6 +122,7 @@ weaponDef
 		thirdPerson {
 			model			"models/weapons2/silencer/silencer.md3"
 			//flashmodel		"models/weapons2/luger/luger_flash.mdc"
+			ejectBrassOffset	16 -4 24
 		}
 	}
 }

--- a/etmain/weapons/ammopack.weap
+++ b/etmain/weapons/ammopack.weap
@@ -42,7 +42,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		//ejectBrassOffset  0 0 0
 
 		adjustLean 1 1 1
 

--- a/etmain/weapons/axis_mortar.weap
+++ b/etmain/weapons/axis_mortar.weap
@@ -43,7 +43,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		//ejectBrassOffset  0 0 0
 
 		adjustLean 1 1 1
 

--- a/etmain/weapons/axis_mortar_set.weap
+++ b/etmain/weapons/axis_mortar_set.weap
@@ -38,7 +38,6 @@ weaponDef
 		missileDlightColor	1 0.7 0.5
 
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		//ejectBrassOffset  0 0 0
 
 		adjustLean 1 1 1
 

--- a/etmain/weapons/bazooka.weap
+++ b/etmain/weapons/bazooka.weap
@@ -42,7 +42,6 @@ weaponDef
 		missileDlightColor	0.75 0.3 0.0
 
 		//ejectBrassFunc		"PanzerFaustEjectBrass"				// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		ejectBrassOffset    -24 -4 24
 
 		adjustLean 1 1 1
 
@@ -89,6 +88,8 @@ weaponDef
 		thirdPerson {
 			model			"models/weapons2/bazooka/bazooka_3rd.md3"
 			flashmodel		"models/weapons2/panzerfaust/pf_flash.mdc"
+
+			ejectBrassOffset	-24 -4 24
 		}
 	}
 }

--- a/etmain/weapons/binocs.weap
+++ b/etmain/weapons/binocs.weap
@@ -42,7 +42,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		//ejectBrassOffset  0 0 0
 
 		adjustLean 1 1 1
 

--- a/etmain/weapons/browning.weap
+++ b/etmain/weapons/browning.weap
@@ -43,7 +43,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		ejectBrassFunc		"MachineGunEjectBrass"				// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		ejectBrassOffset    12 -4 24
 
 		fireRecoil 0.3 0.6 0    // kick angle
 		adjustLean 1 1 1
@@ -119,6 +118,8 @@ weaponDef
 		thirdPerson {
 			model			"models/weapons2/browning/brown30cal_3rd.md3"
 			flashmodel		"models/multiplayer/mg42/mg42_3rd_flash.mdc"
+
+			ejectBrassOffset	12 -4 24
 		}
 	}
 }

--- a/etmain/weapons/colt.weap
+++ b/etmain/weapons/colt.weap
@@ -42,7 +42,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		ejectBrassFunc		"MachineGunEjectBrass"				// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		ejectBrassOffset    24 -4 36
 
 		adjustLean 1 1 1
 
@@ -113,6 +112,8 @@ weaponDef
 		thirdPerson {
 			model			"models/weapons2/colt/ss_colt.mdc"
 			flashmodel		"models/weapons2/colt/colt_flash.mdc"
+
+			ejectBrassOffset	24 -4 36
 		}
 	}
 }

--- a/etmain/weapons/dynamite.weap
+++ b/etmain/weapons/dynamite.weap
@@ -45,7 +45,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		//ejectBrassOffset  0 0 0
 
 		adjustLean 1 1 1
 

--- a/etmain/weapons/fg42.weap
+++ b/etmain/weapons/fg42.weap
@@ -43,7 +43,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		ejectBrassFunc		"MachineGunEjectBrass"				// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		ejectBrassOffset    16 -4 24
 
 		fireRecoil 0.3 0.6 0    // kick angle
 		adjustLean 1 1 1
@@ -107,6 +106,8 @@ weaponDef
 		thirdPerson {
 			model			"models/weapons2/fg42/fg42.md3"
 			flashmodel		"models/weapons2/fg42/fg42_flash.mdc"
+
+			ejectBrassOffset	16 -4 24
 
 			weaponLink
 			{

--- a/etmain/weapons/flamethrower.weap
+++ b/etmain/weapons/flamethrower.weap
@@ -42,7 +42,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		//ejectBrassOffset  0 0 0
 
 		adjustLean 1 1 2
 

--- a/etmain/weapons/gpg40.weap
+++ b/etmain/weapons/gpg40.weap
@@ -53,7 +53,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		//ejectBrassOffset  0 0 0
 
 		adjustLean 1 1 2
 

--- a/etmain/weapons/grenade.weap
+++ b/etmain/weapons/grenade.weap
@@ -52,7 +52,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		//ejectBrassOffset  0 0 0
 
 		adjustLean 1 1 1
 

--- a/etmain/weapons/k43.weap
+++ b/etmain/weapons/k43.weap
@@ -43,7 +43,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		ejectBrassFunc		"MachineGunEjectBrass"				// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		ejectBrassOffset    16 -4 24
 
 		fireRecoil 2 1 0    // kick angle
 		adjustLean 1 1 2
@@ -126,6 +125,8 @@ weaponDef
 		thirdPerson {
 			model			"models/multiplayer/kar98/kar98_3rd.md3"
 			flashmodel		"models/multiplayer/kar98/kar98_3rd_flash.mdc"
+
+			ejectBrassOffset	16 -4 24
 		}
 	}
 }

--- a/etmain/weapons/kar98.weap
+++ b/etmain/weapons/kar98.weap
@@ -43,7 +43,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		ejectBrassFunc		"MachineGunEjectBrass"				// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		ejectBrassOffset    16 -4 24
 
 		fireRecoil 2 1 0    // kick angle
 		adjustLean 1 1 2
@@ -78,6 +77,8 @@ weaponDef
 			axisskin	"models/multiplayer/kar98/kar98_axis.skin"
 			alliedskin	"models/multiplayer/kar98/kar98_allied.skin"
 			flashModel	"models/multiplayer/kar98/v_kar98_flash.mdc"
+
+			ejectBrassOffset	20.0 14.0 -15.0
 
 			dynFov90 -4.0 5.0 1.5
 			dynFov120 1.0 -2.0 1.5
@@ -124,6 +125,8 @@ weaponDef
 		thirdPerson {
 			model			"models/multiplayer/kar98/kar98_gren_pickup.md3"
 			flashmodel		"models/multiplayer/kar98/kar98_3rd_flash.mdc"
+
+			ejectBrassOffset	16 -4 24
 		}
 	}
 }

--- a/etmain/weapons/knife.weap
+++ b/etmain/weapons/knife.weap
@@ -42,7 +42,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		//ejectBrassOffset  0 0 0
 
 		adjustLean 1 1 1
 

--- a/etmain/weapons/knife_kbar.weap
+++ b/etmain/weapons/knife_kbar.weap
@@ -42,7 +42,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		//ejectBrassOffset  0 0 0
 
 		adjustLean 1 1 1
 

--- a/etmain/weapons/landmine.weap
+++ b/etmain/weapons/landmine.weap
@@ -45,7 +45,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		//ejectBrassOffset  0 0 0
 
 		adjustLean 1 1 1
 

--- a/etmain/weapons/luger.weap
+++ b/etmain/weapons/luger.weap
@@ -42,7 +42,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		ejectBrassFunc		"MachineGunEjectBrass"				// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		ejectBrassOffset    24 -4 36
 
 		adjustLean 1 1 1
 
@@ -108,6 +107,8 @@ weaponDef
 		thirdPerson {
 			model			"models/weapons2/luger/ss_luger.mdc"
 			flashmodel		"models/weapons2/luger/luger_flash.mdc"
+
+			ejectBrassOffset	24 -4 36
 		}
 	}
 }

--- a/etmain/weapons/m1_garand.weap
+++ b/etmain/weapons/m1_garand.weap
@@ -43,7 +43,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		ejectBrassFunc		"MachineGunEjectBrass"				// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		ejectBrassOffset    16 -4 24
 
 		fireRecoil 2 1 0    // kick angle
 		adjustLean 1 1 2
@@ -127,6 +126,8 @@ weaponDef
 			//model			"models/multiplayer/m1_garand/m1_garand_3rd.md3"
 			model			"models/multiplayer/m1_garand/m1_garand_gren_pickup.md3"
 			flashmodel		"models/multiplayer/m1_garand/m1_garand_3rd_flash.mdc"
+
+			ejectBrassOffset	16 -4 24
 		}
 	}
 }

--- a/etmain/weapons/m1_garand_s.weap
+++ b/etmain/weapons/m1_garand_s.weap
@@ -43,7 +43,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		ejectBrassFunc		"MachineGunEjectBrass"				// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		ejectBrassOffset    16 -4 24
 
 		fireRecoil 2 1 0    // kick angle
 		adjustLean 1 1 3
@@ -128,6 +127,8 @@ weaponDef
 		thirdPerson {
 			model			"models/multiplayer/m1_garand/m1_garand_3rd.md3"
 			flashmodel		"models/multiplayer/m1_garand/m1_garand_3rd_flash.mdc"
+
+			ejectBrassOffset	16 -4 24
 		}
 	}
 }

--- a/etmain/weapons/m7.weap
+++ b/etmain/weapons/m7.weap
@@ -53,7 +53,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		//ejectBrassFunc	""				// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		//ejectBrassOffset  0 0 0
 
 		adjustLean 1 1 2
 

--- a/etmain/weapons/medpack.weap
+++ b/etmain/weapons/medpack.weap
@@ -42,7 +42,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		//ejectBrassOffset  0 0 0
 
 		adjustLean 1 1 1
 

--- a/etmain/weapons/mg42.weap
+++ b/etmain/weapons/mg42.weap
@@ -43,7 +43,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		ejectBrassFunc		"MachineGunEjectBrass"				// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		ejectBrassOffset    12 -4 24
 
 		fireRecoil 0.3 0.6 0    // kick angle
 		adjustLean 1 1 1
@@ -124,6 +123,8 @@ weaponDef
 		thirdPerson {
 			model			"models/multiplayer/mg42/mg42_3rd.md3"
 			flashmodel		"models/multiplayer/mg42/mg42_3rd_flash.mdc"
+
+			ejectBrassOffset	12 -4 24
 		}
 	}
 }

--- a/etmain/weapons/mortar.weap
+++ b/etmain/weapons/mortar.weap
@@ -43,7 +43,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		//ejectBrassOffset  0 0 0
 
 		adjustLean 1 1 1
 

--- a/etmain/weapons/mortar_set.weap
+++ b/etmain/weapons/mortar_set.weap
@@ -38,7 +38,6 @@ weaponDef
 		missileDlightColor	1 0.7 0.5
 
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		//ejectBrassOffset  0 0 0
 
 		adjustLean 1 1 1
 

--- a/etmain/weapons/mp34.weap
+++ b/etmain/weapons/mp34.weap
@@ -43,8 +43,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		ejectBrassFunc		"MachineGunEjectBrass"				// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		ejectBrassOffset    16 -4 24
-		//brassmodel				"models/weapons2/shells/9mmshell.md3"
 
 		fireRecoil 0.3 0.6 0    // kick angle
 		adjustLean 1 1 1
@@ -78,6 +76,8 @@ weaponDef
 			model			"models/weapons2/mp34/v_mp34.md3"
 			//flashModel		"models/weapons2/sten/v_sten_flash.mdc"
 
+			ejectBrassOffset	15.0 11.0 -8.0
+
 			dynFov90 -3.0 3.2 0.0
 			dynFov120 0.5 -0.3 -1.0
 
@@ -106,6 +106,8 @@ weaponDef
 		thirdPerson {
 			model			"models/weapons2/mp34/mp34_3rd.md3"
 			//flashmodel		"models/weapons2/sten/sten_flash.mdc"
+
+			ejectBrassOffset	16 -4 24
 		}
 	}
 }

--- a/etmain/weapons/mp40.weap
+++ b/etmain/weapons/mp40.weap
@@ -42,7 +42,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		ejectBrassFunc		"MachineGunEjectBrass"				// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		ejectBrassOffset    16 -4 24
 
 		fireRecoil 0.3 0.6 0    // kick angle
 		adjustLean 1 1 1
@@ -106,6 +105,8 @@ weaponDef
 		thirdPerson {
 			model			"models/weapons2/mp40/ss_mp40.md3"
 			flashmodel		"models/weapons2/mp40/mp40_flash.mdc"
+
+			ejectBrassOffset	16 -4 24
 		}
 	}
 }

--- a/etmain/weapons/panzerfaust.weap
+++ b/etmain/weapons/panzerfaust.weap
@@ -42,7 +42,6 @@ weaponDef
 		missileDlightColor	0.75 0.3 0.0
 
 		ejectBrassFunc		"PanzerFaustEjectBrass"				// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		ejectBrassOffset    -24 -4 24
 
 		adjustLean 1 1 1
 
@@ -107,6 +106,8 @@ weaponDef
 		thirdPerson {
 			model			"models/multiplayer/panzerfaust/multi_pf.md3"
 			flashmodel		"models/weapons2/panzerfaust/pf_flash.mdc"
+
+			ejectBrassOffset	-24 -4 24
 		}
 	}
 }

--- a/etmain/weapons/pineapple.weap
+++ b/etmain/weapons/pineapple.weap
@@ -52,7 +52,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		//ejectBrassOffset  0 0 0
 
 		adjustLean 1 1 1
 

--- a/etmain/weapons/pliers.weap
+++ b/etmain/weapons/pliers.weap
@@ -42,7 +42,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		//ejectBrassOffset  0 0 0
 
 		adjustLean 1 1 1
 

--- a/etmain/weapons/satchel.weap
+++ b/etmain/weapons/satchel.weap
@@ -46,7 +46,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		//ejectBrassOffset  0 0 0
 
 		adjustLean 1 1 1
 

--- a/etmain/weapons/satchel_det.weap
+++ b/etmain/weapons/satchel_det.weap
@@ -42,7 +42,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		//ejectBrassOffset  0 0 0
 
 		adjustLean 1 1 1
 

--- a/etmain/weapons/silenced_colt.weap
+++ b/etmain/weapons/silenced_colt.weap
@@ -42,7 +42,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		ejectBrassFunc		"MachineGunEjectBrass"				// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		ejectBrassOffset    24 -4 36
 
 		adjustLean 1 1 1
 
@@ -128,6 +127,8 @@ weaponDef
 		thirdPerson {
 			model			"models/weapons2/colt/silenced.md3"
 			//flashmodel		"models/weapons2/colt/colt_flash.mdc"
+
+			ejectBrassOffset	24 -4 36
 		}
 	}
 }

--- a/etmain/weapons/silenced_luger.weap
+++ b/etmain/weapons/silenced_luger.weap
@@ -42,7 +42,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		ejectBrassFunc		"MachineGunEjectBrass"				// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		ejectBrassOffset    24 -4 36
 
 		adjustLean 1 1 1
 
@@ -122,6 +121,8 @@ weaponDef
 		thirdPerson {
 			model			"models/weapons2/silencer/silencer.md3"
 			//flashmodel		"models/weapons2/luger/luger_flash.mdc"
+
+			ejectBrassOffset	24 -4 36
 		}
 	}
 }

--- a/etmain/weapons/smokegrenade.weap
+++ b/etmain/weapons/smokegrenade.weap
@@ -52,7 +52,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		//ejectBrassOffset  0 0 0
 
 		adjustLean 1 1 1
 

--- a/etmain/weapons/smokemarker.weap
+++ b/etmain/weapons/smokemarker.weap
@@ -52,7 +52,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		//ejectBrassOffset  0 0 0
 
 		//modModel 1		""
 

--- a/etmain/weapons/sten.weap
+++ b/etmain/weapons/sten.weap
@@ -42,7 +42,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		ejectBrassFunc		"MachineGunEjectBrass"				// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		ejectBrassOffset    16 -4 24
 
 		fireRecoil 0.3 0.6 0    // kick angle
 		adjustLean 1 1 1
@@ -104,6 +103,8 @@ weaponDef
 		thirdPerson {
 			model			"models/weapons2/sten/ss_sten.mdc"
 			//flashmodel		"models/weapons2/sten/sten_flash.mdc"
+
+			ejectBrassOffset	16 -4 24
 		}
 	}
 }

--- a/etmain/weapons/syringe.weap
+++ b/etmain/weapons/syringe.weap
@@ -42,7 +42,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		//ejectBrassOffset  0 0 0
 
 		adjustLean 1 1 1
 

--- a/etmain/weapons/thompson.weap
+++ b/etmain/weapons/thompson.weap
@@ -42,7 +42,6 @@ weaponDef
 		//missileDlightColor	0 0 0							// do we still use this?
 
 		ejectBrassFunc		"MachineGunEjectBrass"				// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
-		ejectBrassOffset    16 -4 24
 
 		fireRecoil 0.3 0.6 0    // kick angle
 		adjustLean 1 1 1
@@ -106,6 +105,8 @@ weaponDef
 		thirdPerson {
 			model			"models/weapons2/thompson/thompson.mdc"
 			flashmodel		"models/weapons2/thompson/thompson_flash.mdc"
+
+			ejectBrassOffset	16 -4 24
 		}
 	}
 }

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -986,7 +986,8 @@ typedef struct weaponInfo_s
 	int missileRenderfx;
 
 	void (*ejectBrassFunc)(centity_t *);
-	vec3_t ejectBrassOffset;
+	vec3_t firstPersonEjectBrassOffset;
+	vec3_t thirdPersonEjectBrassOffset;
 
 	vec3_t fireRecoil;                  ///< kick angle
 	vec3_t adjustLean;

--- a/src/cgame/cg_weapon_io.c
+++ b/src/cgame/cg_weapon_io.c
@@ -467,6 +467,20 @@ static qboolean CG_RW_ParseViewType(int handle, weaponInfo_t *weaponInfo, modelV
 				return qfalse;
 			}
 		}
+		else if (viewType == W_FP_MODEL && !Q_stricmp(token.string, "ejectBrassOffset"))
+		{
+			if (!PC_Vec_Parse(handle, &weaponInfo->firstPersonEjectBrassOffset))
+			{
+				return CG_RW_ParseError(handle, "expected ejectBrassOffset as forward left up");
+			}
+		}
+		else if (viewType == W_TP_MODEL && !Q_stricmp(token.string, "ejectBrassOffset"))
+		{
+			if (!PC_Vec_Parse(handle, &weaponInfo->thirdPersonEjectBrassOffset))
+			{
+				return CG_RW_ParseError(handle, "expected ejectBrassOffset as forward left up");
+			}
+		}
 		else if (!Q_stricmp(token.string, "dynFov90"))
 		{
 			if (!PC_Vec_Parse(handle, &weaponInfo->dynFov90))
@@ -1577,13 +1591,6 @@ static qboolean CG_RW_ParseClient(int handle, weaponInfo_t *weaponInfo)
 			else if (!Q_stricmp(filename, "PanzerFaustEjectBrass"))
 			{
 				weaponInfo->ejectBrassFunc = CG_PanzerFaustEjectBrass;
-			}
-		}
-		else if (!Q_stricmp(token.string, "ejectBrassOffset"))
-		{
-			if (!PC_Vec_Parse(handle, &weaponInfo->ejectBrassOffset))
-			{
-				return CG_RW_ParseError(handle, "expected ejectBrassOffset as foward left up");
 			}
 		}
 		else if (!Q_stricmp(token.string, "fireRecoil"))

--- a/src/cgame/cg_weapons.c
+++ b/src/cgame/cg_weapons.c
@@ -225,18 +225,19 @@ void CG_MachineGunEjectBrass(centity_t *cent)
 
 			le->angles.trBase[0] = (rand() & 31) + 60;    // bullets should come out horizontal not vertical JPW NERVE
 
-			// XXX : 1st person offsets for guns with wonky 'tag_brass' tags
-			if (cent->currentState.weapon == WP_KAR98)
+			// apply first person brass offset
+			VectorCopy(cg_weapons[cent->currentState.weapon].firstPersonEjectBrassOffset, offset);
+			if (offset[0] != 0.0 || offset[1] != 0.0 || offset[2] != 0.0)
 			{
-				vec3_t right;
-
-				AngleVectors(cent->lerpAngles, NULL, right, NULL);
-				VectorMA(re->origin, 8.0, right, re->origin);
+				AngleVectors(cent->lerpAngles, forward, right, up);
+				VectorMA(re->origin, offset[0], forward, re->origin);
+				VectorMA(re->origin, offset[1], right, re->origin);
+				VectorMA(re->origin, offset[2], up, re->origin);
 			}
 		}
 		else
 		{
-			VectorCopy(cg_weapons[cent->currentState.weapon].ejectBrassOffset, offset);
+			VectorCopy(cg_weapons[cent->currentState.weapon].thirdPersonEjectBrassOffset, offset);
 			le->angles.trBase[0] = (rand() & 15) + 82;   // bullets should come out horizontal not vertical JPW NERVE
 		}
 	}
@@ -316,7 +317,7 @@ void CG_PanzerFaustEjectBrass(centity_t *cent)
 	float         waterScale = 1.0f;
 	vec3_t        v[3];
 
-	VectorCopy(cg_weapons[cent->currentState.weapon].ejectBrassOffset, offset);
+	VectorCopy(cg_weapons[cent->currentState.weapon].thirdPersonEjectBrassOffset, offset);
 
 	le->leType    = LE_FRAGMENT;
 	le->startTime = cg.time;
@@ -2876,7 +2877,7 @@ qboolean CG_WeaponSelectable(int weapon, qboolean playSound)
 	if (!(COM_BitCheck(cg.predictedPlayerState.weapons, weapon)))
 	{
 		// play noAmmoSound if we try to switch to empty grenades
-      //
+		//
 		// XXX : for some reason, when we use up all our grenades, the grenade
 		// iself becomes unavailable - we still want to play a noAmmoSound in
 		// that scenario tho - so we do the following:


### PR DESCRIPTION
We now allow separate brass eject offsets for both 1P and 3P defined in .weap files.

Also improves kar98 & mp34 offsets.