### PR TITLE
cgame: Add various HUD Editor hotkeys

### DIFF
--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -37,6 +37,7 @@
 #include "cg_local.h"
 
 hudData_t hudData;
+hudComponent_t *showOnlyHudComponent = NULL;
 
 static lagometer_t lagometer;
 
@@ -4219,7 +4220,7 @@ void CG_DrawActiveHud(void)
 	{
 		comp = hudData.active->components[i];
 
-		if (comp && comp->visible && comp->draw)
+		if ((comp && comp->visible && comp->draw) && !(showOnlyHudComponent != NULL && showOnlyHudComponent != comp))
 		{
 			comp->draw(comp);
 		}

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -4395,6 +4395,7 @@ typedef struct
 } hudData_t;
 
 extern hudData_t hudData;
+extern hudComponent_t *showOnlyHudComponent;
 
 typedef struct
 {


### PR DESCRIPTION
* `t`               - hotkey toggles showing only the focused component
* `v`               - hotkey toggles visibility of focused component
* `alt + mwheel`    - changes scale/text size instead of component size
* `alt + shift + v` - sets all components visible