### PR TITLE
cgame: Tweak HUD Editor noise generator

### DIFF
--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -4601,17 +4601,32 @@ static void CG_NoiseGenerator()
 	CG_AddPMItemBig(PM_DEBUG, va(CG_TranslateString("Promoted to rank %s!"), GetRankTableData(cgs.clientinfo[cg.clientNum].team, cgs.clientinfo[cg.clientNum].rank)->names), rankicons[cgs.clientinfo[cg.clientNum].rank][cgs.clientinfo[cg.clientNum].team == TEAM_AXIS ? 1 : 0][0].shader);
 
 	// small popup message
-	if (!(cg.time % 507))
 	{
-		CG_AddPMItem(PM_MESSAGE, "Neque atque quid praeter sed.", " ", cgs.media.pmImages[PM_MESSAGE], 0, 0, colorWhite);
-	}
-	if (!(cg.time % 509))
-	{
-		CG_AddPMItem(PM_DEATH, "Sed ut tum ad senem senex de senectute", " ", cgs.media.pmImages[PM_DEATH], 0, 0, colorWhite);
-	}
-	if (!(cg.time % 513))
-	{
-		CG_AddPMItem(PM_OBJECTIVE, "Nunc vero inanes flatus quorundam vile esse", " ", cgs.media.pmImages[PM_TEAM], 0, 0, colorWhite);
+		static int noiseTime = 0;
+		static int noiseTick = 0;
+
+		noiseTime += cg.frametime;
+		while (noiseTime > 100)
+		{
+			noiseTick++;
+			if (noiseTick == 1)
+			{
+				CG_AddPMItem(PM_MESSAGE, "Neque atque quid praeter sed.", " ", cgs.media.pmImages[PM_MESSAGE], 0, 0, colorWhite);
+			}
+			else if (noiseTick == 2)
+			{
+				CG_AddPMItem(PM_DEATH, "Sed ut tum ad senem senex de senectute", " ", cgs.media.pmImages[PM_DEATH], 0, 0, colorWhite);
+			}
+			else if (noiseTick == 3)
+			{
+				CG_AddPMItem(PM_OBJECTIVE, "Nunc vero inanes flatus quorundam vile esse", " ", cgs.media.pmImages[PM_TEAM], 0, 0, colorWhite);
+			}
+			else if (noiseTick > 4)
+			{
+				noiseTick = 0;
+			}
+			noiseTime -= 100;
+		}
 	}
 
 	// objective indicator simulation

--- a/src/cgame/cg_fireteamoverlay.c
+++ b/src/cgame/cg_fireteamoverlay.c
@@ -428,20 +428,38 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 	vec4_t textOrange               = { 1.0f, 0.6f, 0.0f, 1.0f }; // orange text for ping issues
 	vec4_t nameColor                = { 1.0f, 1.0f, 1.0f, 1.0f };
 
-
-	if (cgs.clientinfo[cg.clientNum].shoutcaster)
+	// early exits
+	if (
+		// we are a shoutcaster
+		cgs.clientinfo[cg.clientNum].shoutcaster
+		// or we are not on a fireteam
+		|| !CG_IsOnFireteam(cg.clientNum)
+		// or assign fireteam data, and early out if not on one
+		|| !(f = CG_IsOnFireteam(cg.clientNum))
+		)
 	{
-		return;
-	}
+		// XXX : TODO : we currently don't generate any noise for the
+		// fireteamoverlay, as it's pretty involved - so we do the minimum here,
+		// which is to just draw a box filling the component size, which also
+		// mentions this fact
+		if (cg.generatingNoiseHud)
+		{
+			const char *info = "Please join a real Fireteam!";
+			int        i     = 0;
 
-	if (!CG_IsOnFireteam(cg.clientNum))
-	{
-		return;
-	}
+			// draw the box
+			w = comp->location.w;
+			h = comp->location.h;
+			CG_FillRect(x, y, w, h * (i + 1), comp->colorBackground);
+			CG_DrawRect_FixedBorder(x, y, w, h * (i + 1), 1, comp->colorBorder);
+			CG_FillRect(x + 1, y + 1, w - 2, h - 1, comp->colorSecondary);
 
-	// assign fireteam data, and early out if not on one
-	if (!(f = CG_IsOnFireteam(cg.clientNum)))
-	{
+			// draw a text info on it
+			scale      = CG_ComputeScale(comp /* h, comp->scale, FONT_TEXT*/);
+			heighTitle = CG_Text_Height_Ext(info, scale, 0, FONT_HEADER);
+			CG_Text_Paint_Ext(x + 4, comp->location.y + ((heighTitle + h) * 0.5), scale, scale, comp->colorMain, info, 0, 0, 0, FONT_TEXT);
+		}
+
 		return;
 	}
 


### PR DESCRIPTION
- generate `popupmessages` items more consistently (used to be modulo to cg.time, which was unpredictable and fps dependent)

- for fireteam overlay, draw a box with an info that mentions to join a real fireteam instead