### PR TITLE
mod: Add toggle HUD Editor bind to Menu (default 'F7')

### DIFF
--- a/etmain/ui/options_controls_advanced.menu
+++ b/etmain/ui/options_controls_advanced.menu
@@ -62,7 +62,7 @@ menuDef {
 	SLIDER( 8, JOYSTICK_Y+100, (SUBWINDOW_WIDTH)-4, 10, _("Yaw:"), .2, 8, "j_yaw" 5 -15 15, _("Set yaw sensitivity") )
 
 #define MISC_Y 32
-	SUBWINDOW( 6+(SUBWINDOW_WIDTH)+6, MISC_Y, (SUBWINDOW_WIDTH), 100, _("MISC") )
+	SUBWINDOW( 6+(SUBWINDOW_WIDTH)+6, MISC_Y, (SUBWINDOW_WIDTH), 112, _("MISC") )
 	MULTI( 8+(SUBWINDOW_WIDTH)+6, MISC_Y+16, (SUBWINDOW_WIDTH)-4, 10, _("Activate lean:"), .2, 8, "cg_activateLean", cvarFloatList { "No" 0 "Yes" 1 }, _("Lean while using the activate button") )
     BIND( 8+(SUBWINDOW_WIDTH)+6, MISC_Y+28, (SUBWINDOW_WIDTH)-4, 10, _("Enemy spawntimer reset:"), .2, 8, "timerReset", "Resets enemy spawntimer" )
     BIND( 8+(SUBWINDOW_WIDTH)+6, MISC_Y+40, (SUBWINDOW_WIDTH)-4, 10, _("Sharetimer:"), .2, 8, "sharetimer", "Share the next time the enemy spawns with your team according to your spawntimer" )
@@ -70,6 +70,7 @@ menuDef {
     BIND( 8+(SUBWINDOW_WIDTH)+6, MISC_Y+64, (SUBWINDOW_WIDTH)-4, 10, _("Shift timer backward:"), .2, 8, "cycle cg_spawntimer_set 0 2147483647 1000", "Shifts enemy spawn timer 1 second backward" )
     BIND( 8+(SUBWINDOW_WIDTH)+6, MISC_Y+76, (SUBWINDOW_WIDTH)-4, 10, _("Shift timer forward:"), .2, 8, "cycle cg_spawntimer_set 2147483647 0 1000", "Shifts enemy spawn timer 1 second forward" )
     BIND( 8+(SUBWINDOW_WIDTH)+6, MISC_Y+88, (SUBWINDOW_WIDTH)-4, 10, _("Request artillery:"), .2, 8, "+zoom;+attack;-attack;-zoom", "Request artillery with single button press." )
+    BIND( 8+(SUBWINDOW_WIDTH)+6, MISC_Y+100, (SUBWINDOW_WIDTH)-4, 10, _("Toggle HUD Editor:"), .2, 8, "edithud", "Toggle open/close the HUD Editor." )
 
 // Buttons //
 	BUTTON( 6, WINDOW_HEIGHT-24, WINDOW_WIDTH-12, 18, _("BACK"), .3, 14, close options_controls_advanced ; open options_controls )

--- a/src/cgame/cg_hud_editor.c
+++ b/src/cgame/cg_hud_editor.c
@@ -2787,6 +2787,18 @@ void CG_DrawHudEditor(void)
 */
 void CG_HudEditor_KeyHandling(int key, qboolean down)
 {
+	// close hud editor menu if any 'edithud' key binding is pressed again
+	if (down)
+	{
+		int b1, b2;
+		cgDC.getKeysForBinding("edithud", &b1, &b2);
+		if ((b1 != -1 && b1 == key) || (b2 != -1 && b2 == key))
+		{
+			CG_EventHandling(CGAME_EVENT_NONE, qfalse);
+			return;
+		}
+	}
+
 	if (BG_PanelButtonsKeyEvent(key, down, hudEditor))
 	{
 		return;

--- a/src/ui/ui_shared.c
+++ b/src/ui/ui_shared.c
@@ -835,6 +835,7 @@ static bind_t g_bindings[] =
 	{ "cycle cg_spawntimer_set 0 2147483647 1000", -1,              -1,  -1,              -1,  -1, -1, -1 },
 	{ "cycle cg_spawntimer_set 2147483647 0 1000", -1,              -1,  -1,              -1,  -1, -1, -1 },
 	{ "+zoom;+attack;-attack;-zoom",               -1,              -1,  -1,              -1,  -1, -1, -1 },
+	{ "edithud",                                   K_F7,            -1,  -1,              -1,  -1, -1, -1 },
 };
 
 static const int g_bindCount = sizeof(g_bindings) / sizeof(bind_t);


### PR DESCRIPTION
'F7' by default now toggles the HUD Editor.

Also fixes an issue that the HUD Editor would not close when issueing
the `edithud` command again.

Adds a new bind entry for it in the Controls Menu.