### PR TITLE
cgame: Fix potential SIGSEV in HUD Editor

### DIFF
--- a/src/cgame/cg_hud_editor.c
+++ b/src/cgame/cg_hud_editor.c
@@ -2579,8 +2579,10 @@ static void CG_HudEditor_ToggleVisibility(void)
 	// otherwise toggle visibility of focused component
 	else
 	{
-		comp          = (hudComponent_t *)((byte *)hudData.active + hudComponentFields[lastFocusComponent->data[0]].offset);
-		comp->visible = comp->visible ? qfalse : qtrue;
+		if (lastFocusComponent != NULL) {
+			comp          = (hudComponent_t *)((byte *)hudData.active + hudComponentFields[lastFocusComponent->data[0]].offset);
+			comp->visible = comp->visible ? qfalse : qtrue;
+		}
 	}
 
 }


### PR DESCRIPTION
Fix a SIGSEV that would be caused when pressing 'v' without having had any component selected.

Regression that came from 2fcccc649f8c323d218f76e0433f955106cf8172