### PR TITLE
cgame: Fix HUD Editor and Limbo for demo playback

### DIFF
--- a/src/cgame/cg_consolecmds.c
+++ b/src/cgame/cg_consolecmds.c
@@ -91,6 +91,12 @@ static void CG_Viewpos_f(void)
  */
 void CG_LimboMenu_f(void)
 {
+	// disallow opening the limbo menu on demoplayback
+	if (cg.demoPlayback)
+	{
+		return;
+	}
+
 	if (cg.showGameView)
 	{
 		CG_EventHandling(CGAME_EVENT_NONE, qfalse);

--- a/src/cgame/cg_hud_editor.c
+++ b/src/cgame/cg_hud_editor.c
@@ -2815,6 +2815,18 @@ void CG_DrawHudEditor(void)
 	}
 }
 
+void CG_HudEditorReset()
+{
+	if (cg.generatingNoiseHud)
+	{
+		CG_HudEditor_Cleanup();
+		cg.generatingNoiseHud = qfalse;
+	}
+
+	cg.editingHud          = qfalse;
+	cg.fullScreenHudEditor = qfalse;
+}
+
 /**
 * @brief CG_HudEditor_KeyHandling
 * @param[in] key

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -4522,6 +4522,7 @@ qboolean CG_HudSave(int HUDToDuplicate, int HUDToDelete);
 void CG_HudEditorSetup(void);
 void CG_DrawHudEditor(void);
 void CG_HudEditor_KeyHandling(int key, qboolean down);
+void CG_HudEditorReset();
 void CG_HudEditorMouseMove_Handling(int x, int y);
 
 typedef struct

--- a/src/cgame/cg_newDraw.c
+++ b/src/cgame/cg_newDraw.c
@@ -633,9 +633,12 @@ void CG_DrawWeapHeat(rectDef_t *rect, int align, qboolean dynamicColor)
 
 	flags |= BAR_LERP_COLOR;
 
-	if (dynamicColor) {
+	if (dynamicColor)
+	{
 		CG_FilledBar(rect->x, rect->y, rect->w, rect->h, dynColor, dynColor2, NULL, NULL, (float)cg.snap->ps.curWeapHeat / 255.0f, 0.f, flags, -1);
-	} else {
+	}
+	else
+	{
 		CG_FilledBar(rect->x, rect->y, rect->w, rect->h, color, color2, NULL, NULL, (float)cg.snap->ps.curWeapHeat / 255.0f, 0.f, flags, -1);
 	}
 }
@@ -842,6 +845,7 @@ void CG_EventHandling(int type, qboolean fForced)
 		cgs.cursorUpdate    = cg.time + 10000;
 		cgs.timescaleUpdate = cg.time + 4000;
 		CG_ScoresUp_f();
+		CG_HudEditorReset();
 		break;
 
 	case CGAME_EVENT_SPEAKEREDITOR:
@@ -911,14 +915,7 @@ void CG_EventHandling(int type, qboolean fForced)
 		}
 		else if (cgs.eventHandling == CGAME_EVENT_HUDEDITOR)
 		{
-			if (cg.generatingNoiseHud)
-			{
-				CG_HudEditor_Cleanup();
-				cg.generatingNoiseHud = qfalse;
-			}
-
-			cg.editingHud          = qfalse;
-			cg.fullScreenHudEditor = qfalse;
+			CG_HudEditorReset();
 		}
 		else if (cgs.eventHandling == CGAME_EVENT_CAMPAIGNBREIFING)
 		{


### PR DESCRIPTION
Block demo/replay playback to open Limbo menu and allow HUD Editor to be closed via the default 'F7' hotkey.