### PR TITLE
cgame: Reduce max `pmitemsbig` message stack from 8 to 3

### DIFF
--- a/src/cgame/cg_popupmessages.c
+++ b/src/cgame/cg_popupmessages.c
@@ -36,7 +36,7 @@
 
 #define NUM_PM_STACK           3
 #define NUM_PM_STACK_ITEMS     32
-#define NUM_PM_STACK_ITEMS_BIG 8 // we shouldn't need many of these
+#define NUM_PM_STACK_ITEMS_BIG 3 // we shouldn't need many of these
 #define NUM_PM_STACK_ITEMS_XP  32
 
 typedef struct pmStackItem_s pmListItem_t;


### PR DESCRIPTION
Currently 8 messages for `pmitemsbig` can be buffered at one given time, this however is needless and annoyingly makes 8 rankups being shown (along with a sound played) for when using 'give skill' a bunch when debugging.