### PR TITLE
cgame: Rename cg_gunFov → cg_gunFovOffset

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2760,7 +2760,7 @@ extern vmCvar_t cg_markTime;
 extern vmCvar_t cg_bloodPuff;
 extern vmCvar_t cg_brassTime;
 extern vmCvar_t cg_gun_frame;
-extern vmCvar_t cg_gunFov;
+extern vmCvar_t cg_gunFovOffset;
 extern vmCvar_t cg_gun_x;
 extern vmCvar_t cg_gun_y;
 extern vmCvar_t cg_gun_z;

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -158,7 +158,7 @@ vmCvar_t cg_weapAnims;
 vmCvar_t cg_weapBankCollisions;
 vmCvar_t cg_weapSwitchNoAmmoSounds;
 vmCvar_t cg_gun_frame;
-vmCvar_t cg_gunFov;
+vmCvar_t cg_gunFovOffset;
 vmCvar_t cg_gun_x;
 vmCvar_t cg_gun_y;
 vmCvar_t cg_gun_z;
@@ -420,7 +420,7 @@ static cvarTable_t cvarTable[] =
 	{ &cg_brassTime,                "cg_brassTime",                "2500",        CVAR_ARCHIVE,                 0 },
 	{ &cg_markTime,                 "cg_markTime",                 "20000",       CVAR_ARCHIVE,                 0 },
 	{ &cg_bloodPuff,                "cg_bloodPuff",                "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_gunFov,                   "cg_gunFov",                   "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_gunFovOffset,             "cg_gunFovOffset",             "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_gun_x,                    "cg_gunX",                     "0",           CVAR_TEMP,                    0 },
 	{ &cg_gun_y,                    "cg_gunY",                     "0",           CVAR_TEMP,                    0 },
 	{ &cg_gun_z,                    "cg_gunZ",                     "0",           CVAR_TEMP,                    0 },

--- a/src/cgame/cg_weapons.c
+++ b/src/cgame/cg_weapons.c
@@ -2432,7 +2432,7 @@ void CG_AddPlayerWeapon(refEntity_t *parent, playerState_t *ps, centity_t *cent)
 
 /**
  * @brief
- * Applies per 'cg_fov' shifts of the hands axis when 'cg_gunFov 0'.
+ * Applies per 'cg_fov' shifts of the hands axis when 'cg_gunFovOffset 0'.
  */
 static void CG_ApplyViewWeaponShift(refEntity_t *hand, vec3_t shifts_90, vec3_t shifts_120)
 {
@@ -2469,13 +2469,13 @@ static void CG_ApplyViewWeaponShift(refEntity_t *hand, vec3_t shifts_90, vec3_t 
  * Applies hand axis modifier for each gun depending on 'cg_fov' according to 2
  * sets of references.
  */
-static void CG_ApplyETLDynamicGunFov(refEntity_t *hand, weapon_t weaponNum)
+static void CG_ApplyETLDynamicGunFovOffset(refEntity_t *hand, weapon_t weaponNum)
 {
 	// NOTE : these values were determined by finding 'up', 'forward' and 'right'
 	//		  shifts for each gun separately for 'cg_fov' 90 and 120 - along the
 	//		  following principles:
 	//
-	// 1. visibility - (as players are used to cg_gunFov 75 now, which
+	// 1. visibility - (as players are used to cg_gunFovOffset 75 now, which
 	//	  essentially removes a good chunk of all vanilla weapon models, they
 	//	  are used to good visibility, i.e. the gun model not taking up too much
 	//	  space) - neither the idle gun model nor reloading it should take up
@@ -2606,8 +2606,8 @@ void CG_AddViewWeapon(playerState_t *ps)
 	// drop gun lower at higher fov
 	if (cg_fov.value >= 75)
 	{
-		fovOffset = -0.2f * (cg_fov.value - cg_gunFov.integer);
-		fovOffset = -0.2f * (cg_fov.value - (cg_gunFov.integer ? cg_gunFov.integer : 90 /* ETL dyn fov values were determined with 90 as reference */));
+		fovOffset = -0.2f * (cg_fov.value - cg_gunFovOffset.integer);
+		fovOffset = -0.2f * (cg_fov.value - (cg_gunFovOffset.integer ? cg_gunFovOffset.integer : 90 /* ETL dyn fov values were determined with 90 as reference */));
 	}
 	else
 	{
@@ -2773,12 +2773,12 @@ void CG_AddViewWeapon(playerState_t *ps)
 		}
 
 		// apply ETL dynamic gun fov
-		if (cg_gunFov.integer == 0)
+		if (cg_gunFovOffset.integer == 0)
 		{
 			AxisToAngles(hand->axis, angles);
 			AngleVectors(angles, forward, right, up);
 
-			CG_ApplyETLDynamicGunFov(hand, ps->weapon);
+			CG_ApplyETLDynamicGunFovOffset(hand, ps->weapon);
 		}
 
 		// add everything onto the hand


### PR DESCRIPTION
The former implies something different which it actually is not about, the latter makes it's function more explicit and also frees us up to use a proper cg_gunFov in the future if needed.