### PR TITLE
mod: Add new muzzle flash sizes

### DIFF
--- a/etmain/weapons/adrenaline.weap
+++ b/etmain/weapons/adrenaline.weap
@@ -77,7 +77,7 @@ weaponDef
 
 		thirdPerson {
 			model		"models/multiplayer/adrenaline/adrenaline.md3"
-			//flashmodel	""
+			//flashModel	""
 		}
 	}
 }

--- a/etmain/weapons/akimbo_colt.weap
+++ b/etmain/weapons/akimbo_colt.weap
@@ -73,6 +73,7 @@ weaponDef
 		firstPerson {
 			model			"models/weapons2/akimbo_colt/v_akimbo_colt.md3"
 			flashModel		"models/weapons2/akimbo_colt/v_akimbo_colt_flash.mdc"
+			flashScale 0.35
 
 			dynFov90 -2.5 2.0 0.0
 			dynFov120 0.0 -3.0 0.0
@@ -111,7 +112,8 @@ weaponDef
 
 		thirdPerson {
 			model			"models/weapons2/colt/ss_colt.mdc"
-			flashmodel		"models/weapons2/colt/colt_flash.mdc"
+			flashModel		"models/weapons2/colt/colt_flash.mdc"
+			flashScale 0.7
 
 			ejectBrassOffset	16 -4 24
 		}

--- a/etmain/weapons/akimbo_luger.weap
+++ b/etmain/weapons/akimbo_luger.weap
@@ -73,6 +73,7 @@ weaponDef
 		firstPerson {
 			model			"models/weapons2/akimbo_luger/v_akimbo_luger.md3"
 			flashModel		"models/weapons2/akimbo_luger/v_akimbo_luger_flash.mdc"
+			flashScale 0.4
 
 			dynFov90 -3.0 2.0 0.0
 			dynFov120 1.0 -3.0 0.0
@@ -111,7 +112,8 @@ weaponDef
 
 		thirdPerson {
 			model			"models/weapons2/luger/ss_luger.mdc"
-			flashmodel		"models/weapons2/luger/luger_flash.mdc"
+			flashModel		"models/weapons2/luger/luger_flash.mdc"
+			flashScale 0.7
 
 			ejectBrassOffset	16 -4 24
 		}

--- a/etmain/weapons/akimbo_silenced_colt.weap
+++ b/etmain/weapons/akimbo_silenced_colt.weap
@@ -121,7 +121,7 @@ weaponDef
 
 		thirdPerson {
 			model			"models/weapons2/colt/silenced.md3"
-			//flashmodel		"models/weapons2/colt/colt_flash.mdc"
+			//flashModel		"models/weapons2/colt/colt_flash.mdc"
 
 			ejectBrassOffset	16 -4 24
 		}

--- a/etmain/weapons/akimbo_silenced_luger.weap
+++ b/etmain/weapons/akimbo_silenced_luger.weap
@@ -121,7 +121,8 @@ weaponDef
 
 		thirdPerson {
 			model			"models/weapons2/silencer/silencer.md3"
-			//flashmodel		"models/weapons2/luger/luger_flash.mdc"
+			//flashModel		"models/weapons2/luger/luger_flash.mdc"
+
 			ejectBrassOffset	16 -4 24
 		}
 	}

--- a/etmain/weapons/ammopack.weap
+++ b/etmain/weapons/ammopack.weap
@@ -57,7 +57,7 @@ weaponDef
 
 		thirdPerson {
 			model			"models/multiplayer/ammopack/ammopack.md3"
-			//flashmodel	""
+			//flashModel	""
 		}
 	}
 }

--- a/etmain/weapons/bazooka.weap
+++ b/etmain/weapons/bazooka.weap
@@ -87,7 +87,7 @@ weaponDef
 
 		thirdPerson {
 			model			"models/weapons2/bazooka/bazooka_3rd.md3"
-			flashmodel		"models/weapons2/panzerfaust/pf_flash.mdc"
+			flashModel		"models/weapons2/panzerfaust/pf_flash.mdc"
 
 			ejectBrassOffset	-24 -4 24
 		}

--- a/etmain/weapons/binocs.weap
+++ b/etmain/weapons/binocs.weap
@@ -54,7 +54,7 @@ weaponDef
 
 		thirdPerson {
 			model			"models/multiplayer/binocs/binocs.md3"
-			//flashmodel	""
+			//flashModel	""
 		}
 	}
 }

--- a/etmain/weapons/browning.weap
+++ b/etmain/weapons/browning.weap
@@ -75,6 +75,7 @@ weaponDef
 		firstPerson {
 			model			"models/weapons2/browning/v_brown30cal.md3"
 			flashModel		"models/multiplayer/mg42/v_mg42_flash.mdc"
+			flashScale 0.65
 
 			dynFov90 -3.0 6.0 -0.5
 			dynFov120 2.0 1.0 0.5
@@ -117,7 +118,8 @@ weaponDef
 
 		thirdPerson {
 			model			"models/weapons2/browning/brown30cal_3rd.md3"
-			flashmodel		"models/multiplayer/mg42/mg42_3rd_flash.mdc"
+			flashModel		"models/multiplayer/mg42/mg42_3rd_flash.mdc"
+			flashScale 0.7
 
 			ejectBrassOffset	12 -4 24
 		}

--- a/etmain/weapons/colt.weap
+++ b/etmain/weapons/colt.weap
@@ -73,6 +73,7 @@ weaponDef
 		firstPerson {
 			model			"models/weapons2/colt/v_colt.mdc"
 			flashModel		"models/weapons2/colt/v_colt_flash.mdc"
+			flashScale 0.35
 
 			dynFov90 -2.0 6.0 1.5
 			dynFov120 3.0 -3.5 1.5
@@ -111,7 +112,8 @@ weaponDef
 
 		thirdPerson {
 			model			"models/weapons2/colt/ss_colt.mdc"
-			flashmodel		"models/weapons2/colt/colt_flash.mdc"
+			flashModel		"models/weapons2/colt/colt_flash.mdc"
+			flashScale 0.7
 
 			ejectBrassOffset	24 -4 36
 		}

--- a/etmain/weapons/dynamite.weap
+++ b/etmain/weapons/dynamite.weap
@@ -87,7 +87,7 @@ weaponDef
 
 		thirdPerson {
 			model		"models/multiplayer/dynamite/dynamite_3rd.md3"
-			//flashmodel	""
+			//flashModel	""
 		}
 	}
 }

--- a/etmain/weapons/fg42.weap
+++ b/etmain/weapons/fg42.weap
@@ -75,6 +75,7 @@ weaponDef
 		firstPerson {
 			model			"models/weapons2/fg42/v_fg42.mdc"
 			flashModel		"models/weapons2/fg42/v_fg42_flash.mdc"
+			flashScale 0.55
 
 			dynFov90 -3.0 3.0 0.0
 			dynFov120 0.0 -2.5 0.0
@@ -105,7 +106,8 @@ weaponDef
 
 		thirdPerson {
 			model			"models/weapons2/fg42/fg42.md3"
-			flashmodel		"models/weapons2/fg42/fg42_flash.mdc"
+			flashModel		"models/weapons2/fg42/fg42_flash.mdc"
+			flashScale 0.8
 
 			ejectBrassOffset	16 -4 24
 

--- a/etmain/weapons/gpg40.weap
+++ b/etmain/weapons/gpg40.weap
@@ -126,7 +126,7 @@ weaponDef
 
 		thirdPerson {
 			model			"models/multiplayer/kar98/kar98_3rd.md3"
-			//flashmodel		"models/multiplayer/kar98/kar98_3rd_flash.mdc"
+			//flashModel		"models/multiplayer/kar98/kar98_3rd_flash.mdc"
 		}
 	}
 }

--- a/etmain/weapons/grenade.weap
+++ b/etmain/weapons/grenade.weap
@@ -95,7 +95,7 @@ weaponDef
 
 		thirdPerson {
 			model			"models/weapons2/grenade/ss_grenade.md3"
-			//flashmodel		""
+			//flashModel		""
 		}
 	}
 }

--- a/etmain/weapons/k43.weap
+++ b/etmain/weapons/k43.weap
@@ -1,4 +1,4 @@
-weaponDef
+weaponDef // silenced kar98
 {
 	// This basically fills out weaponInfo_t
 	client {
@@ -79,6 +79,7 @@ weaponDef
 			axisskin	"models/multiplayer/kar98/kar98_axis.skin"
 			alliedskin	"models/multiplayer/kar98/kar98_allied.skin"
 			flashModel	"models/multiplayer/kar98/v_kar98_flash.mdc"
+			flashScale 0.55
 
 			dynFov90 -2.0 5.0 -1.5
 			dynFov120 3.0 0.0 0.0
@@ -124,7 +125,8 @@ weaponDef
 
 		thirdPerson {
 			model			"models/multiplayer/kar98/kar98_3rd.md3"
-			flashmodel		"models/multiplayer/kar98/kar98_3rd_flash.mdc"
+			flashModel		"models/multiplayer/kar98/kar98_3rd_flash.mdc"
+			flashScale 1.0
 
 			ejectBrassOffset	16 -4 24
 		}

--- a/etmain/weapons/kar98.weap
+++ b/etmain/weapons/kar98.weap
@@ -77,6 +77,7 @@ weaponDef
 			axisskin	"models/multiplayer/kar98/kar98_axis.skin"
 			alliedskin	"models/multiplayer/kar98/kar98_allied.skin"
 			flashModel	"models/multiplayer/kar98/v_kar98_flash.mdc"
+			flashScale 0.55
 
 			ejectBrassOffset	20.0 14.0 -15.0
 
@@ -124,7 +125,8 @@ weaponDef
 
 		thirdPerson {
 			model			"models/multiplayer/kar98/kar98_gren_pickup.md3"
-			flashmodel		"models/multiplayer/kar98/kar98_3rd_flash.mdc"
+			flashModel		"models/multiplayer/kar98/kar98_3rd_flash.mdc"
+			flashScale 0.8
 
 			ejectBrassOffset	16 -4 24
 		}

--- a/etmain/weapons/knife.weap
+++ b/etmain/weapons/knife.weap
@@ -85,7 +85,7 @@ weaponDef
 
 		thirdPerson {
 			model		"models/multiplayer/knife/knife.md3"
-			//flashmodel	""
+			//flashModel	""
 		}
 	}
 }

--- a/etmain/weapons/knife_kbar.weap
+++ b/etmain/weapons/knife_kbar.weap
@@ -85,7 +85,7 @@ weaponDef
 
 		thirdPerson {
 			model		"models/weapons2/knife_kbar/knife.md3"
-			//flashmodel	""
+			//flashModel	""
 		}
 	}
 }

--- a/etmain/weapons/landmine.weap
+++ b/etmain/weapons/landmine.weap
@@ -78,7 +78,7 @@ weaponDef
 
 		thirdPerson {
 			model		"models/multiplayer/landmine/landmine.md3"
-			//flashmodel	""
+			//flashModel	""
 		}
 	}
 }

--- a/etmain/weapons/luger.weap
+++ b/etmain/weapons/luger.weap
@@ -73,6 +73,7 @@ weaponDef
 		firstPerson {
 			model			"models/weapons2/luger/v_luger.mdc"
 			flashModel		"models/weapons2/luger/v_luger_flash.mdc"
+			flashScale 0.35
 
 			dynFov90 0.0 6.0 1.5
 			dynFov120 5.0 -3.0 1.5
@@ -106,7 +107,8 @@ weaponDef
 
 		thirdPerson {
 			model			"models/weapons2/luger/ss_luger.mdc"
-			flashmodel		"models/weapons2/luger/luger_flash.mdc"
+			flashModel		"models/weapons2/luger/luger_flash.mdc"
+			flashScale 0.7
 
 			ejectBrassOffset	24 -4 36
 		}

--- a/etmain/weapons/m1_garand.weap
+++ b/etmain/weapons/m1_garand.weap
@@ -77,6 +77,7 @@ weaponDef
 			axisskin	"models/multiplayer/m1_garand/m1_garand_axis.skin"
 			alliedskin	"models/multiplayer/m1_garand/m1_garand_allied.skin"
 			flashModel	"models/multiplayer/m1_garand/v_m1_garand_flash.mdc"
+			flashScale 0.75
 
 			dynFov90 -3.0 0.0 1.0
 			dynFov120 1.0 -4.0 1.0
@@ -125,7 +126,8 @@ weaponDef
 		thirdPerson {
 			//model			"models/multiplayer/m1_garand/m1_garand_3rd.md3"
 			model			"models/multiplayer/m1_garand/m1_garand_gren_pickup.md3"
-			flashmodel		"models/multiplayer/m1_garand/m1_garand_3rd_flash.mdc"
+			flashModel		"models/multiplayer/m1_garand/m1_garand_3rd_flash.mdc"
+			flashScale 0.8
 
 			ejectBrassOffset	16 -4 24
 		}

--- a/etmain/weapons/m1_garand_s.weap
+++ b/etmain/weapons/m1_garand_s.weap
@@ -79,6 +79,7 @@ weaponDef
 			axisskin	"models/multiplayer/m1_garand/m1_garand_axis.skin"
 			alliedskin	"models/multiplayer/m1_garand/m1_garand_allied.skin"
 			flashModel	"models/multiplayer/m1_garand/v_m1_garand_flash.mdc"
+			flashScale 0.6
 
 			dynFov90 -3.0 5.0 0.0
 			dynFov120 1.0 1.2 2.0
@@ -126,7 +127,8 @@ weaponDef
 
 		thirdPerson {
 			model			"models/multiplayer/m1_garand/m1_garand_3rd.md3"
-			flashmodel		"models/multiplayer/m1_garand/m1_garand_3rd_flash.mdc"
+			flashModel		"models/multiplayer/m1_garand/m1_garand_3rd_flash.mdc"
+			flashScale 1.0
 
 			ejectBrassOffset	16 -4 24
 		}

--- a/etmain/weapons/m7.weap
+++ b/etmain/weapons/m7.weap
@@ -128,7 +128,7 @@ weaponDef
 
 		thirdPerson {
 			model			"models/multiplayer/m1_garand/m1_garand_3rd.md3"
-			//flashmodel		"models/multiplayer/m1_garand/m1_garand_3rd_flash.mdc"
+			//flashModel		"models/multiplayer/m1_garand/m1_garand_3rd_flash.mdc"
 		}
 	}
 }

--- a/etmain/weapons/medpack.weap
+++ b/etmain/weapons/medpack.weap
@@ -55,7 +55,7 @@ weaponDef
 
 		thirdPerson {
 			model			"models/multiplayer/medpack/medpack.md3"
-			//flashmodel	""
+			//flashModel	""
 		}
 	}
 }

--- a/etmain/weapons/mg42.weap
+++ b/etmain/weapons/mg42.weap
@@ -75,6 +75,7 @@ weaponDef
 		firstPerson {
 			model			"models/multiplayer/mg42/v_mg42.md3"
 			flashModel		"models/multiplayer/mg42/v_mg42_flash.mdc"
+			flashScale 0.65
 
 			dynFov90 -2.0 2.5 0.0
 			dynFov120 3.0 -2.0 0.0
@@ -122,7 +123,8 @@ weaponDef
 
 		thirdPerson {
 			model			"models/multiplayer/mg42/mg42_3rd.md3"
-			flashmodel		"models/multiplayer/mg42/mg42_3rd_flash.mdc"
+			flashModel		"models/multiplayer/mg42/mg42_3rd_flash.mdc"
+			flashScale 0.7
 
 			ejectBrassOffset	12 -4 24
 		}

--- a/etmain/weapons/mortar.weap
+++ b/etmain/weapons/mortar.weap
@@ -101,7 +101,7 @@ weaponDef
 
 		thirdPerson {
 			model		"models/multiplayer/mortar/mortar_3rda.md3"
-			//flashmodel	""
+			//flashModel	""
 		}
 	}
 }

--- a/etmain/weapons/mortar_set.weap
+++ b/etmain/weapons/mortar_set.weap
@@ -112,7 +112,7 @@ weaponDef
 
 		thirdPerson {
 			model		"models/multiplayer/mortar/mortar_3rd.md3"
-			//flashmodel	""
+			//flashModel	""
 		}
 	}
 }

--- a/etmain/weapons/mp34.weap
+++ b/etmain/weapons/mp34.weap
@@ -105,7 +105,7 @@ weaponDef
 
 		thirdPerson {
 			model			"models/weapons2/mp34/mp34_3rd.md3"
-			//flashmodel		"models/weapons2/sten/sten_flash.mdc"
+			//flashModel		"models/weapons2/sten/sten_flash.mdc"
 
 			ejectBrassOffset	16 -4 24
 		}

--- a/etmain/weapons/mp40.weap
+++ b/etmain/weapons/mp40.weap
@@ -74,6 +74,7 @@ weaponDef
 		firstPerson {
 			model			"models/weapons2/mp40/v_mp40.md3"
 			flashModel		"models/weapons2/mp40/v_mp40_flash.mdc"
+			flashScale 0.5
 
 			dynFov90 -4.4 5.0 0.0
 			dynFov120 1.0 0.0 0.0
@@ -104,7 +105,8 @@ weaponDef
 
 		thirdPerson {
 			model			"models/weapons2/mp40/ss_mp40.md3"
-			flashmodel		"models/weapons2/mp40/mp40_flash.mdc"
+			flashModel		"models/weapons2/mp40/mp40_flash.mdc"
+			flashScale 0.9
 
 			ejectBrassOffset	16 -4 24
 		}

--- a/etmain/weapons/panzerfaust.weap
+++ b/etmain/weapons/panzerfaust.weap
@@ -67,6 +67,7 @@ weaponDef
 		firstPerson {
 			model			"models/weapons2/panzerfaust/v_pf.md3"
 			flashModel		"models/weapons2/panzerfaust/v_pf_flash.mdc"
+			flashScale 1.50
 
 			dynFov90 -0.5 0.5 0.5
 			dynFov120 2.5 -3.0 0.5
@@ -105,7 +106,8 @@ weaponDef
 
 		thirdPerson {
 			model			"models/multiplayer/panzerfaust/multi_pf.md3"
-			flashmodel		"models/weapons2/panzerfaust/pf_flash.mdc"
+			flashModel		"models/weapons2/panzerfaust/pf_flash.mdc"
+			flashScale 1.00
 
 			ejectBrassOffset	-24 -4 24
 		}

--- a/etmain/weapons/pineapple.weap
+++ b/etmain/weapons/pineapple.weap
@@ -95,7 +95,7 @@ weaponDef
 
 		thirdPerson {
 			model			"models/weapons2/grenade/ss_pineapple.md3"
-			//flashmodel		""
+			//flashModel		""
 		}
 	}
 }

--- a/etmain/weapons/pliers.weap
+++ b/etmain/weapons/pliers.weap
@@ -59,7 +59,7 @@ weaponDef
 
 		thirdPerson {
 			model		"models/multiplayer/pliers/pliers.md3"
-			//flashmodel	""
+			//flashModel	""
 		}
 	}
 }

--- a/etmain/weapons/satchel.weap
+++ b/etmain/weapons/satchel.weap
@@ -98,7 +98,7 @@ weaponDef
 			model			"models/multiplayer/satchel/satchel.md3"
 			axisskin		"models/multiplayer/satchel/satchel_axis.skin"
 			alliedskin		"models/multiplayer/satchel/satchel_allied.skin"
-			//flashmodel	""
+			//flashModel	""
 		}
 	}
 }

--- a/etmain/weapons/satchel_det.weap
+++ b/etmain/weapons/satchel_det.weap
@@ -78,7 +78,7 @@ weaponDef
 
 		thirdPerson {
 			model			"models/multiplayer/satchel/radio.md3"
-			//flashmodel	""
+			//flashModel	""
 		}
 	}
 }

--- a/etmain/weapons/silenced_colt.weap
+++ b/etmain/weapons/silenced_colt.weap
@@ -126,7 +126,7 @@ weaponDef
 
 		thirdPerson {
 			model			"models/weapons2/colt/silenced.md3"
-			//flashmodel		"models/weapons2/colt/colt_flash.mdc"
+			//flashModel		"models/weapons2/colt/colt_flash.mdc"
 
 			ejectBrassOffset	24 -4 36
 		}

--- a/etmain/weapons/silenced_luger.weap
+++ b/etmain/weapons/silenced_luger.weap
@@ -120,7 +120,7 @@ weaponDef
 
 		thirdPerson {
 			model			"models/weapons2/silencer/silencer.md3"
-			//flashmodel		"models/weapons2/luger/luger_flash.mdc"
+			//flashModel		"models/weapons2/luger/luger_flash.mdc"
 
 			ejectBrassOffset	24 -4 36
 		}

--- a/etmain/weapons/smokegrenade.weap
+++ b/etmain/weapons/smokegrenade.weap
@@ -67,7 +67,7 @@ weaponDef
 
 		thirdPerson {
 			model			"models/multiplayer/smokebomb/smokebomb.md3"
-			//flashmodel	""
+			//flashModel	""
 		}
 	}
 }

--- a/etmain/weapons/smokemarker.weap
+++ b/etmain/weapons/smokemarker.weap
@@ -83,7 +83,7 @@ weaponDef
 
 		thirdPerson {
 			model		"models/multiplayer/smokegrenade/smokegrenade.md3"
-			//flashmodel	""
+			//flashModel	""
 		}
 	}
 }

--- a/etmain/weapons/sten.weap
+++ b/etmain/weapons/sten.weap
@@ -102,7 +102,7 @@ weaponDef
 
 		thirdPerson {
 			model			"models/weapons2/sten/ss_sten.mdc"
-			//flashmodel		"models/weapons2/sten/sten_flash.mdc"
+			//flashModel		"models/weapons2/sten/sten_flash.mdc"
 
 			ejectBrassOffset	16 -4 24
 		}

--- a/etmain/weapons/thompson.weap
+++ b/etmain/weapons/thompson.weap
@@ -74,6 +74,7 @@ weaponDef
 		firstPerson {
 			model			"models/weapons2/thompson/v_thompson.md3"
 			flashModel		"models/weapons2/thompson/v_thompson_flash.mdc"
+			flashScale 0.35
 
 			dynFov90 -3.0 3.5 0.0
 			dynFov120 2.5 -0.8 0.5
@@ -104,7 +105,8 @@ weaponDef
 
 		thirdPerson {
 			model			"models/weapons2/thompson/thompson.mdc"
-			flashmodel		"models/weapons2/thompson/thompson_flash.mdc"
+			flashModel		"models/weapons2/thompson/thompson_flash.mdc"
+			flashScale 0.9
 
 			ejectBrassOffset	16 -4 24
 		}

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -958,6 +958,7 @@ typedef struct weaponInfo_s
 	weaponModel_t weaponModel[W_NUM_TYPES];
 	partModel_t partModels[W_NUM_TYPES][W_MAX_PARTS];
 	qhandle_t flashModel[W_NUM_TYPES];
+	float flashScale[2];
 	qhandle_t modModels[6];             ///< like the scope for the rifles
 
 	vec3_t flashDlightColor;
@@ -2778,7 +2779,7 @@ extern vmCvar_t cg_autoswitch;
 extern vmCvar_t cg_fov;
 extern vmCvar_t cg_muzzleFlash;
 extern vmCvar_t cg_muzzleFlashDlight;
-extern vmCvar_t cg_muzzleFlashScale;
+extern vmCvar_t cg_muzzleFlashOld;
 extern vmCvar_t cg_drawEnvAwareness;
 extern vmCvar_t cg_drawEnvAwarenessScale;
 extern vmCvar_t cg_drawEnvAwarenessIconSize;

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -170,7 +170,7 @@ vmCvar_t cg_autoswitch;
 vmCvar_t cg_fov;
 vmCvar_t cg_muzzleFlash;
 vmCvar_t cg_muzzleFlashDlight;
-vmCvar_t cg_muzzleFlashScale;
+vmCvar_t cg_muzzleFlashOld;
 vmCvar_t cg_zoomStepSniper;
 vmCvar_t cg_zoomDefaultSniper;
 vmCvar_t cg_thirdPerson;
@@ -400,7 +400,7 @@ static cvarTable_t cvarTable[] =
 	{ &cg_fov,                      "cg_fov",                      "90",          CVAR_ARCHIVE,                 0 },
 	{ &cg_muzzleFlash,              "cg_muzzleFlash",              "1",           CVAR_ARCHIVE,                 0 },
 	{ &cg_muzzleFlashDlight,        "cg_muzzleFlashDlight",        "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_muzzleFlashScale,         "cg_muzzleFlashScale",         "0.8",         CVAR_ARCHIVE,                 0 },
+	{ &cg_muzzleFlashOld,           "cg_muzzleFlashOld",           "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_letterbox,                "cg_letterbox",                "0",           CVAR_TEMP,                    0 },
 	{ &cg_shadows,                  "cg_shadows",                  "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_gibs,                     "cg_gibs",                     "1",           CVAR_ARCHIVE,                 0 },

--- a/src/cgame/cg_weapon_io.c
+++ b/src/cgame/cg_weapon_io.c
@@ -397,6 +397,7 @@ static qboolean CG_RW_ParseViewType(int handle, weaponInfo_t *weaponInfo, modelV
 {
 	pc_token_t token;
 	char       filename[MAX_QPATH];
+	float       value;
 
 	if (!trap_PC_ReadToken(handle, &token) || Q_stricmp(token.string, "{"))
 	{
@@ -459,6 +460,15 @@ static qboolean CG_RW_ParseViewType(int handle, weaponInfo_t *weaponInfo, modelV
 			}
 
 			weaponInfo->flashModel[viewType] = trap_R_RegisterModel(filename);
+		}
+		else if (!Q_stricmp(token.string, "flashScale"))
+		{
+			if (!PC_Float_Parse(handle, &value))
+			{
+				return CG_RW_ParseError(handle, "expected flashScale as float");
+			}
+
+			weaponInfo->flashScale[viewType] = value;
 		}
 		else if (!Q_stricmp(token.string, "weaponLink"))
 		{


### PR DESCRIPTION
Removes 'cg_muzzleFlashScale', which was introduced in a previous snapshot (not in a release).

Adds 'cg_muzzleFlashOld', which defaults to '0'.

When not set, it scales muzzle flashes via first-person and third-person values set in `.weap` files.

The goal of new muzzle flashes is to have them not heavily obscure the player view such that players are incentivized to switch them off entirely via 'cg_muzzleFlash 0'.