### PR TITLE
cgame: Add 'Toggle Help' Button to HUD Editor

### DIFF
--- a/etmain/ui/menudef.h
+++ b/etmain/ui/menudef.h
@@ -439,4 +439,6 @@
 #define SCREEN_WIDTH            640
 #define SCREEN_HEIGHT           480
 
+#define HUD_EDITOR_SIZE_COEFF   1.28f
+
 #endif // #ifndef INCLUDE_MENUDEF_H

--- a/src/cgame/cg_newDraw.c
+++ b/src/cgame/cg_newDraw.c
@@ -633,9 +633,12 @@ void CG_DrawWeapHeat(rectDef_t *rect, int align, qboolean dynamicColor)
 
 	flags |= BAR_LERP_COLOR;
 
-	if (dynamicColor) {
+	if (dynamicColor)
+	{
 		CG_FilledBar(rect->x, rect->y, rect->w, rect->h, dynColor, dynColor2, NULL, NULL, (float)cg.snap->ps.curWeapHeat / 255.0f, 0.f, flags, -1);
-	} else {
+	}
+	else
+	{
 		CG_FilledBar(rect->x, rect->y, rect->w, rect->h, color, color2, NULL, NULL, (float)cg.snap->ps.curWeapHeat / 255.0f, 0.f, flags, -1);
 	}
 }
@@ -672,8 +675,8 @@ void CG_MouseEvent(int x, int y)
 		if (!cgs.demoCamera.renderingFreeCam)
 		{
 #endif
-		int hudEditorSafeX = SCREEN_WIDTH_SAFE * 1.28f;
-		int hudEditorSafeY = SCREEN_HEIGHT_SAFE * 1.28f;
+		int hudEditorSafeX = SCREEN_WIDTH_SAFE * HUD_EDITOR_SIZE_COEFF;
+		int hudEditorSafeY = SCREEN_HEIGHT_SAFE * HUD_EDITOR_SIZE_COEFF;
 
 		cgs.cursorX += x;
 		if (cg.editingHud && !cg.fullScreenHudEditor)


### PR DESCRIPTION
Currently the Help Text always gets shown when opening the HUD Editor
for the first time since the game was started.

This makes sure that users take note of it, however it also becomes
cumbersome after you know about it's existance.

Instead of showing the help text always at the start, this commit adds a
`Toggle Help` Button and gives it a special color to make it easily
noticeable.
