### PR TITLE
mod: add entity bit stream ET_EBS_SHOUTCAST

### DIFF
--- a/src/cgame/cg_ents.c
+++ b/src/cgame/cg_ents.c
@@ -2578,8 +2578,8 @@ void CG_EBS_Shoutcast(centity_t *cent)
 		ci        = &cgs.clientinfo[clientNum];
 
 		ci->health        = EBS_ReadBitsWithSign(&ebs, 9);
-		ci->ammoclip      = EBS_ReadBits(&ebs, 8);
-		ci->ammo          = EBS_ReadBits(&ebs, 8);
+		ci->ammoclip      = EBS_ReadBits(&ebs, 10);
+		ci->ammo          = EBS_ReadBits(&ebs, 10);
 		ci->currentWeapon = EBS_ReadBits(&ebs, 6);
 		ci->powerups      = EBS_ReadBits(&ebs, 16);
 	}

--- a/src/cgame/cg_ents.c
+++ b/src/cgame/cg_ents.c
@@ -34,6 +34,7 @@
  */
 
 #include "cg_local.h"
+#include "../game/bg_ebs.h"
 
 /**
  * @brief Modifies the entities position and axis by the given
@@ -2543,6 +2544,48 @@ void CG_CalcEntityLerpPositions(centity_t *cent)
 }
 
 /**
+ * @brief CG_EBS_Shoutcast
+ * @param[in] cent
+ */
+void CG_EBS_Shoutcast(centity_t *cent)
+{
+	entityBitStream_t ebs;
+	clientInfo_t      *ci;
+	int               i, version, slotBits, clientNum;
+
+	// should never happen
+	if (!cgs.clientinfo[cg.clientNum].shoutcaster)
+	{
+		return;
+	}
+
+	EBS_InitRead(&ebs, &cent->currentState);
+
+	version = EBS_ReadBits(&ebs, 4);
+	etl_assert(version == 0);
+
+	slotBits = EBS_ReadBits(&ebs, 6);
+
+	for (i = 0; i < 6; i++)
+	{
+		if (!(slotBits & (BIT(i))))
+		{
+			EBS_Skip(&ebs, EBS_SHOUTCAST_PLAYER_SIZE_V0);
+			continue;
+		}
+
+		clientNum = EBS_ReadBits(&ebs, 6);
+		ci        = &cgs.clientinfo[clientNum];
+
+		ci->health        = EBS_ReadBitsWithSign(&ebs, 9);
+		ci->ammoclip      = EBS_ReadBits(&ebs, 8);
+		ci->ammo          = EBS_ReadBits(&ebs, 8);
+		ci->currentWeapon = EBS_ReadBits(&ebs, 6);
+		ci->powerups      = EBS_ReadBits(&ebs, 16);
+	}
+}
+
+/**
  * @brief CG_ProcessEntity
  * @param[in] cent
  * @note All case aren't handle
@@ -2980,6 +3023,12 @@ qboolean CG_AddCEntity_Filter(centity_t *cent)
 	    && cg.mvTotalClients < 2
 #endif
 	    )
+	{
+		return qtrue;
+	}
+
+	// processed in CG_TransitionEntity
+	if (cent->currentState.eType == ET_EBS_SHOUTCAST)
 	{
 		return qtrue;
 	}

--- a/src/cgame/cg_event.c
+++ b/src/cgame/cg_event.c
@@ -2992,6 +2992,11 @@ void CG_CheckEvents(centity_t *cent)
 {
 	int i, event;
 
+	if (cent->currentState.eType == ET_EBS_SHOUTCAST)
+	{
+		return;
+	}
+
 	// calculate the position at exactly the frame time
 	BG_EvaluateTrajectory(&cent->currentState.pos, cg.snap->serverTime, cent->lerpOrigin, qfalse, cent->currentState.effect2Time);
 	CG_SetEntitySoundPosition(cent);

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -706,11 +706,11 @@ typedef struct clientInfo_s
 #ifdef FEATURE_PRESTIGE
 	int prestige;
 #endif
-
-#ifdef FEATURE_MULTIVIEW
-	// per client MV ps info
+	int currentWeapon;
 	int ammo;
 	int ammoclip;
+#ifdef FEATURE_MULTIVIEW
+	// per client MV ps info
 	int chargeTime;
 	qboolean fCrewgun;
 	int cursorHint;
@@ -1157,7 +1157,7 @@ typedef struct
 	int etLegacyClient;                     ///< is either 0 (vanilla client) or a version integer from git_version.h
 	qboolean loading;                       ///< don't defer players at initial startup
 	qboolean intermissionStarted;           ///< don't draw disconnect icon/message because game will end shortly
-	qboolean autoCmdExecuted;				///< has 'cg_autoCmd' been executed yet
+	qboolean autoCmdExecuted;               ///< has 'cg_autoCmd' been executed yet
 
 	// there are only one or two snapshot_t that are relevent at a time
 	int latestSnapshotNum;                  ///< the number of snapshots the client system has received
@@ -3148,7 +3148,7 @@ const char *CG_TranslateString(const char *string);
 
 void CG_InitStatsDebug(void);
 void CG_StatsDebugAddText(const char *text);
-void CG_DrawDebugArtillery(centity_t * cent);
+void CG_DrawDebugArtillery(centity_t *cent);
 
 void CG_AddLagometerFrameInfo(void);
 void CG_AddLagometerSnapshotInfo(snapshot_t *snap);
@@ -3268,6 +3268,7 @@ qboolean CG_AddCEntity_Filter(centity_t *cent);
 qboolean CG_AddLinkedEntity(centity_t *cent, qboolean ignoreframe, int atTime);
 void CG_PositionEntityOnTag(refEntity_t *entity, const refEntity_t *parent, const char *tagName, int startIndex, vec3_t *offset);
 void CG_PositionRotatedEntityOnTag(refEntity_t *entity, const refEntity_t *parent, const char *tagName);
+void CG_EBS_Shoutcast(centity_t *cent);
 
 // cg_weapons_io.c
 void CG_RegisterWeapon(int weaponNum, qboolean force);
@@ -4395,7 +4396,7 @@ typedef struct
 	int count;
 } hudData_t;
 
-extern hudData_t hudData;
+extern hudData_t      hudData;
 extern hudComponent_t *showOnlyHudComponent;
 
 typedef struct

--- a/src/cgame/cg_players.c
+++ b/src/cgame/cg_players.c
@@ -192,10 +192,14 @@ void CG_NewClientInfo(int clientNum)
 	// grabbing some older stuff, if it's a new client, tinfo will update within one second anyway, otherwise you get the health thing flashing red
 	// NOTE: why are we bothering to do all this setting up of a new clientInfo_t anyway? it was all for deffered clients iirc, which we dont have
 	VectorCopy(ci->location, newInfo.location);
-	newInfo.health       = ci->health;
-	newInfo.fireteamData = ci->fireteamData;
-	newInfo.clientNum    = clientNum;
-	newInfo.selected     = ci->selected;
+	newInfo.health        = ci->health;
+	newInfo.fireteamData  = ci->fireteamData;
+	newInfo.clientNum     = clientNum;
+	newInfo.selected      = ci->selected;
+	newInfo.currentWeapon = ci->currentWeapon;
+	newInfo.ammo          = ci->ammo;
+	newInfo.ammoclip      = ci->ammoclip;
+	newInfo.powerups      = ci->powerups;
 
 	// isolate the player's name
 	v = Info_ValueForKey(configstring, "n");

--- a/src/cgame/cg_predict.c
+++ b/src/cgame/cg_predict.c
@@ -102,6 +102,8 @@ void CG_BuildSolidList(void)
 			cg_triggerEntities[cg_numTriggerEntities] = cent;
 			cg_numTriggerEntities++;
 			break;
+		case ET_EBS_SHOUTCAST:
+			continue;
 		default:
 			break;
 		}

--- a/src/cgame/cg_shoutcastoverlay.c
+++ b/src/cgame/cg_shoutcastoverlay.c
@@ -80,6 +80,7 @@ static int CG_GetPlayerCurrentWeapon(clientInfo_t *player)
 
 /**
  * @brief CG_ShoutcastPlayerAmmoValue get the current ammo and/or clip count of the holded weapon (if using ammo).
+ * @param[in] ci
  * @param[out] ammo - the number of ammo left (in the current clip if using clip)
  * @param[out] clips - the total ammount of ammo in all clips (if using clip)
  */

--- a/src/cgame/cg_shoutcastoverlay.c
+++ b/src/cgame/cg_shoutcastoverlay.c
@@ -49,6 +49,12 @@ static int CG_GetPlayerCurrentWeapon(clientInfo_t *player)
 {
 	int curWeap;
 
+	// backward compatibility
+	if (player->currentWeapon)
+	{
+		return player->currentWeapon;
+	}
+
 	if (cg_entities[player->clientNum].currentState.eFlags & EF_MOUNTEDTANK)
 	{
 		if (IS_MOUNTED_TANK_BROWNING(player->clientNum))
@@ -68,7 +74,67 @@ static int CG_GetPlayerCurrentWeapon(clientInfo_t *player)
 	{
 		curWeap = cg_entities[player->clientNum].currentState.weapon;
 	}
+
 	return curWeap;
+}
+
+/**
+ * @brief CG_ShoutcastPlayerAmmoValue get the current ammo and/or clip count of the holded weapon (if using ammo).
+ * @param[out] ammo - the number of ammo left (in the current clip if using clip)
+ * @param[out] clips - the total ammount of ammo in all clips (if using clip)
+ */
+static void CG_ShoutcastPlayerAmmoValue(clientInfo_t *ci, int *ammo, int *clips)
+{
+	int curWeap = CG_GetPlayerCurrentWeapon(ci);
+
+	*ammo = *clips = -1;
+
+	if (!IS_VALID_WEAPON(curWeap))
+	{
+		return;
+	}
+
+	// some weapons don't draw ammo count
+	if (!GetWeaponTableData(curWeap)->useAmmo)
+	{
+		return;
+	}
+
+	// total ammo in clips, grenade launcher is not a clip weapon but show the clip anyway
+	if (GetWeaponTableData(curWeap)->useClip || (curWeap == WP_M7 || curWeap == WP_GPG40))
+	{
+		// current reserve
+		*clips = ci->ammo;
+
+		// current clip
+		*ammo = ci->ammoclip;
+	}
+	else
+	{
+		if (curWeap == WP_LANDMINE)
+		{
+			if (!cgs.gameManager)
+			{
+				*ammo = 0;
+			}
+			else
+			{
+				if (ci->team == TEAM_AXIS)
+				{
+					*ammo = cgs.gameManager->currentState.otherEntityNum;
+				}
+				else
+				{
+					*ammo = cgs.gameManager->currentState.otherEntityNum2;
+				}
+			}
+		}
+		else
+		{
+			// some weapons don't draw ammo clip count text
+			*ammo = ci->ammoclip + ci->ammo;
+		}
+	}
 }
 
 /**
@@ -81,6 +147,7 @@ static int CG_GetPlayerCurrentWeapon(clientInfo_t *player)
 static void CG_DrawShoutcastPlayerOverlayAxis(hudComponent_t *comp, clientInfo_t *player, float y, int index)
 {
 	int    curWeap, weapScale, textWidth, textHeight;
+	int    ammo, clip;
 	float  fraction;
 	float  statusWidth = comp->location.w / 5.f;
 	float  topRowX     = comp->location.x;
@@ -184,7 +251,7 @@ static void CG_DrawShoutcastPlayerOverlayAxis(hudComponent_t *comp, clientInfo_t
 	// draw weapon icon
 	curWeap    = CG_GetPlayerCurrentWeapon(player);
 	weapScale  = cg_weapons[curWeap].weaponIconScale * 10;
-	bottomRowX = comp->location.x + comp->location.w - 63;
+	bottomRowX = comp->location.x + comp->location.w - 73;
 
 	if (IS_VALID_WEAPON(curWeap) && cg_weapons[curWeap].weaponIconScale == 1)
 	{
@@ -200,6 +267,27 @@ static void CG_DrawShoutcastPlayerOverlayAxis(hudComponent_t *comp, clientInfo_t
 	{
 		CG_DrawPic(bottomRowX, y + (height * 0.75f) - 5, -weapScale, 10, cg_weapons[curWeap].weaponIcon[1]);
 	}
+
+	// draw ammo count
+	CG_ShoutcastPlayerAmmoValue(player, &ammo, &clip);
+
+	if (ammo > 0 || clip > 0)
+	{
+		if (clip == -1)
+		{
+			text = va("%i", ammo);
+		}
+		else
+		{
+			text = va("%i/%i", ammo, clip);
+		}
+
+		// Note: if the ammo and clip are both 3 digits and there are 2 powerups being drawn they overlap,
+		// it should rarely happen (only mg/flamethrower with docs and shield, very unlikely scenario)
+		bottomRowX += weapScale + 3;
+		textHeight  = CG_Text_Height_Ext("9", 0.15f, 0, FONT_TEXT);
+		CG_Text_Paint_Ext(bottomRowX, y + (height * 0.75f) + (textHeight * 0.5f), 0.15f, 0.15f, comp->colorMain, text, 0, 0, comp->styleText, FONT_TEXT);
+	}
 }
 
 /**
@@ -212,6 +300,7 @@ static void CG_DrawShoutcastPlayerOverlayAxis(hudComponent_t *comp, clientInfo_t
 static void CG_DrawShoutcastPlayerOverlayAllies(hudComponent_t *comp, clientInfo_t *player, float y, int index)
 {
 	int    curWeap, weapScale, textWidth, textHeight;
+	int    ammo, clip;
 	float  fraction;
 	float  statusWidth = comp->location.w / 5.f;
 	float  topRowX     = comp->location.x;
@@ -319,17 +408,39 @@ static void CG_DrawShoutcastPlayerOverlayAllies(hudComponent_t *comp, clientInfo
 	}
 
 	// draw weapon icon
-	curWeap   = CG_GetPlayerCurrentWeapon(player);
-	weapScale = cg_weapons[curWeap].weaponIconScale * 10;
+	curWeap    = CG_GetPlayerCurrentWeapon(player);
+	weapScale  = cg_weapons[curWeap].weaponIconScale * 10;
+	bottomRowX = comp->location.x + 53;
 
 	// note: WP_NONE is excluded
 	if (IS_VALID_WEAPON(curWeap) && cg_weapons[curWeap].weaponIcon[0])     // do not try to draw nothing
 	{
-		CG_DrawPic(comp->location.x + 43, y + (height * 0.75f) - 5, weapScale, 10, cg_weapons[curWeap].weaponIcon[0]);
+		CG_DrawPic(bottomRowX, y + (height * 0.75f) - 5, weapScale, 10, cg_weapons[curWeap].weaponIcon[0]);
 	}
 	else if (IS_VALID_WEAPON(curWeap) && cg_weapons[curWeap].weaponIcon[1])
 	{
-		CG_DrawPic(comp->location.x + 43, y + (height * 0.75f) - 5, weapScale, 10, cg_weapons[curWeap].weaponIcon[1]);
+		CG_DrawPic(bottomRowX, y + (height * 0.75f) - 5, weapScale, 10, cg_weapons[curWeap].weaponIcon[1]);
+	}
+
+	// draw ammo count
+	CG_ShoutcastPlayerAmmoValue(player, &ammo, &clip);
+
+	if (ammo > 0 || clip > 0)
+	{
+		if (clip == -1)
+		{
+			text = va("%i", ammo);
+		}
+		else
+		{
+			text = va("%i/%i", ammo, clip);
+		}
+
+		// Note: if the ammo and clip are both 3 digits and there are 2 powerups being drawn they overlap,
+		// it should rarely happen (only mg/flamethrower with docs and shield, very unlikely scenario)
+		textHeight = CG_Text_Height_Ext("9", 0.15f, 0, FONT_TEXT);
+		textWidth  = CG_Text_Width_Ext(text, 0.15f, 0, FONT_TEXT);
+		CG_Text_Paint_Ext(bottomRowX - textWidth - 2, y + (height * 0.75f) + (textHeight * 0.5f), 0.15f, 0.15f, comp->colorMain, text, 0, 0, comp->styleText, FONT_TEXT);
 	}
 }
 

--- a/src/cgame/cg_snapshot.c
+++ b/src/cgame/cg_snapshot.c
@@ -88,6 +88,19 @@ static void CG_ResetEntity(centity_t *cent)
  */
 static void CG_TransitionEntity(centity_t *cent)
 {
+	if (cent->nextState.eType == ET_EBS_SHOUTCAST)
+	{
+		if (!memcmp(&cent->currentState, &cent->nextState, sizeof(entityState_t)))
+		{
+			return;
+		}
+
+		cent->currentState = cent->nextState;
+
+		CG_EBS_Shoutcast(cent);
+		return;
+	}
+
 	// update the fireDir if it's on fire
 	if (CG_EntOnFire(cent))
 	{

--- a/src/game/bg_b64.c
+++ b/src/game/bg_b64.c
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2022 Gian 'myT' Schellenbaum.
+ *
+ * This file is part of ET: Legacy - http://www.etlegacy.com
+ *
+ * ET: Legacy is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ET: Legacy is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ET: Legacy. If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * @file bg_b64.c
+ */
+
+#include "../qcommon/q_shared.h"
+#include "bg_b64.h"
+
+void BS_Init(bitStream_t *bs, unsigned char *buffer, int bufferSize)
+{
+	bs->stream = buffer;
+	bs->bytes  = bufferSize;
+	bs->bit    = 0;
+
+	Com_Memset(buffer, 0, bufferSize);
+}
+
+void BS_Write(bitStream_t *bs, int value, int bits)
+{
+	int i;
+
+	if ((bs->bit + bits + 7) / 8 > bs->bytes)
+	{
+		return;
+	}
+
+	for (i = 0; i < bits; ++i)
+	{
+		const int bitIdx  = bs->bit & 7;
+		const int byteIdx = bs->bit >> 3;
+		const int bit     = value & 1;
+
+		bs->stream[byteIdx] |= (unsigned char)(bit << bitIdx);
+		++bs->bit;
+		value >>= 1;
+	}
+}
+
+int BS_Read(bitStream_t *bs, int bits)
+{
+	int i;
+	int value = 0;
+
+	if ((bs->bit + bits + 7) / 8 > bs->bytes)
+	{
+		return 0;
+	}
+
+	for (i = 0; i < bits; ++i)
+	{
+		const int bitIdx  = bs->bit & 7;
+		const int byteIdx = bs->bit >> 3;
+
+		value |= ((int)(bs->stream[byteIdx] >> bitIdx) & 1) << i;
+		++bs->bit;
+	}
+
+	return value;
+}
+
+// Space (' ', 5 bits), double quote ('"', 9 bits) and forward slash ('/', 8 bits) can NOT be used
+// because of how commands get tokenized by the engine ('/' can be the start of a comment).
+// Assuming equal symbol distributions for this base64 table, we would need 557/64 ~ 8.7 bits per symbol.
+// If we had picked a more optimal table, we would have needed 533/64 ~ 8.3 bits per symbol.
+// Because the improvement is so tiny, we opt for the safest option, guarding against dumb engine behavior.
+// The C string for the more optimal base64 table was "(.0123456789:=>@ABCDEFGHLPYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~".
+static const char          b64e[64 + 1] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-";
+static const unsigned char b64d[256]    =
+{
+	66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 64, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66,
+	66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 62, 66, 63, 66, 66, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 66, 66, 66, 65, 66, 66,
+	66, 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 66, 66, 66, 66, 66,
+	66, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 66, 66, 66, 66, 66,
+	66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66,
+	66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66,
+	66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66,
+	66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66
+};
+
+void B64_Encode(char *out, int maxOutChars, const unsigned char *in, int inBits)
+{
+	const int blocksToWrite = (inBits + 23) / 24;
+	const int charsToWrite  = blocksToWrite * 4;
+	int       charsThatMatter;
+	char      *nullTerm;
+	int       i;
+
+	if (charsToWrite >= maxOutChars)   // leaves space for the null-terminator
+	{
+		*out = '\0';
+		return;
+	}
+
+	charsThatMatter = (inBits + 5) / 6;
+	nullTerm        = out + charsThatMatter;
+
+	for (i = 0; i < blocksToWrite; ++i)
+	{
+		// the 4 output bytes are:
+		// bottom 6 of 0
+		// top 2 of 0 and bottom 4 of 1
+		// top 4 of 1 and bottom 2 of 2
+		// top 6 of 2
+		const int in0 = (int)in[0];
+		const int in1 = (int)in[1];
+		const int in2 = (int)in[2];
+
+		out[0] = b64e[in0 & 63];
+		out[1] = b64e[((in1 & 15) << 2) | (in0 >> 6)];
+		out[2] = b64e[((in2 &  3) << 4) | (in1 >> 4)];
+		out[3] = b64e[in2 >> 2];
+		in    += 3;
+		out   += 4;
+	}
+
+	*nullTerm = '\0';
+}
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wchar-subscripts"
+void B64_Decode(unsigned char *out, int maxOutBytes, const char *in, int inBitsReq)
+{
+	const int  inBytes      = (int)strlen(in);
+	const char *end         = in + inBytes;
+	const int  inBits       = inBitsReq <= 0 ? (inBytes * 6) : inBitsReq;
+	const int  blocksToRead = (inBits + 23) / 24;
+	const int  charsToWrite = blocksToRead * 3;
+	int        i;
+
+	if (charsToWrite > maxOutBytes)
+	{
+		return;
+	}
+
+	for (i = 0; i < blocksToRead; ++i)
+	{
+		const int in0  = (in + 0) >= end ? 0 : (int)b64d[in[0]];
+		const int in1  = (in + 1) >= end ? 0 : (int)b64d[in[1]];
+		const int in2  = (in + 2) >= end ? 0 : (int)b64d[in[2]];
+		const int in3  = (in + 3) >= end ? 0 : (int)b64d[in[3]];
+		const int bits = (in3 << 18) | (in2 << 12) | (in1 << 6) | in0;
+
+		etl_assert((in0 | in1 | in2 | in3) < 64); // input sanity check
+		out[0] = (unsigned char)(bits);
+		out[1] = (unsigned char)(bits >>  8);
+		out[2] = (unsigned char)(bits >> 16);
+		in    += 4;
+		out   += 3;
+	}
+}
+#pragma clang diagnostic pop
+
+char B64_Char(int offset)
+{
+	return b64e[offset & 63];
+}
+
+int B64_Offset(char c)
+{
+	return b64d[(int)c];
+}

--- a/src/game/bg_b64.h
+++ b/src/game/bg_b64.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2022 Gian 'myT' Schellenbaum.
+ *
+ * This file is part of ET: Legacy - http://www.etlegacy.com
+ *
+ * ET: Legacy is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ET: Legacy is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ET: Legacy. If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * @file bg_b64.h
+ */
+
+typedef struct
+{
+	unsigned char *stream;
+	int bytes;
+	int bit;
+} bitStream_t;
+
+// byte order: least significant byte first
+// bit  order: least significant bit  first
+void BS_Init(bitStream_t *bs, unsigned char *buffer, int bufferSize);
+void BS_Write(bitStream_t *bs, int value, int bits);
+int BS_Read(bitStream_t *bs, int bits);
+
+// B64_Encode doesn't write padding chars
+// B64_Encode null-terminates the output buffer
+// B64_Decode will decode the full string when inBits <= 0
+void B64_Encode(char *out, int maxOutChars, const unsigned char *in, int inBits);
+void B64_Decode(unsigned char *out, int maxOutBytes, const char *in, int inBits);
+
+char B64_Char(int offset);
+int B64_Offset(char c);

--- a/src/game/bg_ebs.c
+++ b/src/game/bg_ebs.c
@@ -1,0 +1,548 @@
+/*
+ * Copyright (C) 2022 Gian 'myT' Schellenbaum.
+ *
+ * This file is part of ET: Legacy - http://www.etlegacy.com
+ *
+ * ET: Legacy is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ET: Legacy is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ET: Legacy. If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * @file bg_ebs.c
+ */
+
+#include "../qcommon/q_shared.h"
+#include "bg_ebs.h"
+
+// in total, an entityState_t struct provides:
+// 766 generic bits, of which we use ebs_maxIntBits
+// 24 floats
+
+typedef struct
+{
+	int byteOffset;
+	int numBits;
+} intField_t;
+
+// fields are in network order, same as the engine
+// selected fields do not provide forward compatibility
+#define ESF(Field, Bits) { (size_t)(&((entityState_t *)0)->Field), Bits }
+static const intField_t entityIntFields[] =
+{
+	//ESF(eType,         8),  // @NOTE: we can't override this! it's needed for the client to know what to do
+	ESF(eFlags,          24),
+	ESF(pos.trType,      8),
+	ESF(pos.trTime,      32),
+	ESF(pos.trDuration,  32),
+
+	ESF(apos.trType,     8),
+	ESF(apos.trTime,     32),
+	ESF(apos.trDuration, 32),
+
+	ESF(time,            32),
+	ESF(time2,           32),
+
+	ESF(otherEntityNum,  GENTITYNUM_BITS),
+	ESF(otherEntityNum2, GENTITYNUM_BITS),
+	ESF(groundEntityNum, GENTITYNUM_BITS),
+
+	ESF(loopSound,       8),
+	ESF(constantLight,   32),
+	ESF(dl_intensity,    32),
+
+	ESF(modelindex,      9),
+	ESF(modelindex2,     9),
+	ESF(frame,           16),
+	ESF(clientNum,       8),
+	ESF(solid,           24),
+	ESF(event,           10),
+	ESF(eventParm,       8),
+	ESF(eventSequence,   8),
+
+	ESF(events[0],       8),
+	ESF(events[1],       8),
+	ESF(events[2],       8),
+	ESF(events[3],       8),
+
+	ESF(eventParms[0],   8),
+	ESF(eventParms[1],   8),
+	ESF(eventParms[2],   8),
+	ESF(eventParms[3],   8),
+
+	ESF(powerups,        16),
+	ESF(weapon,          8),
+	ESF(legsAnim,        ANIM_BITS),
+	ESF(torsoAnim,       ANIM_BITS),
+	ESF(density,         10),
+	ESF(dmgFlags,        32),
+	ESF(onFireStart,     32),
+	ESF(onFireEnd,       32),
+	ESF(nextWeapon,      8),
+	ESF(teamNum,         8),
+	ESF(effect1Time,     32),
+	ESF(effect2Time,     32),
+	ESF(effect3Time,     32),
+	ESF(animMovetype,    4),
+	ESF(aiState,         2)
+};
+#undef ESF
+const int ebs_fieldCount = ARRAY_LEN(entityIntFields);
+const int ebs_maxIntBits = 758;
+
+// fields are in network order, same as the engine
+#define ESF(Field) (size_t)(&((entityState_t *)0)->Field)
+static const int entityFloatFields[] =
+{
+	ESF(pos.trBase[0]),
+	ESF(pos.trBase[1]),
+	ESF(pos.trBase[2]),
+	ESF(pos.trDelta[0]),
+	ESF(pos.trDelta[1]),
+	ESF(pos.trDelta[2]),
+	ESF(apos.trBase[1]),
+	ESF(apos.trBase[0]),
+	ESF(apos.trBase[2]),
+	ESF(apos.trDelta[0]),
+	ESF(apos.trDelta[1]),
+	ESF(apos.trDelta[2]),
+	ESF(origin[0]),
+	ESF(origin[1]),
+	ESF(origin[2]),
+	ESF(origin2[0]),
+	ESF(origin2[1]),
+	ESF(origin2[2]),
+	ESF(angles[0]),
+	ESF(angles[1]),
+	ESF(angles[2]),
+	ESF(angles2[0]),
+	ESF(angles2[1]),
+	ESF(angles2[2])
+};
+#undef ESF
+
+void EBS_InitWrite(entityBitStream_t *ebs, entityState_t *es, qboolean clear)
+{
+	int i;
+
+	ebs->es      = es;
+	ebs->field   = 0;
+	ebs->bit     = 0;
+	ebs->count   = 0;
+	ebs->read    = qfalse;
+	ebs->cleared = clear;
+
+	if (clear)
+	{
+		for ( i = 0; i < ARRAY_LEN(entityIntFields); ++i )
+		{
+			byte * const field = (byte *)es + entityIntFields[i].byteOffset;
+			*(int *)field = 0;
+		}
+	}
+}
+
+void EBS_InitRead(entityBitStream_t *ebs, const entityState_t *es)
+{
+	ebs->es    = (entityState_t *)es;
+	ebs->field = 0;
+	ebs->bit   = 0;
+	ebs->count = 0;
+	ebs->read  = qtrue;
+}
+
+void EBS_Skip(entityBitStream_t *ebs, int bits)
+{
+	int fieldIndex    = ebs->field;
+	int fieldBitIndex = ebs->bit;
+
+	//etl_assert(ebs->read == qtrue);
+
+	while (bits > 0)
+	{
+		const intField_t *f;
+		int              bitsToSkip;
+
+		if (fieldIndex >= ebs_fieldCount)
+		{
+			break;
+		}
+
+		f          = &entityIntFields[fieldIndex];
+		bitsToSkip = MIN(bits, f->numBits - fieldBitIndex);
+
+		fieldBitIndex += bitsToSkip;
+		bits          -= bitsToSkip;
+		ebs->count    += bitsToSkip;
+		if (fieldBitIndex >= f->numBits)
+		{
+			fieldBitIndex = 0;
+			fieldIndex++;
+		}
+	}
+
+	ebs->field = fieldIndex;
+	ebs->bit   = fieldBitIndex;
+}
+
+void EBS_WriteBits(entityBitStream_t *ebs, int data, int bitsLeftToWrite)
+{
+	int fieldIndex    = ebs->field;
+	int fieldBitIndex = ebs->bit;
+
+	etl_assert(ebs->read == qfalse);
+
+	if (ebs->count + bitsLeftToWrite > ebs_maxIntBits)
+	{
+		etl_assert(0);
+		return;
+	}
+
+	while (bitsLeftToWrite > 0)
+	{
+		const intField_t *f;
+		int              *out;
+		int              i, bitsToWrite;
+
+		if (fieldIndex >= ebs_fieldCount)
+		{
+			break;
+		}
+
+		f   = &entityIntFields[fieldIndex];
+		out = ( int * )((byte *)ebs->es + f->byteOffset);
+		// out         = (int *)ebs->es + (f->byteOffset >> 2);
+		bitsToWrite = MIN(bitsLeftToWrite, f->numBits - fieldBitIndex);
+
+		for ( i = 0; i < bitsToWrite; ++i )
+		{
+			const int bitValue = data & 1;
+			if (bitValue)
+			{
+				*out |= (bitValue << fieldBitIndex);
+			}
+			else if (!ebs->cleared)
+			{
+				*out &= ~(1 << fieldBitIndex);
+			}
+			fieldBitIndex++;
+			data >>= 1;
+		}
+
+		bitsLeftToWrite -= bitsToWrite;
+		ebs->count      += bitsToWrite;
+		if (fieldBitIndex >= f->numBits)
+		{
+			fieldBitIndex = 0;
+			fieldIndex++;
+		}
+	}
+
+	ebs->field = fieldIndex;
+	ebs->bit   = fieldBitIndex;
+}
+
+void EBS_WriteBitsWithSign(entityBitStream_t *ebs, int data, int bitsLeftToRead)
+{
+	etl_assert(bitsLeftToRead > 1);
+	EBS_WriteBits(ebs, data < 0, 1);
+	EBS_WriteBits(ebs, abs(data), bitsLeftToRead - 1);
+}
+
+int EBS_ReadBits(entityBitStream_t *ebs, int bitsLeftToRead)
+{
+	const int fieldCount    = ARRAY_LEN(entityIntFields);
+	int       fieldIndex    = ebs->field;
+	int       fieldBitIndex = ebs->bit;
+	int       data          = 0;
+	int       dataBitIndex  = 0;
+
+	etl_assert(ebs->read == qtrue);
+
+	if (ebs->count + bitsLeftToRead > ebs_maxIntBits)
+	{
+		return 0;
+	}
+
+	while (bitsLeftToRead > 0)
+	{
+		const intField_t *f;
+		int              in, i, bitsToRead;
+
+		if (fieldIndex >= fieldCount)
+		{
+			break;
+		}
+
+		f = &entityIntFields[fieldIndex];
+		// in         = *((const int *)ebs->es + (f->byteOffset >> 2)) >> fieldBitIndex;
+		in         = *(int *)((byte *)ebs->es + f->byteOffset);
+		bitsToRead = MIN(bitsLeftToRead, f->numBits - fieldBitIndex);
+
+		for ( i = 0; i < bitsToRead; ++i )
+		{
+			const int bitValue = (in >> (fieldBitIndex + i)) & 1;
+			data |= bitValue << (dataBitIndex + i);
+		}
+
+		fieldBitIndex  += bitsToRead;
+		bitsLeftToRead -= bitsToRead;
+		ebs->count     += bitsToRead;
+		dataBitIndex   += bitsToRead;
+		if (fieldBitIndex >= f->numBits)
+		{
+			fieldBitIndex = 0;
+			fieldIndex++;
+		}
+	}
+
+	ebs->field = fieldIndex;
+	ebs->bit   = fieldBitIndex;
+
+	return data;
+}
+
+int EBS_ReadBitsWithSign(entityBitStream_t *ebs, int bitsLeftToRead)
+{
+	etl_assert(bitsLeftToRead > 1);
+	const int sign = EBS_ReadBits(ebs, 1) ? -1 : 1;
+	return EBS_ReadBits(ebs, bitsLeftToRead - 1) * sign;
+}
+
+
+void EBS_WriteFloat(entityState_t *es, int index, float data)
+{
+	if ((unsigned int)index >= ARRAY_LEN(entityFloatFields))
+	{
+		etl_assert(0);
+		return;
+	}
+
+	*(float *)((byte *)es + entityFloatFields[index]) = data;
+}
+
+float EBS_ReadFloat(entityState_t *es, int index)
+{
+	if ((unsigned int)index >= ARRAY_LEN(entityFloatFields))
+	{
+		etl_assert(0);
+		return 0.0f;
+	}
+
+	return *(float *)((byte *)es + entityFloatFields[index]);
+}
+
+#ifdef EBS_TESTS
+
+static struct
+{
+	unsigned int table[256];
+	qboolean created;
+} crc32_data = { { 0 }, qfalse };
+
+void CRC32_Begin(unsigned int *crc)
+{
+	int          i, j;
+	unsigned int c;
+	if (!crc32_data.created)
+	{
+		for (i = 0; i < 256; i++)
+		{
+			c = i;
+			for (j = 0; j < 8; j++)
+				c = c & 1 ? (c >> 1) ^ 0xEDB88320UL : c >> 1;
+			crc32_data.table[i] = c;
+		}
+		crc32_data.created = qtrue;
+	}
+	*crc = 0xFFFFFFFFUL;
+}
+
+void CRC32_ProcessBlock(unsigned int *crc, const void *buffer, unsigned int length)
+{
+	unsigned int        hash = *crc;
+	const unsigned char *buf = (const unsigned char *)buffer;
+	while (length--)
+	{
+		hash = crc32_data.table[(hash ^ *buf++) & 0xFF] ^ (hash >> 8);
+	}
+	*crc = hash;
+}
+
+void CRC32_End(unsigned int *crc)
+{
+	*crc ^= 0xFFFFFFFFUL;
+}
+
+static void EBS_SimpleTest()
+{
+	entityBitStream_t s;
+	entityState_t     es = { 0 };
+	int               i, maxCount;
+
+	maxCount = (ebs_maxIntBits - 7) / 11;
+
+	EBS_InitWrite(&s, &es, qtrue);
+	for ( i = 0; i < maxCount; ++i )
+	{
+		EBS_WriteBits(&s, i % 2, 1);
+		EBS_WriteBits(&s, i, 10);
+	}
+	EBS_InitRead(&s, &es);
+	for ( i = 0; i < maxCount; ++i )
+	{
+		if (i % 10 == 0)
+		{
+			EBS_Skip(&s, 11);
+			continue;
+		}
+		etl_assert(EBS_ReadBits(&s, 1) == i % 2);
+		etl_assert(EBS_ReadBits(&s, 10) == i);
+	}
+}
+
+void EBS_RunTests()
+{
+	entityBitStream_t s;
+	entityState_t     es;
+
+	EBS_ValidateTables();
+
+	EBS_SimpleTest();
+
+	EBS_InitWrite(&s, &es, qtrue);
+	EBS_WriteTestPayload(&s);
+	EBS_InitRead(&s, &es);
+	EBS_ValidateTestPayload(&s);
+}
+
+void EBS_ValidateTables(void)
+{
+	int i, numBits;
+
+	// verify all int offsets are multiples of 4
+	numBits = 0;
+	for ( i = 0; i < ARRAY_LEN(entityIntFields); ++i )
+	{
+		etl_assert(entityIntFields[i].byteOffset % 4 == 0);
+		numBits += entityIntFields[i].numBits;
+	}
+
+	// verify we have the expected number of int bits
+	etl_assert(numBits == ebs_maxIntBits);
+
+	// verify all float offsets are multiples of 4
+	for ( i = 0; i < ARRAY_LEN(entityFloatFields); ++i )
+	{
+		etl_assert(entityFloatFields[i] % 4 == 0);
+	}
+}
+
+#define RAWDATASIZE 100
+
+void EBS_WriteTestPayload(entityBitStream_t *ebs)
+{
+	// leave space for the CRC32 checksum
+	const int    dataBitCount      = ebs_maxIntBits - 32;
+	const int    dataByteCount     = (dataBitCount + 7) / 8;
+	const int    dataFullByteCount = dataBitCount / 8;
+	const int    trailingBits      = dataBitCount % 8;
+	byte         rawData[RAWDATASIZE];
+	unsigned int checksum;
+	int          b;
+
+	etl_assert(sizeof(rawData) >= dataByteCount);
+	etl_assert(ebs->count == 0);
+
+	// generate the payload
+	for ( b = 0; b < dataByteCount; ++b )
+	{
+		rawData[b] = rand();
+	}
+
+	// nuke the top bits of the last byte if necessary
+	if (trailingBits > 0)
+	{
+		rawData[dataByteCount - 1] <<= (byte)(8 - trailingBits);
+		rawData[dataByteCount - 1] >>= (byte)(8 - trailingBits);
+	}
+
+	// compute the checksum
+	CRC32_Begin(&checksum);
+	for ( b = 0; b < dataByteCount; ++b )
+	{
+		CRC32_ProcessBlock(&checksum, &rawData[b], 1);
+	}
+	CRC32_End(&checksum);
+
+	// write the generic data
+	for ( b = 0; b < dataFullByteCount; ++b )
+	{
+		EBS_WriteBits(ebs, rawData[b], 8);
+	}
+	if (trailingBits > 0)
+	{
+		EBS_WriteBits(ebs, rawData[b], trailingBits);
+	}
+	EBS_WriteBits(ebs, checksum, 32);
+	etl_assert(ebs->count == ebs_maxIntBits);
+
+	// write the float data
+	for ( b = 0; b < ARRAY_LEN(entityFloatFields); ++b )
+	{
+		rawData[0] = rand();
+		rawData[1] = rand();
+		rawData[2] = rand();
+		rawData[3] = rand();
+		const float data = *(float *)rawData;
+		EBS_WriteFloat(ebs->es, b, data);
+	}
+}
+
+void EBS_ValidateTestPayload(entityBitStream_t *ebs)
+{
+	// leave space for the CRC32 checksum
+	const int    dataBitCount      = ebs_maxIntBits - 32;
+	const int    dataByteCount     = (dataBitCount + 7) / 8;
+	const int    dataFullByteCount = dataBitCount / 8;
+	const int    trailingBits      = dataBitCount % 8;
+	byte         rawData[RAWDATASIZE];
+	unsigned int netChecksum, compChecksum;
+	int          b;
+
+	etl_assert(sizeof(rawData) >= dataByteCount);
+	etl_assert(ebs->count == 0);
+
+	// read the data
+	for ( b = 0; b < dataFullByteCount; ++b )
+	{
+		rawData[b] = EBS_ReadBits(ebs, 8);
+	}
+	if (trailingBits > 0)
+	{
+		rawData[b] = EBS_ReadBits(ebs, trailingBits);
+	}
+	netChecksum = EBS_ReadBits(ebs, 32);
+	etl_assert(ebs->count == ebs_maxIntBits);
+
+	// compute the checksum
+	CRC32_Begin(&compChecksum);
+	for ( b = 0; b < dataByteCount; ++b )
+	{
+		CRC32_ProcessBlock(&compChecksum, &rawData[b], 1);
+	}
+	CRC32_End(&compChecksum);
+
+	// validate the checksum!
+	etl_assert(compChecksum == netChecksum);
+}
+
+#endif

--- a/src/game/bg_ebs.h
+++ b/src/game/bg_ebs.h
@@ -55,4 +55,4 @@ void        EBS_ValidateTestPayload(entityBitStream_t *ebs);
 #endif
 
 // ET_EBS_SHOUTCAST size of player info
-#define EBS_SHOUTCAST_PLAYER_SIZE_V0 (6 + 9 + 8 + 8 + 6 + 16)
+#define EBS_SHOUTCAST_PLAYER_SIZE_V0 (6 + 9 + 10 + 10 + 6 + 16)

--- a/src/game/bg_ebs.h
+++ b/src/game/bg_ebs.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2022 Gian 'myT' Schellenbaum.
+ *
+ * This file is part of ET: Legacy - http://www.etlegacy.com
+ *
+ * ET: Legacy is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ET: Legacy is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ET: Legacy. If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * @file bg_ebs.h
+ */
+
+typedef struct
+{
+	entityState_t *es;
+	int field; // field index
+	int bit;   // bit offset in the field
+	int count; // total bits read/written
+	qboolean read;
+	qboolean cleared;
+} entityBitStream_t;
+
+extern const int ebs_maxIntBits;
+
+// treats entityState_t as a generic float array and bit stream container
+void        EBS_InitWrite(entityBitStream_t *ebs, entityState_t *es, qboolean clear);
+void        EBS_InitRead(entityBitStream_t *ebs, const entityState_t *es);
+void        EBS_WriteBits(entityBitStream_t *ebs, int data, int bits);
+void        EBS_WriteBitsWithSign(entityBitStream_t *ebs, int data, int bitsLeftToRead);
+int         EBS_ReadBits(entityBitStream_t *ebs, int bits);
+int         EBS_ReadBitsWithSign(entityBitStream_t *ebs, int bitsLeftToRead);
+void        EBS_Skip(entityBitStream_t *ebs, int bits);
+void        EBS_WriteFloat(entityState_t *es, int index, float data);
+float       EBS_ReadFloat(entityState_t *es, int index);
+
+#ifdef ETLEGACY_DEBUG
+#define EBS_TESTS 1
+#endif
+
+#ifdef EBS_TESTS
+void        EBS_RunTests(void);
+void        EBS_ValidateTables(void);
+void        EBS_WriteTestPayload(entityBitStream_t *ebs);
+void        EBS_ValidateTestPayload(entityBitStream_t *ebs);
+#endif
+
+// ET_EBS_SHOUTCAST size of player info
+#define EBS_SHOUTCAST_PLAYER_SIZE_V0 (6 + 9 + 8 + 8 + 6 + 16)

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1228,6 +1228,8 @@ typedef struct level_locals_s
 	int numTeamClients[2];
 	int numVotingTeamClients[2];
 
+	int teamClients[2][MAX_CLIENTS];
+
 	// spawn variables
 	qboolean spawning;                          ///< the G_Spawn*() functions are valid
 	int numSpawnVars;
@@ -1388,6 +1390,8 @@ typedef struct level_locals_s
 	demoState_t demoState;     ///< server demo state
 	int demoClientsNum;        ///< number of reserved slots for demo clients
 	int demoClientBotNum;      ///< clientNum of bot that collects stats during recording, optional
+
+	uint64_t shoutcasters;     ///< clients bits of shoutcasters
 } level_locals_t;
 
 /**
@@ -1796,8 +1800,10 @@ void QDECL G_Error(const char *fmt, ...) _attribute((noreturn, format(printf, 1,
 // extension interface
 qboolean trap_GetValue(char *value, int valueSize, const char *key);
 void trap_DemoSupport(const char *commands);
+void trap_SnapshotCallbackExt(void);
 extern int dll_com_trapGetValue;
 extern int dll_trap_DemoSupport;
+extern int dll_trap_SnapshotCallbackExt;
 
 // g_demo_legacy.c
 void G_DemoStateChanged(demoState_t demoState, int demoClientsNum);
@@ -2705,6 +2711,10 @@ void CheckTeamStatus(void);
 int Pickup_Team(gentity_t *ent, gentity_t *other);
 void G_globalFlagIndicator(void);
 void G_clientFlagIndicator(gentity_t *ent);
+
+qboolean G_EBS_ShoutcastCallback(int clientNumReal);
+void G_EBS_ShoutcastThink(gentity_t *ent);
+void G_EBS_InitShoutcast(void);
 
 // g_vote.c
 int G_voteCmdCheck(gentity_t *ent, char *arg, char *arg2, qboolean fRefereeCmd);

--- a/src/game/g_public.h
+++ b/src/game/g_public.h
@@ -228,7 +228,8 @@ typedef enum
 	///< engine extensions padding
 	G_TRAP_GETVALUE = COM_TRAP_GETVALUE,
 
-	G_DEMOSUPPORT
+	G_DEMOSUPPORT,
+	G_SNAPSHOT_CALLBACK_EXT
 
 } gameImport_t;
 
@@ -278,6 +279,7 @@ typedef enum
 	GAME_MESSAGERECEIVED = 14,      ///< ( int cno, const char *buf, int buflen, int commandTime );
 
 	GAME_DEMOSTATECHANGED,          ///< (demoState_t demoState, int demoClientsNum) // server demo playback
+	GAME_SNAPSHOT_CALLBACK_EXT,     ///< ( int entityNum, int clientNum, int clientNumReal ); // return qfalse if you don't want it to be added
 
 } gameExport_t;
 

--- a/src/game/g_referee.c
+++ b/src/game/g_referee.c
@@ -774,6 +774,7 @@ void G_MakeShoutcaster(gentity_t *ent)
 		SetTeam(ent, "spectator", qtrue, -1, -1, qfalse);
 	}
 
+	level.shoutcasters           |= (1ULL << (ent - g_entities));
 	ent->client->sess.shoutcaster = 1;
 	ent->client->sess.spec_invite = TEAM_AXIS | TEAM_ALLIES;
 	AP(va("cp \"%s\n^3has become a shoutcaster\n\"", ent->client->pers.netname));
@@ -791,6 +792,7 @@ void G_RemoveShoutcaster(gentity_t *ent)
 		return;
 	}
 
+	level.shoutcasters           &= ~(1ULL << (ent - g_entities));
 	ent->client->sess.shoutcaster = 0;
 
 	if (!ent->client->sess.referee)    // don't remove referee's invitation

--- a/src/game/g_svcmds.c
+++ b/src/game/g_svcmds.c
@@ -557,7 +557,7 @@ const char *enttypenames[] =
 	"unused ent type",             // ET_LANDMINE_HINT
 	"unused ent type",             // ET_ATTRACTOR_HINT
 	"unused ent type",             // ET_SNIPER_HINT
-	"unused ent type",             // ET_LANDMINESPOT_HINT
+	"ET_EBS_SHOUTCAST",
 
 	"ET_COMMANDMAP_MARKER",
 

--- a/src/game/g_syscalls.c
+++ b/src/game/g_syscalls.c
@@ -826,3 +826,14 @@ void trap_DemoSupport(const char *commands)
 		SystemCall(dll_trap_DemoSupport, commands);
 	}
 }
+
+/**
+* @brief trap_SnapshotCallbackExt Extension for informing engine about extended snapshot callback
+*/
+void trap_SnapshotCallbackExt(void)
+{
+	if (dll_trap_SnapshotCallbackExt)
+	{
+		SystemCall(dll_trap_SnapshotCallbackExt);
+	}
+}

--- a/src/game/g_team.c
+++ b/src/game/g_team.c
@@ -2442,8 +2442,8 @@ static void G_EBS_ShoutcastWritePlayer(gentity_t *ent, entityBitStream_t *ebs)
 
 	EBS_WriteBits(ebs, ent->s.number, 6);
 	EBS_WriteBitsWithSign(ebs, health, 9);
-	EBS_WriteBits(ebs, ent->client->ps.ammoclip[weapon], 8);
-	EBS_WriteBits(ebs, ent->client->ps.ammo[weapon], 8);
+	EBS_WriteBits(ebs, ent->client->ps.ammoclip[weapon], 10);
+	EBS_WriteBits(ebs, ent->client->ps.ammo[weapon], 10);
 	EBS_WriteBits(ebs, weapon, 6);
 	EBS_WriteBits(ebs, ent->s.powerups, 16);
 }

--- a/src/game/g_team.c
+++ b/src/game/g_team.c
@@ -2463,8 +2463,8 @@ static void G_EBS_ShoutcastWritePlayer(gentity_t *ent, entityBitStream_t *ebs)
 <6 player slots>
 6 clientNum
 9 health
-8 ammoClip
-8 ammo
+10 ammoClip
+10 ammo
 6 weapon
 16 powerups
 =============================

--- a/src/qcommon/q_shared.h
+++ b/src/qcommon/q_shared.h
@@ -1567,9 +1567,9 @@ typedef enum
 	//ET_LANDMINE_HINT,         ///< obsolete/unused (landmine hint for botsetgoalstate filter)
 	//ET_ATTRACTOR_HINT,        ///< obsolete/unused (attractor hint for botsetgoalstate filter)
 	//ET_SNIPER_HINT,           ///< obsolete/unused (sniper hint for botsetgoalstate filter)
-	//ET_LANDMINESPOT_HINT,     ///< obsolete/unused (landminespot hint for botsetgoalstate filter)
+	ET_EBS_SHOUTCAST = 58,      ///< replaced ET_LANDMINESPOT_HINT
 
-	ET_COMMANDMAP_MARKER = 59,
+	ET_COMMANDMAP_MARKER,
 
 	ET_WOLF_OBJECTIVE,
 

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -153,6 +153,7 @@ typedef struct
 	playerState_t demoPlayerStates[MAX_CLIENTS];
 
 	int lastAttackLogTime;                  ///< timestamp of latest attack log entry
+	qboolean snapshotCallbackExt;
 } server_t;
 
 /**
@@ -618,6 +619,12 @@ void SV_SendClientMessages(void);
 void SV_SendClientSnapshot(client_t *client);
 void SV_CheckClientUserinfoTimer(void);
 void SV_SendClientIdle(client_t *client);
+
+#ifdef ETLEGACY_DEBUG
+void SV_PrintNetworkOverhead_f(void);
+void SV_ClearNetworkOverhead_f(void);
+void SV_InitNetworkOverhead(void);
+#endif
 
 // sv_game.c
 int SV_NumForGentity(sharedEntity_t *ent);

--- a/src/server/sv_ccmds.c
+++ b/src/server/sv_ccmds.c
@@ -753,6 +753,11 @@ void SV_AddOperatorCommands(void)
 
 	Cmd_AddCommand("tv", SV_CL_Commands_f, "tv commands.");
 
+#ifdef ETLEGACY_DEBUG
+	Cmd_AddCommand("net_overhead_print", SV_PrintNetworkOverhead_f, "Prints network overhead stats.");
+	Cmd_AddCommand("net_overhead_clear", SV_ClearNetworkOverhead_f, "Clears network overhead stats.");
+#endif
+
 	if (com_dedicated->integer)
 	{
 		Cmd_AddCommand("say", SV_ConSay_f, "Prints console messages on dedicated servers.");

--- a/src/server/sv_game.c
+++ b/src/server/sv_game.c
@@ -47,8 +47,9 @@ botlib_export_t *botlib_export;
 
 static ext_trap_keys_t g_extensionTraps[] =
 {
-	{ "trap_DemoSupport_Legacy", G_DEMOSUPPORT, qfalse },
-	{ NULL,                      -1,            qfalse }
+	{ "trap_DemoSupport_Legacy",         G_DEMOSUPPORT,           qfalse },
+	{ "trap_SnapshotCallbackExt_Legacy", G_SNAPSHOT_CALLBACK_EXT, qfalse },
+	{ NULL,                              -1,                      qfalse }
 };
 
 /**
@@ -701,6 +702,9 @@ intptr_t SV_GameSystemCalls(intptr_t *args)
 
 	case G_DEMOSUPPORT:
 		SV_DemoSupport(VMA(1));
+		return 0;
+	case G_SNAPSHOT_CALLBACK_EXT:
+		sv.snapshotCallbackExt = qtrue;
 		return 0;
 
 	case G_TRAP_GETVALUE:

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -1243,6 +1243,10 @@ void SV_Init(void)
 #if defined(FEATURE_IRC_SERVER) && defined(DEDICATED)
 	IRC_Init();
 #endif
+
+#ifdef ETLEGACY_DEBUG
+	SV_InitNetworkOverhead();
+#endif
 }
 
 /**

--- a/src/server/sv_snapshot.c
+++ b/src/server/sv_snapshot.c
@@ -1079,8 +1079,11 @@ void SV_SendMessageToClient(msg_t *msg, client_t *client, qboolean parseEntities
 	// send the datagram
 	SV_Netchan_Transmit(client, msg);
 #ifdef ETLEGACY_DEBUG
-	net_overhead.numBytesSent += msg->cursize;
-	net_overhead.numSent++;
+	if (net_overhead.numSlices)
+	{
+		net_overhead.numBytesSent += msg->cursize;
+		net_overhead.numSent++;
+	}
 #endif
 }
 
@@ -1408,6 +1411,7 @@ void SV_ClearNetworkOverhead_f(void)
 	int i;
 
 	net_overhead.numBytesSent = 0;
+	net_overhead.numSent      = 0;
 	for (i = 0; i < net_overhead.numSlices; i++)
 	{
 		net_overhead.slices[i].numBytesSent    = 0;

--- a/src/server/sv_snapshot.c
+++ b/src/server/sv_snapshot.c
@@ -1397,7 +1397,6 @@ void SV_PrintNetworkOverhead_f(void)
 		Com_Printf("total compression:  %.2fx\n", compression);
 		Com_Printf("average bytes sent: %.2f\n", sentTotal / countTotal);
 		Com_Printf("=========================\n");
-
 	}
 }
 

--- a/src/tvgame/tvg_svcmds.c
+++ b/src/tvgame/tvg_svcmds.c
@@ -463,7 +463,7 @@ const char *enttypenames[] =
 	"unused ent type",             // ET_LANDMINE_HINT
 	"unused ent type",             // ET_ATTRACTOR_HINT
 	"unused ent type",             // ET_SNIPER_HINT
-	"unused ent type",             // ET_LANDMINESPOT_HINT
+	"ET_EBS_SHOUTCAST",
 
 	"ET_COMMANDMAP_MARKER",
 


### PR DESCRIPTION
- add server extension trap_SnapshotCallbackExt_Legacy for new systemcalls G_SNAPSHOT_CALLBACK_EXT and GAME_SNAPSHOT_CALLBACK_EXT.
  Without new snapshot callback it is impossible to send entities to select few clients.
- add new entity ET_EBS_SHOUTCAST replacing ET_LANDMINESPOT_HINT, enabled only if above engine extension exists and on stopwatch gametype.
  Updates only if there are present shoutcasters on server. Sends health, ammoclip, ammo, weapon and powerups. Sent only to shoutcasters.
- update shoutcast overlay with new data.
- add net_overhead_print and net_overhead_clear server commands to help evaluating network overhead, debug builds only.

Compared to previous version from a year ago:
- clients are always saved into same slots, to better utilize delta encoding.
- changed the way ebs is handled on client and server and thus all entityState fields are writeable beside eType (from 644 available int bits to 758 out of 766 total)

https://www.youtube.com/watch?v=gC4SchxcwFk