### PR TITLE
etmain: Update Quality Presets for `r_lodscale`

### DIFF
--- a/etmain/preset_fast.cfg
+++ b/etmain/preset_fast.cfg
@@ -1,5 +1,5 @@
 seta r_subdivisions 12
-seta r_lodbias 1
+seta r_lodscale 5
 seta r_colorbits 0
 seta r_depthbits 24
 seta r_picmip 2

--- a/etmain/preset_fast_ui.cfg
+++ b/etmain/preset_fast_ui.cfg
@@ -1,5 +1,5 @@
 seta ui_r_subdivisions 12
-seta ui_r_lodscale 1
+seta ui_r_lodscale 5
 seta ui_r_colorbits 0
 seta ui_r_depthbits 24
 seta ui_r_picmip 2

--- a/etmain/preset_fastest.cfg
+++ b/etmain/preset_fastest.cfg
@@ -1,5 +1,5 @@
 seta r_subdivisions 20
-seta r_lodbias 2
+seta r_lodscale 0
 seta r_colorbits 16
 seta r_depthbits 24
 seta r_picmip 3

--- a/etmain/preset_fastest_ui.cfg
+++ b/etmain/preset_fastest_ui.cfg
@@ -1,5 +1,5 @@
 seta ui_r_subdivisions 20
-seta ui_r_lodscale 2
+seta ui_r_lodscale 0
 seta ui_r_colorbits 16
 seta ui_r_depthbits 24
 seta ui_r_picmip 3

--- a/etmain/preset_high.cfg
+++ b/etmain/preset_high.cfg
@@ -1,5 +1,5 @@
 seta r_subdivisions 4
-seta r_lodbias 0
+seta r_lodscale 20
 seta r_colorbits 32
 seta r_depthbits 24
 seta r_picmip 0

--- a/etmain/preset_high_ui.cfg
+++ b/etmain/preset_high_ui.cfg
@@ -1,5 +1,5 @@
 seta ui_r_subdivisions 4
-seta ui_r_lodscale 0
+seta ui_r_lodscale 20
 seta ui_r_colorbits 32
 seta ui_r_depthbits 24
 seta ui_r_picmip 0

--- a/etmain/preset_normal.cfg
+++ b/etmain/preset_normal.cfg
@@ -1,5 +1,5 @@
 seta r_subdivisions 4
-seta r_lodbias 0
+seta r_lodscale 5
 seta r_colorbits 0
 seta r_depthbits 24
 seta r_picmip 1

--- a/etmain/preset_normal_ui.cfg
+++ b/etmain/preset_normal_ui.cfg
@@ -1,5 +1,5 @@
 seta ui_r_subdivisions 4
-seta ui_r_lodscale 0
+seta ui_r_lodscale 5
 seta ui_r_colorbits 0
 seta ui_r_depthbits 24
 seta ui_r_picmip 1


### PR DESCRIPTION
We have moved the `Geometric Detail` from changing `r_lodbias` to `r_lodscale` in 78d5775690cbe4b8c60c159143279f3b9c11d717, but haven't chaned the 'Quality Preset' defaults so far.

This change does exactly that.