### PR TITLE
Add Objective_Destroyed log for dynamites

### DIFF
--- a/src/game/g_missile.c
+++ b/src/game/g_missile.c
@@ -425,6 +425,7 @@ void G_ExplodeMissile(gentity_t *ent)
 				{
 					if (ent->parent->client && hit->target_ent && GetMODTableData(MOD_DYNAMITE)->weaponClassForMOD >= hit->target_ent->constructibleStats.weaponclass)
 					{
+						G_LogPrintf("Objective_Destroyed: %d %s\n", (int)(ent->parent - g_entities), hit->track);
 						G_AddKillSkillPointsForDestruction(ent->parent, MOD_DYNAMITE, &hit->target_ent->constructibleStats);
 					}
 

--- a/src/game/g_weapon.c
+++ b/src/game/g_weapon.c
@@ -2129,7 +2129,6 @@ weapengineergoto3:
 							pm->s.effect3Time = hit->s.teamNum;
 							pm->s.teamNum     = ent->client->sess.sessionTeam;
 
-							G_Script_ScriptEvent(hit, "dynamited", ent->client->sess.sessionTeam == TEAM_AXIS ? "axis" : "allies");
 
 #ifdef FEATURE_OMNIBOT
 							// notify omni-bot framework of planted dynamite
@@ -2151,6 +2150,8 @@ weapengineergoto3:
 							}
 							traceEnt->etpro_misc_1 |= 1;
 							traceEnt->etpro_misc_2  = hit->s.number;
+							
+							G_Script_ScriptEvent(hit, "dynamited", ent->client->sess.sessionTeam == TEAM_AXIS ? "axis" : "allies");
 						}
 						// i = num;
 						return NULL;     // bail out here because primary obj's take precendence over constructibles
@@ -2221,7 +2222,6 @@ weapengineergoto3:
 							pm->s.effect3Time = hit->parent->s.teamNum;
 							pm->s.teamNum     = ent->client->sess.sessionTeam;
 
-							G_Script_ScriptEvent(hit, "dynamited", ent->client->sess.sessionTeam == TEAM_AXIS ? "axis" : "allies");
 
 #ifdef FEATURE_OMNIBOT
 							// notify omni-bot framework of planted dynamite
@@ -2243,6 +2243,8 @@ weapengineergoto3:
 								G_DPrintf("dyno chaining: hit: %p\n", hit);
 							}
 							traceEnt->etpro_misc_1 |= 1;
+							
+							G_Script_ScriptEvent(hit, "dynamited", ent->client->sess.sessionTeam == TEAM_AXIS ? "axis" : "allies");
 						}
 						return NULL;
 					}


### PR DESCRIPTION
Also makes Dynamite_Diffuse and Dynamite_Plant log order consistent with "legacy popup" log order.

Partially addresses https://github.com/etlegacy/etlegacy/issues/2333 (engineer repairs are still a TODO), which will allow external stats such as stats.hirntot.org (or other stats parsers/processors) to count and track who dynamited TOI objectives.