### PR TITLE
Log engineer repairs/constructions

### DIFF
--- a/src/game/g_weapon.c
+++ b/src/game/g_weapon.c
@@ -1101,12 +1101,14 @@ static qboolean TryConstructing(gentity_t *ent, gentity_t *trigger)
 		{
 			// call script
 			G_Script_ScriptEvent(constructible, "built", "final");
+			G_LogPrintf("Repair: %d\n", (int)(ent - g_entities));
 		}
 		else
 		{
 			if (constructible->grenadeFired == constructible->count2)
 			{
 				G_Script_ScriptEvent(constructible, "built", "final");
+				G_LogPrintf("Repair: %d\n", (int)(ent - g_entities));
 			}
 			else
 			{


### PR DESCRIPTION
Addresses https://github.com/etlegacy/etlegacy/issues/2333, logs "Repair: clientNum" upon engineer repairs/constructions which currently logs it only for MG42/Browning repairs.