### PR TITLE
client: Add 'CG_CVAR_SETDESCRIPTION' engine extension

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -3819,11 +3819,13 @@ void trap_SysFlashWindow(int state);
 void trap_CommandComplete(const char *value);
 void trap_CmdBackup_Ext(void);
 void trap_MatchPaused(qboolean matchPaused);
+void trap_Cvar_SetDescription(vmCvar_t *vmCvar, const char *text);
 extern int dll_com_trapGetValue;
 extern int dll_trap_SysFlashWindow;
 extern int dll_trap_CommandComplete;
 extern int dll_trap_CmdBackup_Ext;
 extern int dll_trap_MatchPaused;
+extern int dll_trap_Cvar_SetDescription;
 
 bg_playerclass_t *CG_PlayerClassForClientinfo(clientInfo_t *ci, centity_t *cent);
 

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -379,6 +379,14 @@ vmCvar_t cg_crosshairHealth;
 
 vmCvar_t cg_commandMapTime;
 
+// vmCvar_t Descriptions {{{
+#define cg_autoCmd_description \
+		"Allows setting a comand (or commands, ';'-seperated), that will automatically be executed when you first join a match or when the map restarts.\n" \
+		"\n" \
+		"Example:\n" \
+		"  /cg_autoCmd \"team r 2 23 3;say The sanctity of this place has been fouled.\""
+// {{{
+
 typedef struct
 {
 	vmCvar_t *vmCvar;
@@ -391,269 +399,269 @@ typedef struct
 
 static cvarTable_t cvarTable[] =
 {
-	{ &cg_autoswitch,               "cg_autoswitch",               "2",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_drawGun,                  "cg_drawGun",                  "1",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_weapAnims,                "cg_weapAnims",                "15",          CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_weapBankCollisions,       "cg_weapBankCollisions",       "0",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_weapSwitchNoAmmoSounds,   "cg_weapSwitchNoAmmoSounds",   "1",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_gun_frame,                "cg_gun_frame",                "0",           CVAR_TEMP,                    NULL, 0 },
-	{ &cg_zoomDefaultSniper,        "cg_zoomDefaultSniper",        "20",          CVAR_ARCHIVE,                 NULL, 0 },                    // changed per atvi req
-	{ &cg_zoomStepSniper,           "cg_zoomStepSniper",           "2",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_fov,                      "cg_fov",                      "90",          CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_muzzleFlash,              "cg_muzzleFlash",              "1",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_muzzleFlashDlight,        "cg_muzzleFlashDlight",        "0",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_muzzleFlashScale,         "cg_muzzleFlashScale",         "0.8",         CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_letterbox,                "cg_letterbox",                "0",           CVAR_TEMP,                    NULL, 0 },
-	{ &cg_shadows,                  "cg_shadows",                  "0",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_gibs,                     "cg_gibs",                     "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_autoswitch,               "cg_autoswitch",               "2",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_drawGun,                  "cg_drawGun",                  "1",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_weapAnims,                "cg_weapAnims",                "15",          CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_weapBankCollisions,       "cg_weapBankCollisions",       "0",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_weapSwitchNoAmmoSounds,   "cg_weapSwitchNoAmmoSounds",   "1",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_gun_frame,                "cg_gun_frame",                "0",           CVAR_TEMP,                    NULL,                   0 },
+	{ &cg_zoomDefaultSniper,        "cg_zoomDefaultSniper",        "20",          CVAR_ARCHIVE,                 NULL,                   0 },  // changed per atvi req
+	{ &cg_zoomStepSniper,           "cg_zoomStepSniper",           "2",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_fov,                      "cg_fov",                      "90",          CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_muzzleFlash,              "cg_muzzleFlash",              "1",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_muzzleFlashDlight,        "cg_muzzleFlashDlight",        "0",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_muzzleFlashScale,         "cg_muzzleFlashScale",         "0.8",         CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_letterbox,                "cg_letterbox",                "0",           CVAR_TEMP,                    NULL,                   0 },
+	{ &cg_shadows,                  "cg_shadows",                  "0",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_gibs,                     "cg_gibs",                     "1",           CVAR_ARCHIVE,                 NULL,                   0 },
 	// we now draw reticles always in non demoplayback
 	//  { &cg_draw2D, "cg_draw2D", "1", CVAR_CHEAT }, // JPW NERVE changed per atvi req to prevent sniper rifle NULL, zoom cheats
-	{ &cg_draw2D,                   "cg_draw2D",                   "1",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_railTrailTime,            "cg_railTrailTime",            "750",         CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_drawStatus,               "cg_drawStatus",               "1",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_drawFPS,                  "cg_drawFPS",                  "0",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_drawCrosshair,            "cg_drawCrosshair",            "1",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_drawCrosshairFade,        "cg_drawCrosshairFade",        "250",         CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_drawCrosshairPickups,     "cg_drawCrosshairPickups",     "1",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_drawSpectatorNames,       "cg_drawSpectatorNames",       "2",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_drawHintFade,             "cg_drawHintFade",             "250",         CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_useWeapsForZoom,          "cg_useWeapsForZoom",          "1",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_weaponCycleDelay,         "cg_weaponCycleDelay",         "150",         CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_cycleAllWeaps,            "cg_cycleAllWeaps",            "1",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_brassTime,                "cg_brassTime",                "2500",        CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_markTime,                 "cg_markTime",                 "20000",       CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_bloodPuff,                "cg_bloodPuff",                "1",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_gunFovOffset,             "cg_gunFovOffset",             "0",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_gun_x,                    "cg_gunX",                     "0",           CVAR_TEMP,                    NULL, 0 },
-	{ &cg_gun_y,                    "cg_gunY",                     "0",           CVAR_TEMP,                    NULL, 0 },
-	{ &cg_gun_z,                    "cg_gunZ",                     "0",           CVAR_TEMP,                    NULL, 0 },
-	{ &cg_centertime,               "cg_centertime",               "5",           CVAR_ARCHIVE,                 NULL, 0 },                    // changed from 3 to 5
-	{ &cg_bobbing,                  "cg_bobbing",                  "0.0",         CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_drawEnvAwareness,         "cg_drawEnvAwareness",         "7",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_drawEnvAwarenessScale,    "cg_drawEnvAwarenessScale",    "0.80",        CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_drawEnvAwarenessIconSize, "cg_drawEnvAwarenessIconSize", "14",          CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_draw2D,                   "cg_draw2D",                   "1",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_railTrailTime,            "cg_railTrailTime",            "750",         CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_drawStatus,               "cg_drawStatus",               "1",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_drawFPS,                  "cg_drawFPS",                  "0",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_drawCrosshair,            "cg_drawCrosshair",            "1",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_drawCrosshairFade,        "cg_drawCrosshairFade",        "250",         CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_drawCrosshairPickups,     "cg_drawCrosshairPickups",     "1",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_drawSpectatorNames,       "cg_drawSpectatorNames",       "2",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_drawHintFade,             "cg_drawHintFade",             "250",         CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_useWeapsForZoom,          "cg_useWeapsForZoom",          "1",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_weaponCycleDelay,         "cg_weaponCycleDelay",         "150",         CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_cycleAllWeaps,            "cg_cycleAllWeaps",            "1",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_brassTime,                "cg_brassTime",                "2500",        CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_markTime,                 "cg_markTime",                 "20000",       CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_bloodPuff,                "cg_bloodPuff",                "1",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_gunFovOffset,             "cg_gunFovOffset",             "0",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_gun_x,                    "cg_gunX",                     "0",           CVAR_TEMP,                    NULL,                   0 },
+	{ &cg_gun_y,                    "cg_gunY",                     "0",           CVAR_TEMP,                    NULL,                   0 },
+	{ &cg_gun_z,                    "cg_gunZ",                     "0",           CVAR_TEMP,                    NULL,                   0 },
+	{ &cg_centertime,               "cg_centertime",               "5",           CVAR_ARCHIVE,                 NULL,                   0 },  // changed from 3 to 5
+	{ &cg_bobbing,                  "cg_bobbing",                  "0.0",         CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_drawEnvAwareness,         "cg_drawEnvAwareness",         "7",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_drawEnvAwarenessScale,    "cg_drawEnvAwarenessScale",    "0.80",        CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_drawEnvAwarenessIconSize, "cg_drawEnvAwarenessIconSize", "14",          CVAR_ARCHIVE,                 NULL,                   0 },
 
-	{ &cg_dynamicIcons,             "cg_dynamicIcons",             "0",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_dynamicIconsDistance,     "cg_dynamicIconsDistance",     "400",         CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_dynamicIconsSize,         "cg_dynamicIconsSize",         "20",          CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_dynamicIconsMaxScale,     "cg_dynamicIconsMaxScale",     "1.0",         CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_dynamicIconsMinScale,     "cg_dynamicIconsMinScale",     "0.5",         CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_dynamicIcons,             "cg_dynamicIcons",             "0",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_dynamicIconsDistance,     "cg_dynamicIconsDistance",     "400",         CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_dynamicIconsSize,         "cg_dynamicIconsSize",         "20",          CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_dynamicIconsMaxScale,     "cg_dynamicIconsMaxScale",     "1.0",         CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_dynamicIconsMinScale,     "cg_dynamicIconsMinScale",     "0.5",         CVAR_ARCHIVE,                 NULL,                   0 },
 
-	{ &cg_autoactivate,             "cg_autoactivate",             "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_autoactivate,             "cg_autoactivate",             "1",           CVAR_ARCHIVE,                 NULL,                   0 },
 
 	// more fluid rotations
-	{ &cg_swingSpeed,               "cg_swingSpeed",               "0.1",         CVAR_ARCHIVE,                 NULL, 0 },                    // was 0.3 for Q3
-	{ &cg_bloodTime,                "cg_bloodTime",                "120",         CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_swingSpeed,               "cg_swingSpeed",               "0.1",         CVAR_ARCHIVE,                 NULL,                   0 },  // was 0.3 for Q3
+	{ &cg_bloodTime,                "cg_bloodTime",                "120",         CVAR_ARCHIVE,                 NULL,                   0 },
 
-	{ &cg_skybox,                   "cg_skybox",                   "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_skybox,                   "cg_skybox",                   "1",           CVAR_ARCHIVE,                 NULL,                   0 },
 
 	// say, team say, etc.
-	{ &cg_messageType,              "cg_messageType",              "1",           CVAR_TEMP,                    NULL, 0 },
+	{ &cg_messageType,              "cg_messageType",              "1",           CVAR_TEMP,                    NULL,                   0 },
 
-	{ &cg_animSpeed,                "cg_animspeed",                "1",           CVAR_CHEAT,                   NULL, 0 },
-	{ &cg_debugAnim,                "cg_debuganim",                "0",           CVAR_CHEAT,                   NULL, 0 },
-	{ &cg_debugPosition,            "cg_debugposition",            "0",           CVAR_CHEAT,                   NULL, 0 },
-	{ &cg_debugEvents,              "cg_debugevents",              "0",           CVAR_CHEAT,                   NULL, 0 },
-	{ &cg_debugPlayerHitboxes,      "cg_debugPlayerHitboxes",      "0",           CVAR_CHEAT,                   NULL, 0 },
-	{ &cg_debugBullets,             "cg_debugBullets",             "0",           CVAR_CHEAT,                   NULL, 0 },
-	{ &cg_errorDecay,               "cg_errordecay",               "100",         CVAR_CHEAT,                   NULL, 0 },
-	{ &cg_nopredict,                "cg_nopredict",                "0",           CVAR_CHEAT,                   NULL, 0 },
-	{ &cg_noPlayerAnims,            "cg_noplayeranims",            "0",           CVAR_CHEAT,                   NULL, 0 },
-	{ &cg_showmiss,                 "cg_showmiss",                 "0",           0,                            NULL, 0 },
-	{ &cg_tracerChance,             "cg_tracerchance",             "0.4",         CVAR_CHEAT,                   NULL, 0 },
-	{ &cg_tracerWidth,              "cg_tracerwidth",              "0.8",         CVAR_CHEAT,                   NULL, 0 },
-	{ &cg_tracerSpeed,              "cg_tracerSpeed",              "4500",        CVAR_CHEAT,                   NULL, 0 },
-	{ &cg_tracerLength,             "cg_tracerlength",             "160",         CVAR_CHEAT,                   NULL, 0 },
-	{ &cg_thirdPersonRange,         "cg_thirdPersonRange",         "80",          CVAR_CHEAT,                   NULL, 0 },                    // per atvi req
-	{ &cg_thirdPersonAngle,         "cg_thirdPersonAngle",         "0",           CVAR_CHEAT,                   NULL, 0 },
-	{ &cg_thirdPerson,              "cg_thirdPerson",              "0",           CVAR_CHEAT,                   NULL, 0 },                    // per atvi req
-	{ &cg_scopedSensitivityScaler,  "cg_scopedSensitivityScaler",  "0.6",         CVAR_ARCHIVE,                 NULL, 0 },                           // per atvi req
-	{ &cg_teamChatTime,             "cg_teamChatTime",             "8000",        CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_teamChatHeight,           "cg_teamChatHeight",           "8",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_teamChatMention,          "cg_teamChatMention",          "1",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_coronafardist,            "cg_coronafardist",            "1536",        CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_coronas,                  "cg_coronas",                  "1",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_predictItems,             "cg_predictItems",             "1",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_stats,                    "cg_stats",                    "0",           0,                            NULL, 0 },
+	{ &cg_animSpeed,                "cg_animspeed",                "1",           CVAR_CHEAT,                   NULL,                   0 },
+	{ &cg_debugAnim,                "cg_debuganim",                "0",           CVAR_CHEAT,                   NULL,                   0 },
+	{ &cg_debugPosition,            "cg_debugposition",            "0",           CVAR_CHEAT,                   NULL,                   0 },
+	{ &cg_debugEvents,              "cg_debugevents",              "0",           CVAR_CHEAT,                   NULL,                   0 },
+	{ &cg_debugPlayerHitboxes,      "cg_debugPlayerHitboxes",      "0",           CVAR_CHEAT,                   NULL,                   0 },
+	{ &cg_debugBullets,             "cg_debugBullets",             "0",           CVAR_CHEAT,                   NULL,                   0 },
+	{ &cg_errorDecay,               "cg_errordecay",               "100",         CVAR_CHEAT,                   NULL,                   0 },
+	{ &cg_nopredict,                "cg_nopredict",                "0",           CVAR_CHEAT,                   NULL,                   0 },
+	{ &cg_noPlayerAnims,            "cg_noplayeranims",            "0",           CVAR_CHEAT,                   NULL,                   0 },
+	{ &cg_showmiss,                 "cg_showmiss",                 "0",           0,                            NULL,                   0 },
+	{ &cg_tracerChance,             "cg_tracerchance",             "0.4",         CVAR_CHEAT,                   NULL,                   0 },
+	{ &cg_tracerWidth,              "cg_tracerwidth",              "0.8",         CVAR_CHEAT,                   NULL,                   0 },
+	{ &cg_tracerSpeed,              "cg_tracerSpeed",              "4500",        CVAR_CHEAT,                   NULL,                   0 },
+	{ &cg_tracerLength,             "cg_tracerlength",             "160",         CVAR_CHEAT,                   NULL,                   0 },
+	{ &cg_thirdPersonRange,         "cg_thirdPersonRange",         "80",          CVAR_CHEAT,                   NULL,                   0 },  // per atvi req
+	{ &cg_thirdPersonAngle,         "cg_thirdPersonAngle",         "0",           CVAR_CHEAT,                   NULL,                   0 },
+	{ &cg_thirdPerson,              "cg_thirdPerson",              "0",           CVAR_CHEAT,                   NULL,                   0 },  // per atvi req
+	{ &cg_scopedSensitivityScaler,  "cg_scopedSensitivityScaler",  "0.6",         CVAR_ARCHIVE,                 NULL,                   0 },         // per atvi req
+	{ &cg_teamChatTime,             "cg_teamChatTime",             "8000",        CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_teamChatHeight,           "cg_teamChatHeight",           "8",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_teamChatMention,          "cg_teamChatMention",          "1",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_coronafardist,            "cg_coronafardist",            "1536",        CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_coronas,                  "cg_coronas",                  "1",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_predictItems,             "cg_predictItems",             "1",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_stats,                    "cg_stats",                    "0",           0,                            NULL,                   0 },
 
-	{ &cg_timescale,                "timescale",                   "1",           0,                            NULL, 0 },
+	{ &cg_timescale,                "timescale",                   "1",           0,                            NULL,                   0 },
 
-	{ &pmove_fixed,                 "pmove_fixed",                 "0",           CVAR_SYSTEMINFO,              NULL, 0 },
-	{ &pmove_msec,                  "pmove_msec",                  "8",           CVAR_SYSTEMINFO,              NULL, 0 },
+	{ &pmove_fixed,                 "pmove_fixed",                 "0",           CVAR_SYSTEMINFO,              NULL,                   0 },
+	{ &pmove_msec,                  "pmove_msec",                  "8",           CVAR_SYSTEMINFO,              NULL,                   0 },
 
-	{ &cg_spritesFollowHeads,       "cg_spritesFollowHeads",       "1",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_voiceSpriteTime,          "cg_voiceSpriteTime",          "6000",        CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_spritesFollowHeads,       "cg_spritesFollowHeads",       "1",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_voiceSpriteTime,          "cg_voiceSpriteTime",          "6000",        CVAR_ARCHIVE,                 NULL,                   0 },
 
-	{ &cg_teamChatsOnly,            "cg_teamChatsOnly",            "0",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_teamVoiceChatsOnly,       "cg_teamVoiceChatsOnly",       "0",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_voiceChats,               "cg_voiceChats",               "1",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_voiceText,                "cg_voiceText",                "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_teamChatsOnly,            "cg_teamChatsOnly",            "0",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_teamVoiceChatsOnly,       "cg_teamVoiceChatsOnly",       "0",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_voiceChats,               "cg_voiceChats",               "1",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_voiceText,                "cg_voiceText",                "1",           CVAR_ARCHIVE,                 NULL,                   0 },
 
 	// the following variables are created in other parts of the system,
 	// but we also reference them here
 
-	{ &cg_buildScript,              "com_buildScript",             "0",           0,                            NULL, 0 },                    // force loading of all possible data and error on failures
-	{ &cg_paused,                   "cl_paused",                   "0",           CVAR_ROM,                     NULL, 0 },
+	{ &cg_buildScript,              "com_buildScript",             "0",           0,                            NULL,                   0 },  // force loading of all possible data and error on failures
+	{ &cg_paused,                   "cl_paused",                   "0",           CVAR_ROM,                     NULL,                   0 },
 
-	{ &cg_blood,                    "cg_showblood",                "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_blood,                    "cg_showblood",                "1",           CVAR_ARCHIVE,                 NULL,                   0 },
 #ifdef ALLOW_GSYNC
-	{ &cg_synchronousClients,       "g_synchronousClients",        "0",           CVAR_SYSTEMINFO | CVAR_CHEAT, NULL, 0 },                    // communicated by systeminfo
+	{ &cg_synchronousClients,       "g_synchronousClients",        "0",           CVAR_SYSTEMINFO | CVAR_CHEAT, NULL,                   0 },  // communicated by systeminfo
 #endif // ALLOW_GSYNC
 
-	{ &cg_gameType,                 "g_gametype",                  "0",           0,                            NULL, 0 },                    // communicated by systeminfo
-	{ &cg_bluelimbotime,            "",                            "30000",       0,                            NULL, 0 },                    // communicated by systeminfo
-	{ &cg_redlimbotime,             "",                            "30000",       0,                            NULL, 0 },                    // communicated by systeminfo
-	{ &cg_drawNotifyText,           "cg_drawNotifyText",           "1",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_quickMessageAlt,          "cg_quickMessageAlt",          "0",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_antilag,                  "g_antilag",                   "1",           0,                            NULL, 0 },
-	{ &developer,                   "developer",                   "0",           CVAR_CHEAT,                   NULL, 0 },
-	{ &cf_wstats,                   "cf_wstats",                   "1.2",         CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cf_wtopshots,                "cf_wtopshots",                "1.0",         CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_gameType,                 "g_gametype",                  "0",           0,                            NULL,                   0 },  // communicated by systeminfo
+	{ &cg_bluelimbotime,            "",                            "30000",       0,                            NULL,                   0 },  // communicated by systeminfo
+	{ &cg_redlimbotime,             "",                            "30000",       0,                            NULL,                   0 },  // communicated by systeminfo
+	{ &cg_drawNotifyText,           "cg_drawNotifyText",           "1",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_quickMessageAlt,          "cg_quickMessageAlt",          "0",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_antilag,                  "g_antilag",                   "1",           0,                            NULL,                   0 },
+	{ &developer,                   "developer",                   "0",           CVAR_CHEAT,                   NULL,                   0 },
+	{ &cf_wstats,                   "cf_wstats",                   "1.2",         CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cf_wtopshots,                "cf_wtopshots",                "1.0",         CVAR_ARCHIVE,                 NULL,                   0 },
 
-	{ &cg_autoFolders,              "cg_autoFolders",              "1",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_autoAction,               "cg_autoAction",               "4",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_autoReload,               "cg_autoReload",               "1",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_bloodDamageBlend,         "cg_bloodDamageBlend",         "1.0",         CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_bloodFlash,               "cg_bloodFlash",               "1.0",         CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_bloodFlashTime,           "cg_bloodFlashTime",           "1500",        CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_noAmmoAutoSwitch,         "cg_noAmmoAutoSwitch",         "1",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_printObjectiveInfo,       "cg_printObjectiveInfo",       "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_autoFolders,              "cg_autoFolders",              "1",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_autoAction,               "cg_autoAction",               "4",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_autoReload,               "cg_autoReload",               "1",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_bloodDamageBlend,         "cg_bloodDamageBlend",         "1.0",         CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_bloodFlash,               "cg_bloodFlash",               "1.0",         CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_bloodFlashTime,           "cg_bloodFlashTime",           "1500",        CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_noAmmoAutoSwitch,         "cg_noAmmoAutoSwitch",         "1",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_printObjectiveInfo,       "cg_printObjectiveInfo",       "1",           CVAR_ARCHIVE,                 NULL,                   0 },
 #ifdef FEATURE_MULTIVIEW
-	{ &cg_specHelp,                 "cg_specHelp",                 "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_specHelp,                 "cg_specHelp",                 "1",           CVAR_ARCHIVE,                 NULL,                   0 },
 #endif
-	{ &cg_uinfo,                    "cg_uinfo",                    "0",           CVAR_ROM | CVAR_USERINFO,     NULL, 0 },
+	{ &cg_uinfo,                    "cg_uinfo",                    "0",           CVAR_ROM | CVAR_USERINFO,     NULL,                   0 },
 
-	{ &demo_avifpsF1,               "demo_avifpsF1",               "0",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &demo_avifpsF2,               "demo_avifpsF2",               "10",          CVAR_ARCHIVE,                 NULL, 0 },
-	{ &demo_avifpsF3,               "demo_avifpsF3",               "15",          CVAR_ARCHIVE,                 NULL, 0 },
-	{ &demo_avifpsF4,               "demo_avifpsF4",               "20",          CVAR_ARCHIVE,                 NULL, 0 },
-	{ &demo_avifpsF5,               "demo_avifpsF5",               "24",          CVAR_ARCHIVE,                 NULL, 0 },
-	{ &demo_drawTimeScale,          "demo_drawTimeScale",          "1",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &demo_infoWindow,             "demo_infoWindow",             "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &demo_avifpsF1,               "demo_avifpsF1",               "0",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &demo_avifpsF2,               "demo_avifpsF2",               "10",          CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &demo_avifpsF3,               "demo_avifpsF3",               "15",          CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &demo_avifpsF4,               "demo_avifpsF4",               "20",          CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &demo_avifpsF5,               "demo_avifpsF5",               "24",          CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &demo_drawTimeScale,          "demo_drawTimeScale",          "1",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &demo_infoWindow,             "demo_infoWindow",             "1",           CVAR_ARCHIVE,                 NULL,                   0 },
 
 #ifdef FEATURE_EDV
-	{ &demo_weaponcam,              "demo_weaponcam",              "0",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &demo_weaponcam,              "demo_weaponcam",              "0",           CVAR_ARCHIVE,                 NULL,                   0 },
 
-	{ &demo_followDistance,         "demo_followDistance",         "50 0 20",     CVAR_ARCHIVE,                 NULL, 0 },
+	{ &demo_followDistance,         "demo_followDistance",         "50 0 20",     CVAR_ARCHIVE,                 NULL,                   0 },
 
-	{ &demo_yawPitchRollSpeed,      "demo_yawPitchRollSpeed",      "140 140 140", CVAR_ARCHIVE,                 NULL, 0 },
+	{ &demo_yawPitchRollSpeed,      "demo_yawPitchRollSpeed",      "140 140 140", CVAR_ARCHIVE,                 NULL,                   0 },
 
-	{ &demo_freecamspeed,           "demo_freecamspeed",           "800",         CVAR_ARCHIVE,                 NULL, 0 },
-	{ &demo_nopitch,                "demo_nopitch",                "1",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &demo_pvshint,                "demo_pvshint",                "0",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &demo_lookat,                 "demo_lookat",                 "-1",          CVAR_CHEAT,                   NULL, 0 },
-	{ &demo_autotimescaleweapons,   "demo_autotimescaleweapons",   "0",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &demo_autotimescale,          "demo_autotimescale",          "1",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &demo_teamonlymissilecam,     "demo_teamonlymissilecam",     "0",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_predefineddemokeys,       "cg_predefineddemokeys",       "1",           CVAR_CHEAT | CVAR_ARCHIVE,    NULL, 0 },
+	{ &demo_freecamspeed,           "demo_freecamspeed",           "800",         CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &demo_nopitch,                "demo_nopitch",                "1",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &demo_pvshint,                "demo_pvshint",                "0",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &demo_lookat,                 "demo_lookat",                 "-1",          CVAR_CHEAT,                   NULL,                   0 },
+	{ &demo_autotimescaleweapons,   "demo_autotimescaleweapons",   "0",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &demo_autotimescale,          "demo_autotimescale",          "1",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &demo_teamonlymissilecam,     "demo_teamonlymissilecam",     "0",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_predefineddemokeys,       "cg_predefineddemokeys",       "1",           CVAR_CHEAT | CVAR_ARCHIVE,    NULL,                   0 },
 #endif
 
 #ifdef FEATURE_MULTIVIEW
-	{ &mv_sensitivity,              "mv_sensitivity",              "20",          CVAR_ARCHIVE,                 NULL, 0 },
+	{ &mv_sensitivity,              "mv_sensitivity",              "20",          CVAR_ARCHIVE,                 NULL,                   0 },
 #endif
 
 	// Engine mappings
 
-	{ &int_cl_maxpackets,           "cl_maxpackets",               "125",         CVAR_ARCHIVE,                 NULL, 0 },
-	{ &int_cl_timenudge,            "cl_timenudge",                "0",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &int_m_pitch,                 "m_pitch",                     "0.022",       CVAR_ARCHIVE,                 NULL, 0 },
-	{ &int_sensitivity,             "sensitivity",                 "5",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &int_ui_blackout,             "ui_blackout",                 "0",           CVAR_ROM,                     NULL, 0 },
+	{ &int_cl_maxpackets,           "cl_maxpackets",               "125",         CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &int_cl_timenudge,            "cl_timenudge",                "0",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &int_m_pitch,                 "m_pitch",                     "0.022",       CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &int_sensitivity,             "sensitivity",                 "5",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &int_ui_blackout,             "ui_blackout",                 "0",           CVAR_ROM,                     NULL,                   0 },
 
-	{ &cg_atmosphericEffects,       "cg_atmosphericEffects",       "1",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &authLevel,                   "authLevel",                   "0",           CVAR_TEMP | CVAR_ROM,         NULL, 0 },
+	{ &cg_atmosphericEffects,       "cg_atmosphericEffects",       "1",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &authLevel,                   "authLevel",                   "0",           CVAR_TEMP | CVAR_ROM,         NULL,                   0 },
 
-	{ &cg_rconPassword,             "auth_rconPassword",           "",            CVAR_TEMP,                    NULL, 0 },
-	{ &cg_refereePassword,          "auth_refereePassword",        "",            CVAR_TEMP,                    NULL, 0 },
+	{ &cg_rconPassword,             "auth_rconPassword",           "",            CVAR_TEMP,                    NULL,                   0 },
+	{ &cg_refereePassword,          "auth_refereePassword",        "",            CVAR_TEMP,                    NULL,                   0 },
 
-	{ &cg_instanttapout,            "cg_instanttapout",            "0",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_debugSkills,              "cg_debugSkills",              "0",           0,                            NULL, 0 },
-	{ NULL,                         "cg_etVersion",                "",            CVAR_USERINFO | CVAR_ROM,     NULL, 0 },
+	{ &cg_instanttapout,            "cg_instanttapout",            "0",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_debugSkills,              "cg_debugSkills",              "0",           0,                            NULL,                   0 },
+	{ NULL,                         "cg_etVersion",                "",            CVAR_USERINFO | CVAR_ROM,     NULL,                   0 },
 #if 0
-	{ NULL,                         "cg_legacyVersion",            "",            CVAR_USERINFO | CVAR_ROM,     NULL, 0 },
+	{ NULL,                         "cg_legacyVersion",            "",            CVAR_USERINFO | CVAR_ROM,     NULL,                   0 },
 #endif
 	// demo recording cvars
-	{ &cl_demorecording,            "cl_demorecording",            "0",           CVAR_ROM,                     NULL, 0 },
-	{ &cl_demofilename,             "cl_demofilename",             "",            CVAR_ROM,                     NULL, 0 },
-	{ &cl_demooffset,               "cl_demooffset",               "0",           CVAR_ROM,                     NULL, 0 },
+	{ &cl_demorecording,            "cl_demorecording",            "0",           CVAR_ROM,                     NULL,                   0 },
+	{ &cl_demofilename,             "cl_demofilename",             "",            CVAR_ROM,                     NULL,                   0 },
+	{ &cl_demooffset,               "cl_demooffset",               "0",           CVAR_ROM,                     NULL,                   0 },
 	// wav recording cvars
-	{ &cl_waverecording,            "cl_waverecording",            "0",           CVAR_ROM,                     NULL, 0 },
-	{ &cl_wavefilename,             "cl_wavefilename",             "",            CVAR_ROM,                     NULL, 0 },
-	{ &cl_waveoffset,               "cl_waveoffset",               "0",           CVAR_ROM,                     NULL, 0 },
+	{ &cl_waverecording,            "cl_waverecording",            "0",           CVAR_ROM,                     NULL,                   0 },
+	{ &cl_wavefilename,             "cl_wavefilename",             "",            CVAR_ROM,                     NULL,                   0 },
+	{ &cl_waveoffset,               "cl_waveoffset",               "0",           CVAR_ROM,                     NULL,                   0 },
 
-	{ &cg_announcer,                "cg_announcer",                "1",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_hitSounds,                "cg_hitSounds",                "1",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_locations,                "cg_locations",                "3",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_locationMaxChars,         "cg_locationMaxChars",         "0",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_announcer,                "cg_announcer",                "1",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_hitSounds,                "cg_hitSounds",                "1",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_locations,                "cg_locations",                "3",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_locationMaxChars,         "cg_locationMaxChars",         "0",           CVAR_ARCHIVE,                 NULL,                   0 },
 
-	{ &cg_spawnTimer_set,           "cg_spawnTimer_set",           "-1",          CVAR_TEMP,                    NULL, 0 },
+	{ &cg_spawnTimer_set,           "cg_spawnTimer_set",           "-1",          CVAR_TEMP,                    NULL,                   0 },
 
-	{ &cg_spawnTimer_period,        "cg_spawnTimer_period",        "0",           CVAR_TEMP,                    NULL, 0 },
+	{ &cg_spawnTimer_period,        "cg_spawnTimer_period",        "0",           CVAR_TEMP,                    NULL,                   0 },
 
-	{ &cg_logFile,                  "cg_logFile",                  "",            CVAR_ARCHIVE,                 NULL, 0 },                    // we don't log the chats per default
+	{ &cg_logFile,                  "cg_logFile",                  "",            CVAR_ARCHIVE,                 NULL,                   0 },  // we don't log the chats per default
 
-	{ &cg_countryflags,             "cg_countryflags",             "1",           CVAR_ARCHIVE,                 NULL, 0 },                    // GeoIP
-	{ &cg_altHud,                   "cg_altHud",                   "0",           CVAR_ARCHIVE,                 NULL, 0 },                    // Hudstyles
-	{ &cg_shoutcasterHud,           "cg_shoutcasterHud",           "Shoutcaster", CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_tracers,                  "cg_tracers",                  "1",           CVAR_ARCHIVE,                 NULL, 0 },                    // Draw tracers
-	{ &cg_fireteamNameMaxChars,     "cg_fireteamNameMaxChars",     "0",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_fireteamNameAlign,        "cg_fireteamNameAlign",        "0",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_fireteamSprites,          "cg_fireteamSprites",          "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_countryflags,             "cg_countryflags",             "1",           CVAR_ARCHIVE,                 NULL,                   0 },  // GeoIP
+	{ &cg_altHud,                   "cg_altHud",                   "0",           CVAR_ARCHIVE,                 NULL,                   0 },  // Hudstyles
+	{ &cg_shoutcasterHud,           "cg_shoutcasterHud",           "Shoutcaster", CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_tracers,                  "cg_tracers",                  "1",           CVAR_ARCHIVE,                 NULL,                   0 },  // Draw tracers
+	{ &cg_fireteamNameMaxChars,     "cg_fireteamNameMaxChars",     "0",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_fireteamNameAlign,        "cg_fireteamNameAlign",        "0",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_fireteamSprites,          "cg_fireteamSprites",          "1",           CVAR_ARCHIVE,                 NULL,                   0 },
 
-	{ &cg_simpleItems,              "cg_simpleItems",              "0",           CVAR_ARCHIVE,                 NULL, 0 },                    // Bugged atm
-	{ &cg_simpleItemsScale,         "cg_simpleItemsScale",         "1.0",         CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_automapZoom,              "cg_automapZoom",              "5.159",       CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_autoCmd,                  "cg_autoCmd",                  "",            CVAR_TEMP,                    NULL, 0 },
-	{ &cg_popupFadeTime,            "cg_popupFadeTime",            "2500",        CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_popupStayTime,            "cg_popupStayTime",            "2000",        CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_popupTime,                "cg_popupTime",                "0",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_popupXPGainFadeTime,      "cg_popupXPGainFadeTime",      "250",         CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_popupXPGainStayTime,      "cg_popupXPGainStayTime",      "1000",        CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_popupXPGainTime,          "cg_popupXPGainTime",          "200",         CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_weapaltReloads,           "cg_weapaltReloads",           "0",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_weapaltSwitches,          "cg_weapaltSwitches",          "1",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_weapaltMgAutoProne,       "cg_weapaltMgAutoProne",       "1",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_sharetimerText,           "cg_sharetimerText",           "",            CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_simpleItems,              "cg_simpleItems",              "0",           CVAR_ARCHIVE,                 NULL,                   0 },  // Bugged atm
+	{ &cg_simpleItemsScale,         "cg_simpleItemsScale",         "1.0",         CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_automapZoom,              "cg_automapZoom",              "5.159",       CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_autoCmd,                  "cg_autoCmd",                  "",            CVAR_TEMP,                    cg_autoCmd_description, 0 },
+	{ &cg_popupFadeTime,            "cg_popupFadeTime",            "2500",        CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_popupStayTime,            "cg_popupStayTime",            "2000",        CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_popupTime,                "cg_popupTime",                "0",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_popupXPGainFadeTime,      "cg_popupXPGainFadeTime",      "250",         CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_popupXPGainStayTime,      "cg_popupXPGainStayTime",      "1000",        CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_popupXPGainTime,          "cg_popupXPGainTime",          "200",         CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_weapaltReloads,           "cg_weapaltReloads",           "0",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_weapaltSwitches,          "cg_weapaltSwitches",          "1",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_weapaltMgAutoProne,       "cg_weapaltMgAutoProne",       "1",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_sharetimerText,           "cg_sharetimerText",           "",            CVAR_ARCHIVE,                 NULL,                   0 },
 
 	// Fonts
-	{ &cg_fontScaleSP,              "cg_fontScaleSP",              "0.22",        CVAR_ARCHIVE,                 NULL, 0 },                    // SidePrint
+	{ &cg_fontScaleSP,              "cg_fontScaleSP",              "0.22",        CVAR_ARCHIVE,                 NULL,                   0 },  // SidePrint
 
-	{ &cg_optimizePrediction,       "cg_optimizePrediction",       "1",           CVAR_ARCHIVE,                 NULL, 0 },                    // unlagged optimized prediction
+	{ &cg_optimizePrediction,       "cg_optimizePrediction",       "1",           CVAR_ARCHIVE,                 NULL,                   0 },  // unlagged optimized prediction
 
 #if defined(FEATURE_RATING) || defined(FEATURE_PRESTIGE)
-	{ &cg_scoreboard,               "cg_scoreboard",               "0",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_scoreboard,               "cg_scoreboard",               "0",           CVAR_ARCHIVE,                 NULL,                   0 },
 #endif
 
-	{ &cg_quickchat,                "cg_quickchat",                "0",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_quickchat,                "cg_quickchat",                "0",           CVAR_ARCHIVE,                 NULL,                   0 },
 
-	{ &cg_drawUnit,                 "cg_drawUnit",                 "0",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_drawUnit,                 "cg_drawUnit",                 "0",           CVAR_ARCHIVE,                 NULL,                   0 },
 
-	{ &cg_visualEffects,            "cg_visualEffects",            "1",           CVAR_ARCHIVE,                 NULL, 0 },                    // (e.g. : smoke, debris, ...)
-	{ &cg_bannerTime,               "cg_bannerTime",               "10000",       CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_visualEffects,            "cg_visualEffects",            "1",           CVAR_ARCHIVE,                 NULL,                   0 },  // (e.g. : smoke, debris, ...)
+	{ &cg_bannerTime,               "cg_bannerTime",               "10000",       CVAR_ARCHIVE,                 NULL,                   0 },
 
-	{ &cg_shoutcastTeamNameRed,     "cg_shoutcastTeamNameRed",     "Axis",        CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_shoutcastTeamNameBlue,    "cg_shoutcastTeamNameBlue",    "Allies",      CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_shoutcastDrawHealth,      "cg_shoutcastDrawHealth",      "0",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_shoutcastGrenadeTrail,    "cg_shoutcastGrenadeTrail",    "0",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_shoutcastTeamNameRed,     "cg_shoutcastTeamNameRed",     "Axis",        CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_shoutcastTeamNameBlue,    "cg_shoutcastTeamNameBlue",    "Allies",      CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_shoutcastDrawHealth,      "cg_shoutcastDrawHealth",      "0",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_shoutcastGrenadeTrail,    "cg_shoutcastGrenadeTrail",    "0",           CVAR_ARCHIVE,                 NULL,                   0 },
 
-	{ &cg_activateLean,             "cg_activateLean",             "0",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_activateLean,             "cg_activateLean",             "0",           CVAR_ARCHIVE,                 NULL,                   0 },
 
-	{ &cg_drawBreathPuffs,          "cg_drawBreathPuffs",          "1",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_drawAirstrikePlanes,      "cg_drawAirstrikePlanes",      "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_drawBreathPuffs,          "cg_drawBreathPuffs",          "1",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_drawAirstrikePlanes,      "cg_drawAirstrikePlanes",      "1",           CVAR_ARCHIVE,                 NULL,                   0 },
 
-	{ &cg_drawSpawnpoints,          "cg_drawSpawnpoints",          "0",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_drawSpawnpoints,          "cg_drawSpawnpoints",          "0",           CVAR_ARCHIVE,                 NULL,                   0 },
 
-	{ &cg_useCvarCrosshair,         "cg_useCvarCrosshair",         "1",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_crosshairSVG,             "cg_crosshairSVG",             "0",           CVAR_ARCHIVE | CVAR_LATCH,    NULL, 0 },
-	{ &cg_crosshairSize,            "cg_crosshairSize",            "48",          CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_crosshairAlpha,           "cg_crosshairAlpha",           "1.0",         CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_crosshairColor,           "cg_crosshairColor",           "White",       CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_crosshairAlphaAlt,        "cg_crosshairAlphaAlt",        "1.0",         CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_crosshairColorAlt,        "cg_crosshairColorAlt",        "White",       CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_crosshairPulse,           "cg_crosshairPulse",           "1",           CVAR_ARCHIVE,                 NULL, 0 },
-	{ &cg_crosshairHealth,          "cg_crosshairHealth",          "0",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_useCvarCrosshair,         "cg_useCvarCrosshair",         "1",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_crosshairSVG,             "cg_crosshairSVG",             "0",           CVAR_ARCHIVE | CVAR_LATCH,    NULL,                   0 },
+	{ &cg_crosshairSize,            "cg_crosshairSize",            "48",          CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_crosshairAlpha,           "cg_crosshairAlpha",           "1.0",         CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_crosshairColor,           "cg_crosshairColor",           "White",       CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_crosshairAlphaAlt,        "cg_crosshairAlphaAlt",        "1.0",         CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_crosshairColorAlt,        "cg_crosshairColorAlt",        "White",       CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_crosshairPulse,           "cg_crosshairPulse",           "1",           CVAR_ARCHIVE,                 NULL,                   0 },
+	{ &cg_crosshairHealth,          "cg_crosshairHealth",          "0",           CVAR_ARCHIVE,                 NULL,                   0 },
 
-	{ &cg_commandMapTime,           "cg_commandMapTime",           "0",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_commandMapTime,           "cg_commandMapTime",           "0",           CVAR_ARCHIVE,                 NULL,                   0 },
 };
 
 static const unsigned int cvarTableSize = sizeof(cvarTable) / sizeof(cvarTable[0]);

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -48,6 +48,7 @@ int dll_trap_SysFlashWindow;
 int dll_trap_CommandComplete;
 int dll_trap_CmdBackup_Ext;
 int dll_trap_MatchPaused;
+int dll_trap_Cvar_SetDescription;
 
 /**
  * @brief This is the only way control passes into the module.
@@ -2755,6 +2756,7 @@ static ID_INLINE void CG_SetupExtensions(void)
 		CG_SetupExtensionTrap(value, MAX_CVAR_VALUE_STRING, &dll_trap_CommandComplete, "trap_CommandComplete_Legacy");
 		CG_SetupExtensionTrap(value, MAX_CVAR_VALUE_STRING, &dll_trap_CmdBackup_Ext, "trap_CmdBackup_Ext_Legacy");
 		CG_SetupExtensionTrap(value, MAX_CVAR_VALUE_STRING, &dll_trap_MatchPaused, "trap_MatchPaused_Legacy");
+		CG_SetupExtensionTrap(value, MAX_CVAR_VALUE_STRING, &dll_trap_Cvar_SetDescription, "trap_Cvar_SetDescription_Legacy");
 	}
 }
 

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -385,274 +385,275 @@ typedef struct
 	const char *cvarName;
 	const char *defaultString;
 	int cvarFlags;
+	const char *description;
 	int modificationCount;
 } cvarTable_t;
 
 static cvarTable_t cvarTable[] =
 {
-	{ &cg_autoswitch,               "cg_autoswitch",               "2",           CVAR_ARCHIVE,                 0 },
-	{ &cg_drawGun,                  "cg_drawGun",                  "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_weapAnims,                "cg_weapAnims",                "15",          CVAR_ARCHIVE,                 0 },
-	{ &cg_weapBankCollisions,       "cg_weapBankCollisions",       "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_weapSwitchNoAmmoSounds,   "cg_weapSwitchNoAmmoSounds",   "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_gun_frame,                "cg_gun_frame",                "0",           CVAR_TEMP,                    0 },
-	{ &cg_zoomDefaultSniper,        "cg_zoomDefaultSniper",        "20",          CVAR_ARCHIVE,                 0 }, // changed per atvi req
-	{ &cg_zoomStepSniper,           "cg_zoomStepSniper",           "2",           CVAR_ARCHIVE,                 0 },
-	{ &cg_fov,                      "cg_fov",                      "90",          CVAR_ARCHIVE,                 0 },
-	{ &cg_muzzleFlash,              "cg_muzzleFlash",              "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_muzzleFlashDlight,        "cg_muzzleFlashDlight",        "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_muzzleFlashScale,         "cg_muzzleFlashScale",         "0.8",         CVAR_ARCHIVE,                 0 },
-	{ &cg_letterbox,                "cg_letterbox",                "0",           CVAR_TEMP,                    0 },
-	{ &cg_shadows,                  "cg_shadows",                  "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_gibs,                     "cg_gibs",                     "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_autoswitch,               "cg_autoswitch",               "2",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_drawGun,                  "cg_drawGun",                  "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_weapAnims,                "cg_weapAnims",                "15",          CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_weapBankCollisions,       "cg_weapBankCollisions",       "0",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_weapSwitchNoAmmoSounds,   "cg_weapSwitchNoAmmoSounds",   "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_gun_frame,                "cg_gun_frame",                "0",           CVAR_TEMP,                    NULL, 0 },
+	{ &cg_zoomDefaultSniper,        "cg_zoomDefaultSniper",        "20",          CVAR_ARCHIVE,                 NULL, 0 },                    // changed per atvi req
+	{ &cg_zoomStepSniper,           "cg_zoomStepSniper",           "2",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_fov,                      "cg_fov",                      "90",          CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_muzzleFlash,              "cg_muzzleFlash",              "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_muzzleFlashDlight,        "cg_muzzleFlashDlight",        "0",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_muzzleFlashScale,         "cg_muzzleFlashScale",         "0.8",         CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_letterbox,                "cg_letterbox",                "0",           CVAR_TEMP,                    NULL, 0 },
+	{ &cg_shadows,                  "cg_shadows",                  "0",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_gibs,                     "cg_gibs",                     "1",           CVAR_ARCHIVE,                 NULL, 0 },
 	// we now draw reticles always in non demoplayback
-	//  { &cg_draw2D, "cg_draw2D", "1", CVAR_CHEAT }, // JPW NERVE changed per atvi req to prevent sniper rifle zoom cheats
-	{ &cg_draw2D,                   "cg_draw2D",                   "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_railTrailTime,            "cg_railTrailTime",            "750",         CVAR_ARCHIVE,                 0 },
-	{ &cg_drawStatus,               "cg_drawStatus",               "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_drawFPS,                  "cg_drawFPS",                  "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_drawCrosshair,            "cg_drawCrosshair",            "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_drawCrosshairFade,        "cg_drawCrosshairFade",        "250",         CVAR_ARCHIVE,                 0 },
-	{ &cg_drawCrosshairPickups,     "cg_drawCrosshairPickups",     "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_drawSpectatorNames,       "cg_drawSpectatorNames",       "2",           CVAR_ARCHIVE,                 0 },
-	{ &cg_drawHintFade,             "cg_drawHintFade",             "250",         CVAR_ARCHIVE,                 0 },
-	{ &cg_useWeapsForZoom,          "cg_useWeapsForZoom",          "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_weaponCycleDelay,         "cg_weaponCycleDelay",         "150",         CVAR_ARCHIVE,                 0 },
-	{ &cg_cycleAllWeaps,            "cg_cycleAllWeaps",            "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_brassTime,                "cg_brassTime",                "2500",        CVAR_ARCHIVE,                 0 },
-	{ &cg_markTime,                 "cg_markTime",                 "20000",       CVAR_ARCHIVE,                 0 },
-	{ &cg_bloodPuff,                "cg_bloodPuff",                "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_gunFovOffset,             "cg_gunFovOffset",             "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_gun_x,                    "cg_gunX",                     "0",           CVAR_TEMP,                    0 },
-	{ &cg_gun_y,                    "cg_gunY",                     "0",           CVAR_TEMP,                    0 },
-	{ &cg_gun_z,                    "cg_gunZ",                     "0",           CVAR_TEMP,                    0 },
-	{ &cg_centertime,               "cg_centertime",               "5",           CVAR_ARCHIVE,                 0 }, // changed from 3 to 5
-	{ &cg_bobbing,                  "cg_bobbing",                  "0.0",         CVAR_ARCHIVE,                 0 },
-	{ &cg_drawEnvAwareness,         "cg_drawEnvAwareness",         "7",           CVAR_ARCHIVE,                 0 },
-	{ &cg_drawEnvAwarenessScale,    "cg_drawEnvAwarenessScale",    "0.80",        CVAR_ARCHIVE,                 0 },
-	{ &cg_drawEnvAwarenessIconSize, "cg_drawEnvAwarenessIconSize", "14",          CVAR_ARCHIVE,                 0 },
+	//  { &cg_draw2D, "cg_draw2D", "1", CVAR_CHEAT }, // JPW NERVE changed per atvi req to prevent sniper rifle NULL, zoom cheats
+	{ &cg_draw2D,                   "cg_draw2D",                   "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_railTrailTime,            "cg_railTrailTime",            "750",         CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_drawStatus,               "cg_drawStatus",               "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_drawFPS,                  "cg_drawFPS",                  "0",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_drawCrosshair,            "cg_drawCrosshair",            "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_drawCrosshairFade,        "cg_drawCrosshairFade",        "250",         CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_drawCrosshairPickups,     "cg_drawCrosshairPickups",     "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_drawSpectatorNames,       "cg_drawSpectatorNames",       "2",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_drawHintFade,             "cg_drawHintFade",             "250",         CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_useWeapsForZoom,          "cg_useWeapsForZoom",          "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_weaponCycleDelay,         "cg_weaponCycleDelay",         "150",         CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_cycleAllWeaps,            "cg_cycleAllWeaps",            "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_brassTime,                "cg_brassTime",                "2500",        CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_markTime,                 "cg_markTime",                 "20000",       CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_bloodPuff,                "cg_bloodPuff",                "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_gunFovOffset,             "cg_gunFovOffset",             "0",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_gun_x,                    "cg_gunX",                     "0",           CVAR_TEMP,                    NULL, 0 },
+	{ &cg_gun_y,                    "cg_gunY",                     "0",           CVAR_TEMP,                    NULL, 0 },
+	{ &cg_gun_z,                    "cg_gunZ",                     "0",           CVAR_TEMP,                    NULL, 0 },
+	{ &cg_centertime,               "cg_centertime",               "5",           CVAR_ARCHIVE,                 NULL, 0 },                    // changed from 3 to 5
+	{ &cg_bobbing,                  "cg_bobbing",                  "0.0",         CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_drawEnvAwareness,         "cg_drawEnvAwareness",         "7",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_drawEnvAwarenessScale,    "cg_drawEnvAwarenessScale",    "0.80",        CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_drawEnvAwarenessIconSize, "cg_drawEnvAwarenessIconSize", "14",          CVAR_ARCHIVE,                 NULL, 0 },
 
-	{ &cg_dynamicIcons,             "cg_dynamicIcons",             "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_dynamicIconsDistance,     "cg_dynamicIconsDistance",     "400",         CVAR_ARCHIVE,                 0 },
-	{ &cg_dynamicIconsSize,         "cg_dynamicIconsSize",         "20",          CVAR_ARCHIVE,                 0 },
-	{ &cg_dynamicIconsMaxScale,     "cg_dynamicIconsMaxScale",     "1.0",         CVAR_ARCHIVE,                 0 },
-	{ &cg_dynamicIconsMinScale,     "cg_dynamicIconsMinScale",     "0.5",         CVAR_ARCHIVE,                 0 },
+	{ &cg_dynamicIcons,             "cg_dynamicIcons",             "0",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_dynamicIconsDistance,     "cg_dynamicIconsDistance",     "400",         CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_dynamicIconsSize,         "cg_dynamicIconsSize",         "20",          CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_dynamicIconsMaxScale,     "cg_dynamicIconsMaxScale",     "1.0",         CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_dynamicIconsMinScale,     "cg_dynamicIconsMinScale",     "0.5",         CVAR_ARCHIVE,                 NULL, 0 },
 
-	{ &cg_autoactivate,             "cg_autoactivate",             "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_autoactivate,             "cg_autoactivate",             "1",           CVAR_ARCHIVE,                 NULL, 0 },
 
 	// more fluid rotations
-	{ &cg_swingSpeed,               "cg_swingSpeed",               "0.1",         CVAR_ARCHIVE,                 0 }, // was 0.3 for Q3
-	{ &cg_bloodTime,                "cg_bloodTime",                "120",         CVAR_ARCHIVE,                 0 },
+	{ &cg_swingSpeed,               "cg_swingSpeed",               "0.1",         CVAR_ARCHIVE,                 NULL, 0 },                    // was 0.3 for Q3
+	{ &cg_bloodTime,                "cg_bloodTime",                "120",         CVAR_ARCHIVE,                 NULL, 0 },
 
-	{ &cg_skybox,                   "cg_skybox",                   "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_skybox,                   "cg_skybox",                   "1",           CVAR_ARCHIVE,                 NULL, 0 },
 
 	// say, team say, etc.
-	{ &cg_messageType,              "cg_messageType",              "1",           CVAR_TEMP,                    0 },
+	{ &cg_messageType,              "cg_messageType",              "1",           CVAR_TEMP,                    NULL, 0 },
 
-	{ &cg_animSpeed,                "cg_animspeed",                "1",           CVAR_CHEAT,                   0 },
-	{ &cg_debugAnim,                "cg_debuganim",                "0",           CVAR_CHEAT,                   0 },
-	{ &cg_debugPosition,            "cg_debugposition",            "0",           CVAR_CHEAT,                   0 },
-	{ &cg_debugEvents,              "cg_debugevents",              "0",           CVAR_CHEAT,                   0 },
-	{ &cg_debugPlayerHitboxes,      "cg_debugPlayerHitboxes",      "0",           CVAR_CHEAT,                   0 },
-	{ &cg_debugBullets,             "cg_debugBullets",             "0",           CVAR_CHEAT,                   0 },
-	{ &cg_errorDecay,               "cg_errordecay",               "100",         CVAR_CHEAT,                   0 },
-	{ &cg_nopredict,                "cg_nopredict",                "0",           CVAR_CHEAT,                   0 },
-	{ &cg_noPlayerAnims,            "cg_noplayeranims",            "0",           CVAR_CHEAT,                   0 },
-	{ &cg_showmiss,                 "cg_showmiss",                 "0",           0,                            0 },
-	{ &cg_tracerChance,             "cg_tracerchance",             "0.4",         CVAR_CHEAT,                   0 },
-	{ &cg_tracerWidth,              "cg_tracerwidth",              "0.8",         CVAR_CHEAT,                   0 },
-	{ &cg_tracerSpeed,              "cg_tracerSpeed",              "4500",        CVAR_CHEAT,                   0 },
-	{ &cg_tracerLength,             "cg_tracerlength",             "160",         CVAR_CHEAT,                   0 },
-	{ &cg_thirdPersonRange,         "cg_thirdPersonRange",         "80",          CVAR_CHEAT,                   0 }, // per atvi req
-	{ &cg_thirdPersonAngle,         "cg_thirdPersonAngle",         "0",           CVAR_CHEAT,                   0 },
-	{ &cg_thirdPerson,              "cg_thirdPerson",              "0",           CVAR_CHEAT,                   0 }, // per atvi req
-	{ &cg_scopedSensitivityScaler,  "cg_scopedSensitivityScaler",  "0.6",         CVAR_ARCHIVE,                 0 },                           // per atvi req
-	{ &cg_teamChatTime,             "cg_teamChatTime",             "8000",        CVAR_ARCHIVE,                 0 },
-	{ &cg_teamChatHeight,           "cg_teamChatHeight",           "8",           CVAR_ARCHIVE,                 0 },
-	{ &cg_teamChatMention,          "cg_teamChatMention",          "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_coronafardist,            "cg_coronafardist",            "1536",        CVAR_ARCHIVE,                 0 },
-	{ &cg_coronas,                  "cg_coronas",                  "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_predictItems,             "cg_predictItems",             "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_stats,                    "cg_stats",                    "0",           0,                            0 },
+	{ &cg_animSpeed,                "cg_animspeed",                "1",           CVAR_CHEAT,                   NULL, 0 },
+	{ &cg_debugAnim,                "cg_debuganim",                "0",           CVAR_CHEAT,                   NULL, 0 },
+	{ &cg_debugPosition,            "cg_debugposition",            "0",           CVAR_CHEAT,                   NULL, 0 },
+	{ &cg_debugEvents,              "cg_debugevents",              "0",           CVAR_CHEAT,                   NULL, 0 },
+	{ &cg_debugPlayerHitboxes,      "cg_debugPlayerHitboxes",      "0",           CVAR_CHEAT,                   NULL, 0 },
+	{ &cg_debugBullets,             "cg_debugBullets",             "0",           CVAR_CHEAT,                   NULL, 0 },
+	{ &cg_errorDecay,               "cg_errordecay",               "100",         CVAR_CHEAT,                   NULL, 0 },
+	{ &cg_nopredict,                "cg_nopredict",                "0",           CVAR_CHEAT,                   NULL, 0 },
+	{ &cg_noPlayerAnims,            "cg_noplayeranims",            "0",           CVAR_CHEAT,                   NULL, 0 },
+	{ &cg_showmiss,                 "cg_showmiss",                 "0",           0,                            NULL, 0 },
+	{ &cg_tracerChance,             "cg_tracerchance",             "0.4",         CVAR_CHEAT,                   NULL, 0 },
+	{ &cg_tracerWidth,              "cg_tracerwidth",              "0.8",         CVAR_CHEAT,                   NULL, 0 },
+	{ &cg_tracerSpeed,              "cg_tracerSpeed",              "4500",        CVAR_CHEAT,                   NULL, 0 },
+	{ &cg_tracerLength,             "cg_tracerlength",             "160",         CVAR_CHEAT,                   NULL, 0 },
+	{ &cg_thirdPersonRange,         "cg_thirdPersonRange",         "80",          CVAR_CHEAT,                   NULL, 0 },                    // per atvi req
+	{ &cg_thirdPersonAngle,         "cg_thirdPersonAngle",         "0",           CVAR_CHEAT,                   NULL, 0 },
+	{ &cg_thirdPerson,              "cg_thirdPerson",              "0",           CVAR_CHEAT,                   NULL, 0 },                    // per atvi req
+	{ &cg_scopedSensitivityScaler,  "cg_scopedSensitivityScaler",  "0.6",         CVAR_ARCHIVE,                 NULL, 0 },                           // per atvi req
+	{ &cg_teamChatTime,             "cg_teamChatTime",             "8000",        CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_teamChatHeight,           "cg_teamChatHeight",           "8",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_teamChatMention,          "cg_teamChatMention",          "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_coronafardist,            "cg_coronafardist",            "1536",        CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_coronas,                  "cg_coronas",                  "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_predictItems,             "cg_predictItems",             "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_stats,                    "cg_stats",                    "0",           0,                            NULL, 0 },
 
-	{ &cg_timescale,                "timescale",                   "1",           0,                            0 },
+	{ &cg_timescale,                "timescale",                   "1",           0,                            NULL, 0 },
 
-	{ &pmove_fixed,                 "pmove_fixed",                 "0",           CVAR_SYSTEMINFO,              0 },
-	{ &pmove_msec,                  "pmove_msec",                  "8",           CVAR_SYSTEMINFO,              0 },
+	{ &pmove_fixed,                 "pmove_fixed",                 "0",           CVAR_SYSTEMINFO,              NULL, 0 },
+	{ &pmove_msec,                  "pmove_msec",                  "8",           CVAR_SYSTEMINFO,              NULL, 0 },
 
-	{ &cg_spritesFollowHeads,       "cg_spritesFollowHeads",       "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_voiceSpriteTime,          "cg_voiceSpriteTime",          "6000",        CVAR_ARCHIVE,                 0 },
+	{ &cg_spritesFollowHeads,       "cg_spritesFollowHeads",       "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_voiceSpriteTime,          "cg_voiceSpriteTime",          "6000",        CVAR_ARCHIVE,                 NULL, 0 },
 
-	{ &cg_teamChatsOnly,            "cg_teamChatsOnly",            "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_teamVoiceChatsOnly,       "cg_teamVoiceChatsOnly",       "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_voiceChats,               "cg_voiceChats",               "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_voiceText,                "cg_voiceText",                "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_teamChatsOnly,            "cg_teamChatsOnly",            "0",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_teamVoiceChatsOnly,       "cg_teamVoiceChatsOnly",       "0",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_voiceChats,               "cg_voiceChats",               "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_voiceText,                "cg_voiceText",                "1",           CVAR_ARCHIVE,                 NULL, 0 },
 
 	// the following variables are created in other parts of the system,
 	// but we also reference them here
 
-	{ &cg_buildScript,              "com_buildScript",             "0",           0,                            0 }, // force loading of all possible data and error on failures
-	{ &cg_paused,                   "cl_paused",                   "0",           CVAR_ROM,                     0 },
+	{ &cg_buildScript,              "com_buildScript",             "0",           0,                            NULL, 0 },                    // force loading of all possible data and error on failures
+	{ &cg_paused,                   "cl_paused",                   "0",           CVAR_ROM,                     NULL, 0 },
 
-	{ &cg_blood,                    "cg_showblood",                "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_blood,                    "cg_showblood",                "1",           CVAR_ARCHIVE,                 NULL, 0 },
 #ifdef ALLOW_GSYNC
-	{ &cg_synchronousClients,       "g_synchronousClients",        "0",           CVAR_SYSTEMINFO | CVAR_CHEAT, 0 }, // communicated by systeminfo
+	{ &cg_synchronousClients,       "g_synchronousClients",        "0",           CVAR_SYSTEMINFO | CVAR_CHEAT, NULL, 0 },                    // communicated by systeminfo
 #endif // ALLOW_GSYNC
 
-	{ &cg_gameType,                 "g_gametype",                  "0",           0,                            0 }, // communicated by systeminfo
-	{ &cg_bluelimbotime,            "",                            "30000",       0,                            0 }, // communicated by systeminfo
-	{ &cg_redlimbotime,             "",                            "30000",       0,                            0 }, // communicated by systeminfo
-	{ &cg_drawNotifyText,           "cg_drawNotifyText",           "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_quickMessageAlt,          "cg_quickMessageAlt",          "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_antilag,                  "g_antilag",                   "1",           0,                            0 },
-	{ &developer,                   "developer",                   "0",           CVAR_CHEAT,                   0 },
-	{ &cf_wstats,                   "cf_wstats",                   "1.2",         CVAR_ARCHIVE,                 0 },
-	{ &cf_wtopshots,                "cf_wtopshots",                "1.0",         CVAR_ARCHIVE,                 0 },
+	{ &cg_gameType,                 "g_gametype",                  "0",           0,                            NULL, 0 },                    // communicated by systeminfo
+	{ &cg_bluelimbotime,            "",                            "30000",       0,                            NULL, 0 },                    // communicated by systeminfo
+	{ &cg_redlimbotime,             "",                            "30000",       0,                            NULL, 0 },                    // communicated by systeminfo
+	{ &cg_drawNotifyText,           "cg_drawNotifyText",           "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_quickMessageAlt,          "cg_quickMessageAlt",          "0",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_antilag,                  "g_antilag",                   "1",           0,                            NULL, 0 },
+	{ &developer,                   "developer",                   "0",           CVAR_CHEAT,                   NULL, 0 },
+	{ &cf_wstats,                   "cf_wstats",                   "1.2",         CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cf_wtopshots,                "cf_wtopshots",                "1.0",         CVAR_ARCHIVE,                 NULL, 0 },
 
-	{ &cg_autoFolders,              "cg_autoFolders",              "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_autoAction,               "cg_autoAction",               "4",           CVAR_ARCHIVE,                 0 },
-	{ &cg_autoReload,               "cg_autoReload",               "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_bloodDamageBlend,         "cg_bloodDamageBlend",         "1.0",         CVAR_ARCHIVE,                 0 },
-	{ &cg_bloodFlash,               "cg_bloodFlash",               "1.0",         CVAR_ARCHIVE,                 0 },
-	{ &cg_bloodFlashTime,           "cg_bloodFlashTime",           "1500",        CVAR_ARCHIVE,                 0 },
-	{ &cg_noAmmoAutoSwitch,         "cg_noAmmoAutoSwitch",         "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_printObjectiveInfo,       "cg_printObjectiveInfo",       "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_autoFolders,              "cg_autoFolders",              "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_autoAction,               "cg_autoAction",               "4",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_autoReload,               "cg_autoReload",               "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_bloodDamageBlend,         "cg_bloodDamageBlend",         "1.0",         CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_bloodFlash,               "cg_bloodFlash",               "1.0",         CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_bloodFlashTime,           "cg_bloodFlashTime",           "1500",        CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_noAmmoAutoSwitch,         "cg_noAmmoAutoSwitch",         "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_printObjectiveInfo,       "cg_printObjectiveInfo",       "1",           CVAR_ARCHIVE,                 NULL, 0 },
 #ifdef FEATURE_MULTIVIEW
-	{ &cg_specHelp,                 "cg_specHelp",                 "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_specHelp,                 "cg_specHelp",                 "1",           CVAR_ARCHIVE,                 NULL, 0 },
 #endif
-	{ &cg_uinfo,                    "cg_uinfo",                    "0",           CVAR_ROM | CVAR_USERINFO,     0 },
+	{ &cg_uinfo,                    "cg_uinfo",                    "0",           CVAR_ROM | CVAR_USERINFO,     NULL, 0 },
 
-	{ &demo_avifpsF1,               "demo_avifpsF1",               "0",           CVAR_ARCHIVE,                 0 },
-	{ &demo_avifpsF2,               "demo_avifpsF2",               "10",          CVAR_ARCHIVE,                 0 },
-	{ &demo_avifpsF3,               "demo_avifpsF3",               "15",          CVAR_ARCHIVE,                 0 },
-	{ &demo_avifpsF4,               "demo_avifpsF4",               "20",          CVAR_ARCHIVE,                 0 },
-	{ &demo_avifpsF5,               "demo_avifpsF5",               "24",          CVAR_ARCHIVE,                 0 },
-	{ &demo_drawTimeScale,          "demo_drawTimeScale",          "1",           CVAR_ARCHIVE,                 0 },
-	{ &demo_infoWindow,             "demo_infoWindow",             "1",           CVAR_ARCHIVE,                 0 },
+	{ &demo_avifpsF1,               "demo_avifpsF1",               "0",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &demo_avifpsF2,               "demo_avifpsF2",               "10",          CVAR_ARCHIVE,                 NULL, 0 },
+	{ &demo_avifpsF3,               "demo_avifpsF3",               "15",          CVAR_ARCHIVE,                 NULL, 0 },
+	{ &demo_avifpsF4,               "demo_avifpsF4",               "20",          CVAR_ARCHIVE,                 NULL, 0 },
+	{ &demo_avifpsF5,               "demo_avifpsF5",               "24",          CVAR_ARCHIVE,                 NULL, 0 },
+	{ &demo_drawTimeScale,          "demo_drawTimeScale",          "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &demo_infoWindow,             "demo_infoWindow",             "1",           CVAR_ARCHIVE,                 NULL, 0 },
 
 #ifdef FEATURE_EDV
-	{ &demo_weaponcam,              "demo_weaponcam",              "0",           CVAR_ARCHIVE,                 0 },
+	{ &demo_weaponcam,              "demo_weaponcam",              "0",           CVAR_ARCHIVE,                 NULL, 0 },
 
-	{ &demo_followDistance,         "demo_followDistance",         "50 0 20",     CVAR_ARCHIVE,                 0 },
+	{ &demo_followDistance,         "demo_followDistance",         "50 0 20",     CVAR_ARCHIVE,                 NULL, 0 },
 
-	{ &demo_yawPitchRollSpeed,      "demo_yawPitchRollSpeed",      "140 140 140", CVAR_ARCHIVE,                 0 },
+	{ &demo_yawPitchRollSpeed,      "demo_yawPitchRollSpeed",      "140 140 140", CVAR_ARCHIVE,                 NULL, 0 },
 
-	{ &demo_freecamspeed,           "demo_freecamspeed",           "800",         CVAR_ARCHIVE,                 0 },
-	{ &demo_nopitch,                "demo_nopitch",                "1",           CVAR_ARCHIVE,                 0 },
-	{ &demo_pvshint,                "demo_pvshint",                "0",           CVAR_ARCHIVE,                 0 },
-	{ &demo_lookat,                 "demo_lookat",                 "-1",          CVAR_CHEAT,                   0 },
-	{ &demo_autotimescaleweapons,   "demo_autotimescaleweapons",   "0",           CVAR_ARCHIVE,                 0 },
-	{ &demo_autotimescale,          "demo_autotimescale",          "1",           CVAR_ARCHIVE,                 0 },
-	{ &demo_teamonlymissilecam,     "demo_teamonlymissilecam",     "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_predefineddemokeys,       "cg_predefineddemokeys",       "1",           CVAR_CHEAT | CVAR_ARCHIVE,    0 },
+	{ &demo_freecamspeed,           "demo_freecamspeed",           "800",         CVAR_ARCHIVE,                 NULL, 0 },
+	{ &demo_nopitch,                "demo_nopitch",                "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &demo_pvshint,                "demo_pvshint",                "0",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &demo_lookat,                 "demo_lookat",                 "-1",          CVAR_CHEAT,                   NULL, 0 },
+	{ &demo_autotimescaleweapons,   "demo_autotimescaleweapons",   "0",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &demo_autotimescale,          "demo_autotimescale",          "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &demo_teamonlymissilecam,     "demo_teamonlymissilecam",     "0",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_predefineddemokeys,       "cg_predefineddemokeys",       "1",           CVAR_CHEAT | CVAR_ARCHIVE,    NULL, 0 },
 #endif
 
 #ifdef FEATURE_MULTIVIEW
-	{ &mv_sensitivity,              "mv_sensitivity",              "20",          CVAR_ARCHIVE,                 0 },
+	{ &mv_sensitivity,              "mv_sensitivity",              "20",          CVAR_ARCHIVE,                 NULL, 0 },
 #endif
 
 	// Engine mappings
 
-	{ &int_cl_maxpackets,           "cl_maxpackets",               "125",         CVAR_ARCHIVE,                 0 },
-	{ &int_cl_timenudge,            "cl_timenudge",                "0",           CVAR_ARCHIVE,                 0 },
-	{ &int_m_pitch,                 "m_pitch",                     "0.022",       CVAR_ARCHIVE,                 0 },
-	{ &int_sensitivity,             "sensitivity",                 "5",           CVAR_ARCHIVE,                 0 },
-	{ &int_ui_blackout,             "ui_blackout",                 "0",           CVAR_ROM,                     0 },
+	{ &int_cl_maxpackets,           "cl_maxpackets",               "125",         CVAR_ARCHIVE,                 NULL, 0 },
+	{ &int_cl_timenudge,            "cl_timenudge",                "0",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &int_m_pitch,                 "m_pitch",                     "0.022",       CVAR_ARCHIVE,                 NULL, 0 },
+	{ &int_sensitivity,             "sensitivity",                 "5",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &int_ui_blackout,             "ui_blackout",                 "0",           CVAR_ROM,                     NULL, 0 },
 
-	{ &cg_atmosphericEffects,       "cg_atmosphericEffects",       "1",           CVAR_ARCHIVE,                 0 },
-	{ &authLevel,                   "authLevel",                   "0",           CVAR_TEMP | CVAR_ROM,         0 },
+	{ &cg_atmosphericEffects,       "cg_atmosphericEffects",       "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &authLevel,                   "authLevel",                   "0",           CVAR_TEMP | CVAR_ROM,         NULL, 0 },
 
-	{ &cg_rconPassword,             "auth_rconPassword",           "",            CVAR_TEMP,                    0 },
-	{ &cg_refereePassword,          "auth_refereePassword",        "",            CVAR_TEMP,                    0 },
+	{ &cg_rconPassword,             "auth_rconPassword",           "",            CVAR_TEMP,                    NULL, 0 },
+	{ &cg_refereePassword,          "auth_refereePassword",        "",            CVAR_TEMP,                    NULL, 0 },
 
-	{ &cg_instanttapout,            "cg_instanttapout",            "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_debugSkills,              "cg_debugSkills",              "0",           0,                            0 },
-	{ NULL,                         "cg_etVersion",                "",            CVAR_USERINFO | CVAR_ROM,     0 },
+	{ &cg_instanttapout,            "cg_instanttapout",            "0",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_debugSkills,              "cg_debugSkills",              "0",           0,                            NULL, 0 },
+	{ NULL,                         "cg_etVersion",                "",            CVAR_USERINFO | CVAR_ROM,     NULL, 0 },
 #if 0
-	{ NULL,                         "cg_legacyVersion",            "",            CVAR_USERINFO | CVAR_ROM,     0 },
+	{ NULL,                         "cg_legacyVersion",            "",            CVAR_USERINFO | CVAR_ROM,     NULL, 0 },
 #endif
 	// demo recording cvars
-	{ &cl_demorecording,            "cl_demorecording",            "0",           CVAR_ROM,                     0 },
-	{ &cl_demofilename,             "cl_demofilename",             "",            CVAR_ROM,                     0 },
-	{ &cl_demooffset,               "cl_demooffset",               "0",           CVAR_ROM,                     0 },
+	{ &cl_demorecording,            "cl_demorecording",            "0",           CVAR_ROM,                     NULL, 0 },
+	{ &cl_demofilename,             "cl_demofilename",             "",            CVAR_ROM,                     NULL, 0 },
+	{ &cl_demooffset,               "cl_demooffset",               "0",           CVAR_ROM,                     NULL, 0 },
 	// wav recording cvars
-	{ &cl_waverecording,            "cl_waverecording",            "0",           CVAR_ROM,                     0 },
-	{ &cl_wavefilename,             "cl_wavefilename",             "",            CVAR_ROM,                     0 },
-	{ &cl_waveoffset,               "cl_waveoffset",               "0",           CVAR_ROM,                     0 },
+	{ &cl_waverecording,            "cl_waverecording",            "0",           CVAR_ROM,                     NULL, 0 },
+	{ &cl_wavefilename,             "cl_wavefilename",             "",            CVAR_ROM,                     NULL, 0 },
+	{ &cl_waveoffset,               "cl_waveoffset",               "0",           CVAR_ROM,                     NULL, 0 },
 
-	{ &cg_announcer,                "cg_announcer",                "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_hitSounds,                "cg_hitSounds",                "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_locations,                "cg_locations",                "3",           CVAR_ARCHIVE,                 0 },
-	{ &cg_locationMaxChars,         "cg_locationMaxChars",         "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_announcer,                "cg_announcer",                "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_hitSounds,                "cg_hitSounds",                "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_locations,                "cg_locations",                "3",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_locationMaxChars,         "cg_locationMaxChars",         "0",           CVAR_ARCHIVE,                 NULL, 0 },
 
-	{ &cg_spawnTimer_set,           "cg_spawnTimer_set",           "-1",          CVAR_TEMP,                    0 },
+	{ &cg_spawnTimer_set,           "cg_spawnTimer_set",           "-1",          CVAR_TEMP,                    NULL, 0 },
 
-	{ &cg_spawnTimer_period,        "cg_spawnTimer_period",        "0",           CVAR_TEMP,                    0 },
+	{ &cg_spawnTimer_period,        "cg_spawnTimer_period",        "0",           CVAR_TEMP,                    NULL, 0 },
 
-	{ &cg_logFile,                  "cg_logFile",                  "",            CVAR_ARCHIVE,                 0 }, // we don't log the chats per default
+	{ &cg_logFile,                  "cg_logFile",                  "",            CVAR_ARCHIVE,                 NULL, 0 },                    // we don't log the chats per default
 
-	{ &cg_countryflags,             "cg_countryflags",             "1",           CVAR_ARCHIVE,                 0 }, // GeoIP
-	{ &cg_altHud,                   "cg_altHud",                   "0",           CVAR_ARCHIVE,                 0 }, // Hudstyles
-	{ &cg_shoutcasterHud,           "cg_shoutcasterHud",           "Shoutcaster", CVAR_ARCHIVE,                 0 },
-	{ &cg_tracers,                  "cg_tracers",                  "1",           CVAR_ARCHIVE,                 0 }, // Draw tracers
-	{ &cg_fireteamNameMaxChars,     "cg_fireteamNameMaxChars",     "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_fireteamNameAlign,        "cg_fireteamNameAlign",        "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_fireteamSprites,          "cg_fireteamSprites",          "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_countryflags,             "cg_countryflags",             "1",           CVAR_ARCHIVE,                 NULL, 0 },                    // GeoIP
+	{ &cg_altHud,                   "cg_altHud",                   "0",           CVAR_ARCHIVE,                 NULL, 0 },                    // Hudstyles
+	{ &cg_shoutcasterHud,           "cg_shoutcasterHud",           "Shoutcaster", CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_tracers,                  "cg_tracers",                  "1",           CVAR_ARCHIVE,                 NULL, 0 },                    // Draw tracers
+	{ &cg_fireteamNameMaxChars,     "cg_fireteamNameMaxChars",     "0",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_fireteamNameAlign,        "cg_fireteamNameAlign",        "0",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_fireteamSprites,          "cg_fireteamSprites",          "1",           CVAR_ARCHIVE,                 NULL, 0 },
 
-	{ &cg_simpleItems,              "cg_simpleItems",              "0",           CVAR_ARCHIVE,                 0 }, // Bugged atm
-	{ &cg_simpleItemsScale,         "cg_simpleItemsScale",         "1.0",         CVAR_ARCHIVE,                 0 },
-	{ &cg_automapZoom,              "cg_automapZoom",              "5.159",       CVAR_ARCHIVE,                 0 },
-	{ &cg_autoCmd,                  "cg_autoCmd",                  "",            CVAR_TEMP,                    0 },
-	{ &cg_popupFadeTime,            "cg_popupFadeTime",            "2500",        CVAR_ARCHIVE,                 0 },
-	{ &cg_popupStayTime,            "cg_popupStayTime",            "2000",        CVAR_ARCHIVE,                 0 },
-	{ &cg_popupTime,                "cg_popupTime",                "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_popupXPGainFadeTime,      "cg_popupXPGainFadeTime",      "250",         CVAR_ARCHIVE,                 0 },
-	{ &cg_popupXPGainStayTime,      "cg_popupXPGainStayTime",      "1000",        CVAR_ARCHIVE,                 0 },
-	{ &cg_popupXPGainTime,          "cg_popupXPGainTime",          "200",         CVAR_ARCHIVE,                 0 },
-	{ &cg_weapaltReloads,           "cg_weapaltReloads",           "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_weapaltSwitches,          "cg_weapaltSwitches",          "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_weapaltMgAutoProne,       "cg_weapaltMgAutoProne",       "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_sharetimerText,           "cg_sharetimerText",           "",            CVAR_ARCHIVE,                 0 },
+	{ &cg_simpleItems,              "cg_simpleItems",              "0",           CVAR_ARCHIVE,                 NULL, 0 },                    // Bugged atm
+	{ &cg_simpleItemsScale,         "cg_simpleItemsScale",         "1.0",         CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_automapZoom,              "cg_automapZoom",              "5.159",       CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_autoCmd,                  "cg_autoCmd",                  "",            CVAR_TEMP,                    NULL, 0 },
+	{ &cg_popupFadeTime,            "cg_popupFadeTime",            "2500",        CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_popupStayTime,            "cg_popupStayTime",            "2000",        CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_popupTime,                "cg_popupTime",                "0",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_popupXPGainFadeTime,      "cg_popupXPGainFadeTime",      "250",         CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_popupXPGainStayTime,      "cg_popupXPGainStayTime",      "1000",        CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_popupXPGainTime,          "cg_popupXPGainTime",          "200",         CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_weapaltReloads,           "cg_weapaltReloads",           "0",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_weapaltSwitches,          "cg_weapaltSwitches",          "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_weapaltMgAutoProne,       "cg_weapaltMgAutoProne",       "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_sharetimerText,           "cg_sharetimerText",           "",            CVAR_ARCHIVE,                 NULL, 0 },
 
 	// Fonts
-	{ &cg_fontScaleSP,              "cg_fontScaleSP",              "0.22",        CVAR_ARCHIVE,                 0 }, // SidePrint
+	{ &cg_fontScaleSP,              "cg_fontScaleSP",              "0.22",        CVAR_ARCHIVE,                 NULL, 0 },                    // SidePrint
 
-	{ &cg_optimizePrediction,       "cg_optimizePrediction",       "1",           CVAR_ARCHIVE,                 0 }, // unlagged optimized prediction
+	{ &cg_optimizePrediction,       "cg_optimizePrediction",       "1",           CVAR_ARCHIVE,                 NULL, 0 },                    // unlagged optimized prediction
 
 #if defined(FEATURE_RATING) || defined(FEATURE_PRESTIGE)
-	{ &cg_scoreboard,               "cg_scoreboard",               "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_scoreboard,               "cg_scoreboard",               "0",           CVAR_ARCHIVE,                 NULL, 0 },
 #endif
 
-	{ &cg_quickchat,                "cg_quickchat",                "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_quickchat,                "cg_quickchat",                "0",           CVAR_ARCHIVE,                 NULL, 0 },
 
-	{ &cg_drawUnit,                 "cg_drawUnit",                 "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_drawUnit,                 "cg_drawUnit",                 "0",           CVAR_ARCHIVE,                 NULL, 0 },
 
-	{ &cg_visualEffects,            "cg_visualEffects",            "1",           CVAR_ARCHIVE,                 0 }, // (e.g. : smoke, debris, ...)
-	{ &cg_bannerTime,               "cg_bannerTime",               "10000",       CVAR_ARCHIVE,                 0 },
+	{ &cg_visualEffects,            "cg_visualEffects",            "1",           CVAR_ARCHIVE,                 NULL, 0 },                    // (e.g. : smoke, debris, ...)
+	{ &cg_bannerTime,               "cg_bannerTime",               "10000",       CVAR_ARCHIVE,                 NULL, 0 },
 
-	{ &cg_shoutcastTeamNameRed,     "cg_shoutcastTeamNameRed",     "Axis",        CVAR_ARCHIVE,                 0 },
-	{ &cg_shoutcastTeamNameBlue,    "cg_shoutcastTeamNameBlue",    "Allies",      CVAR_ARCHIVE,                 0 },
-	{ &cg_shoutcastDrawHealth,      "cg_shoutcastDrawHealth",      "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_shoutcastGrenadeTrail,    "cg_shoutcastGrenadeTrail",    "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_shoutcastTeamNameRed,     "cg_shoutcastTeamNameRed",     "Axis",        CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_shoutcastTeamNameBlue,    "cg_shoutcastTeamNameBlue",    "Allies",      CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_shoutcastDrawHealth,      "cg_shoutcastDrawHealth",      "0",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_shoutcastGrenadeTrail,    "cg_shoutcastGrenadeTrail",    "0",           CVAR_ARCHIVE,                 NULL, 0 },
 
-	{ &cg_activateLean,             "cg_activateLean",             "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_activateLean,             "cg_activateLean",             "0",           CVAR_ARCHIVE,                 NULL, 0 },
 
-	{ &cg_drawBreathPuffs,          "cg_drawBreathPuffs",          "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_drawAirstrikePlanes,      "cg_drawAirstrikePlanes",      "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_drawBreathPuffs,          "cg_drawBreathPuffs",          "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_drawAirstrikePlanes,      "cg_drawAirstrikePlanes",      "1",           CVAR_ARCHIVE,                 NULL, 0 },
 
-	{ &cg_drawSpawnpoints,          "cg_drawSpawnpoints",          "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_drawSpawnpoints,          "cg_drawSpawnpoints",          "0",           CVAR_ARCHIVE,                 NULL, 0 },
 
-	{ &cg_useCvarCrosshair,         "cg_useCvarCrosshair",         "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_crosshairSVG,             "cg_crosshairSVG",             "0",           CVAR_ARCHIVE | CVAR_LATCH,    0 },
-	{ &cg_crosshairSize,            "cg_crosshairSize",            "48",          CVAR_ARCHIVE,                 0 },
-	{ &cg_crosshairAlpha,           "cg_crosshairAlpha",           "1.0",         CVAR_ARCHIVE,                 0 },
-	{ &cg_crosshairColor,           "cg_crosshairColor",           "White",       CVAR_ARCHIVE,                 0 },
-	{ &cg_crosshairAlphaAlt,        "cg_crosshairAlphaAlt",        "1.0",         CVAR_ARCHIVE,                 0 },
-	{ &cg_crosshairColorAlt,        "cg_crosshairColorAlt",        "White",       CVAR_ARCHIVE,                 0 },
-	{ &cg_crosshairPulse,           "cg_crosshairPulse",           "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_crosshairHealth,          "cg_crosshairHealth",          "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_useCvarCrosshair,         "cg_useCvarCrosshair",         "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_crosshairSVG,             "cg_crosshairSVG",             "0",           CVAR_ARCHIVE | CVAR_LATCH,    NULL, 0 },
+	{ &cg_crosshairSize,            "cg_crosshairSize",            "48",          CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_crosshairAlpha,           "cg_crosshairAlpha",           "1.0",         CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_crosshairColor,           "cg_crosshairColor",           "White",       CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_crosshairAlphaAlt,        "cg_crosshairAlphaAlt",        "1.0",         CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_crosshairColorAlt,        "cg_crosshairColorAlt",        "White",       CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_crosshairPulse,           "cg_crosshairPulse",           "1",           CVAR_ARCHIVE,                 NULL, 0 },
+	{ &cg_crosshairHealth,          "cg_crosshairHealth",          "0",           CVAR_ARCHIVE,                 NULL, 0 },
 
-	{ &cg_commandMapTime,           "cg_commandMapTime",           "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_commandMapTime,           "cg_commandMapTime",           "0",           CVAR_ARCHIVE,                 NULL, 0 },
 };
 
 static const unsigned int cvarTableSize = sizeof(cvarTable) / sizeof(cvarTable[0]);
@@ -701,6 +702,11 @@ void CG_RegisterCvars(void)
 			else
 			{
 				cv->modificationCount = cv->vmCvar->modificationCount;
+			}
+
+			if (cv->description != NULL)
+			{
+				trap_Cvar_SetDescription(cv->vmCvar, cv->description);
 			}
 		}
 	}

--- a/src/cgame/cg_public.h
+++ b/src/cgame/cg_public.h
@@ -290,6 +290,8 @@ typedef enum
 	CG_CMDBACKUP_EXT,
 	CG_MATCHPAUSED,
 
+	CG_CVAR_SETDESCRIPTION,
+
 } cgameImport_t;
 
 /**

--- a/src/cgame/cg_syscalls.c
+++ b/src/cgame/cg_syscalls.c
@@ -1983,3 +1983,14 @@ void trap_MatchPaused(qboolean matchPaused)
 		SystemCall(dll_trap_MatchPaused, matchPaused);
 	}
 }
+
+/**
+ * @brief Extension for setting the description of a vmCvar
+ */
+void trap_Cvar_SetDescription(vmCvar_t *vmCvar, const char *text)
+{
+	if (dll_trap_Cvar_SetDescription)
+	{
+		SystemCall(dll_trap_Cvar_SetDescription, vmCvar, text);
+	}
+}

--- a/src/client/cl_cgame.c
+++ b/src/client/cl_cgame.c
@@ -42,11 +42,12 @@
 
 static ext_trap_keys_t cg_extensionTraps[] =
 {
-	{ "trap_SysFlashWindow_Legacy",  CG_SYS_FLASH_WINDOW, qfalse },
-	{ "trap_CommandComplete_Legacy", CG_COMMAND_COMPLETE, qfalse },
-	{ "trap_CmdBackup_Ext_Legacy",   CG_CMDBACKUP_EXT,    qfalse },
-	{ "trap_MatchPaused_Legacy",     CG_MATCHPAUSED,      qfalse },
-	{ NULL,                          -1,                  qfalse }
+	{ "trap_SysFlashWindow_Legacy",      CG_SYS_FLASH_WINDOW,    qfalse },
+	{ "trap_CommandComplete_Legacy",     CG_COMMAND_COMPLETE,    qfalse },
+	{ "trap_CmdBackup_Ext_Legacy",       CG_CMDBACKUP_EXT,       qfalse },
+	{ "trap_MatchPaused_Legacy",         CG_MATCHPAUSED,         qfalse },
+	{ "trap_Cvar_SetDescription_Legacy", CG_CVAR_SETDESCRIPTION, qfalse },
+	{ NULL,                              -1,                     qfalse }
 };
 
 extern botlib_export_t *botlib_export;
@@ -1128,7 +1129,9 @@ intptr_t CL_CgameSystemCalls(intptr_t *args)
 	case CG_MATCHPAUSED:
 		S_PauseSounds(args[1]);
 		return 0;
-
+	case CG_CVAR_SETDESCRIPTION:
+		Cvar_SetDescription_FromVmCvar(VMA(1), VMA(2));
+		return 0;
 	default:
 		Com_Error(ERR_DROP, "Bad cgame system trap: %ld", (long int) args[0]);
 		break;

--- a/src/qcommon/cvar.c
+++ b/src/qcommon/cvar.c
@@ -949,7 +949,9 @@ void Cvar_Print(cvar_t *v)
 
 	if (v->description)
 	{
-		Com_Printf("%s\n", v->description);
+		Com_Printf(
+			"----------------------------------------------------------------------"
+			"\n%s\n", v->description);
 	}
 }
 
@@ -1737,6 +1739,21 @@ void Cvar_SetDescription(cvar_t *cv, const char *varDescription)
 		}
 		cv->description = CopyString(varDescription);
 	}
+}
+
+void Cvar_SetDescription_FromVmCvar(vmCvar_t *vmCvar, const char *varDescription)
+{
+	cvar_t *cv = NULL;
+	etl_assert(vmCvar);
+
+	if ((unsigned)vmCvar->handle >= cvar_numIndexes)
+	{
+		Com_Error(ERR_DROP, "Cvar_SetDescription_FromVmCvar: handle out of range");
+	}
+
+	cv = cvar_indexes + vmCvar->handle;
+
+	Cvar_SetDescription(cv, varDescription);
 }
 
 /**

--- a/src/qcommon/qcommon.h
+++ b/src/qcommon/qcommon.h
@@ -743,6 +743,7 @@ char *Cvar_InfoString_Big(int bit);
 void Cvar_InfoStringBuffer(int bit, char *buff, size_t buffsize);
 void Cvar_CheckRange(cvar_t *cv, float minVal, float maxVal, qboolean shouldBeIntegral);
 void Cvar_SetDescription(cvar_t *cv, const char *varDescription);
+void Cvar_SetDescription_FromVmCvar(vmCvar_t *vmCvar, const char *varDescription);
 
 void Cvar_Restart(qboolean unsetVM);
 void Cvar_Restart_f(void);


### PR DESCRIPTION
Allows setting descriptions for CVARs in cgame.

Also adds a 'trap_Cvar_SetDescription' shim to cgame and makes use of it by adding a description to `cg_autoCmd`.