### PR TITLE
mod: add cg_crosshairX/Y, cg_crosshairScaleX/Y for cvar crosshair

### DIFF
--- a/src/cgame/cg_consolecmds.c
+++ b/src/cgame/cg_consolecmds.c
@@ -2973,22 +2973,56 @@ static void CG_EditHudComponentComplete(void)
 
 #define EDITCOMPONENT_CROSSHAIR_STRING "editcomponent crosshair"
 
-static void CG_CrosshairSize_f(void)
+static void CG_CrosshairSizePos_f(void)
 {
 	if (trap_Argc() > 1)
 	{
-		const char *token;
-
-		token = CG_Argv(1);
+		const char *token = CG_Argv(1);
 
 		if (Q_isanumber(token))
 		{
-			float size = Q_atof(token);
+			const float value = Q_atof(token);
 
-			CG_GetActiveHUD()->crosshair.location.x = (Ccg_WideX(SCREEN_WIDTH) - size) * .5f;
-			CG_GetActiveHUD()->crosshair.location.y = (SCREEN_HEIGHT - size) * .5f;
-			CG_GetActiveHUD()->crosshair.location.w = size;
-			CG_GetActiveHUD()->crosshair.location.h = size;
+			float sizeX = cg_crosshairSize.value;
+			float sizeY = cg_crosshairSize.value;
+
+			float scaleX = cg_crosshairScaleX.value;
+			float scaleY = cg_crosshairScaleY.value;
+
+			float offsetX = cg_crosshairX.value;
+			float offsetY = cg_crosshairY.value;
+
+			const char *cmd = CG_Argv(0);
+
+			if (!Q_stricmp(cmd, "cg_crosshairSize_f"))
+			{
+				sizeX = sizeY = value;
+			}
+			else if (!Q_stricmp(cmd, "cg_crosshairX_f"))
+			{
+				offsetX = value;
+			}
+			else if (!Q_stricmp(cmd, "cg_crosshairY_f"))
+			{
+				offsetY = value;
+			}
+			else if (!Q_stricmp(cmd, "cg_crosshairScaleX_f"))
+			{
+				scaleX = value;
+			}
+			else if (!Q_stricmp(cmd, "cg_crosshairScaleY_f"))
+			{
+				scaleY = value;
+			}
+
+			// always perform scaling no matter the command, so we get the correct final size
+			sizeX *= scaleX;
+			sizeY *= scaleY;
+
+			CG_GetActiveHUD()->crosshair.location.x = (Ccg_WideX(SCREEN_WIDTH) - sizeX + offsetX) * .5f;
+			CG_GetActiveHUD()->crosshair.location.y = (SCREEN_HEIGHT - sizeY + offsetY) * .5f;
+			CG_GetActiveHUD()->crosshair.location.w = sizeX;
+			CG_GetActiveHUD()->crosshair.location.h = sizeY;
 		}
 	}
 }
@@ -3213,13 +3247,17 @@ static consoleCommand_t commands[] =
 	{ "editcomponent",          CG_EditComponent_f        },
 
 	// TODO: Implement "alias" system and create those as customizable alias command
-	{ "cg_crosshairSize_f",     CG_CrosshairSize_f        },
+	{ "cg_crosshairSize_f",     CG_CrosshairSizePos_f     },
 	{ "cg_crosshairAlpha_f",    CG_CrosshairAlpha_f       },
 	{ "cg_crosshairColor_f",    CG_CrosshairColor_f       },
 	{ "cg_crosshairAlphaAlt_f", CG_CrosshairAlphaAlt_f    },
 	{ "cg_crosshairColorAlt_f", CG_CrosshairColorAlt_f    },
 	{ "cg_crosshairPulse_f",    CG_CrosshairPulse_f       },
 	{ "cg_crosshairHealth_f",   CG_CrosshairHealth_f      },
+	{ "cg_crosshairX_f",        CG_CrosshairSizePos_f     },
+	{ "cg_crosshairY_f",        CG_CrosshairSizePos_f     },
+	{ "cg_crosshairScaleX_f",   CG_CrosshairSizePos_f     },
+	{ "cg_crosshairScaleY_f",   CG_CrosshairSizePos_f     },
 
 	{ NULL,                     NULL                      }
 };

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1159,7 +1159,7 @@ typedef struct
 	int etLegacyClient;                     ///< is either 0 (vanilla client) or a version integer from git_version.h
 	qboolean loading;                       ///< don't defer players at initial startup
 	qboolean intermissionStarted;           ///< don't draw disconnect icon/message because game will end shortly
-	qboolean autoCmdExecuted;				///< has 'cg_autoCmd' been executed yet
+	qboolean autoCmdExecuted;               ///< has 'cg_autoCmd' been executed yet
 
 	// there are only one or two snapshot_t that are relevent at a time
 	int latestSnapshotNum;                  ///< the number of snapshots the client system has received
@@ -2981,6 +2981,10 @@ extern vmCvar_t cg_crosshairAlphaAlt;
 extern vmCvar_t cg_crosshairColorAlt;
 extern vmCvar_t cg_crosshairPulse;
 extern vmCvar_t cg_crosshairHealth;
+extern vmCvar_t cg_crosshairX;
+extern vmCvar_t cg_crosshairY;
+extern vmCvar_t cg_crosshairScaleX;
+extern vmCvar_t cg_crosshairScaleY;
 
 extern vmCvar_t cg_commandMapTime;
 
@@ -3151,7 +3155,7 @@ const char *CG_TranslateString(const char *string);
 
 void CG_InitStatsDebug(void);
 void CG_StatsDebugAddText(const char *text);
-void CG_DrawDebugArtillery(centity_t * cent);
+void CG_DrawDebugArtillery(centity_t *cent);
 
 void CG_AddLagometerFrameInfo(void);
 void CG_AddLagometerSnapshotInfo(snapshot_t *snap);
@@ -4398,7 +4402,7 @@ typedef struct
 	int count;
 } hudData_t;
 
-extern hudData_t hudData;
+extern hudData_t      hudData;
 extern hudComponent_t *showOnlyHudComponent;
 
 typedef struct

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -375,6 +375,10 @@ vmCvar_t cg_crosshairAlphaAlt;
 vmCvar_t cg_crosshairColorAlt;
 vmCvar_t cg_crosshairPulse;
 vmCvar_t cg_crosshairHealth;
+vmCvar_t cg_crosshairX;
+vmCvar_t cg_crosshairY;
+vmCvar_t cg_crosshairScaleX;
+vmCvar_t cg_crosshairScaleY;
 
 vmCvar_t cg_commandMapTime;
 
@@ -650,6 +654,10 @@ static cvarTable_t cvarTable[] =
 	{ &cg_crosshairColorAlt,        "cg_crosshairColorAlt",        "White",       CVAR_ARCHIVE,                 0 },
 	{ &cg_crosshairPulse,           "cg_crosshairPulse",           "1",           CVAR_ARCHIVE,                 0 },
 	{ &cg_crosshairHealth,          "cg_crosshairHealth",          "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_crosshairX,               "cg_crosshairX",               "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_crosshairY,               "cg_crosshairY",               "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_crosshairScaleX,          "cg_crosshairScaleX",          "1.0",         CVAR_ARCHIVE,                 0 },
+	{ &cg_crosshairScaleY,          "cg_crosshairScaleY",          "1.0",         CVAR_ARCHIVE,                 0 },
 
 	{ &cg_commandMapTime,           "cg_commandMapTime",           "0",           CVAR_ARCHIVE,                 0 },
 };
@@ -692,7 +700,9 @@ void CG_RegisterCvars(void)
 			         && (cv->vmCvar == &cg_crosshairSize
 			             || cv->vmCvar == &cg_crosshairAlpha || cv->vmCvar == &cg_crosshairColor
 			             || cv->vmCvar == &cg_crosshairAlphaAlt || cv->vmCvar == &cg_crosshairColorAlt
-			             || cv->vmCvar == &cg_crosshairPulse || cv->vmCvar == &cg_crosshairHealth))
+			             || cv->vmCvar == &cg_crosshairPulse || cv->vmCvar == &cg_crosshairHealth
+			             || cv->vmCvar == &cg_crosshairX || cv->vmCvar == &cg_crosshairY
+			             || cv->vmCvar == &cg_crosshairScaleX || cv->vmCvar == &cg_crosshairScaleY))
 			{
 				// force usage of crosshair values
 				cv->modificationCount = -1;
@@ -781,7 +791,9 @@ void CG_UpdateCvars(void)
 				else if (cv->vmCvar == &cg_crosshairSize
 				         || cv->vmCvar == &cg_crosshairAlpha || cv->vmCvar == &cg_crosshairColor
 				         || cv->vmCvar == &cg_crosshairAlphaAlt || cv->vmCvar == &cg_crosshairColorAlt
-				         || cv->vmCvar == &cg_crosshairPulse || cv->vmCvar == &cg_crosshairHealth)
+				         || cv->vmCvar == &cg_crosshairPulse || cv->vmCvar == &cg_crosshairHealth
+				         || cv->vmCvar == &cg_crosshairX || cv->vmCvar == &cg_crosshairY
+				         || cv->vmCvar == &cg_crosshairScaleX || cv->vmCvar == &cg_crosshairScaleY)
 				{
 					if (cg.clientFrame == 0)
 					{

--- a/src/ui/ui_local.h
+++ b/src/ui/ui_local.h
@@ -98,6 +98,8 @@ extern vmCvar_t ui_cg_crosshairColorAlt;
 extern vmCvar_t ui_cg_crosshairAlpha;
 extern vmCvar_t ui_cg_crosshairAlphaAlt;
 extern vmCvar_t ui_cg_crosshairSize;
+extern vmCvar_t ui_cg_crosshairScaleX;
+extern vmCvar_t ui_cg_crosshairScaleY;
 
 extern vmCvar_t cl_bypassMouseInput;
 

--- a/src/ui/ui_main.c
+++ b/src/ui/ui_main.c
@@ -2942,19 +2942,21 @@ static void UI_DrawRedBlue(rectDef_t *rect, float scale, vec4_t color, int textS
  */
 static void UI_DrawCrosshair(rectDef_t *rect, float scale, vec4_t color)
 {
-	float size = ui_cg_crosshairSize.integer;
+	float sizeX = ui_cg_crosshairSize.value * ui_cg_crosshairScaleX.value;
+	float sizeY = ui_cg_crosshairSize.value * ui_cg_crosshairScaleY.value;
 
 	if (uiInfo.currentCrosshair < 0 || uiInfo.currentCrosshair >= NUM_CROSSHAIRS)
 	{
 		uiInfo.currentCrosshair = 0;
 	}
 
-	size = (rect->w / 96.0f) * ((size > 96.0f) ? 96.0f : ((size < 24.0f) ? 24.0f : size));
+	sizeX = (rect->w / 96.0f) * ((sizeX > 96.0f) ? 96.0f : ((sizeX < 24.0f) ? 24.0f : sizeX));
+	sizeY = (rect->w / 96.0f) * ((sizeY > 96.0f) ? 96.0f : ((sizeY < 24.0f) ? 24.0f : sizeY));
 
 	trap_R_SetColor(uiInfo.xhairColor);
-	UI_DrawHandlePic(rect->x + (rect->w - size) * 0.5f, rect->y + (rect->h - size) * 0.5f, size, size, uiInfo.uiDC.Assets.crosshairShader[uiInfo.currentCrosshair]);
+	UI_DrawHandlePic(rect->x + (rect->w - sizeX) * 0.5f, rect->y + (rect->h - sizeY) * 0.5f, sizeX, sizeY, uiInfo.uiDC.Assets.crosshairShader[uiInfo.currentCrosshair]);
 	trap_R_SetColor(uiInfo.xhairColorAlt);
-	UI_DrawHandlePic(rect->x + (rect->w - size) * 0.5f, rect->y + (rect->h - size) * 0.5f, size, size, uiInfo.uiDC.Assets.crosshairAltShader[uiInfo.currentCrosshair]);
+	UI_DrawHandlePic(rect->x + (rect->w - sizeX) * 0.5f, rect->y + (rect->h - sizeY) * 0.5f, sizeX, sizeY, uiInfo.uiDC.Assets.crosshairAltShader[uiInfo.currentCrosshair]);
 
 	trap_R_SetColor(NULL);
 }
@@ -9225,6 +9227,8 @@ vmCvar_t ui_cg_crosshairColorAlt;
 vmCvar_t ui_cg_crosshairAlpha;
 vmCvar_t ui_cg_crosshairAlphaAlt;
 vmCvar_t ui_cg_crosshairSize;
+vmCvar_t ui_cg_crosshairScaleX;
+vmCvar_t ui_cg_crosshairScaleY;
 
 vmCvar_t cl_bypassMouseInput;
 
@@ -9326,6 +9330,8 @@ static cvarTable_t cvarTable[] =
 	{ &ui_cg_crosshairColor,               "cg_crosshairColor",                   "White",                      CVAR_ARCHIVE,                   0 },
 	{ &ui_cg_crosshairColorAlt,            "cg_crosshairColorAlt",                "White",                      CVAR_ARCHIVE,                   0 },
 	{ &ui_cg_crosshairSize,                "cg_crosshairSize",                    "48",                         CVAR_ARCHIVE,                   0 },
+	{ &ui_cg_crosshairScaleX,              "cg_crosshairScaleX",                  "1.0",                        CVAR_ARCHIVE,                   0 },
+	{ &ui_cg_crosshairScaleY,              "cg_crosshairScaleY",                  "1.0",                        CVAR_ARCHIVE,                   0 },
 	{ NULL,                                "cg_crosshairPulse",                   "1",                          CVAR_ARCHIVE,                   0 },
 	{ NULL,                                "cg_crosshairHealth",                  "0",                          CVAR_ARCHIVE,                   0 },
 


### PR DESCRIPTION
HUD editor is able to move the crosshair around and perform non-uniform scaling. This wasn't possible when using `cg_useCvarCrosshair`, as `cg_crosshairX/Y` were removed, and scaling options were never added. Crosshair customization should now have feature parity between HUD editor and cvars.

fixes #2543 
refs #1967 