### PR TITLE
cgame: disallow SVG crosshairs for non-ETL clients

### DIFF
--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -1812,8 +1812,10 @@ static void CG_RegisterGraphics(void)
 
 	for (i = 0 ; i < NUM_CROSSHAIRS ; i++)
 	{
-		cgs.media.crosshairShader[i] = trap_R_RegisterShader(va("gfx/2d/crosshair%c%s", 'a' + i, cg_crosshairSVG.integer ? "_svg" : ""));
-		cg.crosshairShaderAlt[i]     = trap_R_RegisterShader(va("gfx/2d/crosshair%c_alt%s", 'a' + i, cg_crosshairSVG.integer ? "_svg" : ""));
+		const qboolean useSVG = cg_crosshairSVG.integer && cg.etLegacyClient;
+
+		cgs.media.crosshairShader[i] = trap_R_RegisterShader(va("gfx/2d/crosshair%c%s", 'a' + i, useSVG ? "_svg" : ""));
+		cg.crosshairShaderAlt[i]     = trap_R_RegisterShader(va("gfx/2d/crosshair%c_alt%s", 'a' + i, useSVG ? "_svg" : ""));
 	}
 
 	for (i = 0 ; i < SK_NUM_SKILLS ; i++)


### PR DESCRIPTION
Don't let other engines register SVG crosshairs as they are not necessarily supported.

refs #2942 