### PR TITLE
qcommon: allow viewlog to be spawned during runtime

### DIFF
--- a/src/qcommon/common.c
+++ b/src/qcommon/common.c
@@ -3404,6 +3404,17 @@ void Com_Frame(void)
 	// write config file if anything changed
 	Com_WriteConfiguration();
 
+	// if "viewlog" has been modified, show or hide the log console
+	if (com_viewlog->modified)
+	{
+		if (!com_dedicated->integer)
+		{
+			Win_ShowConsole(com_viewlog->integer, qfalse);
+		}
+
+		com_viewlog->modified = qfalse;
+	}
+
 	// main event loop
 	if (com_speeds->integer)
 	{


### PR DESCRIPTION
For reasons unknown to me, this was made impossible 10 years ago in https://github.com/etlegacy/etlegacy/commit/af0ae3bac42610c028dea4eea6fed0333d50c9f4 by removing the check for the cvar modification from `Com_Frame`, which made it impossible to spawn the console any other way besides as a startup option. The viewlog remains a cheat cvar though, so it's mainly useful for debugging things, better alternative to `con_drawNotify` (e.g. while mapping and debugging mapscripts) and specifically in ETJump as it provides a cvar unlocker to view the console window even when cheats are disabled.

`Win_ShowConsole` is a stub macro on non-Windows platforms, so the code doesn't do anything on them.