### PR TITLE
cgame: Add Custom Crosshairs

### DIFF
--- a/src/cgame/cg_customcrosshair.c
+++ b/src/cgame/cg_customcrosshair.c
@@ -1,0 +1,304 @@
+/*
+ * Wolfenstein: Enemy Territory GPL Source Code
+ * Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company.
+ *
+ * ET: Legacy
+ * Copyright (C) 2012-2024 ET:Legacy team <mail@etlegacy.com>
+ *
+ * This file is part of ET: Legacy - http://www.etlegacy.com
+ *
+ * ET: Legacy is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ET: Legacy is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ET: Legacy. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * In addition, Wolfenstein: Enemy Territory GPL Source Code is also
+ * subject to certain additional terms. You should have received a copy
+ * of these additional terms immediately following the terms and conditions
+ * of the GNU General Public License which accompanied the source code.
+ * If not, please request a copy in writing from id Software at the address below.
+ *
+ * id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, Maryland 20850 USA.
+ */
+/**
+ * @file cg_crosshair.c
+ * @brief Handling of new "vectorized" custom crosshair.
+ */
+
+#include "cg_local.h"
+
+static int x, y;
+
+static const float *cached_color = NULL;
+
+static float *fgColor;
+static float *bgColor;
+
+static inline void CG_CustomCrosshairSetColor(const float *color)
+{
+	if (cached_color == NULL || cached_color != color)
+	{
+		trap_R_SetColor(color);
+		cached_color = color;
+	}
+}
+
+static inline void CG_CustomCrosshairDrawRect(float x, float y, float width, float height, float outlineWidth, qboolean rounded, uint8_t filled)
+{
+	if (outlineWidth > 0.0)
+	{
+		int offsetX = 0;
+		if (rounded)
+		{
+			offsetX = outlineWidth;
+		}
+
+		CG_CustomCrosshairSetColor(bgColor);
+
+		trap_R_DrawStretchPic(x + offsetX, // top
+		                      y - outlineWidth,
+		                      width + outlineWidth + outlineWidth - offsetX - offsetX, outlineWidth, 0, 0, 0, 1, cgs.media.whiteShader);
+
+		trap_R_DrawStretchPic(x + offsetX, // bottom
+		                      y + height,
+		                      width + outlineWidth + outlineWidth - offsetX - offsetX, outlineWidth, 0, 0, 0, 1, cgs.media.whiteShader);
+
+		trap_R_DrawStretchPic(x, // left
+		                      y,
+		                      outlineWidth, height, 0, 0, 0, 1, cgs.media.whiteShader);
+
+		trap_R_DrawStretchPic(x + width + outlineWidth, // right
+		                      y,
+		                      outlineWidth, height, 0, 0, 0, 1, cgs.media.whiteShader);
+	}
+
+	if (filled)
+	{
+		CG_CustomCrosshairSetColor(fgColor);
+		trap_R_DrawStretchPic(x + outlineWidth,
+		                      y,
+		                      width, height, 0, 0, 0, 1, cgs.media.whiteShader);
+	}
+}
+
+static float CG_CustomCrosshairCalcSpread()
+{
+	float spreadDistance = cg_customCrosshairCrossSpreadDistance.value;
+	if (spreadDistance)
+	{
+		if (cg.predictedPlayerState.groundEntityNum == ENTITYNUM_NONE)
+		{
+			return spreadDistance * cg_customCrosshairCrossSpreadOTGCoef.value;
+		}
+		else
+		{
+			return ((float)cg.snap->ps.aimSpreadScale / 255.0) * spreadDistance;
+		}
+	}
+
+	return 0.0;
+}
+
+void CG_DrawCustomCrosshair()
+{
+	static float   innerWidth, innerWidthOffset, outlineWidth, crossLength;
+	static float   crossGap, crossSpread;
+	static uint8_t outlineRounded;
+
+	x = (cgs.glconfig.vidWidth / 2);
+	y = (cgs.glconfig.vidHeight / 2);
+
+	crossSpread = CG_CustomCrosshairCalcSpread();
+	crossGap    = cg_customCrosshairCrossGap.value + crossSpread;
+
+	// draw dot and/or small cross
+	if (cg_customCrosshair.integer == CUSTOMCROSSHAIR_DOT_WITH_SMALLCROSS
+	    || cg_customCrosshair.integer == CUSTOMCROSSHAIR_DOT
+	    || cg_customCrosshair.integer == CUSTOMCROSSHAIR_SMALLCROSS)
+	{
+		// draw dot
+		if (cg_customCrosshair.integer == CUSTOMCROSSHAIR_DOT_WITH_SMALLCROSS || cg_customCrosshair.integer == CUSTOMCROSSHAIR_DOT)
+		{
+			innerWidth       = cg_customCrosshairDotWidth.value;
+			innerWidthOffset = innerWidth / 2;
+			outlineWidth     = cg_customCrosshairDotOutlineWidth.value;
+			crossLength      = cg_customCrosshairCrossLength.value;
+			outlineRounded   = cg_customCrosshairDotOutlineRounded.integer;
+			fgColor          = cgs.customCrosshairDotColor;
+			bgColor          = cgs.customCrosshairDotOutlineColor;
+
+			// TODO : make rounded look proper > 1.0 outlineWidth as well
+			if (outlineWidth > 1.0) {
+				outlineRounded = qfalse;
+			}
+
+			CG_CustomCrosshairDrawRect(
+				x - innerWidthOffset - outlineWidth,
+				y - innerWidthOffset,
+				innerWidth, innerWidth, outlineWidth, cg_customCrosshairDotOutlineRounded.integer, qtrue);
+		}
+
+		// draw small cross
+		if (cg_customCrosshair.integer == CUSTOMCROSSHAIR_DOT_WITH_SMALLCROSS || cg_customCrosshair.integer == CUSTOMCROSSHAIR_SMALLCROSS)
+		{
+			innerWidth       = cg_customCrosshairCrossWidth.value;
+			innerWidthOffset = innerWidth / 2;
+			outlineWidth     = cg_customCrosshairCrossOutlineWidth.value;
+			outlineRounded   = cg_customCrosshairCrossOutlineRounded.integer;
+			crossLength      = cg_customCrosshairCrossLength.value;
+			fgColor          = cgs.customCrosshairCrossColor;
+			bgColor          = cgs.customCrosshairCrossOutlineColor;
+
+			// TODO : make rounded look proper > 1.0 outlineWidth as well
+			if (outlineWidth > 1.0) {
+				outlineRounded = qfalse;
+			}
+
+			// top outline
+			CG_CustomCrosshairDrawRect(
+				x - innerWidthOffset - outlineWidth,
+				y - innerWidthOffset - (outlineWidth * 2) - crossLength - crossGap,
+				innerWidth, crossLength, outlineWidth, outlineRounded, qtrue);
+
+			// bottom outline
+			CG_CustomCrosshairDrawRect(
+				x - innerWidthOffset - outlineWidth,
+				y - innerWidthOffset + innerWidth + (outlineWidth * 2) + crossGap,
+				innerWidth, crossLength, outlineWidth, outlineRounded, qtrue);
+
+			// left outline
+			CG_CustomCrosshairDrawRect(
+				x - innerWidthOffset - (outlineWidth * 3) - crossLength - crossGap,
+				y - innerWidthOffset,
+				crossLength, innerWidth, outlineWidth, outlineRounded, qtrue);
+
+			// right outline
+			CG_CustomCrosshairDrawRect(
+				x - innerWidthOffset + innerWidth + (outlineWidth * 1) + crossGap,
+				y - innerWidthOffset,
+				crossLength, innerWidth, outlineWidth, outlineRounded, qtrue);
+		}
+	}
+	// draw full cross
+	else if (cg_customCrosshair.integer == CUSTOMCROSSHAIR_FULLCROSS)
+	{
+		innerWidth       = cg_customCrosshairCrossWidth.value;
+		innerWidthOffset = innerWidth / 2;
+		outlineRounded   = cg_customCrosshairCrossOutlineRounded.integer;
+		outlineWidth     = cg_customCrosshairCrossOutlineWidth.value;
+		crossLength      = cg_customCrosshairCrossLength.value;
+		fgColor          = cgs.customCrosshairCrossColor;
+		bgColor          = cgs.customCrosshairCrossOutlineColor;
+
+		// TODO : make rounded look proper > 1.0 outlineWidth as well
+		if (outlineWidth > 1.0) {
+			outlineRounded = qfalse;
+		}
+
+		if (crossSpread != 0.0)
+		{
+			crossLength += crossSpread;
+		}
+
+		CG_CustomCrosshairSetColor(fgColor);
+
+		// vertical filling
+		trap_R_DrawStretchPic(x - innerWidthOffset,
+		                      y - innerWidthOffset - crossLength,
+		                      innerWidth, crossLength, 0, 0, 0, 1, cgs.media.whiteShader);
+
+		trap_R_DrawStretchPic(x - innerWidthOffset,
+		                      y + innerWidthOffset,
+		                      innerWidth, crossLength, 0, 0, 0, 1, cgs.media.whiteShader);
+
+		// horizontal filling
+		trap_R_DrawStretchPic(x - innerWidthOffset - crossLength,
+		                      y - innerWidthOffset,
+		                      crossLength, innerWidth, 0, 0, 0, 1, cgs.media.whiteShader);
+
+		trap_R_DrawStretchPic(x - innerWidthOffset + innerWidth,
+		                      y - innerWidthOffset,
+		                      crossLength, innerWidth, 0, 0, 0, 1, cgs.media.whiteShader);
+
+		CG_CustomCrosshairSetColor(cgs.customCrosshairDotColor);
+
+		// center filling
+		trap_R_DrawStretchPic(x - innerWidthOffset,
+		                      y - innerWidthOffset,
+		                      innerWidth, innerWidth, 0, 0, 0, 1, cgs.media.whiteShader);
+
+		if (outlineWidth > 0.0)
+		{
+			int roundedOffset = 0.0;
+			if (cg_customCrosshairCrossOutlineRounded.integer)
+			{
+				roundedOffset = outlineWidth;
+			}
+
+			CG_CustomCrosshairSetColor(bgColor);
+
+			// top outline
+			trap_R_DrawStretchPic(x - innerWidthOffset - crossLength,
+			                      y - innerWidthOffset - outlineWidth,
+			                      crossLength, outlineWidth, 0, 0, 0, 1, cgs.media.whiteShader);
+
+			trap_R_DrawStretchPic(x - innerWidthOffset,
+			                      y - innerWidthOffset - crossLength - outlineWidth,
+			                      innerWidth, outlineWidth, 0, 0, 0, 1, cgs.media.whiteShader);
+
+			trap_R_DrawStretchPic(x + outlineWidth,
+			                      y - innerWidthOffset - outlineWidth,
+			                      crossLength, outlineWidth, 0, 0, 0, 1, cgs.media.whiteShader);
+
+			// bottom outline
+			trap_R_DrawStretchPic(x - innerWidthOffset - crossLength,
+			                      y - innerWidthOffset + innerWidth,
+			                      crossLength, outlineWidth, 0, 0, 0, 1, cgs.media.whiteShader);
+
+			trap_R_DrawStretchPic(x - innerWidthOffset,
+			                      y - innerWidthOffset + innerWidth + crossLength,
+			                      innerWidth, outlineWidth, 0, 0, 0, 1, cgs.media.whiteShader);
+
+			trap_R_DrawStretchPic(x + outlineWidth,
+			                      y - innerWidthOffset + innerWidth,
+			                      crossLength, outlineWidth, 0, 0, 0, 1, cgs.media.whiteShader);
+
+			// sides-top outline
+			trap_R_DrawStretchPic(x - innerWidthOffset - outlineWidth,
+			                      y - innerWidthOffset - crossLength - outlineWidth + roundedOffset,
+			                      outlineWidth, crossLength - roundedOffset, 0, 0, 0, 1, cgs.media.whiteShader);
+
+			trap_R_DrawStretchPic(x + outlineWidth,
+			                      y - innerWidthOffset - crossLength - outlineWidth + roundedOffset,
+			                      outlineWidth, crossLength - roundedOffset, 0, 0, 0, 1, cgs.media.whiteShader);
+
+			// sides-center outline
+			trap_R_DrawStretchPic(x - innerWidthOffset - crossLength - outlineWidth,
+			                      y - innerWidthOffset - outlineWidth + roundedOffset,
+			                      outlineWidth, innerWidth + (outlineWidth - roundedOffset) * 2, 0, 0, 0, 1, cgs.media.whiteShader);
+
+			trap_R_DrawStretchPic(x - innerWidthOffset + innerWidth + crossLength,
+			                      y - innerWidthOffset - outlineWidth + roundedOffset,
+			                      outlineWidth, innerWidth + (outlineWidth - roundedOffset) * 2, 0, 0, 0, 1, cgs.media.whiteShader);
+
+			// sides-bottom outline
+			trap_R_DrawStretchPic(x - innerWidthOffset - outlineWidth,
+			                      y - innerWidthOffset + innerWidth + outlineWidth,
+			                      outlineWidth, crossLength - roundedOffset, 0, 0, 0, 1, cgs.media.whiteShader);
+
+			trap_R_DrawStretchPic(x + outlineWidth,
+			                      y - innerWidthOffset + innerWidth + outlineWidth,
+			                      outlineWidth, crossLength - roundedOffset, 0, 0, 0, 1, cgs.media.whiteShader);
+		}
+	}
+
+	CG_CustomCrosshairSetColor(NULL);
+}

--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -1263,6 +1263,8 @@ CROSSHAIRS
 static void CG_DrawScopedReticle(void)
 {
 	int weapon;
+	int x = (cgs.glconfig.vidWidth / 2);
+	int y = (cgs.glconfig.vidHeight / 2);
 
 	// So that we will draw reticle
 	if ((cg.snap->ps.pm_flags & PMF_FOLLOW) || cg.demoPlayback)
@@ -1279,6 +1281,8 @@ static void CG_DrawScopedReticle(void)
 		return;
 	}
 
+	// TODO : add support for ultra-widescreen / remove 16:9 assumption
+
 	// sides
 	CG_FillRect(0, 0, 80 + cgs.wideXoffset, SCREEN_HEIGHT, colorBlack);
 	CG_FillRect(560 + cgs.wideXoffset, 0, 80 + cgs.wideXoffset, SCREEN_HEIGHT, colorBlack);
@@ -1292,32 +1296,70 @@ static void CG_DrawScopedReticle(void)
 	if (weapon == WP_FG42_SCOPE)
 	{
 		// hairs
-		CG_FillRect(84 + cgs.wideXoffset, 239, 150, 3, colorBlack);     // left
-		CG_FillRect(234 + cgs.wideXoffset, 240, 173, 1, colorBlack);    // horiz center
-		CG_FillRect(407 + cgs.wideXoffset, 239, 150, 3, colorBlack);    // right
+		trap_R_SetColor(colorBlack);
 
+		// inside left
+		trap_R_DrawStretchPic((x - 1) * 0.80,
+		                      y - 1,
+		                      (x - 1) * 0.20, 2, 0, 0, 0, 1, cgs.media.whiteShader);
+		// outside left
+		trap_R_DrawStretchPic(0,
+		                      y - 2,
+		                      (x - 1) * 0.80, 4, 0, 0, 0, 1, cgs.media.whiteShader);
+		// inside right
+		trap_R_DrawStretchPic(x,
+		                      y - 1,
+		                      (x - 1) * 0.80, 2, 0, 0, 0, 1, cgs.media.whiteShader);
+		// outside right
+		trap_R_DrawStretchPic(cgs.glconfig.vidWidth - (x * 0.80),
+		                      y - 2,
+		                      (x - 1) * 0.80, 4, 0, 0, 0, 1, cgs.media.whiteShader);
+		// inside top
+		trap_R_DrawStretchPic(x - 2,
+		                      0,
+		                      4, (y - 1) * 0.65, 0, 0, 0, 1, cgs.media.whiteShader);
+		// outside top
+		trap_R_DrawStretchPic(x - 1,
+		                      ((y - 1) * 0.65),
+		                      2, (y - 1) * 0.35, 0, 0, 0, 1, cgs.media.whiteShader);
+		// inside bottom
+		trap_R_DrawStretchPic(x - 1,
+		                      y + 1,
+		                      2, (y - 1) * 0.35, 0, 0, 0, 1, cgs.media.whiteShader);
+		// outside bottom
+		trap_R_DrawStretchPic(x - 2,
+		                      y + 1 + ((y - 1) * 0.35),
+		                      4, (y - 1) * 0.65, 0, 0, 0, 1, cgs.media.whiteShader);
+		// center
+		trap_R_DrawStretchPic(x - 1,
+		                      y - 1,
+		                      2, 2, 0, 0, 0, 1, cgs.media.whiteShader);
 
-		CG_FillRect(319 + cgs.wideXoffset, 2, 3, 151, colorBlack);      // top center top
-		CG_FillRect(320 + cgs.wideXoffset, 153, 1, 114, colorBlack);    // top center bot
-
-		CG_FillRect(320 + cgs.wideXoffset, 241, 1, 87, colorBlack);     // bot center top
-		CG_FillRect(319 + cgs.wideXoffset, 327, 3, 151, colorBlack);    // bot center bot
+		trap_R_SetColor(NULL);
 	}
-	else if (weapon == WP_GARAND_SCOPE)
+	else if (weapon == WP_GARAND_SCOPE || weapon == WP_K43_SCOPE)
 	{
 		// hairs
-		CG_FillRect(84 + cgs.wideXoffset, 239, 177, 2, colorBlack);     // left
-		CG_FillRect(320 + cgs.wideXoffset, 242, 1, 58, colorBlack);     // center top
-		CG_FillRect(319 + cgs.wideXoffset, 300, 2, 178, colorBlack);    // center bot
-		CG_FillRect(380 + cgs.wideXoffset, 239, 177, 2, colorBlack);    // right
-	}
-	else if (weapon == WP_K43_SCOPE)
-	{
-		// hairs
-		CG_FillRect(84 + cgs.wideXoffset, 239, 177, 2, colorBlack);     // left
-		CG_FillRect(320 + cgs.wideXoffset, 242, 1, 58, colorBlack);     // center top
-		CG_FillRect(319 + cgs.wideXoffset, 300, 2, 178, colorBlack);    // center bot
-		CG_FillRect(380 + cgs.wideXoffset, 239, 177, 2, colorBlack);    // right
+		trap_R_SetColor(colorBlack);
+
+		// left
+		trap_R_DrawStretchPic(0,
+		                      y - 2,
+		                      (x * 0.85), 4, 0, 0, 0, 1, cgs.media.whiteShader);
+		// right
+		trap_R_DrawStretchPic(cgs.glconfig.vidWidth - (x * 0.85),
+		                      y - 2,
+		                      (x * 0.85), 4, 0, 0, 0, 1, cgs.media.whiteShader);
+		// inside bottom
+		trap_R_DrawStretchPic(x - 1,
+		                      y + 1,
+		                      2, (y - 1) * 0.25, 0, 0, 0, 1, cgs.media.whiteShader);
+		// outside bottom
+		trap_R_DrawStretchPic(x - 2,
+		                      y + 1 + ((y - 1) * 0.25),
+		                      4, (y - 1) * 0.75, 0, 0, 0, 1, cgs.media.whiteShader);
+
+		trap_R_SetColor(NULL);
 	}
 }
 

--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -1775,6 +1775,13 @@ void CG_DrawCrosshair(hudComponent_t *comp)
 		return;
 	}
 
+	if (cg_customCrosshair.integer > CUSTOMCROSSHAIR_NONE && cg_customCrosshair.integer < CUSTOMCROSSHAIR_MAX)
+	{
+		CG_DrawCustomCrosshair();
+		CG_DrawNoShootIcon(comp);
+		return;
+	}
+
 	if (comp->showBackGround)
 	{
 		CG_FillRect(comp->location.x, comp->location.y, comp->location.w, comp->location.h, comp->colorBackground);

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2491,6 +2491,12 @@ typedef struct cgs_s
 
 	clientInfo_t clientinfo[MAX_CLIENTS];
 
+	// colors
+	vec4_t customCrosshairDotOutlineColor;
+	vec4_t customCrosshairDotColor;
+	vec4_t customCrosshairCrossOutlineColor;
+	vec4_t customCrosshairCrossColor;
+
 	// teamchat width is *3 because of embedded color codes
 	char teamChatMsgs[TEAMCHAT_HEIGHT][TEAMCHAT_WIDTH * 3 + 1];
 	int teamChatMsgTimes[TEAMCHAT_HEIGHT];
@@ -2985,6 +2991,22 @@ extern vmCvar_t cg_crosshairX;
 extern vmCvar_t cg_crosshairY;
 extern vmCvar_t cg_crosshairScaleX;
 extern vmCvar_t cg_crosshairScaleY;
+
+extern vmCvar_t cg_customCrosshair;
+extern vmCvar_t cg_customCrosshairDotWidth;
+extern vmCvar_t cg_customCrosshairDotColor;
+extern vmCvar_t cg_customCrosshairDotOutlineRounded;
+extern vmCvar_t cg_customCrosshairDotOutlineColor;
+extern vmCvar_t cg_customCrosshairDotOutlineWidth;
+extern vmCvar_t cg_customCrosshairCrossWidth;
+extern vmCvar_t cg_customCrosshairCrossLength;
+extern vmCvar_t cg_customCrosshairCrossGap;
+extern vmCvar_t cg_customCrosshairCrossSpreadDistance;
+extern vmCvar_t cg_customCrosshairCrossSpreadOTGCoef;
+extern vmCvar_t cg_customCrosshairCrossColor;
+extern vmCvar_t cg_customCrosshairCrossOutlineRounded;
+extern vmCvar_t cg_customCrosshairCrossOutlineColor;
+extern vmCvar_t cg_customCrosshairCrossOutlineWidth;
 
 extern vmCvar_t cg_commandMapTime;
 
@@ -4432,6 +4454,19 @@ hudStucture_t *CG_ReadSingleHudJsonFile(const char *filename);
 qboolean CG_WriteHudsToFile();
 qboolean CG_TryReadHudFromFile(const char *filename, qboolean isEditable);
 void CG_ReadHudsFromFile(void);
+
+// cg_customcrosshair.c
+void CG_DrawCustomCrosshair();
+
+typedef enum
+{
+	CUSTOMCROSSHAIR_NONE,
+	CUSTOMCROSSHAIR_DOT_WITH_SMALLCROSS,
+	CUSTOMCROSSHAIR_DOT,
+	CUSTOMCROSSHAIR_SMALLCROSS,
+	CUSTOMCROSSHAIR_FULLCROSS,
+	CUSTOMCROSSHAIR_MAX,
+} customcrosshair_t;
 
 // cg_draw_hud.c
 hudStucture_t *CG_GetActiveHUD();

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -380,6 +380,22 @@ vmCvar_t cg_crosshairY;
 vmCvar_t cg_crosshairScaleX;
 vmCvar_t cg_crosshairScaleY;
 
+vmCvar_t cg_customCrosshair;
+vmCvar_t cg_customCrosshairDotWidth;
+vmCvar_t cg_customCrosshairDotColor;
+vmCvar_t cg_customCrosshairDotOutlineRounded;
+vmCvar_t cg_customCrosshairDotOutlineColor;
+vmCvar_t cg_customCrosshairDotOutlineWidth;
+vmCvar_t cg_customCrosshairCrossWidth;
+vmCvar_t cg_customCrosshairCrossLength;
+vmCvar_t cg_customCrosshairCrossGap;
+vmCvar_t cg_customCrosshairCrossSpreadDistance;
+vmCvar_t cg_customCrosshairCrossSpreadOTGCoef;
+vmCvar_t cg_customCrosshairCrossColor;
+vmCvar_t cg_customCrosshairCrossOutlineRounded;
+vmCvar_t cg_customCrosshairCrossOutlineColor;
+vmCvar_t cg_customCrosshairCrossOutlineWidth;
+
 vmCvar_t cg_commandMapTime;
 
 typedef struct
@@ -393,278 +409,319 @@ typedef struct
 
 static cvarTable_t cvarTable[] =
 {
-	{ &cg_autoswitch,               "cg_autoswitch",               "2",           CVAR_ARCHIVE,                 0 },
-	{ &cg_drawGun,                  "cg_drawGun",                  "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_weapAnims,                "cg_weapAnims",                "15",          CVAR_ARCHIVE,                 0 },
-	{ &cg_weapBankCollisions,       "cg_weapBankCollisions",       "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_weapSwitchNoAmmoSounds,   "cg_weapSwitchNoAmmoSounds",   "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_gun_frame,                "cg_gun_frame",                "0",           CVAR_TEMP,                    0 },
-	{ &cg_zoomDefaultSniper,        "cg_zoomDefaultSniper",        "20",          CVAR_ARCHIVE,                 0 }, // changed per atvi req
-	{ &cg_zoomStepSniper,           "cg_zoomStepSniper",           "2",           CVAR_ARCHIVE,                 0 },
-	{ &cg_fov,                      "cg_fov",                      "90",          CVAR_ARCHIVE,                 0 },
-	{ &cg_muzzleFlash,              "cg_muzzleFlash",              "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_muzzleFlashDlight,        "cg_muzzleFlashDlight",        "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_muzzleFlashOld,           "cg_muzzleFlashOld",           "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_letterbox,                "cg_letterbox",                "0",           CVAR_TEMP,                    0 },
-	{ &cg_shadows,                  "cg_shadows",                  "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_gibs,                     "cg_gibs",                     "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_autoswitch,                         "cg_autoswitch",                         "2",           CVAR_ARCHIVE,                 0 },
+	{ &cg_drawGun,                            "cg_drawGun",                            "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_weapAnims,                          "cg_weapAnims",                          "15",          CVAR_ARCHIVE,                 0 },
+	{ &cg_weapBankCollisions,                 "cg_weapBankCollisions",                 "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_weapSwitchNoAmmoSounds,             "cg_weapSwitchNoAmmoSounds",             "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_gun_frame,                          "cg_gun_frame",                          "0",           CVAR_TEMP,                    0 },
+	{ &cg_zoomDefaultSniper,                  "cg_zoomDefaultSniper",                  "20",          CVAR_ARCHIVE,                 0 }, // changed per atvi req
+	{ &cg_zoomStepSniper,                     "cg_zoomStepSniper",                     "2",           CVAR_ARCHIVE,                 0 },
+	{ &cg_fov,                                "cg_fov",                                "90",          CVAR_ARCHIVE,                 0 },
+	{ &cg_muzzleFlash,                        "cg_muzzleFlash",                        "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_muzzleFlashDlight,                  "cg_muzzleFlashDlight",                  "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_muzzleFlashOld,                     "cg_muzzleFlashOld",                     "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_letterbox,                          "cg_letterbox",                          "0",           CVAR_TEMP,                    0 },
+	{ &cg_shadows,                            "cg_shadows",                            "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_gibs,                               "cg_gibs",                               "1",           CVAR_ARCHIVE,                 0 },
 	// we now draw reticles always in non demoplayback
 	//  { &cg_draw2D, "cg_draw2D", "1", CVAR_CHEAT }, // JPW NERVE changed per atvi req to prevent sniper rifle zoom cheats
-	{ &cg_draw2D,                   "cg_draw2D",                   "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_railTrailTime,            "cg_railTrailTime",            "750",         CVAR_ARCHIVE,                 0 },
-	{ &cg_drawStatus,               "cg_drawStatus",               "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_drawFPS,                  "cg_drawFPS",                  "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_drawCrosshair,            "cg_drawCrosshair",            "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_drawCrosshairFade,        "cg_drawCrosshairFade",        "250",         CVAR_ARCHIVE,                 0 },
-	{ &cg_drawCrosshairPickups,     "cg_drawCrosshairPickups",     "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_drawSpectatorNames,       "cg_drawSpectatorNames",       "2",           CVAR_ARCHIVE,                 0 },
-	{ &cg_drawHintFade,             "cg_drawHintFade",             "250",         CVAR_ARCHIVE,                 0 },
-	{ &cg_useWeapsForZoom,          "cg_useWeapsForZoom",          "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_weaponCycleDelay,         "cg_weaponCycleDelay",         "150",         CVAR_ARCHIVE,                 0 },
-	{ &cg_cycleAllWeaps,            "cg_cycleAllWeaps",            "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_brassTime,                "cg_brassTime",                "2500",        CVAR_ARCHIVE,                 0 },
-	{ &cg_markTime,                 "cg_markTime",                 "20000",       CVAR_ARCHIVE,                 0 },
-	{ &cg_bloodPuff,                "cg_bloodPuff",                "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_gunFovOffset,             "cg_gunFovOffset",             "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_gun_x,                    "cg_gunX",                     "0",           CVAR_TEMP,                    0 },
-	{ &cg_gun_y,                    "cg_gunY",                     "0",           CVAR_TEMP,                    0 },
-	{ &cg_gun_z,                    "cg_gunZ",                     "0",           CVAR_TEMP,                    0 },
-	{ &cg_centertime,               "cg_centertime",               "5",           CVAR_ARCHIVE,                 0 }, // changed from 3 to 5
-	{ &cg_bobbing,                  "cg_bobbing",                  "0.0",         CVAR_ARCHIVE,                 0 },
-	{ &cg_drawEnvAwareness,         "cg_drawEnvAwareness",         "7",           CVAR_ARCHIVE,                 0 },
-	{ &cg_drawEnvAwarenessScale,    "cg_drawEnvAwarenessScale",    "0.80",        CVAR_ARCHIVE,                 0 },
-	{ &cg_drawEnvAwarenessIconSize, "cg_drawEnvAwarenessIconSize", "14",          CVAR_ARCHIVE,                 0 },
+	{ &cg_draw2D,                             "cg_draw2D",                             "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_railTrailTime,                      "cg_railTrailTime",                      "750",         CVAR_ARCHIVE,                 0 },
+	{ &cg_drawStatus,                         "cg_drawStatus",                         "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_drawFPS,                            "cg_drawFPS",                            "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_drawCrosshair,                      "cg_drawCrosshair",                      "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_drawCrosshairFade,                  "cg_drawCrosshairFade",                  "250",         CVAR_ARCHIVE,                 0 },
+	{ &cg_drawCrosshairPickups,               "cg_drawCrosshairPickups",               "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_drawSpectatorNames,                 "cg_drawSpectatorNames",                 "2",           CVAR_ARCHIVE,                 0 },
+	{ &cg_drawHintFade,                       "cg_drawHintFade",                       "250",         CVAR_ARCHIVE,                 0 },
+	{ &cg_useWeapsForZoom,                    "cg_useWeapsForZoom",                    "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_weaponCycleDelay,                   "cg_weaponCycleDelay",                   "150",         CVAR_ARCHIVE,                 0 },
+	{ &cg_cycleAllWeaps,                      "cg_cycleAllWeaps",                      "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_brassTime,                          "cg_brassTime",                          "2500",        CVAR_ARCHIVE,                 0 },
+	{ &cg_markTime,                           "cg_markTime",                           "20000",       CVAR_ARCHIVE,                 0 },
+	{ &cg_bloodPuff,                          "cg_bloodPuff",                          "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_gunFovOffset,                       "cg_gunFovOffset",                       "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_gun_x,                              "cg_gunX",                               "0",           CVAR_TEMP,                    0 },
+	{ &cg_gun_y,                              "cg_gunY",                               "0",           CVAR_TEMP,                    0 },
+	{ &cg_gun_z,                              "cg_gunZ",                               "0",           CVAR_TEMP,                    0 },
+	{ &cg_centertime,                         "cg_centertime",                         "5",           CVAR_ARCHIVE,                 0 }, // changed from 3 to 5
+	{ &cg_bobbing,                            "cg_bobbing",                            "0.0",         CVAR_ARCHIVE,                 0 },
+	{ &cg_drawEnvAwareness,                   "cg_drawEnvAwareness",                   "7",           CVAR_ARCHIVE,                 0 },
+	{ &cg_drawEnvAwarenessScale,              "cg_drawEnvAwarenessScale",              "0.80",        CVAR_ARCHIVE,                 0 },
+	{ &cg_drawEnvAwarenessIconSize,           "cg_drawEnvAwarenessIconSize",           "14",          CVAR_ARCHIVE,                 0 },
 
-	{ &cg_dynamicIcons,             "cg_dynamicIcons",             "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_dynamicIconsDistance,     "cg_dynamicIconsDistance",     "400",         CVAR_ARCHIVE,                 0 },
-	{ &cg_dynamicIconsSize,         "cg_dynamicIconsSize",         "20",          CVAR_ARCHIVE,                 0 },
-	{ &cg_dynamicIconsMaxScale,     "cg_dynamicIconsMaxScale",     "1.0",         CVAR_ARCHIVE,                 0 },
-	{ &cg_dynamicIconsMinScale,     "cg_dynamicIconsMinScale",     "0.5",         CVAR_ARCHIVE,                 0 },
+	{ &cg_dynamicIcons,                       "cg_dynamicIcons",                       "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_dynamicIconsDistance,               "cg_dynamicIconsDistance",               "400",         CVAR_ARCHIVE,                 0 },
+	{ &cg_dynamicIconsSize,                   "cg_dynamicIconsSize",                   "20",          CVAR_ARCHIVE,                 0 },
+	{ &cg_dynamicIconsMaxScale,               "cg_dynamicIconsMaxScale",               "1.0",         CVAR_ARCHIVE,                 0 },
+	{ &cg_dynamicIconsMinScale,               "cg_dynamicIconsMinScale",               "0.5",         CVAR_ARCHIVE,                 0 },
 
-	{ &cg_autoactivate,             "cg_autoactivate",             "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_autoactivate,                       "cg_autoactivate",                       "1",           CVAR_ARCHIVE,                 0 },
 
 	// more fluid rotations
-	{ &cg_swingSpeed,               "cg_swingSpeed",               "0.1",         CVAR_ARCHIVE,                 0 }, // was 0.3 for Q3
-	{ &cg_bloodTime,                "cg_bloodTime",                "120",         CVAR_ARCHIVE,                 0 },
+	{ &cg_swingSpeed,                         "cg_swingSpeed",                         "0.1",         CVAR_ARCHIVE,                 0 },           // was 0.3 for Q3
+	{ &cg_bloodTime,                          "cg_bloodTime",                          "120",         CVAR_ARCHIVE,                 0 },
 
-	{ &cg_skybox,                   "cg_skybox",                   "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_skybox,                             "cg_skybox",                             "1",           CVAR_ARCHIVE,                 0 },
 
 	// say, team say, etc.
-	{ &cg_messageType,              "cg_messageType",              "1",           CVAR_TEMP,                    0 },
+	{ &cg_messageType,                        "cg_messageType",                        "1",           CVAR_TEMP,                    0 },
 
-	{ &cg_animSpeed,                "cg_animspeed",                "1",           CVAR_CHEAT,                   0 },
-	{ &cg_debugAnim,                "cg_debuganim",                "0",           CVAR_CHEAT,                   0 },
-	{ &cg_debugPosition,            "cg_debugposition",            "0",           CVAR_CHEAT,                   0 },
-	{ &cg_debugEvents,              "cg_debugevents",              "0",           CVAR_CHEAT,                   0 },
-	{ &cg_debugPlayerHitboxes,      "cg_debugPlayerHitboxes",      "0",           CVAR_CHEAT,                   0 },
-	{ &cg_debugBullets,             "cg_debugBullets",             "0",           CVAR_CHEAT,                   0 },
-	{ &cg_errorDecay,               "cg_errordecay",               "100",         CVAR_CHEAT,                   0 },
-	{ &cg_nopredict,                "cg_nopredict",                "0",           CVAR_CHEAT,                   0 },
-	{ &cg_noPlayerAnims,            "cg_noplayeranims",            "0",           CVAR_CHEAT,                   0 },
-	{ &cg_showmiss,                 "cg_showmiss",                 "0",           0,                            0 },
-	{ &cg_tracerChance,             "cg_tracerchance",             "0.4",         CVAR_CHEAT,                   0 },
-	{ &cg_tracerWidth,              "cg_tracerwidth",              "0.8",         CVAR_CHEAT,                   0 },
-	{ &cg_tracerSpeed,              "cg_tracerSpeed",              "4500",        CVAR_CHEAT,                   0 },
-	{ &cg_tracerLength,             "cg_tracerlength",             "160",         CVAR_CHEAT,                   0 },
-	{ &cg_thirdPersonRange,         "cg_thirdPersonRange",         "80",          CVAR_CHEAT,                   0 }, // per atvi req
-	{ &cg_thirdPersonAngle,         "cg_thirdPersonAngle",         "0",           CVAR_CHEAT,                   0 },
-	{ &cg_thirdPerson,              "cg_thirdPerson",              "0",           CVAR_CHEAT,                   0 }, // per atvi req
-	{ &cg_scopedSensitivityScaler,  "cg_scopedSensitivityScaler",  "0.6",         CVAR_ARCHIVE,                 0 },                           // per atvi req
-	{ &cg_teamChatTime,             "cg_teamChatTime",             "8000",        CVAR_ARCHIVE,                 0 },
-	{ &cg_teamChatHeight,           "cg_teamChatHeight",           "8",           CVAR_ARCHIVE,                 0 },
-	{ &cg_teamChatMention,          "cg_teamChatMention",          "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_coronafardist,            "cg_coronafardist",            "1536",        CVAR_ARCHIVE,                 0 },
-	{ &cg_coronas,                  "cg_coronas",                  "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_predictItems,             "cg_predictItems",             "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_stats,                    "cg_stats",                    "0",           0,                            0 },
+	{ &cg_animSpeed,                          "cg_animspeed",                          "1",           CVAR_CHEAT,                   0 },
+	{ &cg_debugAnim,                          "cg_debuganim",                          "0",           CVAR_CHEAT,                   0 },
+	{ &cg_debugPosition,                      "cg_debugposition",                      "0",           CVAR_CHEAT,                   0 },
+	{ &cg_debugEvents,                        "cg_debugevents",                        "0",           CVAR_CHEAT,                   0 },
+	{ &cg_debugPlayerHitboxes,                "cg_debugPlayerHitboxes",                "0",           CVAR_CHEAT,                   0 },
+	{ &cg_debugBullets,                       "cg_debugBullets",                       "0",           CVAR_CHEAT,                   0 },
+	{ &cg_errorDecay,                         "cg_errordecay",                         "100",         CVAR_CHEAT,                   0 },
+	{ &cg_nopredict,                          "cg_nopredict",                          "0",           CVAR_CHEAT,                   0 },
+	{ &cg_noPlayerAnims,                      "cg_noplayeranims",                      "0",           CVAR_CHEAT,                   0 },
+	{ &cg_showmiss,                           "cg_showmiss",                           "0",           0,                            0 },
+	{ &cg_tracerChance,                       "cg_tracerchance",                       "0.4",         CVAR_CHEAT,                   0 },
+	{ &cg_tracerWidth,                        "cg_tracerwidth",                        "0.8",         CVAR_CHEAT,                   0 },
+	{ &cg_tracerSpeed,                        "cg_tracerSpeed",                        "4500",        CVAR_CHEAT,                   0 },
+	{ &cg_tracerLength,                       "cg_tracerlength",                       "160",         CVAR_CHEAT,                   0 },
+	{ &cg_thirdPersonRange,                   "cg_thirdPersonRange",                   "80",          CVAR_CHEAT,                   0 },           // per atvi req
+	{ &cg_thirdPersonAngle,                   "cg_thirdPersonAngle",                   "0",           CVAR_CHEAT,                   0 },
+	{ &cg_thirdPerson,                        "cg_thirdPerson",                        "0",           CVAR_CHEAT,                   0 },           // per atvi req
+	{ &cg_scopedSensitivityScaler,            "cg_scopedSensitivityScaler",            "0.6",         CVAR_ARCHIVE,                 0 },           // per atvi req
+	{ &cg_teamChatTime,                       "cg_teamChatTime",                       "8000",        CVAR_ARCHIVE,                 0 },
+	{ &cg_teamChatHeight,                     "cg_teamChatHeight",                     "8",           CVAR_ARCHIVE,                 0 },
+	{ &cg_teamChatMention,                    "cg_teamChatMention",                    "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_coronafardist,                      "cg_coronafardist",                      "1536",        CVAR_ARCHIVE,                 0 },
+	{ &cg_coronas,                            "cg_coronas",                            "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_predictItems,                       "cg_predictItems",                       "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_stats,                              "cg_stats",                              "0",           0,                            0 },
 
-	{ &cg_timescale,                "timescale",                   "1",           0,                            0 },
+	{ &cg_timescale,                          "timescale",                             "1",           0,                            0 },
 
-	{ &pmove_fixed,                 "pmove_fixed",                 "0",           CVAR_SYSTEMINFO,              0 },
-	{ &pmove_msec,                  "pmove_msec",                  "8",           CVAR_SYSTEMINFO,              0 },
+	{ &pmove_fixed,                           "pmove_fixed",                           "0",           CVAR_SYSTEMINFO,              0 },
+	{ &pmove_msec,                            "pmove_msec",                            "8",           CVAR_SYSTEMINFO,              0 },
 
-	{ &cg_spritesFollowHeads,       "cg_spritesFollowHeads",       "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_voiceSpriteTime,          "cg_voiceSpriteTime",          "6000",        CVAR_ARCHIVE,                 0 },
+	{ &cg_spritesFollowHeads,                 "cg_spritesFollowHeads",                 "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_voiceSpriteTime,                    "cg_voiceSpriteTime",                    "6000",        CVAR_ARCHIVE,                 0 },
 
-	{ &cg_teamChatsOnly,            "cg_teamChatsOnly",            "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_teamVoiceChatsOnly,       "cg_teamVoiceChatsOnly",       "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_voiceChats,               "cg_voiceChats",               "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_voiceText,                "cg_voiceText",                "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_teamChatsOnly,                      "cg_teamChatsOnly",                      "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_teamVoiceChatsOnly,                 "cg_teamVoiceChatsOnly",                 "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_voiceChats,                         "cg_voiceChats",                         "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_voiceText,                          "cg_voiceText",                          "1",           CVAR_ARCHIVE,                 0 },
 
 	// the following variables are created in other parts of the system,
 	// but we also reference them here
 
-	{ &cg_buildScript,              "com_buildScript",             "0",           0,                            0 }, // force loading of all possible data and error on failures
-	{ &cg_paused,                   "cl_paused",                   "0",           CVAR_ROM,                     0 },
+	{ &cg_buildScript,                        "com_buildScript",                       "0",           0,                            0 },           // force loading of all possible data and error on failures
+	{ &cg_paused,                             "cl_paused",                             "0",           CVAR_ROM,                     0 },
 
-	{ &cg_blood,                    "cg_showblood",                "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_blood,                              "cg_showblood",                          "1",           CVAR_ARCHIVE,                 0 },
 #ifdef ALLOW_GSYNC
-	{ &cg_synchronousClients,       "g_synchronousClients",        "0",           CVAR_SYSTEMINFO | CVAR_CHEAT, 0 }, // communicated by systeminfo
+	{ &cg_synchronousClients,                 "g_synchronousClients",                  "0",           CVAR_SYSTEMINFO | CVAR_CHEAT, 0 },           // communicated by systeminfo
 #endif // ALLOW_GSYNC
 
-	{ &cg_gameType,                 "g_gametype",                  "0",           0,                            0 }, // communicated by systeminfo
-	{ &cg_bluelimbotime,            "",                            "30000",       0,                            0 }, // communicated by systeminfo
-	{ &cg_redlimbotime,             "",                            "30000",       0,                            0 }, // communicated by systeminfo
-	{ &cg_drawNotifyText,           "cg_drawNotifyText",           "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_quickMessageAlt,          "cg_quickMessageAlt",          "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_antilag,                  "g_antilag",                   "1",           0,                            0 },
-	{ &developer,                   "developer",                   "0",           CVAR_CHEAT,                   0 },
-	{ &cf_wstats,                   "cf_wstats",                   "1.2",         CVAR_ARCHIVE,                 0 },
-	{ &cf_wtopshots,                "cf_wtopshots",                "1.0",         CVAR_ARCHIVE,                 0 },
+	{ &cg_gameType,                           "g_gametype",                            "0",           0,                            0 }, // communicated by systeminfo
+	{ &cg_bluelimbotime,                      "",                                      "30000",       0,                            0 }, // communicated by systeminfo
+	{ &cg_redlimbotime,                       "",                                      "30000",       0,                            0 }, // communicated by systeminfo
+	{ &cg_drawNotifyText,                     "cg_drawNotifyText",                     "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_quickMessageAlt,                    "cg_quickMessageAlt",                    "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_antilag,                            "g_antilag",                             "1",           0,                            0 },
+	{ &developer,                             "developer",                             "0",           CVAR_CHEAT,                   0 },
+	{ &cf_wstats,                             "cf_wstats",                             "1.2",         CVAR_ARCHIVE,                 0 },
+	{ &cf_wtopshots,                          "cf_wtopshots",                          "1.0",         CVAR_ARCHIVE,                 0 },
 
-	{ &cg_autoFolders,              "cg_autoFolders",              "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_autoAction,               "cg_autoAction",               "4",           CVAR_ARCHIVE,                 0 },
-	{ &cg_autoReload,               "cg_autoReload",               "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_bloodDamageBlend,         "cg_bloodDamageBlend",         "1.0",         CVAR_ARCHIVE,                 0 },
-	{ &cg_bloodFlash,               "cg_bloodFlash",               "1.0",         CVAR_ARCHIVE,                 0 },
-	{ &cg_bloodFlashTime,           "cg_bloodFlashTime",           "1500",        CVAR_ARCHIVE,                 0 },
-	{ &cg_noAmmoAutoSwitch,         "cg_noAmmoAutoSwitch",         "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_printObjectiveInfo,       "cg_printObjectiveInfo",       "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_autoFolders,                        "cg_autoFolders",                        "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_autoAction,                         "cg_autoAction",                         "4",           CVAR_ARCHIVE,                 0 },
+	{ &cg_autoReload,                         "cg_autoReload",                         "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_bloodDamageBlend,                   "cg_bloodDamageBlend",                   "1.0",         CVAR_ARCHIVE,                 0 },
+	{ &cg_bloodFlash,                         "cg_bloodFlash",                         "1.0",         CVAR_ARCHIVE,                 0 },
+	{ &cg_bloodFlashTime,                     "cg_bloodFlashTime",                     "1500",        CVAR_ARCHIVE,                 0 },
+	{ &cg_noAmmoAutoSwitch,                   "cg_noAmmoAutoSwitch",                   "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_printObjectiveInfo,                 "cg_printObjectiveInfo",                 "1",           CVAR_ARCHIVE,                 0 },
 #ifdef FEATURE_MULTIVIEW
-	{ &cg_specHelp,                 "cg_specHelp",                 "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_specHelp,                           "cg_specHelp",                           "1",           CVAR_ARCHIVE,                 0 },
 #endif
-	{ &cg_uinfo,                    "cg_uinfo",                    "0",           CVAR_ROM | CVAR_USERINFO,     0 },
+	{ &cg_uinfo,                              "cg_uinfo",                              "0",           CVAR_ROM | CVAR_USERINFO,     0 },
 
-	{ &demo_avifpsF1,               "demo_avifpsF1",               "0",           CVAR_ARCHIVE,                 0 },
-	{ &demo_avifpsF2,               "demo_avifpsF2",               "10",          CVAR_ARCHIVE,                 0 },
-	{ &demo_avifpsF3,               "demo_avifpsF3",               "15",          CVAR_ARCHIVE,                 0 },
-	{ &demo_avifpsF4,               "demo_avifpsF4",               "20",          CVAR_ARCHIVE,                 0 },
-	{ &demo_avifpsF5,               "demo_avifpsF5",               "24",          CVAR_ARCHIVE,                 0 },
-	{ &demo_drawTimeScale,          "demo_drawTimeScale",          "1",           CVAR_ARCHIVE,                 0 },
-	{ &demo_infoWindow,             "demo_infoWindow",             "1",           CVAR_ARCHIVE,                 0 },
+	{ &demo_avifpsF1,                         "demo_avifpsF1",                         "0",           CVAR_ARCHIVE,                 0 },
+	{ &demo_avifpsF2,                         "demo_avifpsF2",                         "10",          CVAR_ARCHIVE,                 0 },
+	{ &demo_avifpsF3,                         "demo_avifpsF3",                         "15",          CVAR_ARCHIVE,                 0 },
+	{ &demo_avifpsF4,                         "demo_avifpsF4",                         "20",          CVAR_ARCHIVE,                 0 },
+	{ &demo_avifpsF5,                         "demo_avifpsF5",                         "24",          CVAR_ARCHIVE,                 0 },
+	{ &demo_drawTimeScale,                    "demo_drawTimeScale",                    "1",           CVAR_ARCHIVE,                 0 },
+	{ &demo_infoWindow,                       "demo_infoWindow",                       "1",           CVAR_ARCHIVE,                 0 },
 
 #ifdef FEATURE_EDV
-	{ &demo_weaponcam,              "demo_weaponcam",              "0",           CVAR_ARCHIVE,                 0 },
+	{ &demo_weaponcam,                        "demo_weaponcam",                        "0",           CVAR_ARCHIVE,                 0 },
 
-	{ &demo_followDistance,         "demo_followDistance",         "50 0 20",     CVAR_ARCHIVE,                 0 },
+	{ &demo_followDistance,                   "demo_followDistance",                   "50 0 20",     CVAR_ARCHIVE,                 0 },
 
-	{ &demo_yawPitchRollSpeed,      "demo_yawPitchRollSpeed",      "140 140 140", CVAR_ARCHIVE,                 0 },
+	{ &demo_yawPitchRollSpeed,                "demo_yawPitchRollSpeed",                "140 140 140", CVAR_ARCHIVE,                 0 },
 
-	{ &demo_freecamspeed,           "demo_freecamspeed",           "800",         CVAR_ARCHIVE,                 0 },
-	{ &demo_nopitch,                "demo_nopitch",                "1",           CVAR_ARCHIVE,                 0 },
-	{ &demo_pvshint,                "demo_pvshint",                "0",           CVAR_ARCHIVE,                 0 },
-	{ &demo_lookat,                 "demo_lookat",                 "-1",          CVAR_CHEAT,                   0 },
-	{ &demo_autotimescaleweapons,   "demo_autotimescaleweapons",   "0",           CVAR_ARCHIVE,                 0 },
-	{ &demo_autotimescale,          "demo_autotimescale",          "1",           CVAR_ARCHIVE,                 0 },
-	{ &demo_teamonlymissilecam,     "demo_teamonlymissilecam",     "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_predefineddemokeys,       "cg_predefineddemokeys",       "1",           CVAR_CHEAT | CVAR_ARCHIVE,    0 },
+	{ &demo_freecamspeed,                     "demo_freecamspeed",                     "800",         CVAR_ARCHIVE,                 0 },
+	{ &demo_nopitch,                          "demo_nopitch",                          "1",           CVAR_ARCHIVE,                 0 },
+	{ &demo_pvshint,                          "demo_pvshint",                          "0",           CVAR_ARCHIVE,                 0 },
+	{ &demo_lookat,                           "demo_lookat",                           "-1",          CVAR_CHEAT,                   0 },
+	{ &demo_autotimescaleweapons,             "demo_autotimescaleweapons",             "0",           CVAR_ARCHIVE,                 0 },
+	{ &demo_autotimescale,                    "demo_autotimescale",                    "1",           CVAR_ARCHIVE,                 0 },
+	{ &demo_teamonlymissilecam,               "demo_teamonlymissilecam",               "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_predefineddemokeys,                 "cg_predefineddemokeys",                 "1",           CVAR_CHEAT | CVAR_ARCHIVE,    0 },
 #endif
 
 #ifdef FEATURE_MULTIVIEW
-	{ &mv_sensitivity,              "mv_sensitivity",              "20",          CVAR_ARCHIVE,                 0 },
+	{ &mv_sensitivity,                        "mv_sensitivity",                        "20",          CVAR_ARCHIVE,                 0 },
 #endif
 
 	// Engine mappings
 
-	{ &int_cl_maxpackets,           "cl_maxpackets",               "125",         CVAR_ARCHIVE,                 0 },
-	{ &int_cl_timenudge,            "cl_timenudge",                "0",           CVAR_ARCHIVE,                 0 },
-	{ &int_m_pitch,                 "m_pitch",                     "0.022",       CVAR_ARCHIVE,                 0 },
-	{ &int_sensitivity,             "sensitivity",                 "5",           CVAR_ARCHIVE,                 0 },
-	{ &int_ui_blackout,             "ui_blackout",                 "0",           CVAR_ROM,                     0 },
+	{ &int_cl_maxpackets,                     "cl_maxpackets",                         "125",         CVAR_ARCHIVE,                 0 },
+	{ &int_cl_timenudge,                      "cl_timenudge",                          "0",           CVAR_ARCHIVE,                 0 },
+	{ &int_m_pitch,                           "m_pitch",                               "0.022",       CVAR_ARCHIVE,                 0 },
+	{ &int_sensitivity,                       "sensitivity",                           "5",           CVAR_ARCHIVE,                 0 },
+	{ &int_ui_blackout,                       "ui_blackout",                           "0",           CVAR_ROM,                     0 },
 
-	{ &cg_atmosphericEffects,       "cg_atmosphericEffects",       "1",           CVAR_ARCHIVE,                 0 },
-	{ &authLevel,                   "authLevel",                   "0",           CVAR_TEMP | CVAR_ROM,         0 },
+	{ &cg_atmosphericEffects,                 "cg_atmosphericEffects",                 "1",           CVAR_ARCHIVE,                 0 },
+	{ &authLevel,                             "authLevel",                             "0",           CVAR_TEMP | CVAR_ROM,         0 },
 
-	{ &cg_rconPassword,             "auth_rconPassword",           "",            CVAR_TEMP,                    0 },
-	{ &cg_refereePassword,          "auth_refereePassword",        "",            CVAR_TEMP,                    0 },
+	{ &cg_rconPassword,                       "auth_rconPassword",                     "",            CVAR_TEMP,                    0 },
+	{ &cg_refereePassword,                    "auth_refereePassword",                  "",            CVAR_TEMP,                    0 },
 
-	{ &cg_instanttapout,            "cg_instanttapout",            "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_debugSkills,              "cg_debugSkills",              "0",           0,                            0 },
-	{ NULL,                         "cg_etVersion",                "",            CVAR_USERINFO | CVAR_ROM,     0 },
+	{ &cg_instanttapout,                      "cg_instanttapout",                      "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_debugSkills,                        "cg_debugSkills",                        "0",           0,                            0 },
+	{ NULL,                                   "cg_etVersion",                          "",            CVAR_USERINFO | CVAR_ROM,     0 },
 #if 0
-	{ NULL,                         "cg_legacyVersion",            "",            CVAR_USERINFO | CVAR_ROM,     0 },
+	{ NULL,                                   "cg_legacyVersion",                      "",            CVAR_USERINFO | CVAR_ROM,     0 },
 #endif
 	// demo recording cvars
-	{ &cl_demorecording,            "cl_demorecording",            "0",           CVAR_ROM,                     0 },
-	{ &cl_demofilename,             "cl_demofilename",             "",            CVAR_ROM,                     0 },
-	{ &cl_demooffset,               "cl_demooffset",               "0",           CVAR_ROM,                     0 },
+	{ &cl_demorecording,                      "cl_demorecording",                      "0",           CVAR_ROM,                     0 },
+	{ &cl_demofilename,                       "cl_demofilename",                       "",            CVAR_ROM,                     0 },
+	{ &cl_demooffset,                         "cl_demooffset",                         "0",           CVAR_ROM,                     0 },
 	// wav recording cvars
-	{ &cl_waverecording,            "cl_waverecording",            "0",           CVAR_ROM,                     0 },
-	{ &cl_wavefilename,             "cl_wavefilename",             "",            CVAR_ROM,                     0 },
-	{ &cl_waveoffset,               "cl_waveoffset",               "0",           CVAR_ROM,                     0 },
+	{ &cl_waverecording,                      "cl_waverecording",                      "0",           CVAR_ROM,                     0 },
+	{ &cl_wavefilename,                       "cl_wavefilename",                       "",            CVAR_ROM,                     0 },
+	{ &cl_waveoffset,                         "cl_waveoffset",                         "0",           CVAR_ROM,                     0 },
 
-	{ &cg_announcer,                "cg_announcer",                "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_hitSounds,                "cg_hitSounds",                "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_locations,                "cg_locations",                "3",           CVAR_ARCHIVE,                 0 },
-	{ &cg_locationMaxChars,         "cg_locationMaxChars",         "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_announcer,                          "cg_announcer",                          "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_hitSounds,                          "cg_hitSounds",                          "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_locations,                          "cg_locations",                          "3",           CVAR_ARCHIVE,                 0 },
+	{ &cg_locationMaxChars,                   "cg_locationMaxChars",                   "0",           CVAR_ARCHIVE,                 0 },
 
-	{ &cg_spawnTimer_set,           "cg_spawnTimer_set",           "-1",          CVAR_TEMP,                    0 },
+	{ &cg_spawnTimer_set,                     "cg_spawnTimer_set",                     "-1",          CVAR_TEMP,                    0 },
 
-	{ &cg_spawnTimer_period,        "cg_spawnTimer_period",        "0",           CVAR_TEMP,                    0 },
+	{ &cg_spawnTimer_period,                  "cg_spawnTimer_period",                  "0",           CVAR_TEMP,                    0 },
 
-	{ &cg_logFile,                  "cg_logFile",                  "",            CVAR_ARCHIVE,                 0 }, // we don't log the chats per default
+	{ &cg_logFile,                            "cg_logFile",                            "",            CVAR_ARCHIVE,                 0 },           // we don't log the chats per default
 
-	{ &cg_countryflags,             "cg_countryflags",             "1",           CVAR_ARCHIVE,                 0 }, // GeoIP
-	{ &cg_altHud,                   "cg_altHud",                   "0",           CVAR_ARCHIVE,                 0 }, // Hudstyles
-	{ &cg_shoutcasterHud,           "cg_shoutcasterHud",           "Shoutcaster", CVAR_ARCHIVE,                 0 },
-	{ &cg_tracers,                  "cg_tracers",                  "1",           CVAR_ARCHIVE,                 0 }, // Draw tracers
-	{ &cg_fireteamNameMaxChars,     "cg_fireteamNameMaxChars",     "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_fireteamNameAlign,        "cg_fireteamNameAlign",        "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_fireteamSprites,          "cg_fireteamSprites",          "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_countryflags,                       "cg_countryflags",                       "1",           CVAR_ARCHIVE,                 0 },           // GeoIP
+	{ &cg_altHud,                             "cg_altHud",                             "0",           CVAR_ARCHIVE,                 0 },           // Hudstyles
+	{ &cg_shoutcasterHud,                     "cg_shoutcasterHud",                     "Shoutcaster", CVAR_ARCHIVE,                 0 },
+	{ &cg_tracers,                            "cg_tracers",                            "1",           CVAR_ARCHIVE,                 0 },           // Draw tracers
+	{ &cg_fireteamNameMaxChars,               "cg_fireteamNameMaxChars",               "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_fireteamNameAlign,                  "cg_fireteamNameAlign",                  "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_fireteamSprites,                    "cg_fireteamSprites",                    "1",           CVAR_ARCHIVE,                 0 },
 
-	{ &cg_simpleItems,              "cg_simpleItems",              "0",           CVAR_ARCHIVE,                 0 }, // Bugged atm
-	{ &cg_simpleItemsScale,         "cg_simpleItemsScale",         "1.0",         CVAR_ARCHIVE,                 0 },
-	{ &cg_automapZoom,              "cg_automapZoom",              "5.159",       CVAR_ARCHIVE,                 0 },
-	{ &cg_autoCmd,                  "cg_autoCmd",                  "",            CVAR_TEMP,                    0 },
-	{ &cg_popupFadeTime,            "cg_popupFadeTime",            "2500",        CVAR_ARCHIVE,                 0 },
-	{ &cg_popupStayTime,            "cg_popupStayTime",            "2000",        CVAR_ARCHIVE,                 0 },
-	{ &cg_popupTime,                "cg_popupTime",                "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_popupXPGainFadeTime,      "cg_popupXPGainFadeTime",      "250",         CVAR_ARCHIVE,                 0 },
-	{ &cg_popupXPGainStayTime,      "cg_popupXPGainStayTime",      "1000",        CVAR_ARCHIVE,                 0 },
-	{ &cg_popupXPGainTime,          "cg_popupXPGainTime",          "200",         CVAR_ARCHIVE,                 0 },
-	{ &cg_weapaltReloads,           "cg_weapaltReloads",           "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_weapaltSwitches,          "cg_weapaltSwitches",          "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_weapaltMgAutoProne,       "cg_weapaltMgAutoProne",       "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_sharetimerText,           "cg_sharetimerText",           "",            CVAR_ARCHIVE,                 0 },
+	{ &cg_simpleItems,                        "cg_simpleItems",                        "0",           CVAR_ARCHIVE,                 0 },           // Bugged atm
+	{ &cg_simpleItemsScale,                   "cg_simpleItemsScale",                   "1.0",         CVAR_ARCHIVE,                 0 },
+	{ &cg_automapZoom,                        "cg_automapZoom",                        "5.159",       CVAR_ARCHIVE,                 0 },
+	{ &cg_autoCmd,                            "cg_autoCmd",                            "",            CVAR_TEMP,                    0 },
+	{ &cg_popupFadeTime,                      "cg_popupFadeTime",                      "2500",        CVAR_ARCHIVE,                 0 },
+	{ &cg_popupStayTime,                      "cg_popupStayTime",                      "2000",        CVAR_ARCHIVE,                 0 },
+	{ &cg_popupTime,                          "cg_popupTime",                          "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_popupXPGainFadeTime,                "cg_popupXPGainFadeTime",                "250",         CVAR_ARCHIVE,                 0 },
+	{ &cg_popupXPGainStayTime,                "cg_popupXPGainStayTime",                "1000",        CVAR_ARCHIVE,                 0 },
+	{ &cg_popupXPGainTime,                    "cg_popupXPGainTime",                    "200",         CVAR_ARCHIVE,                 0 },
+	{ &cg_weapaltReloads,                     "cg_weapaltReloads",                     "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_weapaltSwitches,                    "cg_weapaltSwitches",                    "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_weapaltMgAutoProne,                 "cg_weapaltMgAutoProne",                 "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_sharetimerText,                     "cg_sharetimerText",                     "",            CVAR_ARCHIVE,                 0 },
 
 	// Fonts
-	{ &cg_fontScaleSP,              "cg_fontScaleSP",              "0.22",        CVAR_ARCHIVE,                 0 }, // SidePrint
+	{ &cg_fontScaleSP,                        "cg_fontScaleSP",                        "0.22",        CVAR_ARCHIVE,                 0 },           // SidePrint
 
-	{ &cg_optimizePrediction,       "cg_optimizePrediction",       "1",           CVAR_ARCHIVE,                 0 }, // unlagged optimized prediction
+	{ &cg_optimizePrediction,                 "cg_optimizePrediction",                 "1",           CVAR_ARCHIVE,                 0 },           // unlagged optimized prediction
 
 #if defined(FEATURE_RATING) || defined(FEATURE_PRESTIGE)
-	{ &cg_scoreboard,               "cg_scoreboard",               "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_scoreboard,                         "cg_scoreboard",                         "0",           CVAR_ARCHIVE,                 0 },
 #endif
 
-	{ &cg_quickchat,                "cg_quickchat",                "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_quickchat,                          "cg_quickchat",                          "0",           CVAR_ARCHIVE,                 0 },
 
-	{ &cg_drawUnit,                 "cg_drawUnit",                 "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_drawUnit,                           "cg_drawUnit",                           "0",           CVAR_ARCHIVE,                 0 },
 
-	{ &cg_visualEffects,            "cg_visualEffects",            "1",           CVAR_ARCHIVE,                 0 }, // (e.g. : smoke, debris, ...)
-	{ &cg_bannerTime,               "cg_bannerTime",               "10000",       CVAR_ARCHIVE,                 0 },
+	{ &cg_visualEffects,                      "cg_visualEffects",                      "1",           CVAR_ARCHIVE,                 0 },           // (e.g. : smoke, debris, ...)
+	{ &cg_bannerTime,                         "cg_bannerTime",                         "10000",       CVAR_ARCHIVE,                 0 },
 
-	{ &cg_shoutcastTeamNameRed,     "cg_shoutcastTeamNameRed",     "Axis",        CVAR_ARCHIVE,                 0 },
-	{ &cg_shoutcastTeamNameBlue,    "cg_shoutcastTeamNameBlue",    "Allies",      CVAR_ARCHIVE,                 0 },
-	{ &cg_shoutcastDrawHealth,      "cg_shoutcastDrawHealth",      "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_shoutcastGrenadeTrail,    "cg_shoutcastGrenadeTrail",    "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_shoutcastTeamNameRed,               "cg_shoutcastTeamNameRed",               "Axis",        CVAR_ARCHIVE,                 0 },
+	{ &cg_shoutcastTeamNameBlue,              "cg_shoutcastTeamNameBlue",              "Allies",      CVAR_ARCHIVE,                 0 },
+	{ &cg_shoutcastDrawHealth,                "cg_shoutcastDrawHealth",                "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_shoutcastGrenadeTrail,              "cg_shoutcastGrenadeTrail",              "0",           CVAR_ARCHIVE,                 0 },
 
-	{ &cg_activateLean,             "cg_activateLean",             "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_activateLean,                       "cg_activateLean",                       "0",           CVAR_ARCHIVE,                 0 },
 
-	{ &cg_drawBreathPuffs,          "cg_drawBreathPuffs",          "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_drawAirstrikePlanes,      "cg_drawAirstrikePlanes",      "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_drawBreathPuffs,                    "cg_drawBreathPuffs",                    "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_drawAirstrikePlanes,                "cg_drawAirstrikePlanes",                "1",           CVAR_ARCHIVE,                 0 },
 
-	{ &cg_drawSpawnpoints,          "cg_drawSpawnpoints",          "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_drawSpawnpoints,                    "cg_drawSpawnpoints",                    "0",           CVAR_ARCHIVE,                 0 },
 
-	{ &cg_useCvarCrosshair,         "cg_useCvarCrosshair",         "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_crosshairSVG,             "cg_crosshairSVG",             "0",           CVAR_ARCHIVE | CVAR_LATCH,    0 },
-	{ &cg_crosshairSize,            "cg_crosshairSize",            "48",          CVAR_ARCHIVE,                 0 },
-	{ &cg_crosshairAlpha,           "cg_crosshairAlpha",           "1.0",         CVAR_ARCHIVE,                 0 },
-	{ &cg_crosshairColor,           "cg_crosshairColor",           "White",       CVAR_ARCHIVE,                 0 },
-	{ &cg_crosshairAlphaAlt,        "cg_crosshairAlphaAlt",        "1.0",         CVAR_ARCHIVE,                 0 },
-	{ &cg_crosshairColorAlt,        "cg_crosshairColorAlt",        "White",       CVAR_ARCHIVE,                 0 },
-	{ &cg_crosshairPulse,           "cg_crosshairPulse",           "1",           CVAR_ARCHIVE,                 0 },
-	{ &cg_crosshairHealth,          "cg_crosshairHealth",          "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_crosshairX,               "cg_crosshairX",               "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_crosshairY,               "cg_crosshairY",               "0",           CVAR_ARCHIVE,                 0 },
-	{ &cg_crosshairScaleX,          "cg_crosshairScaleX",          "1.0",         CVAR_ARCHIVE,                 0 },
-	{ &cg_crosshairScaleY,          "cg_crosshairScaleY",          "1.0",         CVAR_ARCHIVE,                 0 },
+	{ &cg_useCvarCrosshair,                   "cg_useCvarCrosshair",                   "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_crosshairSVG,                       "cg_crosshairSVG",                       "0",           CVAR_ARCHIVE | CVAR_LATCH,    0 },
+	{ &cg_crosshairSize,                      "cg_crosshairSize",                      "48",          CVAR_ARCHIVE,                 0 },
+	{ &cg_crosshairAlpha,                     "cg_crosshairAlpha",                     "1.0",         CVAR_ARCHIVE,                 0 },
+	{ &cg_crosshairColor,                     "cg_crosshairColor",                     "White",       CVAR_ARCHIVE,                 0 },
+	{ &cg_crosshairAlphaAlt,                  "cg_crosshairAlphaAlt",                  "1.0",         CVAR_ARCHIVE,                 0 },
+	{ &cg_crosshairColorAlt,                  "cg_crosshairColorAlt",                  "White",       CVAR_ARCHIVE,                 0 },
+	{ &cg_crosshairPulse,                     "cg_crosshairPulse",                     "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_crosshairHealth,                    "cg_crosshairHealth",                    "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_crosshairX,                         "cg_crosshairX",                         "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_crosshairY,                         "cg_crosshairY",                         "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_crosshairScaleX,                    "cg_crosshairScaleX",                    "1.0",         CVAR_ARCHIVE,                 0 },
+	{ &cg_crosshairScaleY,                    "cg_crosshairScaleY",                    "1.0",         CVAR_ARCHIVE,                 0 },
 
-	{ &cg_commandMapTime,           "cg_commandMapTime",           "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_customCrosshair,                    "cg_customCrosshair",                    "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_customCrosshairDotWidth,            "cg_customCrosshairDotWidth",            "2.0",         CVAR_ARCHIVE,                 0 },
+	{ &cg_customCrosshairDotColor,            "cg_customCrosshairDotColor",            "#00FF00E6",   CVAR_ARCHIVE,                 0 },
+	{ &cg_customCrosshairDotOutlineRounded,   "cg_customCrosshairDotOutlineRounded",   "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_customCrosshairDotOutlineColor,     "cg_customCrosshairDotOutlineColor",     "#000000E6",   CVAR_ARCHIVE,                 0 },
+	{ &cg_customCrosshairDotOutlineWidth,     "cg_customCrosshairDotOutlineWidth",     "1.0",         CVAR_ARCHIVE,                 0 },
+	{ &cg_customCrosshairCrossWidth,          "cg_customCrosshairCrossWidth",          "2.0",         CVAR_ARCHIVE,                 0 },
+	{ &cg_customCrosshairCrossLength,         "cg_customCrosshairCrossLength",         "8.0",         CVAR_ARCHIVE,                 0 },
+	{ &cg_customCrosshairCrossGap,            "cg_customCrosshairCrossGap",            "2.0",         CVAR_ARCHIVE,                 0 },
+	{ &cg_customCrosshairCrossSpreadDistance, "cg_customCrosshairCrossSpreadDistance", "10.0",        CVAR_ARCHIVE,                 0 },
+	{ &cg_customCrosshairCrossSpreadOTGCoef,  "cg_customCrosshairCrossSpreadOTGCoef",  "2.0",         CVAR_ARCHIVE,                 0 },
+	{ &cg_customCrosshairCrossColor,          "cg_customCrosshairCrossColor",          "#00FF00E6",   CVAR_ARCHIVE,                 0 },
+	{ &cg_customCrosshairCrossOutlineRounded, "cg_customCrosshairCrossOutlineRounded", "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_customCrosshairCrossOutlineColor,   "cg_customCrosshairCrossOutlineColor",   "#000000E6",   CVAR_ARCHIVE,                 0 },
+	{ &cg_customCrosshairCrossOutlineWidth,   "cg_customCrosshairCrossOutlineWidth",   "1.0",         CVAR_ARCHIVE,                 0 },
+
+	{ &cg_commandMapTime,                     "cg_commandMapTime",                     "0",           CVAR_ARCHIVE,                 0 },
 };
 
 static const unsigned int cvarTableSize = sizeof(cvarTable) / sizeof(cvarTable[0]);
 static qboolean           cvarsLoaded   = qfalse;
 void CG_setClientFlags(void);
+
+static qboolean CG_RegisterOrUpdateCvars(cvarTable_t *cv)
+{
+	if (cv->vmCvar == &cg_customCrosshairDotColor)
+	{
+		Q_ParseColor(cg_customCrosshairDotColor.string, cgs.customCrosshairDotColor);
+		return qtrue;
+	}
+	else if (cv->vmCvar == &cg_customCrosshairDotOutlineColor)
+	{
+		Q_ParseColor(cg_customCrosshairDotOutlineColor.string, cgs.customCrosshairDotOutlineColor);
+		return qtrue;
+	}
+	else if (cv->vmCvar == &cg_customCrosshairCrossColor)
+	{
+		Q_ParseColor(cg_customCrosshairCrossColor.string, cgs.customCrosshairCrossColor);
+		return qtrue;
+	}
+	else if (cv->vmCvar == &cg_customCrosshairCrossOutlineColor)
+	{
+		Q_ParseColor(cg_customCrosshairCrossOutlineColor.string, cgs.customCrosshairCrossOutlineColor);
+		return qtrue;
+	}
+	return qfalse;
+}
 
 /**
  * @brief CG_RegisterCvars
@@ -709,7 +766,10 @@ void CG_RegisterCvars(void)
 			}
 			else
 			{
-				cv->modificationCount = cv->vmCvar->modificationCount;
+				if (CG_RegisterOrUpdateCvars(cv))
+				{
+					cv->modificationCount = cv->vmCvar->modificationCount;
+				}
 			}
 		}
 	}
@@ -805,6 +865,10 @@ void CG_UpdateCvars(void)
 					{
 						trap_SendConsoleCommand(va("%s_f %s\n", cv->cvarName, cv->vmCvar->string));
 					}
+				}
+				else
+				{
+					CG_RegisterOrUpdateCvars(cv);
 				}
 			}
 		}


### PR DESCRIPTION
Adds a set of "vectorized", configurable crosshairs, that replace any
previously configured crosshair settings in case `cg_customCrosshair >
0` (default: `0`).

They can be configured via the following CVARs:

```
cg_customCrosshair
	0 - disabled
	1 - dot with small cross
	2 - only dot
	3 - only small cross
	4 - full cross
cg_customCrosshairDotWidth
	Circumference of the center dot.
cg_customCrosshairDotColor
	Color of the center dot (or intersection for full cross).
cg_customCrosshairDotOutlineRounded
	Switch if outline around the center dot should be rounded or not.
cg_customCrosshairDotOutlineColor
	Color of the outline around the center dot.
cg_customCrosshairDotOutlineWidth
	Width of the outline around the center dot.
cg_customCrosshairCrossWidth
	Circumference of the cross.
cg_customCrosshairCrossLength
	Length of the cross.
cg_customCrosshairCrossGap
	Fixed gap between the center dot and the cross.
cg_customCrosshairCrossSpreadDistance
	Distance that is used for 100% spread value.
cg_customCrosshairCrossSpreadOTGCoef
	Coefficient used on 'cg_customCrosshairCrossSpreadDistance' for when a
	player is Off-the-ground (OTG).
cg_customCrosshairCrossColor
	Color of the cross.
cg_customCrosshairCrossOutlineRounded
	Switch if outline around the cross should be rounded or not.
cg_customCrosshairCrossOutlineColor
	Color of the outline of the cross.
cg_customCrosshairCrossOutlineWidth
	Width of the outline around the cross.
```