### PR TITLE
game: Fix tweaked Spectator aim-following

### DIFF
--- a/src/game/g_active.c
+++ b/src/game/g_active.c
@@ -520,16 +520,17 @@ qboolean G_SpectatorAttackFollow(gentity_t *ent)
 	trace_t tr;
 	vec3_t  forward;
 	vec3_t  mins, maxs;
+	vec3_t  start, end;
 
 	static float enlargeMins[3] = { -4.0f, -4.0f, -3.0f };
 	static float enlargeMaxs[3] = { 4.0f, 4.0f, 0.0f };
-
-	vec3_t start, end;
 
 	if (!ent->client)
 	{
 		return qfalse;
 	}
+
+	AngleVectors(ent->client->ps.viewangles, forward, NULL, NULL);
 
 	VectorCopy(ent->client->ps.origin, start);
 	VectorMA(start, MAX_TRACE, forward, end);
@@ -546,7 +547,7 @@ qboolean G_SpectatorAttackFollow(gentity_t *ent)
 		{
 			G_HistoricalTrace(ent, &tr, start,
 			                  NULL, NULL,
-			                  end, ent->s.number, CONTENTS_BODY | CONTENTS_CORPSE);
+			                  end, ent->s.number, CONTENTS_BODY);
 		}
 		else
 		{
@@ -555,7 +556,7 @@ qboolean G_SpectatorAttackFollow(gentity_t *ent)
 
 			G_HistoricalTrace(ent, &tr, start,
 			                  mins, maxs,
-			                  end, ent->s.number, CONTENTS_BODY | CONTENTS_CORPSE);
+			                  end, ent->s.number, CONTENTS_BODY);
 		}
 
 		if ((&g_entities[tr.entityNum])->client != NULL)


### PR DESCRIPTION
Followup to https://github.com/etlegacy/etlegacy/commit/15a79f95a663681947b2f1e141263d49dce5a4b5, as 'forward'
direction was never initialized.

Also skip spectating downed players when holding "+sprint".