### PR TITLE
game: Fix potential SIGSEGV due to unchecked gentity deref

### DIFF
--- a/src/game/g_mover.c
+++ b/src/game/g_mover.c
@@ -1604,7 +1604,9 @@ void Use_BinaryMover(gentity_t *ent, gentity_t *other, gentity_t *activator)
 		isblocked = IsBinaryMoverBlocked(ent, other, activator);
 	}
 
-	BG_AnimScriptEvent(&other->client->ps, other->client->pers.character->animModelInfo, ANIM_ET_ACTIVATE, qfalse);
+	if (other && other->client) {
+		BG_AnimScriptEvent(&other->client->ps, other->client->pers.character->animModelInfo, ANIM_ET_ACTIVATE, qfalse);
+	}
 
 	if (isblocked)
 	{


### PR DESCRIPTION
`other` can possibly be NULL.

Original report ↓

--- Report this to the project - START ---
ERROR: Caught SIGSEGV(11)
VERSION: v2.83.1 (v2.83.1)
BTIME: 2024-11-11T22:04:40 UTC
BACKTRACE:
/home/etl-server-FAtest[0x481fac]
/lib/x86_64-linux-gnu/libc.so.6(+0x43090)[0x7fc5bcb41090] /home/etl-server-FAtest/legacy/qagame.mp.x86_64.so(+0xa93af)[0x7fc5ad3d63af] /home/etl-server-FAtest/legacy/qagame.mp.x86_64.so(+0x4c95d)[0x7fc5ad37995d] /home/etl-server-FAtest/legacy/qagame.mp.x86_64.so(+0x4e6d2)[0x7fc5ad37b6d2] /home/etl-server-FAtest/legacy/qagame.mp.x86_64.so(+0x4ec51)[0x7fc5ad37bc51] /home/etl-server-FAtest/legacy/qagame.mp.x86_64.so(vmMain+0x1c9)[0x7fc5ad3bc389] /home/etl-server-FAtest[0x455a48]
/home/etl-server-FAtest[0x4715ac]
/home/etl-server-FAtest[0x454745]
/home/etl-server-FAtest/legacy/qagame.mp.x86_64.so(_ZN11ETInterface14UpdateBotInputEiRK11ClientInput+0x1a6)[0x7fc5ad430a46] ./legacy/omni-bot/omnibot_et.x86_64.so(_ZN6Client6UpdateEv+0x241)[0x7fc5ac241261] ./legacy/omni-bot/omnibot_et.x86_64.so(_ZN5IGame10UpdateGameEv+0x4b)[0x7fc5ac2a64ab] ./legacy/omni-bot/omnibot_et.x86_64.so(_ZN12IGameManager10UpdateGameEv+0x49)[0x7fc5ac2b0b09] /home/etl-server-FAtest/legacy/qagame.mp.x86_64.so(Bot_Interface_Update+0x276)[0x7fc5ad430476] /home/etl-server-FAtest/legacy/qagame.mp.x86_64.so(vmMain+0x1e0)[0x7fc5ad3bc3a0] /home/etl-server-FAtest[0x455a48]
/home/etl-server-FAtest[0x4782e3]
/home/etl-server-FAtest[0x421d40]
/home/etl-server-FAtest[0x40f4ad]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf3)[0x7fc5bcb22083] /home/etl-server-FAtest[0x40f4ec]
--- Report this to the project -  END  ---