### PR TITLE
game: fix flamethrower damage timestamps

### DIFF
--- a/src/game/g_weapon.c
+++ b/src/game/g_weapon.c
@@ -3868,8 +3868,8 @@ void G_BurnMeGood(gentity_t *self, gentity_t *body, gentity_t *chunk, const qboo
 
 	// add the new damage
 	body->flameQuota         += 5;
-	body->flameQuotaTime      = level.time;
-	body->lastBurnedFrameTime = level.time;
+	body->flameQuotaTime      = level.time - level.time % DEFAULT_SV_FRAMETIME;
+	body->lastBurnedFrameTime = level.time - level.time % DEFAULT_SV_FRAMETIME;
 
 	// fill in our own origin if we have no flamechunk
 	if (chunk != NULL)


### PR DESCRIPTION
Align timestamps to 50ms intervals, so the damage gating in `G_BurnMeGood` works as expected on any `sv_fps` value. Because we already align the flamechunk spawn time to 100ms intervals, the damage timestamps must be aligned as well, otherwise if `level.time` does not perfectly align to 50ms intervals (e.g. at `sv_fps 125`), there can be scenarios where the dps gets effectively halved.

refs #1637 