### PR TITLE
client: fix +strafe framerate dependency

### DIFF
--- a/src/client/cl_input.c
+++ b/src/client/cl_input.c
@@ -954,6 +954,7 @@ void CL_MouseMove(usercmd_t *cmd)
 	float mx, my;
 	float accelSensitivity;
 	float rate;
+	float deltaStrafeSensitivity;
 
 	// allow mouse smoothing
 	if (m_filter->integer)
@@ -989,10 +990,13 @@ void CL_MouseMove(usercmd_t *cmd)
 		return;
 	}
 
+	// normalize '+strafe' sensitivity to 125FPS
+	deltaStrafeSensitivity = 0.008f * (1000.0f / (float)frame_msec);
+
 	// add mouse X/Y movement to cmd
 	if (kb[KB_STRAFE].active)
 	{
-		cmd->rightmove = ClampChar(cmd->rightmove + m_side->value * mx);
+		cmd->rightmove = ClampChar(cmd->rightmove + m_side->value * deltaStrafeSensitivity * mx);
 	}
 	else
 	{
@@ -1005,7 +1009,7 @@ void CL_MouseMove(usercmd_t *cmd)
 	}
 	else
 	{
-		cmd->forwardmove = ClampChar(cmd->forwardmove - m_forward->value * my);
+		cmd->forwardmove = ClampChar(cmd->forwardmove - m_forward->value * deltaStrafeSensitivity * my);
 	}
 }
 


### PR DESCRIPTION
Strafing around using `+strafe` was framerate dependant, and same mouse move with 125FPS would result in half the traveled distance with 250FPS. Normalize all movement to 125FPS, so `m_forward/side` behave the same regardless of framerate.