### PR TITLE
game: Fix potential SIGSEGV involving 'LaunchItem'

### DIFF
--- a/src/game/g_items.c
+++ b/src/game/g_items.c
@@ -788,7 +788,7 @@ void Touch_Item(gentity_t *ent, gentity_t *other, trace_t *trace)
 		te->s.eventParm = ent->s.modelindex;
 		te->r.svFlags  |= SVF_BROADCAST;
 	}
-    
+
 	// fire item targets
 	G_UseTargets(ent, other);
 
@@ -895,11 +895,14 @@ gentity_t *LaunchItem(gitem_t *item, vec3_t origin, vec3_t velocity, int ownerNu
 		dropped->think                          = Team_DroppedFlagThink;
 		dropped->nextthink                      = level.time + 30000;
 
-		if (level.gameManager)
+		if (flag && flag->item)
 		{
-			G_Script_ScriptEvent(level.gameManager, "trigger", flag->item->giPowerUp == PW_REDFLAG ? "allied_object_dropped" : "axis_object_dropped");
+			if (level.gameManager)
+			{
+				G_Script_ScriptEvent(level.gameManager, "trigger", flag->item->giPowerUp == PW_REDFLAG ? "allied_object_dropped" : "axis_object_dropped");
+			}
+			G_Script_ScriptEvent(flag, "trigger", "dropped");
 		}
-		G_Script_ScriptEvent(flag, "trigger", "dropped");
 	}
 	else     // auto-remove after 30 seconds
 	{


### PR DESCRIPTION
There seem to be cases where 'LaunchItem' attempts to throw something NULL.

Fixes the following SIGSEGV we received:

> Thread 1 "etl.x86_64" hit Catchpoint 2 (signal SIGSEGV), LaunchItem (item=0x7fff9dd8ac08 <bg_itemlist+6952>, origin=0x7fffffffd3c4, velocity=0x7fffffffd3ac, ownerNum=11)
>     at home/user/workspace/etlegacy/src/game/g_items.c:916
> 916				G_Script_ScriptEvent(level.gameManager, "trigger", flag->item->giPowerUp == PW_REDFLAG ? "allied_object_dropped" : "axis_object_dropped");
> [GDB] Caught signal SIGSEGV, Segmentation fault!
> #0  LaunchItem (item=0x7fff9dd8ac08 <bg_itemlist+6952>, origin=0x7fffffffd3c4, velocity=0x7fffffffd3ac, ownerNum=11) at home/user/workspace/etlegacy/src/game/g_items.c:916
> #1  0x00007fff9dc5d0a2 in G_DropItems (self=0x7fffa0315500 <g_entities+19008>) at home/user/workspace/etlegacy/src/game/g_cmds.c:1438
> #2  0x00007fff9dc6f4c8 in player_die (self=0x7fffa0315500 <g_entities+19008>, inflictor=0x7fffa0315500 <g_entities+19008>, attacker=0x7fffa0315500 <g_entities+19008>,
>     damage=100000, meansOfDeath=MOD_SUICIDE) at home/user/workspace/etlegacy/src/game/g_combat.c:628
> #3  0x00007fff9dc5c891 in Cmd_Kill_f (ent=0x7fffa0315500 <g_entities+19008>, dwCommand=38, value=1) at home/user/workspace/etlegacy/src/game/g_cmds.c:1283
> #4  0x00007fff9dc695bf in G_commandCheck (ent=0x7fffa0315500 <g_entities+19008>, cmd=0x7fffffffd580 "kill") at home/user/workspace/etlegacy/src/game/g_cmds_ext.c:257
> #5  0x00007fff9dc69202 in ClientCommand (clientNum=11) at home/user/workspace/etlegacy/src/game/g_cmds.c:5302
> #6  0x00007fff9dc8e7c1 in vmMain (command=6, arg0=11, arg1=0, arg2=0, arg3=0, arg4=0, arg5=0, arg6=0) at home/user/workspace/etlegacy/src/game/g_main.c:812
> #7  0x00005555555af401 in VM_CallFunc (vm=0x5555557e2b80 <vmTable>, callNum=6) at home/user/workspace/etlegacy/src/qcommon/vm.c:779
> #8  0x00005555556091cc in SV_ExecuteClientCommand (cl=0x7fffb6a56408, s=0x5555557b4380 <string> "kill", clientOK=qtrue, premaprestart=qfalse)
>     at home/user/workspace/etlegacy/src/server/sv_client.c:2179
> #9  0x000055555560c8bd in SV_DemoReadClientCommand (msg=0x7fffffffdcc0) at home/user/workspace/etlegacy/src/server/sv_demo.c:1416
> #10 0x000055555560d937 in SV_DemoReadFrame () at home/user/workspace/etlegacy/src/server/sv_demo.c:1970
> #11 0x0000555555616769 in SV_Frame_Ext (frameMsec=25) at home/user/workspace/etlegacy/src/server/sv_main.c:1689
> #12 0x00005555556169fe in SV_Frame (msec=30) at home/user/workspace/etlegacy/src/server/sv_main.c:1824
> #13 0x000055555557f94c in Com_Frame () at home/user/workspace/etlegacy/src/qcommon/common.c:3538
> #14 0x000055555561ce82 in Sys_GameLoop () at home/user/workspace/etlegacy/src/sys/sys_main.c:1079
> #15 0x000055555561cf8f in main (argc=26, argv=0x7fffffffe398) at home/user/workspace/etlegacy/src/sys/sys_main.c:1229
> #16 0x00007ffff6d45e08 in ?? () from /usr/lib/libc.so.6
> #17 0x00007ffff6d45ecc in __libc_start_main () from /usr/lib/libc.so.6
> #18 0x0000555555565ae5 in _start ()