### PR TITLE
qcommon: Fix 'Q_ParseColor' not setting Alpha

### DIFF
--- a/src/qcommon/q_shared.c
+++ b/src/qcommon/q_shared.c
@@ -2096,6 +2096,8 @@ int Q_ParseColor(const char *colString, float *outColor)
 		return qfalse;
 	}
 
+	outColor[3] = 1.0f;
+
 	// if there is a hex prefix
 	if (*s == '0' && (*(s + 1) == 'x' || *(s + 1) == 'X'))
 	{


### PR DESCRIPTION
In a bunch of paths, 'Q_ParseColor' never set alpha value.

Fixes https://github.com/etlegacy/etlegacy/issues/2991