### PR TITLE
game: fix 'BG_PlayerTouchesObjective'

### DIFF
--- a/src/game/bg_misc.c
+++ b/src/game/bg_misc.c
@@ -2532,7 +2532,7 @@ qboolean BG_PlayerTouchesObjective(playerState_t *ps, entityState_t *item, int a
 	BG_EvaluateTrajectory(&item->pos, atTime, origin, qfalse, item->effect2Time);
 
 	// we are ignoring ducked differences here
-	return (ps->origin[0] - origin[0] > 36
+	return !(ps->origin[0] - origin[0] > 36
 	        || ps->origin[0] - origin[0] < -36
 	        || ps->origin[1] - origin[1] > 36
 	        || ps->origin[1] - origin[1] < -36


### PR DESCRIPTION
In v2.83, I discovered that in the map `password2`, the objective can pickuped before entering the password.
The current code picks up the objective when it is out of range, which is different from the v2.82.
fixed this.

ref: https://github.com/etlegacy/etlegacy/blob/0a24c70f84cf21940277ddabd736ce83535cb794/src/game/bg_misc.c#L2529