### PR TITLE
Add version info to development builds loading panel

### DIFF
--- a/src/cgame/cg_loadpanel.c
+++ b/src/cgame/cg_loadpanel.c
@@ -341,10 +341,12 @@ void CG_DrawConnectScreen(qboolean interactive, qboolean forcerefresh)
 
 		if (ETLEGACY_VERSION_IS_DEVELOPMENT_BUILD)
 		{
-			CG_Text_Paint_Centred_Ext(x, y, 0.22f, 0.22f, clr3, va("^1%s ^8DEVELOPMENT BUILD", MODNAME), 0, 0, 0, &cgs.media.bg_loadscreenfont1);
+			y = 317;
+			CG_Text_Paint_Centred_Ext(x, y, 0.20f, 0.20f, clr3, va("^8DEVELOPMENT BUILD ^1%s", MODNAME), 0, 0, 0, &cgs.media.bg_loadscreenfont1);
+			CG_Text_Paint_Centred_Ext(x, y + 9, 0.19f, 0.19f, clr3, va("^0%s", ETLEGACY_VERSION), 0, 0, 0, &cgs.media.bg_loadscreenfont1);
 		}
 		else
-		{
+		{			
 			CG_Text_Paint_Centred_Ext(x, y, 0.22f, 0.22f, clr3, va("^1%s ^0%s", MODNAME, ETLEGACY_VERSION), 0, 0, 0, &cgs.media.bg_loadscreenfont1);
 		}
 

--- a/src/cgame/cg_loadpanel.c
+++ b/src/cgame/cg_loadpanel.c
@@ -342,11 +342,11 @@ void CG_DrawConnectScreen(qboolean interactive, qboolean forcerefresh)
 		if (ETLEGACY_VERSION_IS_DEVELOPMENT_BUILD)
 		{
 			y = 317;
-			CG_Text_Paint_Centred_Ext(x, y, 0.20f, 0.20f, clr3, va("^8DEVELOPMENT BUILD ^1%s", MODNAME), 0, 0, 0, &cgs.media.bg_loadscreenfont1);
-			CG_Text_Paint_Centred_Ext(x, y + 9, 0.19f, 0.19f, clr3, va("^0%s", ETLEGACY_VERSION), 0, 0, 0, &cgs.media.bg_loadscreenfont1);
+			CG_Text_Paint_Centred_Ext(x, y, 0.18f, 0.18f, clr3, va("^1%s ^8DEVELOPMENT BUILD", MODNAME), 0, 0, 0, &cgs.media.bg_loadscreenfont1);
+			CG_Text_Paint_Centred_Ext(x, y + 7, 0.16f, 0.16f, clr3, va("^0%s", ETLEGACY_VERSION), 0, 0, 0, &cgs.media.bg_loadscreenfont1);
 		}
 		else
-		{			
+		{
 			CG_Text_Paint_Centred_Ext(x, y, 0.22f, 0.22f, clr3, va("^1%s ^0%s", MODNAME, ETLEGACY_VERSION), 0, 0, 0, &cgs.media.bg_loadscreenfont1);
 		}
 


### PR DESCRIPTION
When the `DEVELOPMENT BUILD` label was added in (#2969), `ETLEGACY_VERSION` was removed due to space constraints.  The version information is extremely useful to have so this commit aims to solve both the need for the development build label as well as having version information on the loading panel.

Positioning of the start of the print was adjusted to account for having two lines versus one, as well as text sizing adjustments to ensure two lines are still readable within the desired area.  Keeping the version on a separate line also ensures space for longer build strings should it be necessary over the current example below rendered by this commit:


![image](https://github.com/user-attachments/assets/607054a2-6e1c-4efc-b332-60760ab91404)


