### PR TITLE
game: restore implicit linking of entities via create

### DIFF
--- a/src/game/g_lua.c
+++ b/src/game/g_lua.c
@@ -1303,9 +1303,10 @@ static void _et_gentity_getweaponstat(lua_State *L, weapon_stat_t *ws)
 
 gentity_t *G_Lua_CreateEntity(char *params)
 {
-	char *token;
-	char *p = params;
-	char key[MAX_TOKEN_CHARS], value[MAX_TOKEN_CHARS];
+	gentity_t *create;
+	char      *token;
+	char      *p = params;
+	char      key[MAX_TOKEN_CHARS], value[MAX_TOKEN_CHARS];
 
 	level.numSpawnVars     = 0;
 	level.numSpawnVarChars = 0;
@@ -1349,7 +1350,15 @@ gentity_t *G_Lua_CreateEntity(char *params)
 		level.numSpawnVars++;
 	}
 
-	return G_SpawnGEntityFromSpawnVars();
+	create = G_SpawnGEntityFromSpawnVars();
+
+	if (!create)
+	{
+		return NULL;
+	}
+
+	trap_LinkEntity(create);
+	return create;
 }
 
 // entnum = _et_G_Lua_CreateEntity( params )

--- a/src/game/g_script_actions.c
+++ b/src/game/g_script_actions.c
@@ -5126,9 +5126,10 @@ qboolean G_ScriptAction_Delete(gentity_t *ent, char *params)
  */
 qboolean G_ScriptAction_Create(gentity_t *ent, char *params)
 {
-	char *token;
-	char *p = params;
-	char key[MAX_TOKEN_CHARS], value[MAX_TOKEN_CHARS];
+	gentity_t *create;
+	char      *token;
+	char      *p = params;
+	char      key[MAX_TOKEN_CHARS], value[MAX_TOKEN_CHARS];
 
 	level.numSpawnVars     = 0;
 	level.numSpawnVarChars = 0;
@@ -5169,6 +5170,13 @@ qboolean G_ScriptAction_Create(gentity_t *ent, char *params)
 		level.numSpawnVars++;
 	}
 
-	G_SpawnGEntityFromSpawnVars();
+	create = G_SpawnGEntityFromSpawnVars();
+
+	// link only if spawned successfully
+	if (create)
+	{
+		trap_LinkEntity(create);
+	}
+
 	return qtrue;
 }


### PR DESCRIPTION
Allows spawning of e.g. `trigger_heal/ammo` without reusing an existing bmodel, which is used in some mapscripts. Realistically this is not the correct way to do this I think, but if it's a bug that users rely on, then it's a feature.

refs #2868 