### PR TITLE
cgame: don't draw cursorhint text without a value

### DIFF
--- a/src/cgame/cg_newDraw.c
+++ b/src/cgame/cg_newDraw.c
@@ -473,7 +473,7 @@ void CG_DrawCursorHintBar(hudComponent_t *comp)
 		return;
 	}
 
-	if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_SPECTATOR)
+	if (!cg.cursorHintValue)
 	{
 		return;
 	}
@@ -521,7 +521,7 @@ void CG_DrawCursorHintText(hudComponent_t *comp)
 		return;
 	}
 
-	if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_SPECTATOR)
+	if (!cg.cursorHintValue)
 	{
 		return;
 	}


### PR DESCRIPTION
Caused e.g. ladders and item pickups to draw 0% as value.

refs 7ea94b97b9d10b16aff9f2488f13392d76319da9