### PR TITLE
client: prevent OOB read in Key_GetBinding

### DIFF
--- a/src/client/cl_keys.c
+++ b/src/client/cl_keys.c
@@ -1019,7 +1019,7 @@ void Key_SetBinding(int keynum, const char *binding)
  */
 char *Key_GetBinding(int keynum)
 {
-	if (keynum == -1)
+	if (keynum < 0 || keynum >= MAX_KEYS)
 	{
 		return "";
 	}


### PR DESCRIPTION
Prevent mod developers from doing something stupid like calling `trap_Key_GetBindingBuf` on a key char event, which would cause out of bounds read.