### PR TITLE
cgame: Reset 'VoiceMedic' Request on Max Health

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -435,7 +435,8 @@ typedef struct centity_s
 	int processedFrame;                 ///< frame we were last added to the scene
 
 	int voiceChatSprite;
-	int voiceChatSpriteTime;
+	int voiceChatSpriteTime;            ///< time when voice chat sprite expires
+	int voiceChatSpriteUninterruptible; ///< voice chat sprite can't be interrupted. e.g. healed up to Max Health on 'VoiceMedic'
 
 	// item highlighting
 	int highlightTime;

--- a/src/cgame/cg_players.c
+++ b/src/cgame/cg_players.c
@@ -2247,6 +2247,31 @@ static void CG_PlayerSprites(centity_t *cent)
 	// show voice chat signal so players know who's talking
 	if (cent->voiceChatSpriteTime > cg.time)
 	{
+		// SPECIAL CASE: Reset 'VoiceMedic' Request when MaxHealth has been reached
+		if ((cent->voiceChatSpriteTime > cg.time)
+		    && (cent->voiceChatSprite == cgs.media.medicIcon))
+		{
+			if (ci->health == CG_GetPlayerMaxHealth(ci->clientNum, ci->cls, ci->team))
+			{
+				if (!cent->voiceChatSpriteUninterruptible)
+				{
+					cent->voiceChatSpriteTime = cg.time;
+				}
+			}
+			else
+			{
+				// if health dips below MaxHealth while
+				// 'voiceChatSpriteUninterruptible' is true - reset it, such that
+				// the sprite will be cleared once we heal back up to MaxHealth
+				// again
+				if (cent->voiceChatSpriteUninterruptible)
+				{
+					cent->voiceChatSpriteUninterruptible = qfalse;
+				}
+
+			}
+		}
+
 		if (sameTeam)
 		{
 			CG_PlayerFloatSprite(cent, cent->voiceChatSprite, height, numIcons++, NULL);

--- a/src/cgame/cg_players.c
+++ b/src/cgame/cg_players.c
@@ -3034,7 +3034,7 @@ void CG_Player(centity_t *cent)
 	{
 		int damagedState = -1;
 		// show blooded face for teammates depending on their health
-		if (ci->team == cg.predictedPlayerState.teamNum)
+		if (ci->team == cg.predictedPlayerState.teamNum || cent->currentState.powerups & (1 << PW_OPS_DISGUISED))
 		{
 			if (cent->currentState.eFlags & EF_DEAD)
 			{

--- a/src/cgame/cg_servercmds.c
+++ b/src/cgame/cg_servercmds.c
@@ -1792,31 +1792,36 @@ void CG_PlayVoiceChat(bufferedVoiceChat_t *vchat)
 	// don't show icons for the HQ (clientnum -1)
 	if (vchat->clientNum != -1)
 	{
-		// Show icon above head
+		centity_t    *cent;
+		clientInfo_t *ci;
+
 		if (vchat->clientNum == cg.snap->ps.clientNum)
 		{
-			cg.predictedPlayerEntity.voiceChatSprite = vchat->sprite;
-			if (vchat->sprite == cgs.media.medicIcon || vchat->sprite == cgs.media.ammoIcon)
-			{
-				cg.predictedPlayerEntity.voiceChatSpriteTime = cg.time + cg_voiceSpriteTime.integer * 2;
-			}
-			else
-			{
-				cg.predictedPlayerEntity.voiceChatSpriteTime = cg.time + cg_voiceSpriteTime.integer;
-			}
+			cent = &cg.predictedPlayerEntity;
 		}
 		else
 		{
-			cg_entities[vchat->clientNum].voiceChatSprite = vchat->sprite;
-			VectorCopy(vchat->origin, cg_entities[vchat->clientNum].lerpOrigin);
-			if (vchat->sprite == cgs.media.medicIcon || vchat->sprite == cgs.media.ammoIcon)
+			cent = &cg_entities[vchat->clientNum];
+		}
+		ci = &cgs.clientinfo[cent->currentState.clientNum];
+
+		// Show icon above head
+		cent->voiceChatSpriteUninterruptible = qfalse;
+		cent->voiceChatSprite                = vchat->sprite;
+		if (vchat->sprite == cgs.media.medicIcon || vchat->sprite == cgs.media.ammoIcon)
+		{
+			if (
+				vchat->sprite == cgs.media.medicIcon
+				&& (ci->health == CG_GetPlayerMaxHealth(ci->clientNum, ci->cls, ci->team)))
 			{
-				cg_entities[vchat->clientNum].voiceChatSpriteTime = cg.time + cg_voiceSpriteTime.integer * 2;
+				cent->voiceChatSpriteUninterruptible = qtrue;
 			}
-			else
-			{
-				cg_entities[vchat->clientNum].voiceChatSpriteTime = cg.time + cg_voiceSpriteTime.integer;
-			}
+
+			cent->voiceChatSpriteTime = cg.time + cg_voiceSpriteTime.integer * 2;
+		}
+		else
+		{
+			cent->voiceChatSpriteTime = cg.time + cg_voiceSpriteTime.integer;
 		}
 	}
 

--- a/src/cgame/cg_snapshot.c
+++ b/src/cgame/cg_snapshot.c
@@ -306,6 +306,22 @@ static void CG_TransitionSnapshot(void)
 	BG_PlayerStateToEntityState(&cg.snap->ps, &cg_entities[cg.snap->ps.clientNum].currentState, cg.time, qfalse);
 	cg_entities[cg.snap->ps.clientNum].interpolate = qfalse;
 
+	// Also record 'ps.identifyClientHealth' (health of an alive team member
+	// you have your crosshair over) in 'cgs.clientinfo'.
+	//
+	// This is in addition to the passive health info we regularly get of all
+	// team members (for the Fireteam Window) - however 'identifyClientHealth'
+	// gets updated every snap, while the former gets updated only each second
+	// or somesuch.
+	{
+		int identifyClientNum = cg.snap->ps.identifyClient;
+		if (identifyClientNum != cg.predictedPlayerState.clientNum)
+		{
+			clientInfo_t *ci = &cgs.clientinfo[identifyClientNum];
+			ci->health = cg.snap->ps.identifyClientHealth;
+		}
+	}
+
 	for (i = 0 ; i < cg.snap->numEntities ; i++)
 	{
 		id = cg.snap->entities[i].number;


### PR DESCRIPTION
**DONT `Squash and Merge` THIS PR - BUT `Rebase and Merge` IT INSTEAD**

----

The 'VoiceMedic' Voice Chat Sprite (Need Medic/ Heal Me etc.) now
disappears once a player has been healed back up to Max Health.

If the 'VoiceMedic' Sprite is played when a player already is on Max
Health, the Sprite will remain until either the usual Voice Chat timeout
occurs or when the player dips below Max Health and then gets healed up
to it again.

'CG_PlayVoiceChat' is mildly refactored in order to set
'voiceChatSpriteTime' only once.

Furthermore 'identifyClientHealth' is now also recorded in ClientInfo, 
which improves the responsiveness of 'ci->health' values.