### PR TITLE
client: fix qwfwd proxy compatibility

### DIFF
--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -1648,9 +1648,9 @@ static void CL_CheckForResend(void)
 	break;
 	case CA_CHALLENGING:
 	{
-		qboolean connectingThroghQwfwd = Info_ValueForKey(Cvar_InfoString(CVAR_USERINFO), "prx")[0] != 0;
-		// first get the server information, skip if connecting trhough qwfwd proxy
-		if (cls.challengeState == CA_CHALLENGING_INFO && !connectingThroghQwfwd)
+		qboolean connectingThroughQwfwd = Info_ValueForKey(Cvar_InfoString(CVAR_USERINFO), "prx")[0] != 0;
+		// first get the server information, skip if connecting through qwfwd proxy
+		if (cls.challengeState == CA_CHALLENGING_INFO && !connectingThroughQwfwd)
 		{
 			Com_sprintf(buffer, sizeof(buffer), "getinfo %i", clc.challenge);
 			NET_OutOfBandPrint(NS_CLIENT, &clc.serverAddress, buffer);

--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -1648,8 +1648,9 @@ static void CL_CheckForResend(void)
 	break;
 	case CA_CHALLENGING:
 	{
-		// first get the server information
-		if (cls.challengeState == CA_CHALLENGING_INFO)
+		qboolean connectingThroghQwfwd = Info_ValueForKey(Cvar_InfoString(CVAR_USERINFO), "prx")[0] != 0;
+		// first get the server information, skip if connecting trhough qwfwd proxy
+		if (cls.challengeState == CA_CHALLENGING_INFO && !connectingThroghQwfwd)
 		{
 			Com_sprintf(buffer, sizeof(buffer), "getinfo %i", clc.challenge);
 			NET_OutOfBandPrint(NS_CLIENT, &clc.serverAddress, buffer);


### PR DESCRIPTION
qwfwd is the recommended proxy for finding lower ping connection to QuakeWorld servers [1]. 
It also supports quake3 like protocol games [2,3] and it works with ET protocol too. This should especially help oceania players who want to play on European servers  ( I know two players who use VPN to get lower ping ).
CNQ3 1.53 engine also provides utility cvar `net_proxy` for this feature [4]. But commit 17ee01f introduced another step that requests `getinfo $(challenge number)`, which qwfwd doesn't relay.

This will just skip that step if "prx" userinfo cvar is set. 
It could be improved that `getinfo` be sent to last address in "prx" chain and do the check then.

I don't know what issue this `getinfo` check actually solves. I'm not sure if this would be some problem. It seems that server can't set "prx" and only user should be able by executing `setu prx ...` explicitly. I suppose if someone would use such feature, would not connect to some unknown servers.

Another problem with this is that it could allow players to evade IP bans, but servers can detect proxy user by checking `*qwfwd` key in userinfo [5].

Example of connecting command:
`setu prx fr.clanrot.org:30000@etlegacy.com:27960; connect de.quake.world:30000` This will route connection via de.quake.world:30000 -> fr.clanrot.org:30000 -> etlegacy.com:27960

https://www.quakeservers.net/quakeworld/servers/t=proxy/ provides list of proxies

To test this you can try the example command above. Which should display `/reconnect ASAP!` message:
 
![shot0000](https://github.com/user-attachments/assets/933c7fc3-6fdd-46cf-8dbb-6e5d67ccf926)
And then just enter `reconnect`:
![shot0001](https://github.com/user-attachments/assets/cc134217-4339-45ef-8221-7c32db9c3745)


Another improvement could be to port `connectbr` command [6] which finds best route based on ping data from qwfwd servers, though that would require ET server to run qwfwd proxy on same address or user would have to pick last proxy in chain himself.

[1] https://www.quakeworld.nu/wiki/QWfwd
[2] https://www.quakeworld.nu/forum/topic/5036/qwfwd-the-proxy-for-q3cpma
[3] https://github.com/QW-Group/qwfwd
[4] https://playmorepromode.com/docs/cnq3-153-changelog
[5] https://github.com/QW-Group/qwfwd/blob/f657ff72d5b8f04a4e277054a5725e96f85999be/src/svc.c#L290
[6] https://ezquake.com/docs/commands.html