### PR TITLE
mod: improve g_inactivity and tvg_inactivity, refs #1366

### DIFF
--- a/src/game/g_active.c
+++ b/src/game/g_active.c
@@ -815,30 +815,40 @@ qboolean ClientInactivityTimer(gclient_t *client)
 		{
 			int secondsLeft = (client->inactivityTime + inactivity - level.time) / 1000;
 
-			// countdown expired..
-			if (secondsLeft <= 0)
+			if (client->inactivitySecondsLeft != secondsLeft)
 			{
-				CPx(client - level.clients, "cp \"^3Moved to spectator for inactivity\n\"");
-			}
-			// display a message at 30 seconds, and countdown at last 10 ..
-			else if (secondsLeft <= 10 || secondsLeft == 30)
-			{
-				CPx(client - level.clients, va("cp \"^1%i ^3seconds until moving to spectator for inactivity\n\"", secondsLeft));
+				client->inactivitySecondsLeft = secondsLeft;
+
+				// countdown expired..
+				if (secondsLeft <= 0)
+				{
+					CPx(client - level.clients, "cp \"^3Moved to spectator for inactivity\n\"");
+				}
+				// display a message at 30 seconds, and countdown at last 10 ..
+				else if (secondsLeft <= 10 || secondsLeft == 30)
+				{
+					CPx(client - level.clients, va("cp \"^1%i ^3seconds until moving to spectator for inactivity\n\"", secondsLeft));
+				}
 			}
 		}
 		else if (doDrop && g_spectatorInactivity.integer && !inTeam)
 		{
 			int secondsLeft = (client->inactivityTime + inactivityspec - level.time) / 1000;
 
-			// countdown expired..
-			if (secondsLeft <= 0)
+			if (client->inactivitySecondsLeft != secondsLeft)
 			{
-				CPx(client - level.clients, "cp \"^3Dropped for inactivity\n\"");
-			}
-			// display a message at 30 seconds, and countdown at last 10 ..
-			else if (secondsLeft <= 10 || secondsLeft == 30)
-			{
-				CPx(client - level.clients, va("cp \"^1%i ^3seconds until inactivity drop\n\"", secondsLeft));
+				client->inactivitySecondsLeft = secondsLeft;
+
+				// countdown expired..
+				if (secondsLeft <= 0)
+				{
+					CPx(client - level.clients, "cp \"^3Dropped for inactivity\n\"");
+				}
+				// display a message at 30 seconds, and countdown at last 10 ..
+				else if (secondsLeft <= 10 || secondsLeft == 30)
+				{
+					CPx(client - level.clients, va("cp \"^1%i ^3seconds until inactivity drop\n\"", secondsLeft));
+				}
 			}
 		}
 	}
@@ -861,6 +871,14 @@ qboolean ClientInactivityTimer(gclient_t *client)
 			trap_DropClient(client - level.clients, "Dropped due to inactivity", 0);
 			return qfalse;
 		}
+	}
+
+	// sending a command to client could possibly lead to reliable command overflow
+	// which leads to client being kicked and it's data wiped, but the rest of the 'client think' and 'pmove' could happen after anyway
+	// which would be undefined behaviour that could be (and possibly is according to reports) leading to server crashes
+	if (client->pers.connected == CON_DISCONNECTED)
+	{
+		return qfalse;
 	}
 
 	// do not kick by default


### PR DESCRIPTION
- Changed from 1 inactivity warning command per user command to 1 per second.
- Previous implementation meant that for example client on 500fps and maxpackets 125 would receive around 500 exact same warning commads per second. 
- Countdown lasts 10 seconds so the sum of all commands would equal to 5000, such ridiculous amount during some network instability between client and server could potentially lead to reliable command buffer overflow.
- Regardless of the change added additional check for potential reliable command buffer overflow when sending the warning. Because if overflow happens client gets kicked but the rest of the ClientThink and pmove could still happend after it, which could lead to even server crashes.

refs #1366