### PR TITLE
cgame: fix potential buffer overflow with dlight stylestrings

### DIFF
--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -1438,7 +1438,7 @@ void CG_SetupDlightstyles(void)
 		cent   = &cg_entities[entnum];
 
 		token = COM_Parse(&str);     // stylestring
-		Q_strncpyz(cent->dl_stylestring, token, strlen(token));
+		Q_strncpyz(cent->dl_stylestring, token, sizeof(cent->dl_stylestring));
 
 		token             = COM_Parse(&str); // offset
 		cent->dl_frame    = Q_atoi(token);


### PR DESCRIPTION
String copy was using input length as the size rather than destination size, so if someone made the stylestring longer than the destination (64 chars in this case), this would overflow.