### PR TITLE
cgame: Fade in 1P weapon when revived

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,7 +1,13 @@
 # Structured changelog, human-readable.
 # Intended for player consumption, in one shape or form.
 
-upcoming: []
+upcoming:
+  - title: Fade in first-person weapon when being revived
+    categ: cgame
+    descr: |
+      When being revived, weapons now fade in from the bottom in a non-linear fashion.
+      Purely visual, does not affect hit detection.
+    optout: 'set `cg_gunReviveFadeIn` to `0` (default: `1`)'
 
 # TODO - add previous version history
 # v82.3.0: []

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,0 +1,7 @@
+# Structured changelog, human-readable.
+# Intended for player consumption, in one shape or form.
+
+upcoming: []
+
+# TODO - add previous version history
+# v82.3.0: []

--- a/etmain/weapons/adrenaline.weap
+++ b/etmain/weapons/adrenaline.weap
@@ -44,6 +44,7 @@ weaponDef
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
 
 		adjustLean 1 1 1
+		reviveLowerHeight 4.3
 
 		//modModel 1		""
 

--- a/etmain/weapons/akimbo_colt.weap
+++ b/etmain/weapons/akimbo_colt.weap
@@ -44,6 +44,7 @@ weaponDef
 		ejectBrassFunc		"MachineGunEjectBrass"				// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
 
 		adjustLean 1 1 1
+		reviveLowerHeight 4.4
 
 		//modModel 1		""
 

--- a/etmain/weapons/akimbo_silenced_colt.weap
+++ b/etmain/weapons/akimbo_silenced_colt.weap
@@ -44,6 +44,7 @@ weaponDef
 		ejectBrassFunc		"MachineGunEjectBrass"				// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
 
 		adjustLean 1 1 1
+		reviveLowerHeight 4.4
 
 		//modModel 1		""
 

--- a/etmain/weapons/ammopack.weap
+++ b/etmain/weapons/ammopack.weap
@@ -44,6 +44,7 @@ weaponDef
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
 
 		adjustLean 1 1 1
+		reviveLowerHeight 3.6
 
 		modModel 0		"models/multiplayer/supplies/ammobox_2"
 

--- a/etmain/weapons/axis_mortar.weap
+++ b/etmain/weapons/axis_mortar.weap
@@ -45,6 +45,7 @@ weaponDef
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
 
 		adjustLean 1 1 1
+		reviveLowerHeight 4.7
 
 		//modModel 1		""
 

--- a/etmain/weapons/axis_mortar_set.weap
+++ b/etmain/weapons/axis_mortar_set.weap
@@ -40,6 +40,7 @@ weaponDef
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
 
 		adjustLean 1 1 1
+		reviveLowerHeight 4.7
 
 		//modModel 1		""
 

--- a/etmain/weapons/bazooka.weap
+++ b/etmain/weapons/bazooka.weap
@@ -44,6 +44,7 @@ weaponDef
 		//ejectBrassFunc		"PanzerFaustEjectBrass"				// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
 
 		adjustLean 1 1 1
+		reviveLowerHeight 4.4
 
 		//modModel 1		""
 

--- a/etmain/weapons/binocs.weap
+++ b/etmain/weapons/binocs.weap
@@ -44,6 +44,7 @@ weaponDef
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
 
 		adjustLean 1 1 1
+		reviveLowerHeight 2.8
 
 		//modModel 1		""
 

--- a/etmain/weapons/browning.weap
+++ b/etmain/weapons/browning.weap
@@ -46,6 +46,7 @@ weaponDef
 
 		fireRecoil 0.3 0.6 0    // kick angle
 		adjustLean 1 1 1
+		reviveLowerHeight 7.2
 
 		modModel 0				"models/weapons2/browning/brown30cal_3rd_bipod.md3"
 

--- a/etmain/weapons/colt.weap
+++ b/etmain/weapons/colt.weap
@@ -44,6 +44,7 @@ weaponDef
 		ejectBrassFunc		"MachineGunEjectBrass"				// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
 
 		adjustLean 1 1 1
+		reviveLowerHeight 4.4
 
 		//modModel 1		""
 

--- a/etmain/weapons/dynamite.weap
+++ b/etmain/weapons/dynamite.weap
@@ -47,6 +47,7 @@ weaponDef
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
 
 		adjustLean 1 1 1
+		reviveLowerHeight 3.5
 
 		//modModel 1		""
 

--- a/etmain/weapons/fg42.weap
+++ b/etmain/weapons/fg42.weap
@@ -46,6 +46,7 @@ weaponDef
 
 		fireRecoil 0.3 0.6 0    // kick angle
 		adjustLean 1 1 1
+		reviveLowerHeight 4.5
 
 		//modModel 1		""
 

--- a/etmain/weapons/flamethrower.weap
+++ b/etmain/weapons/flamethrower.weap
@@ -44,6 +44,7 @@ weaponDef
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
 
 		adjustLean 1 1 2
+		reviveLowerHeight 3.75
 
 		//modModel 1		""
 

--- a/etmain/weapons/gpg40.weap
+++ b/etmain/weapons/gpg40.weap
@@ -55,6 +55,7 @@ weaponDef
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
 
 		adjustLean 1 1 2
+		reviveLowerHeight 6
 
 		modModel 0			"models/multiplayer/kar98/v_kar98_scope.md3"
 		modModel 1			"models/multiplayer/kar98/kar98_att.md3"

--- a/etmain/weapons/grenade.weap
+++ b/etmain/weapons/grenade.weap
@@ -54,6 +54,7 @@ weaponDef
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
 
 		adjustLean 1 1 1
+		reviveLowerHeight 3.5
 
 		//modModel 1		""
 

--- a/etmain/weapons/k43.weap
+++ b/etmain/weapons/k43.weap
@@ -46,6 +46,7 @@ weaponDef // silenced kar98
 
 		fireRecoil 2 1 0    // kick angle
 		adjustLean 1 1 2
+		reviveLowerHeight 6
 
 		modModel 0			"models/multiplayer/kar98/v_kar98_scope2.md3"
 		modModel 1			"models/multiplayer/kar98/v_kar98_silencer.md3"

--- a/etmain/weapons/kar98.weap
+++ b/etmain/weapons/kar98.weap
@@ -46,6 +46,7 @@ weaponDef
 
 		fireRecoil 2 1 0    // kick angle
 		adjustLean 1 1 2
+		reviveLowerHeight 6
 
 		modModel 0			"models/multiplayer/kar98/v_kar98_scope.md3"
 

--- a/etmain/weapons/knife.weap
+++ b/etmain/weapons/knife.weap
@@ -44,6 +44,7 @@ weaponDef
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
 
 		adjustLean 1 1 1
+		reviveLowerHeight 3.9
 
 		impactDurationCoeff 1
 		impactMarkMaxRange  384	// -1 infinite

--- a/etmain/weapons/knife_kbar.weap
+++ b/etmain/weapons/knife_kbar.weap
@@ -44,6 +44,7 @@ weaponDef
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
 
 		adjustLean 1 1 1
+		reviveLowerHeight 3.9
 
 		//modModel 1		""
 

--- a/etmain/weapons/landmine.weap
+++ b/etmain/weapons/landmine.weap
@@ -47,6 +47,7 @@ weaponDef
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
 
 		adjustLean 1 1 1
+		reviveLowerHeight 3.5
 
 		modModel 0			"models/multiplayer/mine_marker/allied_marker.md3"
 		modModel 1			"models/multiplayer/mine_marker/axis_marker.md3"

--- a/etmain/weapons/m1_garand.weap
+++ b/etmain/weapons/m1_garand.weap
@@ -46,6 +46,7 @@ weaponDef
 
 		fireRecoil 2 1 0    // kick angle
 		adjustLean 1 1 2
+		reviveLowerHeight 7.5
 
 		modModel 0			"models/multiplayer/m1_garand/v_m1_garand_scope.md3"
 

--- a/etmain/weapons/m1_garand_s.weap
+++ b/etmain/weapons/m1_garand_s.weap
@@ -46,6 +46,7 @@ weaponDef
 
 		fireRecoil 2 1 0    // kick angle
 		adjustLean 1 1 3
+		reviveLowerHeight 7.5
 
 		modModel 0			"models/multiplayer/m1_garand/v_m1_garand_scope2.md3"
 		modModel 1			"models/multiplayer/m1_garand/v_m1_garand_silencer.md3"

--- a/etmain/weapons/m7.weap
+++ b/etmain/weapons/m7.weap
@@ -55,6 +55,7 @@ weaponDef
 		//ejectBrassFunc	""				// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
 
 		adjustLean 1 1 2
+		reviveLowerHeight 7.5
 
 		modModel 0			"models/multiplayer/m1_garand/v_m1_garand_scope.md3"
 		modModel 1			"models/multiplayer/m1_garand/m1_garand_att.md3"

--- a/etmain/weapons/medpack.weap
+++ b/etmain/weapons/medpack.weap
@@ -44,6 +44,7 @@ weaponDef
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
 
 		adjustLean 1 1 1
+		reviveLowerHeight 3.4
 
 		firstPerson {
 			model			"models/multiplayer/medpack/v_medpack.md3"

--- a/etmain/weapons/mg42.weap
+++ b/etmain/weapons/mg42.weap
@@ -46,6 +46,7 @@ weaponDef
 
 		fireRecoil 0.3 0.6 0    // kick angle
 		adjustLean 1 1 1
+		reviveLowerHeight 8
 
 		modModel 0			"models/multiplayer/mg42/mg42_3rd_bipod.md3"
 

--- a/etmain/weapons/mortar.weap
+++ b/etmain/weapons/mortar.weap
@@ -45,6 +45,7 @@ weaponDef
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
 
 		adjustLean 1 1 1
+		reviveLowerHeight 4.7
 
 		//modModel 1		""
 

--- a/etmain/weapons/mortar_set.weap
+++ b/etmain/weapons/mortar_set.weap
@@ -40,6 +40,7 @@ weaponDef
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
 
 		adjustLean 1 1 1
+		reviveLowerHeight 4.7
 
 		//modModel 1		""
 

--- a/etmain/weapons/mp34.weap
+++ b/etmain/weapons/mp34.weap
@@ -46,6 +46,7 @@ weaponDef
 
 		fireRecoil 0.3 0.6 0    // kick angle
 		adjustLean 1 1 1
+		reviveLowerHeight 5
 
 		//modModel 1		""
 

--- a/etmain/weapons/panzerfaust.weap
+++ b/etmain/weapons/panzerfaust.weap
@@ -44,6 +44,7 @@ weaponDef
 		ejectBrassFunc		"PanzerFaustEjectBrass"				// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
 
 		adjustLean 1 1 1
+		reviveLowerHeight 2.93
 
 		//modModel 1		""
 

--- a/etmain/weapons/pineapple.weap
+++ b/etmain/weapons/pineapple.weap
@@ -54,6 +54,7 @@ weaponDef
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
 
 		adjustLean 1 1 1
+		reviveLowerHeight 2.5
 
 		//modModel 1		""
 

--- a/etmain/weapons/pliers.weap
+++ b/etmain/weapons/pliers.weap
@@ -44,6 +44,7 @@ weaponDef
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
 
 		adjustLean 1 1 1
+		reviveLowerHeight 4.1
 
 		//modModel 1		""
 

--- a/etmain/weapons/satchel.weap
+++ b/etmain/weapons/satchel.weap
@@ -48,6 +48,7 @@ weaponDef
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
 
 		adjustLean 1 1 1
+		reviveLowerHeight 3.6
 
 		//modModel 1		""
 

--- a/etmain/weapons/satchel_det.weap
+++ b/etmain/weapons/satchel_det.weap
@@ -44,6 +44,7 @@ weaponDef
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
 
 		adjustLean 1 1 1
+		reviveLowerHeight 4
 
 		modModel 0			"models/multiplayer/satchel/light.md3"
 		modModel 1			"models/multiplayer/satchel/needle.md3"

--- a/etmain/weapons/silenced_colt.weap
+++ b/etmain/weapons/silenced_colt.weap
@@ -44,6 +44,7 @@ weaponDef
 		ejectBrassFunc		"MachineGunEjectBrass"				// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
 
 		adjustLean 1 1 1
+		reviveLowerHeight 4.4
 
 		//modModel 1		""
 

--- a/etmain/weapons/smokegrenade.weap
+++ b/etmain/weapons/smokegrenade.weap
@@ -54,6 +54,7 @@ weaponDef
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
 
 		adjustLean 1 1 1
+		reviveLowerHeight 2.6
 
 		//modModel 1		""
 

--- a/etmain/weapons/smokemarker.weap
+++ b/etmain/weapons/smokemarker.weap
@@ -56,6 +56,7 @@ weaponDef
 		//modModel 1		""
 
 		adjustLean 1 1 1
+		reviveLowerHeight 2.6
 
 		impactDurationCoeff 3
 		impactMarkMaxRange  -1	// -1 infinite

--- a/etmain/weapons/sten.weap
+++ b/etmain/weapons/sten.weap
@@ -45,6 +45,7 @@ weaponDef
 
 		fireRecoil 0.3 0.6 0    // kick angle
 		adjustLean 1 1 1
+		reviveLowerHeight 4.7
 
 		//modModel 1		""
 

--- a/etmain/weapons/syringe.weap
+++ b/etmain/weapons/syringe.weap
@@ -44,6 +44,7 @@ weaponDef
 		//ejectBrassFunc	""									// supports "MachineGunEjectBrass" and "PanzerFaustEjectBrass"
 
 		adjustLean 1 1 1
+		reviveLowerHeight 3.35
 
 		modModel 0		"models/multiplayer/syringe/100percent"
 		modModel 1		"models/multiplayer/syringe/0percent"

--- a/etmain/weapons/thompson.weap
+++ b/etmain/weapons/thompson.weap
@@ -45,6 +45,7 @@ weaponDef
 
 		fireRecoil 0.3 0.6 0    // kick angle
 		adjustLean 1 1 1
+		reviveLowerHeight 3.8
 
 		//modModel 1		""
 

--- a/src/cgame/cg_event.c
+++ b/src/cgame/cg_event.c
@@ -2948,7 +2948,12 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 	{
 		sfxHandle_t sound;
 		int         reviver = es->clientNum;
-		// int revivee = es->eventParm;
+		int revivee = es->eventParm;
+
+		if (revivee == cg.clientNum) {
+			cg.lastBeingRevivedTime = cg.time;
+		}
+
 		// int invulnEndTime = invulnEndTime;
 
 		if (reviver == cg.clientNum)

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -994,6 +994,7 @@ typedef struct weaponInfo_s
 
 	vec3_t fireRecoil;                  ///< kick angle
 	vec3_t adjustLean;
+	float reviveLowerHeight;
 
 	sfxHandle_t readySound;             ///< an ambient sound the weapon makes when it's /not/ firing
 	sfxHandle_t firingSound;
@@ -1333,6 +1334,7 @@ typedef struct
 	float damageX, damageY, damageValue;
 
 	int grenLastTime;
+	int lastBeingRevivedTime;
 	int lastReviveTime;
 
 	int switchbackWeapon;
@@ -2780,6 +2782,7 @@ extern vmCvar_t cg_bloodPuff;
 extern vmCvar_t cg_brassTime;
 extern vmCvar_t cg_gun_frame;
 extern vmCvar_t cg_gunFovOffset;
+extern vmCvar_t cg_gunReviveFadeIn;
 extern vmCvar_t cg_gun_x;
 extern vmCvar_t cg_gun_y;
 extern vmCvar_t cg_gun_z;

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -159,6 +159,7 @@ vmCvar_t cg_weapBankCollisions;
 vmCvar_t cg_weapSwitchNoAmmoSounds;
 vmCvar_t cg_gun_frame;
 vmCvar_t cg_gunFovOffset;
+vmCvar_t cg_gunReviveFadeIn;
 vmCvar_t cg_gun_x;
 vmCvar_t cg_gun_y;
 vmCvar_t cg_gun_z;
@@ -443,6 +444,7 @@ static cvarTable_t cvarTable[] =
 	{ &cg_brassTime,                          "cg_brassTime",                          "2500",        CVAR_ARCHIVE,                 0 },
 	{ &cg_markTime,                           "cg_markTime",                           "20000",       CVAR_ARCHIVE,                 0 },
 	{ &cg_bloodPuff,                          "cg_bloodPuff",                          "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_gunReviveFadeIn,                    "cg_gunReviveFadeIn",                    "1",           CVAR_ARCHIVE,                 0 },
 	{ &cg_gunFovOffset,                       "cg_gunFovOffset",                       "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_gun_x,                              "cg_gunX",                               "0",           CVAR_TEMP,                    0 },
 	{ &cg_gun_y,                              "cg_gunY",                               "0",           CVAR_TEMP,                    0 },

--- a/src/cgame/cg_weapon_io.c
+++ b/src/cgame/cg_weapon_io.c
@@ -1617,6 +1617,13 @@ static qboolean CG_RW_ParseClient(int handle, weaponInfo_t *weaponInfo)
 				return CG_RW_ParseError(handle, "expected adjustLean as pitch yaw roll");
 			}
 		}
+		else if (!Q_stricmp(token.string, "reviveLowerHeight"))
+		{
+			if (!PC_Float_Parse(handle, &weaponInfo->reviveLowerHeight))
+			{
+				return CG_RW_ParseError(handle, "expected reviveLowerHeight value");
+			}
+		}
 		else if (!Q_stricmp(token.string, "impactDurationCoeff"))
 		{
 			if (!PC_Int_Parse(handle, &weaponInfo->impactDurationCoeff))

--- a/src/cgame/cg_weapons.c
+++ b/src/cgame/cg_weapons.c
@@ -2889,6 +2889,20 @@ void CG_AddViewWeapon(playerState_t *ps)
 		gunoff[1] = cg_gun_y.value;
 		gunoff[2] = cg_gun_z.value;
 
+		// slowly raise gun from the bottom of the viewport when standing
+		// up/being revived
+		if ((cg_gunReviveFadeIn.value) && ((cg.lastBeingRevivedTime + 2000) >= cg.time))
+		{
+			double offset;
+			int    diff = (cg.lastBeingRevivedTime + 2000) - cg.time;
+
+			offset  = ((double)diff / 2000.0f);
+			offset *= (weapon->reviveLowerHeight) ? (weapon->reviveLowerHeight) : 4.5;
+			offset *= offset;
+
+			gunoff[2] -= offset;
+		}
+
 		VectorMA(hand->origin, gunoff[0], cg.refdef_current->viewaxis[0], hand->origin);
 		VectorMA(hand->origin, gunoff[1], cg.refdef_current->viewaxis[1], hand->origin);
 		VectorMA(hand->origin, (gunoff[2] + fovOffset), cg.refdef_current->viewaxis[2], hand->origin);


### PR DESCRIPTION
Slowly fade in 1P weapons when being revived.

Can be disabled via 'cg_gunReviveFadeIn 0' (default 1).

**Preview**: https://www.youtube.com/watch?v=hUF87unz5E0