### PR TITLE
engine: improve time resolution from milliseconds to microseconds

### DIFF
--- a/src/client/cl_input.c
+++ b/src/client/cl_input.c
@@ -35,8 +35,9 @@
 
 #include "client.h"
 
-unsigned frame_msec;
-int      old_com_frameTime;
+double  frame_msec;
+int64_t frame_usec;
+int64_t old_com_frameTimeUS;
 
 /*
 ===============================================================================
@@ -187,11 +188,11 @@ void IN_KeyUp(kbutton_t *b)
 	uptime = Q_atoi(c);
 	if (uptime)
 	{
-		b->msec += uptime - b->downtime;
+		b->usec += uptime - b->downtime;
 	}
 	else
 	{
-		b->msec += frame_msec / 2;
+		b->usec += frame_usec / 2;
 	}
 
 	b->active = qfalse;
@@ -204,33 +205,33 @@ void IN_KeyUp(kbutton_t *b)
  */
 float CL_KeyState(kbutton_t *key)
 {
-	float val;
-	int   msec = key->msec;
+	float   val;
+	int64_t usec = key->usec;
 
-	key->msec = 0;
+	key->usec = 0;
 
 	if (key->active)
 	{
 		// still down
 		if (!key->downtime)
 		{
-			msec = com_frameTime;
+			usec = com_frameTimeUS;
 		}
 		else
 		{
-			msec += com_frameTime - key->downtime;
+			usec += com_frameTimeUS - key->downtime;
 		}
-		key->downtime = com_frameTime;
+		key->downtime = com_frameTimeUS;
 	}
 
 #if 0
-	if (msec)
+	if (usec)
 	{
-		Com_Printf("%i ", msec);
+		Com_Printf("%i ", usec);
 	}
 #endif
 
-	val = (float)msec / frame_msec;
+	val = (float)usec / frame_usec;
 	if (val < 0)
 	{
 		val = 0;
@@ -1171,22 +1172,25 @@ void CL_CreateNewCommands(void)
 		return;
 	}
 
-	frame_msec = com_frameTime - old_com_frameTime;
+	frame_usec = com_frameTimeUS - old_com_frameTimeUS;
+	frame_msec = frame_usec / 1000.0;
 
-	// force at least 1 msec frametime to avoid CL_KeyState returning
-	// bogus values resulting in #IND cl.viewangles[]
-	if (frame_msec < 1)
+	// force at least 1 usec frametime to avoid divide by 0 in CL_KeyState and CL_MouseMove
+	if (frame_usec < 1)
 	{
-		frame_msec = 1;
+		frame_usec = 1;
+		frame_msec = 0.001;
 	}
 
 	// if running less than 5fps, truncate the extra time to prevent
 	// unexpected moves after a hitch
-	if (frame_msec > 200)
+	if (frame_usec > 200000)
 	{
-		frame_msec = 200;
+		frame_usec = 200000;
+		frame_msec = 200.0;
 	}
-	old_com_frameTime = com_frameTime;
+
+	old_com_frameTimeUS = com_frameTimeUS;
 
 	// generate a command for this frame
 	cl.cmdNumber++;

--- a/src/client/cl_input.c
+++ b/src/client/cl_input.c
@@ -135,7 +135,7 @@ void IN_KeyDown(kbutton_t *b)
 
 	// save timestamp for partial frame summing
 	c           = Cmd_Argv(2);
-	b->downtime = Q_atoi(c);
+	b->downtime = strtoll(c, NULL, 10);
 
 	b->active     = qtrue;
 	b->wasPressed = qtrue;
@@ -147,9 +147,9 @@ void IN_KeyDown(kbutton_t *b)
  */
 void IN_KeyUp(kbutton_t *b)
 {
-	int      k;
-	char     *c;
-	unsigned uptime;
+	int     k;
+	char    *c;
+	int64_t uptime;
 
 	c = Cmd_Argv(1);
 	if (c[0])
@@ -185,7 +185,7 @@ void IN_KeyUp(kbutton_t *b)
 
 	// save timestamp for partial frame summing
 	c      = Cmd_Argv(2);
-	uptime = Q_atoi(c);
+	uptime = strtoll(c, NULL, 10);
 	if (uptime)
 	{
 		b->usec += uptime - b->downtime;

--- a/src/client/cl_scrn.c
+++ b/src/client/cl_scrn.c
@@ -340,12 +340,12 @@ void SCR_DebugGraph(float value)
  */
 void SCR_DrawDebugGraph(void)
 {
-	int   a, x, y, w, i, h;
-	float v;
+	int   a, i;
+	float v, x, y, w, h = cl_graphheight->integer;
 
 	// draw the graph
-	w = cls.glconfig.vidWidth;
-	x = 0;
+	w = cls.glconfig.vidWidth < ARRAY_LEN(values) ? cls.glconfig.vidWidth : ARRAY_LEN(values);
+	x = (cls.glconfig.vidWidth / 2) - (w / 2);
 	y = cls.glconfig.vidHeight;
 	re.SetColor(g_color_table[0]);
 	re.DrawStretchPic(x, y - cl_graphheight->integer,

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -601,8 +601,8 @@ void CL_DemoShutdown(void);
 typedef struct
 {
 	int down[2];                ///< key nums holding it down
-	unsigned downtime;          ///< msec timestamp
-	unsigned msec;              ///< msec down this frame if both a down and up happened
+	int64_t downtime;           ///< usec timestamp
+	int64_t usec;               ///< usec down this frame if both a down and up happened
 	qboolean active;            ///< current state
 	qboolean wasPressed;        ///< set when down, not cleared when up
 } kbutton_t;

--- a/src/qcommon/common.c
+++ b/src/qcommon/common.c
@@ -169,10 +169,11 @@ int time_game;
 int time_frontend;          // renderer frontend time
 int time_backend;           // renderer backend time
 
-int com_frameTime;
-int com_frameNumber;
-int com_expectedhunkusage;
-int com_hunkusedvalue;
+int     com_frameTime;
+int64_t com_frameTimeUS;
+int     com_frameNumber;
+int     com_expectedhunkusage;
+int     com_hunkusedvalue;
 
 qboolean com_errorEntered;
 qboolean com_fullyInitialized;
@@ -2285,7 +2286,7 @@ static int eventTail = 0;
  * @param[in] ptrLength
  * @param[in] ptr
  */
-void Com_QueueEvent(int time, sysEventType_t type, int value, int value2, int ptrLength, void *ptr)
+void Com_QueueEvent(int64_t time, sysEventType_t type, int value, int value2, int ptrLength, void *ptr)
 {
 	sysEvent_t *ev = &eventQueue[eventHead & MASK_QUEUED_EVENTS];
 
@@ -2359,7 +2360,7 @@ sysEvent_t Com_GetSystemEvent(void)
 
 	// create an empty event to return
 	Com_Memset(&ev, 0, sizeof(ev));
-	ev.evTime = Sys_Milliseconds();
+	ev.evTime = Sys_Microseconds();
 
 	return ev;
 }
@@ -2514,7 +2515,7 @@ extern qboolean consoleButtonWasPressed;
  * @brief Com_EventLoop
  * @return Last event time
  */
-int Com_EventLoop(void)
+int64_t Com_EventLoop(void)
 {
 	sysEvent_t ev;
 	netadr_t   evFrom;
@@ -2598,6 +2599,15 @@ int Com_EventLoop(void)
  * @return Sys_Milliseconds (finally)
  */
 int Com_Milliseconds(void)
+{
+	return Com_Microseconds() / 1000;
+}
+
+/**
+ * @brief Com_Microseconds
+ * @return Sys_Microseconds
+ */
+int64_t Com_Microseconds(void)
 {
 	sysEvent_t ev;
 
@@ -3075,7 +3085,8 @@ void Com_Init(char *commandLine)
 	// set com_frameTime so that if a map is started on the
 	// command line it will still be able to count on com_frameTime
 	// being random enough for a serverid
-	com_frameTime = Com_Milliseconds();
+	com_frameTimeUS = Com_Microseconds();
+	com_frameTime   = com_frameTimeUS / 1000;
 
 	// add + commands from command line
 	if (!Com_AddStartupCommands())
@@ -3340,22 +3351,22 @@ static void Com_WatchDog(void)
 
 /**
  * @brief Com_TimeVal
- * @param[in] minMsec
+ * @param[in] minUsec
  * @return
  */
-int Com_TimeVal(int minMsec)
+int64_t Com_TimeVal(int64_t minUsec)
 {
-	int timeVal;
+	int64_t timeVal;
 
-	timeVal = Sys_Milliseconds() - com_frameTime;
+	timeVal = Sys_Microseconds() - com_frameTimeUS;
 
-	if (timeVal >= minMsec)
+	if (timeVal >= minUsec)
 	{
 		timeVal = 0;
 	}
 	else
 	{
-		timeVal = minMsec - timeVal;
+		timeVal = minUsec - timeVal;
 	}
 
 	return timeVal;
@@ -3366,14 +3377,14 @@ int Com_TimeVal(int minMsec)
  */
 void Com_Frame(void)
 {
-	int        msec, minMsec = 0;
-	int        timeVal, timeValSV;
-	static int lastTime = 0, bias = 0;
-	int        timeBeforeFirstEvents;
-	int        timeBeforeServer;
-	int        timeBeforeEvents;
-	int        timeBeforeClient;
-	int        timeAfter;
+	int            msec;
+	int64_t        timeVal, timeValSV, minUsec = 0;
+	static int64_t lastTime = 0, lastTimeUS = 0, bias = 0;
+	int            timeBeforeFirstEvents;
+	int            timeBeforeServer;
+	int            timeBeforeEvents;
+	int            timeBeforeClient;
+	int            timeAfter;
 
 	if (setjmp(abortframe))
 	{
@@ -3414,7 +3425,7 @@ void Com_Frame(void)
 	{
 		if (com_dedicated->integer)
 		{
-			minMsec = SV_FrameMsec();
+			minUsec = SV_FrameMsec() * 1000;
 		}
 		else
 		{
@@ -3426,11 +3437,11 @@ void Com_Frame(void)
 			{
 				if (com_maxfpsMinimized->integer < 0)  // default
 				{
-					minMsec = 100; // = 1000/10;
+					minUsec = 100000; // = 1000/10;
 				}
 				else if (com_maxfpsMinimized->integer > 0)
 				{
-					minMsec = 1000 / com_maxfpsMinimized->integer;
+					minUsec = 1000000 / com_maxfpsMinimized->integer;
 				}
 			}
 			else if (
@@ -3441,48 +3452,48 @@ void Com_Frame(void)
 			{
 				if (com_maxfpsUnfocused->integer < 0)  // default
 				{
-					minMsec = 1000 / (com_maxfps->integer / 2);
+					minUsec = 1000000 / (com_maxfps->integer / 2);
 				}
 				else if (com_maxfpsUnfocused->integer > 0)
 				{
-					minMsec = 1000 / com_maxfpsUnfocused->integer;
+					minUsec = 1000000 / com_maxfpsUnfocused->integer;
 				}
 			}
 			else if (com_maxfps->integer < 0)
 			{
-				minMsec = 1;
+				minUsec = 1000;
 			}
 
 			// fallback to com_maxfps
-			if (minMsec == 0)
+			if (minUsec == 0)
 			{
-				minMsec = 1000 / com_maxfps->integer;
+				minUsec = 1000000 / com_maxfps->integer;
 			}
 
-			timeVal = com_frameTime - lastTime;
-			bias   += timeVal - minMsec;
+			timeVal = com_frameTimeUS - lastTimeUS;
+			bias   += timeVal - minUsec;
 
-			if (bias > minMsec)
+			if (bias > minUsec)
 			{
-				bias = minMsec;
+				bias = minUsec;
 			}
 
-			// Adjust minMsec if previous frame took too long to render so
+			// Adjust minUsec if previous frame took too long to render so
 			// that framerate is stable at the requested value.
-			minMsec -= bias;
+			minUsec -= bias;
 		}
 	}
 	else
 	{
-		minMsec = 1;
+		minUsec = 1000;
 	}
 
 	do
 	{
 		if (com_sv_running->integer)
 		{
-			timeValSV = SV_SendQueuedPackets();
-			timeVal   = Com_TimeVal(minMsec);
+			timeValSV = SV_SendQueuedPackets() * 1000;
+			timeVal   = Com_TimeVal(minUsec);
 
 			if (timeValSV < timeVal)
 			{
@@ -3491,26 +3502,28 @@ void Com_Frame(void)
 		}
 		else
 		{
-			timeVal = Com_TimeVal(minMsec);
+			timeVal = Com_TimeVal(minUsec);
 		}
 
-		if (timeVal < 1)
+		if (timeVal < 1000)
 		{
 			NET_Sleep(0);
 		}
 		else
 		{
-			NET_Sleep(timeVal - 1);
+			NET_Sleep(timeVal - 1000);
 		}
 	}
-	while (Com_TimeVal(minMsec));
+	while (Com_TimeVal(minUsec));
 
 #ifndef DEDICATED
 	IN_Frame();
 #endif
 
-	lastTime      = com_frameTime;
-	com_frameTime = Com_EventLoop();
+	lastTimeUS      = com_frameTimeUS;
+	lastTime        = com_frameTime;
+	com_frameTimeUS = Com_EventLoop();
+	com_frameTime   = com_frameTimeUS / 1000;
 
 	msec = com_frameTime - lastTime;
 

--- a/src/qcommon/net_ip.c
+++ b/src/qcommon/net_ip.c
@@ -2167,7 +2167,7 @@ void NET_Sleep(int64_t usec)
 	if (highestfd == INVALID_SOCKET)
 	{
 		// windows ain't happy when select is called without valid FDs
-		SleepEx(usec * 1000, 0);
+		SleepEx(usec / 1000, 0);
 		return;
 	}
 #endif

--- a/src/qcommon/net_ip.c
+++ b/src/qcommon/net_ip.c
@@ -2130,19 +2130,19 @@ void NET_Event(fd_set *fdr)
 }
 
 /**
- * @brief Sleeps msec or until something happens on the network
- * @param[in] msec
+ * @brief Sleeps usec or until something happens on the network
+ * @param[in] usec
  */
-void NET_Sleep(int msec)
+void NET_Sleep(int64_t usec)
 {
 	struct timeval timeout;
 	fd_set         fdset;
 	int            retval;
 	SOCKET         highestfd = INVALID_SOCKET;
 
-	if (msec < 0)
+	if (usec < 0)
 	{
-		msec = 0;
+		usec = 0;
 	}
 
 	FD_ZERO(&fdset);
@@ -2167,13 +2167,13 @@ void NET_Sleep(int msec)
 	if (highestfd == INVALID_SOCKET)
 	{
 		// windows ain't happy when select is called without valid FDs
-		SleepEx(msec, 0);
+		SleepEx(usec * 1000, 0);
 		return;
 	}
 #endif
 
-	timeout.tv_sec  = msec / 1000;
-	timeout.tv_usec = (msec % 1000) * 1000;
+	timeout.tv_sec  = usec / 1000000;
+	timeout.tv_usec = (usec % 1000000);
 	retval          = select(highestfd + 1, &fdset, NULL, NULL, &timeout);
 
 	if (retval == SOCKET_ERROR)

--- a/src/qcommon/qcommon.h
+++ b/src/qcommon/qcommon.h
@@ -233,7 +233,7 @@ const char *NET_AdrToString(const netadr_t *a);
 const char *NET_AdrToStringNoPort(const netadr_t *a);
 int NET_StringToAdr(const char *s, netadr_t *a, netadrtype_t family);
 qboolean NET_GetLoopPacket(netsrc_t sock, netadr_t *net_from, msg_t *net_message);
-void NET_Sleep(int msec);
+void NET_Sleep(int64_t usec);
 
 /**
  * @def MAX_MSGLEN
@@ -1041,6 +1041,7 @@ void QDECL Com_Error(int code, const char *fmt, ...) _attribute((noreturn, forma
 void Com_Quit_f(void) _attribute((noreturn));
 
 int Com_Milliseconds(void);     // will be journaled properly
+int64_t Com_Microseconds(void);
 unsigned int Com_BlockChecksum(const void *buffer, size_t length);
 unsigned int Com_BlockChecksumKey(void *buffer, int length, int key);
 char *Com_MD5FileETCompat(const char *fileName);
@@ -1110,9 +1111,10 @@ extern int time_game;
 extern int time_frontend;
 extern int time_backend;            // renderer backend time
 
-extern int com_frameTime;
-extern int com_expectedhunkusage;
-extern int com_hunkusedvalue;
+extern int     com_frameTime;
+extern int64_t com_frameTimeUS;
+extern int     com_expectedhunkusage;
+extern int     com_hunkusedvalue;
 
 extern qboolean com_errorEntered;
 
@@ -1349,7 +1351,7 @@ typedef enum
  */
 typedef struct
 {
-	int evTime;
+	int64_t evTime;
 	sysEventType_t evType;
 	int evValue, evValue2;
 	int evPtrLength;                ///< bytes of data pointed to by evPtr, for journaling
@@ -1358,8 +1360,8 @@ typedef struct
 
 
 #define MAX_JOYSTICK_AXIS 16
-void Com_QueueEvent(int time, sysEventType_t type, int value, int value2, int ptrLength, void *ptr);
-int Com_EventLoop(void);
+void Com_QueueEvent(int64_t time, sysEventType_t type, int value, int value2, int ptrLength, void *ptr);
+int64_t Com_EventLoop(void);
 sysEvent_t Com_GetSystemEvent(void);
 void Com_RunAndTimeServerPacket(const netadr_t *evFrom, msg_t *buf);
 
@@ -1397,6 +1399,7 @@ void Sys_Print(const char *msg);
 // Sys_Milliseconds should only be used for profiling purposes,
 // any game related timing information should come from event timestamps
 int Sys_Milliseconds(void);
+int64_t Sys_Microseconds(void);
 
 int Sys_PID(void);
 qboolean Sys_WritePIDFile(void);

--- a/src/sdl/sdl_input.c
+++ b/src/sdl/sdl_input.c
@@ -65,7 +65,7 @@ SDL_Window *mainScreen    = NULL;
 // The engine simulates *the period from the last frame's beginning to the current frame's beginning* when it simulates the current frame.
 // It's not simulating "the next 1/60th or 1/125th" of a second. If you give it "now" as input timestamps, your inputs do not occur until the *next* simulated chunk of time.
 // Try it. com_maxfps 1, press "forward", have fun.
-static int lasttime = 0; // if 0, Com_QueueEvent will use the current time. This is for the first frame.
+static int64_t lasttime = 0; // if 0, Com_QueueEvent will use the current time. This is for the first frame.
 
 #ifdef __ANDROID__
 // Margin rectangle structure for the "shoot button" area
@@ -1816,7 +1816,7 @@ void IN_Frame(void)
 	qboolean cinematic = (cls.state == CA_CINEMATIC);
 
 	// Get the timestamp to give the next frame's input events (not the ones we're gathering right now, though)
-	int start = Sys_Milliseconds();
+	int64_t start = Sys_Microseconds();
 
 #ifdef __ANDROID__
 

--- a/src/sys/sys_unix.c
+++ b/src/sys/sys_unix.c
@@ -67,60 +67,60 @@ static char homePath[MAX_OSPATH] = { 0 };
 #ifdef  __ANDROID__
 char *Sys_CdToExtStorage(void)
 {
-    JNIEnv *env = (JNIEnv *) SDL_AndroidGetJNIEnv();
-    jthrowable exception;
-    const char *path;
+	JNIEnv     *env = (JNIEnv *) SDL_AndroidGetJNIEnv();
+	jthrowable exception;
+	const char *path;
 
-    // Get File object for the external storage directory.
-    jclass classEnvironment = (*env)->FindClass(env, "android/os/Environment");
-    if (!classEnvironment)
-    {
-        return NULL;
-    }
-    jmethodID methodIDgetExternalStorageDirectory = (*env)->GetStaticMethodID(env, classEnvironment, "getExternalStorageDirectory", "()Ljava/io/File;"); // public static File getExternalStoragePublicDirectory ()
-    if (!methodIDgetExternalStorageDirectory)
-    {
-        return NULL;
-    }
-    jobject objectFile = (*env)->CallStaticObjectMethod(env, classEnvironment, methodIDgetExternalStorageDirectory);
-    exception = (*env)->ExceptionOccurred(env);
-    if (exception)
-    {
-        (*env)->ExceptionDescribe(env);
-        (*env)->ExceptionClear(env);
-    }
+	// Get File object for the external storage directory.
+	jclass classEnvironment = (*env)->FindClass(env, "android/os/Environment");
+	if (!classEnvironment)
+	{
+		return NULL;
+	}
+	jmethodID methodIDgetExternalStorageDirectory = (*env)->GetStaticMethodID(env, classEnvironment, "getExternalStorageDirectory", "()Ljava/io/File;"); // public static File getExternalStoragePublicDirectory ()
+	if (!methodIDgetExternalStorageDirectory)
+	{
+		return NULL;
+	}
+	jobject objectFile = (*env)->CallStaticObjectMethod(env, classEnvironment, methodIDgetExternalStorageDirectory);
+	exception = (*env)->ExceptionOccurred(env);
+	if (exception)
+	{
+		(*env)->ExceptionDescribe(env);
+		(*env)->ExceptionClear(env);
+	}
 
-    // Call method on File object to retrieve String object.
-    jclass classFile = (*env)->GetObjectClass(env, objectFile);
-    if (!classFile)
-    {
-        return NULL;
-    }
-    jmethodID methodIDgetAbsolutePath = (*env)->GetMethodID(env, classFile, "getAbsolutePath", "()Ljava/lang/String;");
-    if (!methodIDgetAbsolutePath)
-    {
-        return NULL;
-    }
-    jstring stringPath = (*env)->CallObjectMethod(env, objectFile, methodIDgetAbsolutePath);
-    exception = (*env)->ExceptionOccurred(env);
-    if (exception)
-    {
-        (*env)->ExceptionDescribe(env);
-        (*env)->ExceptionClear(env);
-    }
-    // Extract a C string from the String object, and chdir() to it.
-    const char *wpath3 = (*env)->GetStringUTFChars(env, stringPath, NULL);
-    if (chdir(wpath3) != 0)
-    {
-        fprintf(stderr, "Error: Unable to change working directory to %s.\n", wpath3);
-        perror(NULL);
-    }
+	// Call method on File object to retrieve String object.
+	jclass classFile = (*env)->GetObjectClass(env, objectFile);
+	if (!classFile)
+	{
+		return NULL;
+	}
+	jmethodID methodIDgetAbsolutePath = (*env)->GetMethodID(env, classFile, "getAbsolutePath", "()Ljava/lang/String;");
+	if (!methodIDgetAbsolutePath)
+	{
+		return NULL;
+	}
+	jstring stringPath = (*env)->CallObjectMethod(env, objectFile, methodIDgetAbsolutePath);
+	exception = (*env)->ExceptionOccurred(env);
+	if (exception)
+	{
+		(*env)->ExceptionDescribe(env);
+		(*env)->ExceptionClear(env);
+	}
+	// Extract a C string from the String object, and chdir() to it.
+	const char *wpath3 = (*env)->GetStringUTFChars(env, stringPath, NULL);
+	if (chdir(wpath3) != 0)
+	{
+		fprintf(stderr, "Error: Unable to change working directory to %s.\n", wpath3);
+		perror(NULL);
+	}
 
-    path = SDL_strdup(wpath3);
+	path = SDL_strdup(wpath3);
 
-    (*env)->ReleaseStringUTFChars(env, stringPath, wpath3);
+	(*env)->ReleaseStringUTFChars(env, stringPath, wpath3);
 
-    return path;
+	return path;
 }
 #endif
 
@@ -148,8 +148,8 @@ char *Sys_DefaultHomePath(void)
 #ifdef __ANDROID__
 		if (SDL_AndroidGetExternalStorageState())
 		{
-            Q_strncpyz(homePath, Sys_CdToExtStorage(), sizeof(homePath));
-            Q_strcat(homePath, sizeof(homePath), "/Documents/etlegacy");
+			Q_strncpyz(homePath, Sys_CdToExtStorage(), sizeof(homePath));
+			Q_strcat(homePath, sizeof(homePath), "/Documents/etlegacy");
 		}
 		else
 		{
@@ -267,6 +267,15 @@ int Sys_Milliseconds(void)
 	curtime = ((time.tv_sec * 1000) + (time.tv_nsec / 1000000)) - sys_timeBase;
 
 	return curtime;
+}
+
+/**
+ * @brief Sys_Microseconds
+ * @return
+ */
+int64_t Sys_Microseconds(void)
+{
+	return Sys_Milliseconds() * 1000;
 }
 
 /**
@@ -470,10 +479,10 @@ char *Sys_Cwd(void)
 
 	cwd[MAX_OSPATH - 1] = 0;
 #else
-    Q_strncpyz(cwd, SDL_AndroidGetExternalStoragePath(), sizeof(cwd));
-    Q_strcat(cwd, sizeof(homePath), "/etlegacy");
+	Q_strncpyz(cwd, SDL_AndroidGetExternalStoragePath(), sizeof(cwd));
+	Q_strcat(cwd, sizeof(homePath), "/etlegacy");
 #endif
-    return cwd;
+	return cwd;
 }
 
 /*

--- a/src/sys/sys_win32.c
+++ b/src/sys/sys_win32.c
@@ -140,7 +140,27 @@ char *Sys_DefaultHomePath(void)
 	return homePath;
 }
 
-int sys_timeBase;
+static LARGE_INTEGER sys_timeBase, sys_timeNow, sys_timeFrequency;
+
+/**
+ * @brief Sys_Microseconds
+ * @return
+ */
+int64_t Sys_Microseconds(void)
+{
+	static qboolean initialized = qfalse;
+
+	if (!initialized)
+	{
+		QueryPerformanceFrequency(&sys_timeFrequency);
+		QueryPerformanceCounter(&sys_timeBase);
+		initialized = qtrue;
+	}
+
+	QueryPerformanceCounter(&sys_timeNow);
+
+	return ((sys_timeNow.QuadPart - sys_timeBase.QuadPart) * 1000000LL) / sys_timeFrequency.QuadPart;
+}
 
 /**
  * @brief Sys_Milliseconds
@@ -148,18 +168,7 @@ int sys_timeBase;
  */
 int Sys_Milliseconds(void)
 {
-	int             sys_curtime;
-	static qboolean initialized = qfalse;
-
-	if (!initialized)
-	{
-		sys_timeBase = timeGetTime();
-		initialized  = qtrue;
-	}
-
-	sys_curtime = timeGetTime() - sys_timeBase;
-
-	return sys_curtime;
+	return Sys_Microseconds() / 1000;
 }
 
 /**


### PR DESCRIPTION
- meant as a fix for input timestamp, so when frametime drops below 1ms keydown inputs don't start being registered as not pressed ( https://www.youtube.com/watch?v=mIpGvIDW5-8 ). Inputs are "scaled" using time, so this will affect both mouse movement and keypresses. Might not be really noticeable though.
- only windows
- client and server code still uses milliseconds, only input and sleep is using more accurate time
- fix timegraph duplicating and center it, refs #2416