### PR TITLE
cgame: fix incorrect player position at the start of intermission

### DIFF
--- a/src/cgame/cg_limbopanel.c
+++ b/src/cgame/cg_limbopanel.c
@@ -3525,9 +3525,9 @@ void CG_LimboPanel_RenderCounter(panel_button_t *button)
 }
 
 /**
- * @brief CG_LimboPanel_SetWeapons
+ * @brief CG_LimboPanel_SelectLoadout
  */
-void CG_LimboPanel_SetWeapons(void)
+void CG_LimboPanel_SelectLoadout(void)
 {
 	const clientInfo_t *ci = &cgs.clientinfo[cg.clientNum];
 	int                i;
@@ -3609,7 +3609,7 @@ void CG_LimboPanel_Setup(void)
 		}
 	}
 
-	CG_LimboPanel_SetWeapons();
+	CG_LimboPanel_SelectLoadout();
 
 	cgs.ccRequestedObjective = cgs.ccSelectedObjective = CG_LimboPanel_GetMaxObjectives();
 	CG_LimboPanel_RequestObjective();

--- a/src/cgame/cg_limbopanel.c
+++ b/src/cgame/cg_limbopanel.c
@@ -3525,14 +3525,54 @@ void CG_LimboPanel_RenderCounter(panel_button_t *button)
 }
 
 /**
+ * @brief CG_LimboPanel_SetWeapons
+ */
+void CG_LimboPanel_SetWeapons(void)
+{
+	const clientInfo_t *ci = &cgs.clientinfo[cg.clientNum];
+	int                i;
+
+	// if loadout is already set, no need to do anything
+	if (cgs.limboLoadoutSelected)
+	{
+		return;
+	}
+
+	// check selected team before selecting weapon to ensure it is properly set after next map / map restart
+	// and to check if the selected weapon is still valid and linked to the correct team
+	for (i = 0; i < 3; i++)
+	{
+		if (teamOrder[i] == ci->team)
+		{
+			cgs.ccSelectedTeam = i;
+		}
+	}
+
+	if (ci->team != TEAM_SPECTATOR)
+	{
+		cgs.ccSelectedClass = ci->cls;
+	}
+
+	CG_LimboPanel_SetSelectedWeaponNum(PRIMARY_SLOT, (weapon_t)cgs.clientinfo[cg.clientNum].latchedweapon);
+
+	if (!CG_LimboPanel_IsValidSelectedWeapon(PRIMARY_SLOT) || CG_LimboPanel_RealWeaponIsDisabled(cgs.ccSelectedPrimaryWeapon))
+	{
+		CG_LimboPanel_SetDefaultWeapon(PRIMARY_SLOT);
+	}
+
+	if (!CG_LimboPanel_IsValidSelectedWeapon(SECONDARY_SLOT))
+	{
+		CG_LimboPanel_SetDefaultWeapon(SECONDARY_SLOT);
+	}
+}
+
+/**
  * @brief CG_LimboPanel_Setup
  */
 void CG_LimboPanel_Setup(void)
 {
 	panel_button_t *button;
 	panel_button_t **buttons = limboPanelButtons;
-	clientInfo_t   *ci       = &cgs.clientinfo[cg.clientNum];
-	int            i;
 	char           buffer[256];
 
 	cgs.limboLoadoutModified = qfalse;
@@ -3569,35 +3609,7 @@ void CG_LimboPanel_Setup(void)
 		}
 	}
 
-	if (!cgs.limboLoadoutSelected)
-	{
-		// check selected team before selecting weapon to ensure it is properly set after next map / map restart
-		// and to check if the selected weapon is still valid and linked to the correct team
-		for (i = 0; i < 3; i++)
-		{
-			if (teamOrder[i] == ci->team)
-			{
-				cgs.ccSelectedTeam = i;
-			}
-		}
-
-		if (ci->team != TEAM_SPECTATOR)
-		{
-			cgs.ccSelectedClass = ci->cls;
-		}
-
-		CG_LimboPanel_SetSelectedWeaponNum(PRIMARY_SLOT, (weapon_t)cgs.clientinfo[cg.clientNum].latchedweapon);
-
-		if (!CG_LimboPanel_IsValidSelectedWeapon(PRIMARY_SLOT) || CG_LimboPanel_RealWeaponIsDisabled(cgs.ccSelectedPrimaryWeapon))
-		{
-			CG_LimboPanel_SetDefaultWeapon(PRIMARY_SLOT);
-		}
-
-		if (!CG_LimboPanel_IsValidSelectedWeapon(SECONDARY_SLOT))
-		{
-			CG_LimboPanel_SetDefaultWeapon(SECONDARY_SLOT);
-		}
-	}
+	CG_LimboPanel_SetWeapons();
 
 	cgs.ccRequestedObjective = cgs.ccSelectedObjective = CG_LimboPanel_GetMaxObjectives();
 	CG_LimboPanel_RequestObjective();

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -4081,6 +4081,7 @@ qboolean CG_LimboPanel_ClassIsDisabled(team_t selectedTeam, int classIndex);
 qboolean CG_LimboPanel_TeamIsDisabled(team_t checkTeam);
 int CG_LimboPanel_FindFreeClass(team_t checkTeam);
 int CG_LimboPanel_GetWeaponNumberForPos(int pos);
+void CG_LimboPanel_SetWeapons();
 
 /**
  * @struct mapScissor_s

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -4081,7 +4081,7 @@ qboolean CG_LimboPanel_ClassIsDisabled(team_t selectedTeam, int classIndex);
 qboolean CG_LimboPanel_TeamIsDisabled(team_t checkTeam);
 int CG_LimboPanel_FindFreeClass(team_t checkTeam);
 int CG_LimboPanel_GetWeaponNumberForPos(int pos);
-void CG_LimboPanel_SetWeapons();
+void CG_LimboPanel_SelectLoadout();
 
 /**
  * @struct mapScissor_s

--- a/src/cgame/cg_players.c
+++ b/src/cgame/cg_players.c
@@ -346,7 +346,7 @@ void CG_NewClientInfo(int clientNum)
 
 		// Make sure primary class and primary weapons are correct for
 		// subsequent calls to CG_LimboPanel_SendSetupMsg
-		CG_LimboPanel_Setup();
+		CG_LimboPanel_SetWeapons();
 
 		for (i = 0; i < SK_NUM_SKILLS; i++)
 		{

--- a/src/cgame/cg_players.c
+++ b/src/cgame/cg_players.c
@@ -346,7 +346,7 @@ void CG_NewClientInfo(int clientNum)
 
 		// Make sure primary class and primary weapons are correct for
 		// subsequent calls to CG_LimboPanel_SendSetupMsg
-		CG_LimboPanel_SetWeapons();
+		CG_LimboPanel_SelectLoadout();
 
 		for (i = 0; i < SK_NUM_SKILLS; i++)
 		{


### PR DESCRIPTION
Don't run full limbopanel setup when client info is updated, only run the relevant part (weapons), otherwise we get placed to a wrong position when intermission starts and potentially break any intermission scenes involving entities, because they are no longer in our PVS.

This also fixes `getspawnpt` being run immediately when intermission starts, similar to what `obj` did, which prompted the change to allow it during intermission (which broke this whole thing). We probably should allow it to run during intermission though, as limbo panel can be opened during intermission to switch teams, which will trigger the prompt that the command is not allowed during intermission.

Opening the limbo panel during intermission will still predictably break the intermission screen (as it triggers sending `obj -1`, which is what broke this), but fixing that is out of scope for this commit (tracked in https://github.com/etlegacy/etlegacy/issues/3058).

fixes #3055 
refs #2731 
refs #3039 