### PR TITLE
ui: Make Map/Player Callvote Menu taller

### DIFF
--- a/etmain/ui/ingame_vote_map.menu
+++ b/etmain/ui/ingame_vote_map.menu
@@ -5,7 +5,7 @@
 #define WINDOW_X		16
 #define WINDOW_Y		16
 #define WINDOW_WIDTH	252
-#define WINDOW_HEIGHT	180
+#define WINDOW_HEIGHT	350
 #define GROUP_NAME		"grpIngameVoteMap"
 
 // Map Vote Menu //
@@ -40,7 +40,7 @@ menuDef {
 	itemDef {
 		name			"mapList_maps"
 		group			GROUP_NAME
-		rect			6 48 240 102
+		rect			6 48 240 272
 		type			ITEM_TYPE_LISTBOX
 		textfont		UI_FONT_COURBD_21
 		textscale		.2
@@ -60,7 +60,7 @@ menuDef {
 	itemDef {
 		name			"mapList_campaigns"
 		group			GROUP_NAME
-		rect			6 32 240 118
+		rect			6 32 240 288
 		type			ITEM_TYPE_LISTBOX
 		textfont		UI_FONT_COURBD_21
 		textscale		.2

--- a/etmain/ui/ingame_vote_players.menu
+++ b/etmain/ui/ingame_vote_players.menu
@@ -5,7 +5,7 @@
 #define WINDOW_X		16
 #define WINDOW_Y		16
 #define WINDOW_WIDTH	348
-#define WINDOW_HEIGHT	198
+#define WINDOW_HEIGHT	350
 #define GROUP_NAME		"grpIngameVotePlayers"
 
 // Players Vote Menu //
@@ -24,11 +24,11 @@ menuDef {
 // Window //
 	WINDOW( _("PLAYERS"), 68)
 
-// Map Selection //
+// Player Selection //
 	itemDef {
 		name			"playerList"
 		group			GROUP_NAME
-		rect			6 32 196 118
+		rect			6 32 196 290
 		type			ITEM_TYPE_LISTBOX
 		textfont		UI_FONT_COURBD_21
 		textscale		.2


### PR DESCRIPTION
I've seen players scroll a lot, as both lists tend to be larger than the 8 or so items it can hold by default.

The vertical screen space is already there, so let's just use it.