### PR TITLE
cgame: fix excessive demo version prints

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -3592,6 +3592,8 @@ void CG_parseWeaponStats_cmd(void(txt_dump) (const char *));
 void CG_UpdateSvCvars(void);
 void CG_ResetVoiceSprites(qboolean revived);
 
+void CG_ParseDemoVersion(void);
+
 /**
  * @struct consoleCommand_t
  * @brief

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -3196,6 +3196,11 @@ void CG_Init(int serverMessageNum, int serverCommandSequence, int clientNum, qbo
 
 	CG_ParseModInfo();
 
+	if (demoPlayback)
+	{
+		CG_ParseDemoVersion();
+	}
+
 	//CG_Printf("Time taken: %i\n", trap_Milliseconds() - startat);
 
 #ifdef FEATURE_EDV

--- a/src/cgame/cg_servercmds.c
+++ b/src/cgame/cg_servercmds.c
@@ -206,7 +206,7 @@ static void CG_FillVersionInfo(version_t *version, char *versionStr, const char 
 	version->patch = Q_atoi(strtok(NULL, delimiter));
 }
 
-static void CG_ParseDemoVersion(void)
+void CG_ParseDemoVersion(void)
 {
 	const char *serverInfoCS = CG_ConfigString(CS_SERVERINFO);
 	char       *versionStr   = Info_ValueForKey(serverInfoCS, "mod_version");
@@ -289,11 +289,6 @@ void CG_ParseServerinfo(void)
 
 	// make this available for ingame_callvote
 	trap_Cvar_Set("cg_ui_voteFlags", ((authLevel.integer == RL_NONE) ? Info_ValueForKey(info, "voteFlags") : "0"));
-
-	if (cg.demoPlayback)
-	{
-		CG_ParseDemoVersion();
-	}
 }
 
 /**


### PR DESCRIPTION
Instead of printing it every time server info is parsed (which is quite often, especially since demo rewinding calls it), only print it on init when we load the demo.

refs #2632 