### PR TITLE
Increase FPS_RECOIL_FACTOR to 83

### DIFF
--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -3354,7 +3354,7 @@ static qboolean PM_CheckGrenade()
 	return qfalse;
 }
 
-#define FPS_RECOIL_FACTOR 71
+#define FPS_RECOIL_FACTOR 83
 
 /**
  * @brief PM_HandleRecoil


### PR DESCRIPTION
71 is too buffed at the moment together with the increased time window for sprint+scope, so let's increase the recoil a bit to even it out.