### PR TITLE
engine: mark sv_fps cvar as CVAR_SYSTEMINFO, refs #2787, #1637

### DIFF
--- a/src/cgame/cg_servercmds.c
+++ b/src/cgame/cg_servercmds.c
@@ -366,7 +366,7 @@ void CG_ParseSysteminfo(void)
 	if (!cgs.sv_fps)
 	{
 		// no way to know for sure, assume default
-		cgs.sv_fps = 20;
+		cgs.sv_fps = DEFAULT_SV_FPS;
 	}
 
 	cgs.sv_cheats = (atoi(Info_ValueForKey(info, "sv_cheats"))) ? qtrue : qfalse;

--- a/src/client/cl_cgame.c
+++ b/src/client/cl_cgame.c
@@ -209,8 +209,6 @@ qboolean CL_GetSnapshot(int snapshotNumber, snapshot_t *snapshot)
 	return qtrue;
 }
 
-extern cvar_t *sv_fps;
-
 /**
  * @brief CL_InterpolationCheckRange
  */
@@ -224,7 +222,7 @@ static void CL_InterpolationCheckRange(void)
 	}
 
 	snaps      = Cvar_VariableValue("snaps");
-	updateRate = snaps < sv_fps->integer ? 1000 / snaps : 1000 / sv_fps->integer;
+	updateRate = snaps < cl.sv_fps ? 1000 / snaps : 1000 / cl.sv_fps;
 	buffer     = (FRAMETIME / 2) / updateRate - 1;
 
 	if (cl_interpolation->integer > buffer)
@@ -1491,7 +1489,7 @@ void CL_AdjustTimeDelta(void)
 
 				if (com_sv_running->integer)
 				{
-					svFrameTime = 1000 / sv_fps->integer;
+					svFrameTime = 1000 / cl.sv_fps;
 				}
 				else
 				{

--- a/src/client/cl_parse.c
+++ b/src/client/cl_parse.c
@@ -629,6 +629,13 @@ void CL_SystemInfoChanged(void)
 	// NOTE: when the serverId changes, any further messages we send to the server will use this new serverId
 	// in some cases, outdated cp commands might get sent with this news serverId
 	cl.serverId = Q_atoi(Info_ValueForKey(systemInfo, "sv_serverid"));
+	cl.sv_fps   = Q_atoi(Info_ValueForKey(systemInfo, "sv_fps"));
+
+	// fallback to default engine sv_fps
+	if (!cl.sv_fps)
+	{
+		cl.sv_fps = DEFAULT_SV_FPS;
+	}
 
 	Com_Memset(&entLastVisible, 0, sizeof(entLastVisible));
 

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -190,6 +190,8 @@ typedef struct
 	qboolean corruptedTranslationFile;
 	char translationVersion[MAX_STRING_TOKENS];
 
+	int sv_fps;
+
 } clientActive_t;
 
 extern clientActive_t cl;

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -178,9 +178,6 @@ extern vec3_t playerHeadProneMaxs;
 #define SVF_SELF_PORTAL             0x00008000  ///< use self->origin2 as portal
 #define SVF_SELF_PORTAL_EXCLUSIVE   0x00010000  ///< use self->origin2 as portal and DONT add self->origin PVS ents
 
-// default server frametime at sv_fps 20, for framerate independent timings
-#define DEFAULT_SV_FRAMETIME 50
-
 /**
  * @struct svCvar_s
  * @typedef svCvar_t
@@ -657,7 +654,7 @@ typedef struct
 } pmove_t;
 
 // if a full pmove isn't done on the client, you can just update the angles
-void PM_UpdateViewAngles(playerState_t * ps, pmoveExt_t * pmext, usercmd_t * cmd, void(trace) (trace_t *results, const vec3_t start, const vec3_t mins, const vec3_t maxs, const vec3_t end, int passEntityNum, int contentMask), int tracemask);
+void PM_UpdateViewAngles(playerState_t * ps, pmoveExt_t * pmext, usercmd_t * cmd, void(trace) (trace_t * results, const vec3_t start, const vec3_t mins, const vec3_t maxs, const vec3_t end, int passEntityNum, int contentMask), int tracemask);
 int Pmove(pmove_t *pmove);
 void PmovePredict(pmove_t *pmove, float frametime);
 
@@ -769,7 +766,7 @@ typedef enum
 #define EF_MOVER_STOP       0x10000000                         ///< will push otherwise	///< moved down to make space for one more client flag
 #define EF_MOVER_BLOCKED    0x20000000                         ///< mover was blocked dont lerp on the client///< moved down to make space for client flag
 
-#define BG_PlayerMounted(eFlags) ((eFlags & EF_MG42_ACTIVE) || (eFlags & EF_MOUNTEDTANK) || (eFlags & EF_AAGUN_ACTIVE))
+#define BG_PlayerMounted(eFlags) ((eFlags &EF_MG42_ACTIVE) || (eFlags &EF_MOUNTEDTANK) || (eFlags &EF_AAGUN_ACTIVE))
 #define BG_IsSkillAvailable(skill, skillType, requiredlvl) (GetSkillTableData(skillType)->skillLevels[requiredlvl] > -1 && skill[skillType] >= requiredlvl)
 
 /**
@@ -3081,8 +3078,8 @@ typedef enum popupMessageXPGainType_e
 #define HITBOXBIT_LEGS   2048
 #define HITBOXBIT_CLIENT 4096
 
-void PM_TraceLegs(trace_t * trace, float *legsOffset, vec3_t start, vec3_t end, trace_t * bodytrace, vec3_t viewangles, void(tracefunc)(trace_t *results, const vec3_t start, const vec3_t mins, const vec3_t maxs, const vec3_t end, int passEntityNum, int contentMask), int ignoreent, int tracemask);
-void PM_TraceHead(trace_t * trace, vec3_t start, vec3_t end, trace_t * bodytrace, vec3_t viewangles, void(tracefunc)(trace_t *results, const vec3_t start, const vec3_t mins, const vec3_t maxs, const vec3_t end, int passEntityNum, int contentMask), int ignoreent, int tracemask);
+void PM_TraceLegs(trace_t * trace, float *legsOffset, vec3_t start, vec3_t end, trace_t * bodytrace, vec3_t viewangles, void(tracefunc)(trace_t * results, const vec3_t start, const vec3_t mins, const vec3_t maxs, const vec3_t end, int passEntityNum, int contentMask), int ignoreent, int tracemask);
+void PM_TraceHead(trace_t * trace, vec3_t start, vec3_t end, trace_t * bodytrace, vec3_t viewangles, void(tracefunc)(trace_t * results, const vec3_t start, const vec3_t mins, const vec3_t maxs, const vec3_t end, int passEntityNum, int contentMask), int ignoreent, int tracemask);
 void PM_TraceAllParts(trace_t *trace, float *legsOffset, vec3_t start, vec3_t end);
 void PM_TraceAll(trace_t *trace, vec3_t start, vec3_t end);
 

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -392,6 +392,7 @@ cvarTable_t gameCvarTable[] =
 {
 	// don't override the cheat state set by the system
 	{ &g_cheats,                          "sv_cheats",                         "",                           0,                                               0, qfalse, qfalse },
+	{ &sv_fps,                            "sv_fps",                            DEFAULT_SV_FPS_STR,           CVAR_SYSTEMINFO,                                 0, qfalse, qfalse },
 
 	// noset vars
 	{ NULL,                               "gamename",                          MODNAME,                      CVAR_SERVERINFO | CVAR_ROM,                      0, qfalse, qfalse },
@@ -669,7 +670,6 @@ cvarTable_t gameCvarTable[] =
 
 	{ &g_corpses,                         "g_corpses",                         "0",                          CVAR_LATCH | CVAR_ARCHIVE,                       0, qfalse, qfalse },
 	{ &g_realHead,                        "g_realHead",                        "1",                          0,                                               0, qfalse, qfalse },
-	{ &sv_fps,                            "sv_fps",                            "20",                         CVAR_SYSTEMINFO,                                 0, qfalse, qfalse },
 	{ &g_skipCorrection,                  "g_skipCorrection",                  "1",                          0,                                               0, qfalse, qfalse },
 	{ &g_extendedNames,                   "g_extendedNames",                   "1",                          0,                                               0, qfalse, qfalse },
 #ifdef FEATURE_RATING

--- a/src/game/g_mdx.c
+++ b/src/game/g_mdx.c
@@ -1334,7 +1334,7 @@ void mdx_LoadHitsFile(char *animationGroup, animModelInfo_t *animModelInfo)
 	Q_strncpyz(hitsfile, animationGroup, sizeof(hitsfile) - 4);
 	if ((sep = strrchr(hitsfile, '.'))) // FIXME: should abort on /'s
 	{
-		Q_strncpyz(sep, ".hit", sizeof(hitsfile) - (sep - sizeof(hitsfile));
+		Q_strncpyz(sep, ".hit", sizeof(hitsfile) - (sep - sizeof(hitsfile)));
 	}
 	else
 	{
@@ -1877,7 +1877,7 @@ static void mdx_SwingAngles(float destination, float swingTolerance, float clamp
 	// swing towards the destination angle
 	if (swing >= 0)
 	{
-		move = 1000.f / trap_Cvar_VariableIntegerValue("sv_fps") * scale * speed;
+		move = 1000.f / sv_fps.integer * scale * speed;
 		if (move >= swing)
 		{
 			move      = swing;
@@ -1891,7 +1891,7 @@ static void mdx_SwingAngles(float destination, float swingTolerance, float clamp
 	}
 	else if (swing < 0)
 	{
-		move = 1000.f / trap_Cvar_VariableIntegerValue("sv_fps") * scale * -speed;
+		move = 1000.f / sv_fps.integer * scale * -speed;
 		if (move <= swing)
 		{
 			move      = swing;
@@ -2434,7 +2434,8 @@ static void mdx_RunLerpFrame(gentity_t *ent, glerpFrame_t *lf, int newAnimation,
 		if (f >= anim->numFrames)
 		{
 			int loopFrames = anim->loopFrames;
-			if (anim->loopFrames == -1) {
+			if (anim->loopFrames == -1)
+			{
 				loopFrames = anim->numFrames;
 			}
 

--- a/src/qcommon/q_shared.h
+++ b/src/qcommon/q_shared.h
@@ -464,6 +464,12 @@ typedef int clipHandle_t;
 
 #define DEFAULT_NAME "ETLegacyPlayer"
 
+// these should never be changed
+#define DEFAULT_SV_FPS     20
+#define DEFAULT_SV_FPS_STR "20"
+// default server frametime at sv_fps 20, for framerate independent timings
+#define DEFAULT_SV_FRAMETIME 1000 / DEFAULT_SV_FPS
+
 extern char *GlobalGameTitle;
 
 /**

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -952,6 +952,8 @@ typedef struct
 	entityState_t parseEntities[MAX_PARSE_ENTITIES];
 	entityShared_t parseEntitiesShared[MAX_PARSE_ENTITIES];
 
+	int sv_fps;
+
 } svclientActive_t;
 
 extern svclientActive_t svcl;

--- a/src/server/sv_cl_parse.c
+++ b/src/server/sv_cl_parse.c
@@ -101,6 +101,13 @@ void SV_CL_SystemInfoChanged(void)
 	// NOTE: when the serverId changes, any further messages we send to the server will use this new serverId
 	// in some cases, outdated cp commands might get sent with this news serverId
 	svcl.serverId = Q_atoi(Info_ValueForKey(systemInfo, "sv_serverid"));
+	svcl.sv_fps   = Q_atoi(Info_ValueForKey(systemInfo, "sv_fps"));
+
+	// fallback to default engine sv_fps
+	if (!svcl.sv_fps)
+	{
+		svcl.sv_fps = DEFAULT_SV_FPS;
+	}
 
 	// don't set any vars when playing a demo
 	if (svclc.demo.playing)

--- a/src/server/sv_client.c
+++ b/src/server/sv_client.c
@@ -2017,7 +2017,7 @@ void SV_UserinfoChanged(client_t *cl)
 	}
 	else
 	{
-		i = 50; // 1000 / sv_fps->integer
+		i = DEFAULT_SV_FRAMETIME;
 	}
 
 	if (i != cl->snapshotMsec)

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -1094,6 +1094,7 @@ void SV_Init(void)
 	sv_cheats   = Cvar_Get("sv_cheats", "1", CVAR_SYSTEMINFO | CVAR_ROM);
 	sv_serverid = Cvar_Get("sv_serverid", "0", CVAR_SYSTEMINFO | CVAR_ROM);
 	sv_pure     = Cvar_Get("sv_pure", "1", CVAR_SYSTEMINFO);
+	sv_fps      = Cvar_Get("sv_fps", DEFAULT_SV_FPS_STR, CVAR_SYSTEMINFO);
 	Cvar_Get("sv_paks", "", CVAR_SYSTEMINFO | CVAR_ROM);
 	Cvar_Get("sv_pakNames", "", CVAR_SYSTEMINFO | CVAR_ROM);
 	Cvar_Get("sv_referencedPaks", "", CVAR_SYSTEMINFO | CVAR_ROM);
@@ -1145,7 +1146,6 @@ void SV_Init(void)
 	// server vars
 	sv_rconPassword    = Cvar_Get("rconPassword", "", CVAR_TEMP);
 	sv_privatePassword = Cvar_Get("sv_privatePassword", "", CVAR_TEMP);
-	sv_fps             = Cvar_Get("sv_fps", "20", CVAR_TEMP);
 	sv_timeout         = Cvar_Get("sv_timeout", "60", CVAR_TEMP); // used in game (also vid_restart)
 	sv_dl_timeout      = Cvar_Get("sv_dl_timeout", "300", CVAR_TEMP); // in between this time a client should download the biggest custom pk3
 	sv_zombietime      = Cvar_Get("sv_zombietime", "2", CVAR_TEMP);

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -1778,7 +1778,7 @@ void SV_Frame(int msec)
 	// if it isn't time for the next frame, do nothing
 	if (sv_fps->integer < 1)
 	{
-		Cvar_Set("sv_fps", "10");
+		Cvar_Set("sv_fps", DEFAULT_SV_FPS_STR);
 	}
 	frameMsec = 1000 / sv_fps->integer;
 

--- a/src/tvgame/tvg_main.c
+++ b/src/tvgame/tvg_main.c
@@ -143,7 +143,7 @@ tvcvarTable_t gameCvarTable[] =
 	{ &tvg_cheats,              "sv_cheats",               "",                           0,                                           0, qfalse },
 	{ &tvg_dedicated,           "dedicated",               "0",                          0,                                           0, qfalse,},
 
-	{ &sv_fps,                  "sv_fps",                  "20",                         CVAR_SYSTEMINFO,                             0, qfalse,},
+	{ &sv_fps,                  "sv_fps",                  DEFAULT_SV_FPS_STR,           0,                                           0, qfalse,},
 	{ &pmove_fixed,             "pmove_fixed",             "0",                          CVAR_SYSTEMINFO | CVAR_ROM,                  0, qfalse,},
 	{ &pmove_msec,              "pmove_msec",              "8",                          CVAR_SYSTEMINFO | CVAR_ROM,                  0, qfalse,},
 

--- a/src/tvgame/tvg_main.c
+++ b/src/tvgame/tvg_main.c
@@ -143,7 +143,7 @@ tvcvarTable_t gameCvarTable[] =
 	{ &tvg_cheats,              "sv_cheats",               "",                           0,                                           0, qfalse },
 	{ &tvg_dedicated,           "dedicated",               "0",                          0,                                           0, qfalse,},
 
-	{ &sv_fps,                  "sv_fps",                  DEFAULT_SV_FPS_STR,           0,                                           0, qfalse,},
+	{ &sv_fps,                  "sv_fps",                  DEFAULT_SV_FPS_STR,           CVAR_SYSTEMINFO,                             0, qfalse,},
 	{ &pmove_fixed,             "pmove_fixed",             "0",                          CVAR_SYSTEMINFO | CVAR_ROM,                  0, qfalse,},
 	{ &pmove_msec,              "pmove_msec",              "8",                          CVAR_SYSTEMINFO | CVAR_ROM,                  0, qfalse,},
 


### PR DESCRIPTION
- change sv_fps cvar to `CVAR_SYSTEMINFO` so client(s) can tell what is the exact server fps at all times.
- fix missing closing bracket in g_mdx.c
- tvgame and game modules register `CVAR_SYSTEMINFO` flag only in case if engine doesn't have sv_fps cvar registered (if it exists they cannot overwrite neither the value nor the flag of cvar)

refs #2787, #1637