### PR TITLE
github-actions: Fixup CI Pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Check changes
         if: github.event_name == 'pull_request'
         run: |
-          pixi run check-changes --diff --github "origin/master"
+          pixi run check-changes --github "origin/master"
 
       - name: Fetch git version information
         id: git


### PR DESCRIPTION
Missed removing now obsolete '--diff' flag.