### PR TITLE
game: Add 'debug_crash' command

### DIFF
--- a/src/game/g_cmds_ext.c
+++ b/src/game/g_cmds_ext.c
@@ -179,6 +179,7 @@ static const cmd_reference_t aCommandInfo[] =
 	{ "where",          CMD_USAGE_ANY_TIME,          qtrue,       qfalse, Cmd_Where_f,                         ":^7 Show the current XYZ player position"                                                   },
 	{ "ws",             CMD_USAGE_ANY_TIME,          qtrue,       qfalse, Cmd_WeaponStat_f,                    ":^7 Shows weapon stats"                                                                     },
 	{ "wstats",         CMD_USAGE_ANY_TIME,          qtrue,       qfalse, Cmd_wStats_f,                        ""                                                                                           },
+	{ "debug_crash",    CMD_USAGE_ANY_TIME,          qtrue,       qfalse, Cmd_Debug_Crash_f,                   "Deliberately cause a fatal process crash for debugging purposes."                           },
 	{ NULL,             CMD_USAGE_ANY_TIME,          qtrue,       qfalse, NULL,                                ""                                                                                           }
 };
 

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1476,6 +1476,7 @@ void Cmd_Notarget_f(gentity_t *ent, unsigned int dwCommand, int value);
 void Cmd_Noclip_f(gentity_t *ent, unsigned int dwCommand, int value);
 void Cmd_Nostamina_f(gentity_t *ent, unsigned int dwCommand, int value);
 void Cmd_Kill_f(gentity_t *ent, unsigned int dwCommand, int value);
+void Cmd_Debug_Crash_f(gentity_t *ent, unsigned int dwCommand, int value);
 void Cmd_DropObjective_f(gentity_t *ent, unsigned int dwCommand, int value);
 void Cmd_FollowNext_f(gentity_t *ent, unsigned int dwCommand, int value);
 void Cmd_FollowPrevious_f(gentity_t *ent, unsigned int dwCommand, int value);


### PR DESCRIPTION
	/debug_crash
	debug_crash: confirm via calling this command again with: 2102983296 <crashType>
	             <crashType> is one of these integers: {1: Segfault, 2: Stack Overflow}]

	/debug_crash 2102983296 1
	debug_crash: Crash code confirmed, producing a Segfault ...

	Thread 1 "etl.x86_64" hit Catchpoint 2 (signal SIGSEGV), 0x00007fffa1a5e671 in cmd_debug_crash (crashType=1) at /home/vor/workspace/etlegacy/src/game/g_cmds.c:563

The Crash code is initialized randomly each time.