### PR TITLE
github-actions: update Windows runners to windows-2022

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,7 +185,7 @@ jobs:
           if-no-files-found: error
 
   win-mod:
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs: version
     steps:
       - uses: actions/checkout@v4
@@ -211,7 +211,7 @@ jobs:
           if-no-files-found: error
 
   win64-mod:
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs: version
     steps:
       - uses: actions/checkout@v4
@@ -578,7 +578,7 @@ jobs:
           if-no-files-found: error
 
   win:
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs: [ version, mod-merger ]
     outputs:
       win: ${{ steps.artifact-upload-step.outputs.artifact-id }}
@@ -619,7 +619,7 @@ jobs:
           if-no-files-found: error
 
   win64:
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs: [ version, mod-merger ]
     outputs:
       win64: ${{ steps.artifact-upload-step.outputs.artifact-id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
         run: ./easybuild.sh package -64 --osx=10.10 --osx-arc="x86_64;arm64" -j
 
   win:
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs: [ pre-build ]
     env:
       CI_ETL_DESCRIBE: ${{needs.version.outputs.describe}}
@@ -187,7 +187,7 @@ jobs:
         run: cpack
 
   win64:
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs: [ pre-build ]
     env:
       CI_ETL_DESCRIBE: ${{needs.version.outputs.describe}}


### PR DESCRIPTION
`windows-2019` runners are deprecated on 30th of June.