### PR TITLE
github-actions: Fixup for build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -587,6 +587,7 @@ jobs:
 
   win:
     runs-on: windows-2022
+    needs: [version, mod-merger]
     outputs:
       win: ${{ steps.artifact-upload-step.outputs.artifact-id }}
     env:


### PR DESCRIPTION
d3bd5727a7b6d375392f54d9d943bf38e0ab1fdf accidentally removed the 'needs' line for 'win' ETLBuild - likely a manual editing mistake