### PR TITLE
game: fix Team_ResetFlag not freeing dropped objective correctly

### DIFF
--- a/src/game/g_items.c
+++ b/src/game/g_items.c
@@ -728,6 +728,18 @@ void Touch_Item(gentity_t *ent, gentity_t *other, trace_t *trace)
 		return;
 	}
 
+	// ensure we don't pick a dropped obj up right away
+	// FIXME: this really should be in 'BG_CanItemBeGrabbed', but we'd need to store the drop timestamp somewhere
+	if (ent->item->giType == IT_TEAM && level.time - other->client->dropObjectiveTime < PICKUP_DROPPED_COOLDOWN)
+	{
+		return;
+	}
+
+	if (g_gamestate.integer == GS_PLAYING)
+	{
+		G_LogPrintf("Item: %i %s\n", other->s.number, ent->item->classname);
+	}
+
 	// call the item-specific pickup function
 	switch (ent->item->giType)
 	{
@@ -748,11 +760,6 @@ void Touch_Item(gentity_t *ent, gentity_t *other, trace_t *trace)
 	if (!respawn)
 	{
 		return;
-	}
-
-	if (g_gamestate.integer == GS_PLAYING)
-	{
-		G_LogPrintf("Item: %i %s\n", other->s.number, ent->item->classname);
 	}
 
 	// play sounds

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -716,9 +716,10 @@ typedef struct
 #define PICKUP_TOUCH    1   ///< pickup items when touched
 #define PICKUP_FORCE    2   ///< pickup the next item when touched (and reset to PICKUP_ACTIVATE when done)
 
-#define PICKUP_RESPAWN_NEVER -1     ///< picked up items will not trigger respawn item
-#define PICKUP_INVALID 0            ///< cannot pickup items
-#define PICKUP_RESPAWN_TIME  1000   ///< picked up items will trigger respawn item
+#define PICKUP_RESPAWN_NEVER (-1)      ///< picked up items will not trigger respawn item
+#define PICKUP_INVALID 0               ///< cannot pickup items
+#define PICKUP_RESPAWN_TIME  1000      ///< picked up items will trigger respawn item
+#define PICKUP_DROPPED_COOLDOWN 2000   ///< delay until objective can be picked up again after dropping
 
 // zinx etpro antiwarp
 #define LAG_MAX_COMMANDS 512

--- a/src/game/g_team.c
+++ b/src/game/g_team.c
@@ -396,12 +396,6 @@ int Pickup_Team(gentity_t *ent, gentity_t *other)
 		return PICKUP_INVALID;
 	}
 
-	// ensure we don't pick a dropped obj up right away
-	if (level.time - cl->dropObjectiveTime < 2000)
-	{
-		return PICKUP_INVALID;
-	}
-
 	trap_SendServerCommand(other - g_entities, "cp \"You picked up the objective!\"");
 
 	// set timer

--- a/src/game/g_team.c
+++ b/src/game/g_team.c
@@ -88,7 +88,7 @@ void Team_ResetFlag(gentity_t *ent)
 	if (ent->flags & FL_DROPPED_ITEM)
 	{
 		Team_ResetFlag(&g_entities[ent->s.otherEntityNum]);
-		ent->freeAfterEvent = qtrue;
+		G_FreeEntity(ent);
 	}
 	else
 	{
@@ -195,6 +195,7 @@ void Team_DroppedFlagThink(gentity_t *ent)
 			G_Script_ScriptEvent(level.gameManager, "trigger", "allied_object_returned");
 		}
 	}
+	// 'Team_ResetFlag' will delete this entity
 }
 
 /**
@@ -255,6 +256,7 @@ static int Team_TouchOurFlag(gentity_t *ent, gentity_t *other, int team)
 		// reward player for returning objective item
 		G_AddSkillPoints(other, SK_BATTLE_SENSE, 5.f, "objective returned");
 
+		// 'Team_ResetFlag' will remove this entity, we must return 0!
 		Team_FlagSound(ent, team, TEAM_FLAG_STATE_RETURNED);
 		Team_ResetFlag(ent);
 		return PICKUP_ACTIVATE;


### PR DESCRIPTION
`Team_ResetFlag` must immediately free the entity upon touch, otherwise the freeing will be queued to happen after `EVENT_VALID_MSEC` (300ms), which causes dropped objectives to be returned multiple times by a defender, as they will have time to trigger `Touch_Item` multiple times. This creates multiple copies of the returned entity, which causes objectives to respawn after pickup even for objectives which are supposed to be single pickup items.

refs 9481360ccbe4413906fda537b6c604a6376834a7