### PR TITLE
game: Add 'lua_shutdown' / 'lua_init' svcmds

### DIFF
--- a/src/game/g_svcmds.c
+++ b/src/game/g_svcmds.c
@@ -2624,6 +2624,16 @@ qboolean ConsoleCommand(void)
 		G_LuaRestart();
 		return qtrue;
 	}
+	else if (!Q_stricmp(cmd, "lua_shutdown"))
+	{
+		G_LuaShutdown();
+		return qtrue;
+	}
+	else if (!Q_stricmp(cmd, "lua_init"))
+	{
+		G_LuaInit();
+		return qtrue;
+	}
 	else if (Q_stricmp(cmd, "lua_api") == 0)
 	{
 		G_LuaStackDump();


### PR DESCRIPTION
There are cases involving '.so' Lua modules where 'lua_restart' will SEGFAULT.

In order to account for these, we expose separate 'lua_shutdown' / 'lua_init' commands, so that Lua module makers have more control to dev-cycle.