### PR TITLE
general: move vtos to q_shared, add vtosf

### DIFF
--- a/src/cgame/cg_spawn.c
+++ b/src/cgame/cg_spawn.c
@@ -134,26 +134,6 @@ qboolean CG_SpawnVector2D(const char *key, const char *defaultString, float *out
 }
 
 /**
- * @brief This is just a convenience function for printing vectors
- * @param[in] v
- * @return
- */
-char *vtos(const vec3_t v)
-{
-	static int  index;
-	static char str[8][32];
-	char        *s;
-
-	// use an array so that multiple vtos won't collide
-	s     = str[index];
-	index = (index + 1) & 7;
-
-	Com_sprintf(s, 32, "(%i %i %i)", (int)v[0], (int)v[1], (int)v[2]);
-
-	return s;
-}
-
-/**
  * @brief SP_path_corner_2
  */
 void SP_path_corner_2(void)

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1569,8 +1569,6 @@ void G_ClientSound(gentity_t *ent, int soundIndex);
 
 void G_TouchTriggers(gentity_t *ent);
 
-char *vtos(const vec3_t v);
-
 void G_AddPredictableEvent(gentity_t *ent, int event, int eventParm);
 void G_AddEvent(gentity_t *ent, int event, int eventParm);
 void G_SetOrigin(gentity_t *ent, vec3_t origin);

--- a/src/game/g_utils.c
+++ b/src/game/g_utils.c
@@ -727,26 +727,6 @@ void G_UseTargets(gentity_t *ent, gentity_t *activator)
 }
 
 /**
- * @brief This is just a convenience function for printing vectors
- * @param[in] v
- * @return
- */
-char *vtos(const vec3_t v)
-{
-	static int  index;
-	static char str[8][32];
-	char        *s;
-
-	// use an array so that multiple vtos won't collide
-	s     = str[index];
-	index = (index + 1) & 7;
-
-	Com_sprintf(s, 32, "(%i %i %i)", (int)v[0], (int)v[1], (int)v[2]);
-
-	return s;
-}
-
-/**
  * @brief The editor only specifies a single value for angles (yaw),
  * but we have special constants to generate an up or down direction.
  * Angles will be cleared, because it is being used to represent a direction

--- a/src/qcommon/q_shared.c
+++ b/src/qcommon/q_shared.c
@@ -2431,6 +2431,46 @@ float *tv(float x, float y, float z)
 	return v;
 }
 
+/**
+ * @brief This is just a convenience function for printing vectors
+ * @param[in] v
+ * @return
+ */
+char *vtos(const vec3_t v)
+{
+	static int  index;
+	static char str[8][32];
+	char        *s;
+
+	// use an array so that multiple vtos won't collide
+	s     = str[index];
+	index = (index + 1) & 7;
+
+	Com_sprintf(s, 32, "(%i %i %i)", (int)v[0], (int)v[1], (int)v[2]);
+
+	return s;
+}
+
+/**
+ * @brief This is just a convenience function for printing vectors
+ * @param[in] v
+ * @return
+ */
+char *vtosf(const vec3_t v)
+{
+	static int  index;
+	static char str[8][64];
+	char        *s;
+
+	// use an array so that multiple vtosf won't collide
+	s     = str[index];
+	index = (index + 1) & 7;
+
+	Com_sprintf(s, 64, "(%f %f %f)", v[0], v[1], v[2]);
+
+	return s;
+}
+
 /*
 =====================================================================
   INFO STRINGS

--- a/src/qcommon/q_shared.h
+++ b/src/qcommon/q_shared.h
@@ -893,6 +893,8 @@ long Q_GenerateHashValue(const char *fname, int size, qboolean fullPath, qboolea
 //=============================================
 
 float *tv(float x, float y, float z);
+char *vtos(const vec3_t v);
+char *vtosf(const vec3_t v);
 
 #define rc(x) va("%s^7", x) ///< shortcut for color reset after printing variable
 


### PR DESCRIPTION
Makes `vtos` easily accessible pretty much everywhere in mod and engine. `vtosf` works the same way, but prints floats instead of ints.