### PR TITLE
client: fix date in etkey generation

### DIFF
--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -587,7 +587,7 @@ static void CL_GenerateETKey(void)
 		Com_RandomBytes(&last, sizeof(int));
 		last = abs(last) % 10000;
 
-		Com_sprintf(buff, sizeof(buff), "0000001002%04i%02i%02i%02i%02i%02i%04i", t->tm_year, t->tm_mon, t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec, last);
+		Com_sprintf(buff, sizeof(buff), "0000001002%04i%02i%02i%02i%02i%02i%04i", t->tm_year + 1900, t->tm_mon + 1, t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec, last);
 
 		f = FS_SV_FOpenFileWrite(BASEGAME "/" ETKEY_FILE);
 		if (!f)


### PR DESCRIPTION
The year wasn't offset by 1900 and month was 0-indexed, which wrote incorrect generation dates to etkey. Ultimately this doesn't really matter since it gets hashed anyway, but this is in line with PB-issued etkeys, which have the correct generation date.