### PR TITLE
ui: Fix scrollbar behavior

### DIFF
--- a/src/ui/ui_menu.c
+++ b/src/ui/ui_menu.c
@@ -1269,24 +1269,7 @@ void Menu_HandleMouseMove(menuDef_t *menu, float x, float y)
 		return;
 	}
 
-	if (itemCapture)
-	{
-		if (itemCapture->type == ITEM_TYPE_LISTBOX)
-		{
-			// lose capture if out of client rect
-			if (!Rect_ContainsPoint(&itemCapture->window.rect, x, y))
-			{
-				itemCapture = NULL;
-				captureFunc = NULL;
-				captureData = NULL;
-			}
-
-		}
-		//Item_MouseMove(itemCapture, x, y);
-		return;
-	}
-
-	if (g_waitingForKey || g_editingField)
+	if (itemCapture || g_waitingForKey || g_editingField)
 	{
 		return;
 	}

--- a/src/ui/ui_menuitem.c
+++ b/src/ui/ui_menuitem.c
@@ -640,6 +640,13 @@ void Item_ListBox_MouseEnter(itemDef_t *item, float x, float y, qboolean click)
 	item->window.flags &= ~(WINDOW_LB_LEFTARROW | WINDOW_LB_RIGHTARROW | WINDOW_LB_THUMB | WINDOW_LB_PGUP | WINDOW_LB_PGDN | WINDOW_LB_SOMEWHERE);
 	item->window.flags |= Item_ListBox_OverLB(item, x, y);
 
+	// prevent listbox selection changing if we're dragging the scrollbar and
+	// moving the cursor over the listbox
+	if (Menus_CaptureFuncActive())
+	{
+		return;
+	}
+
 	if (click)
 	{
 		if (item->window.flags & WINDOW_HORIZONTAL)


### PR DESCRIPTION
Draggin scrollbar would stop at arbitrary points, it now allows scrolling no matter where the cursor goes as long as you click on a scrollbar and keep dragging.