### PR TITLE
cgame: added /selectclosestspawnpt command, refs #2206

### DIFF
--- a/src/cgame/cg_consolecmds.c
+++ b/src/cgame/cg_consolecmds.c
@@ -3183,7 +3183,7 @@ static void CG_SelectSpawn_f(void)
 	cg_spawnpoint_t *spawnpoint;
 	cg_spawnpoint_t *bestMinorSpawn  = NULL;
 	float           closestMinorDist = FLT_MAX;
-	const float     maxDistSq        = (1024.0f * 1024.0f);
+	const float     maxDistSq        = (1536.0f * 1536.0f);
 	int             i;
 	team_t          playerTeam;
 	qboolean        spawnSet = qfalse;
@@ -3441,6 +3441,8 @@ static consoleCommand_t commands[] =
 	{ "resetmaxspeed",          CG_ResetMaxSpeed_f        },
 	{ "listspawnpt",            CG_ListSpawnPoints_f      },
 	{ "setspawnpt",             CG_SetSpawnPoint_f        },
+	{ "selectclosestspawnpt",   CG_SelectSpawn_f          },
+
 
 	{ "loc",                    CG_Location_f             },
 	{ "camera",                 CG_Camera_f               },
@@ -3552,6 +3554,7 @@ static const char *gameCommand[] =
 	"setviewpos",
 	// "getspawnpt",  // not meant to be set manually
 	"setspawnpt",
+	"selectclosestspawnpt",
 	"sgstats",
 	"showstats",
 	"specinvite",

--- a/src/cgame/cg_consolecmds.c
+++ b/src/cgame/cg_consolecmds.c
@@ -3205,20 +3205,24 @@ static void CG_SetClosestSpawn_f(void)
 
 	for (i = 0; i < cg.numSpawnpointEnts; i++)
 	{
+		qboolean inPVS;
+		float    dist;
+
 		spawnpoint = &cgs.spawnpointEnt[i];
 		if (spawnpoint->isMajor)
 		{
 			continue;
 		}
 
-		qboolean inPVS = trap_R_inPVS(cg.refdef_current->vieworg, spawnpoint->origin);
-		float    dist  = VectorDistanceSquared(playerOrigin, spawnpoint->origin);
-
-		if (!inPVS && dist > maxDistSq)
+		if (spawnpoint->team != playerTeam && spawnpoint->team != TEAM_FREE)
 		{
 			continue;
 		}
-		if (spawnpoint->team != playerTeam && spawnpoint->team != TEAM_FREE)
+
+		inPVS = trap_R_inPVS(cg.refdef_current->vieworg, spawnpoint->origin);
+		dist  = VectorDistanceSquared(playerOrigin, spawnpoint->origin);
+
+		if (!inPVS && dist > maxDistSq)
 		{
 			continue;
 		}
@@ -3237,6 +3241,8 @@ static void CG_SetClosestSpawn_f(void)
 
 		for (i = 0; i < cg.numMajorSpawnpointEnts; i++)
 		{
+			float dist;
+
 			spawnpoint = &cgs.majorSpawnpointEnt[i];
 
 			if (CG_GetSelectableMajorSpawn(spawnpoint->name, playerTeam) == -1)
@@ -3244,7 +3250,7 @@ static void CG_SetClosestSpawn_f(void)
 				continue;
 			}
 
-			float dist = VectorDistanceSquared(bestMinorSpawn->origin, spawnpoint->origin);
+			dist = VectorDistanceSquared(bestMinorSpawn->origin, spawnpoint->origin);
 			if (dist < closestParentDist)
 			{
 				closestParentDist = dist;
@@ -3275,17 +3281,20 @@ static void CG_SetClosestSpawn_f(void)
 
 		for (i = 0; i < cg.numMajorSpawnpointEnts; i++)
 		{
+			qboolean inPVS;
+			float    dist;
+
 			spawnpoint = &cgs.majorSpawnpointEnt[i];
 
-			qboolean inPVS = trap_R_inPVS(cg.refdef_current->vieworg, spawnpoint->origin);
-			float    dist  = VectorDistanceSquared(playerOrigin, spawnpoint->origin);
-
-			if (!inPVS && dist > maxDistSq)
+			if (CG_GetSelectableMajorSpawn(spawnpoint->name, playerTeam) == -1)
 			{
 				continue;
 			}
 
-			if (CG_GetSelectableMajorSpawn(spawnpoint->name, playerTeam) == -1)
+			inPVS = trap_R_inPVS(cg.refdef_current->vieworg, spawnpoint->origin);
+			dist  = VectorDistanceSquared(playerOrigin, spawnpoint->origin);
+
+			if (!inPVS && dist > maxDistSq)
 			{
 				continue;
 			}

--- a/src/cgame/cg_consolecmds.c
+++ b/src/cgame/cg_consolecmds.c
@@ -3177,7 +3177,7 @@ static int CG_GetSelectableMajorSpawn(const char *targetName, team_t playerTeam)
 /**
  * @brief Command to select the nearest visible or nearby minor spawnpoint
  */
-static void CG_SelectSpawn_f(void)
+static void CG_SetClosestSpawn_f(void)
 {
 	vec3_t          playerOrigin;
 	cg_spawnpoint_t *spawnpoint;
@@ -3441,7 +3441,7 @@ static consoleCommand_t commands[] =
 	{ "resetmaxspeed",          CG_ResetMaxSpeed_f        },
 	{ "listspawnpt",            CG_ListSpawnPoints_f      },
 	{ "setspawnpt",             CG_SetSpawnPoint_f        },
-	{ "selectclosestspawnpt",   CG_SelectSpawn_f          },
+	{ "setclosestspawnpt",      CG_SetClosestSpawn_f      },
 
 
 	{ "loc",                    CG_Location_f             },
@@ -3554,7 +3554,7 @@ static const char *gameCommand[] =
 	"setviewpos",
 	// "getspawnpt",  // not meant to be set manually
 	"setspawnpt",
-	"selectclosestspawnpt",
+	"setclosestspawnpt",
 	"sgstats",
 	"showstats",
 	"specinvite",


### PR DESCRIPTION
Adds a /selectclosestspawnpt command that automatically selects the minor (or major) spawn closest to you.

Doesn't work for mapscripted team_WOLF_objective major spawns. If you add minor ids via mapscript to existing spawns, however, it works.