### PR TITLE
Fireteam spawnpoints

### DIFF
--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -59,7 +59,7 @@ const hudComponentFields_t hudComponentFields[] =
 	{ HUDF(statsdisplay),       CG_DrawSkills,                    0.25f,  { "Column" } },
 	{ HUDF(weaponicon),         CG_DrawGunIcon,                   0.19f,  { "Icon Flash",    "Dynamic Heat Color" } },
 	{ HUDF(weaponammo),         CG_DrawAmmoCount,                 0.25f,  { "Dynamic Color" } },
-	{ HUDF(fireteam),           CG_DrawFireTeamOverlay,           0.20f,  { "Latched Class", "No Header",    "Colorless Name", "Status Color Name", "Status Color Row", "Spawn Point"} },// FIXME: outside cg_draw_hud
+	{ HUDF(fireteam),           CG_DrawFireTeamOverlay,           0.20f,  { "Latched Class", "No Header",    "Colorless Name", "Status Color Name", "Status Color Row", "Spawn Point", "Spawn Point Location", "Minor Spawn Point"} }, // FIXME: outside cg_draw_hud
 	{ HUDF(popupmessages),      CG_DrawPM,                        0.22f,  { "No Connect",    "No TeamJoin",  "No Mission",     "No Pickup", "No Death", "Weapon Icon", "Alt Weap Icons", "Swap V<->K", "Force Colors", "Scroll Down"} }, // FIXME: outside cg_draw_hud
 	{ HUDF(popupmessages2),     CG_DrawPM,                        0.22f,  { "No Connect",    "No TeamJoin",  "No Mission",     "No Pickup", "No Death", "Weapon Icon", "Alt Weap Icons", "Swap V<->K", "Force Colors", "Scroll Down"} }, // FIXME: outside cg_draw_hud
 	{ HUDF(popupmessages3),     CG_DrawPM,                        0.22f,  { "No Connect",    "No TeamJoin",  "No Mission",     "No Pickup", "No Death", "Weapon Icon", "Alt Weap Icons", "Swap V<->K", "Force Colors", "Scroll Down"} }, // FIXME: outside cg_draw_hud

--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -59,7 +59,7 @@ const hudComponentFields_t hudComponentFields[] =
 	{ HUDF(statsdisplay),       CG_DrawSkills,                    0.25f,  { "Column" } },
 	{ HUDF(weaponicon),         CG_DrawGunIcon,                   0.19f,  { "Icon Flash",    "Dynamic Heat Color" } },
 	{ HUDF(weaponammo),         CG_DrawAmmoCount,                 0.25f,  { "Dynamic Color" } },
-	{ HUDF(fireteam),           CG_DrawFireTeamOverlay,           0.20f,  { "Latched Class", "No Header",    "Colorless Name", "Status Color Name", "Status Color Row", "Spawn Point", "Minor Spawn Point"} },// FIXME: outside cg_draw_hud
+	{ HUDF(fireteam),           CG_DrawFireTeamOverlay,           0.20f,  { "Latched Class", "No Header",    "Colorless Name", "Status Color Name", "Status Color Row", "Spawn Point"} },// FIXME: outside cg_draw_hud
 	{ HUDF(popupmessages),      CG_DrawPM,                        0.22f,  { "No Connect",    "No TeamJoin",  "No Mission",     "No Pickup", "No Death", "Weapon Icon", "Alt Weap Icons", "Swap V<->K", "Force Colors", "Scroll Down"} }, // FIXME: outside cg_draw_hud
 	{ HUDF(popupmessages2),     CG_DrawPM,                        0.22f,  { "No Connect",    "No TeamJoin",  "No Mission",     "No Pickup", "No Death", "Weapon Icon", "Alt Weap Icons", "Swap V<->K", "Force Colors", "Scroll Down"} }, // FIXME: outside cg_draw_hud
 	{ HUDF(popupmessages3),     CG_DrawPM,                        0.22f,  { "No Connect",    "No TeamJoin",  "No Mission",     "No Pickup", "No Death", "Weapon Icon", "Alt Weap Icons", "Swap V<->K", "Force Colors", "Scroll Down"} }, // FIXME: outside cg_draw_hud

--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -59,7 +59,7 @@ const hudComponentFields_t hudComponentFields[] =
 	{ HUDF(statsdisplay),       CG_DrawSkills,                    0.25f,  { "Column" } },
 	{ HUDF(weaponicon),         CG_DrawGunIcon,                   0.19f,  { "Icon Flash",    "Dynamic Heat Color" } },
 	{ HUDF(weaponammo),         CG_DrawAmmoCount,                 0.25f,  { "Dynamic Color" } },
-	{ HUDF(fireteam),           CG_DrawFireTeamOverlay,           0.20f,  { "Latched Class", "No Header",    "Colorless Name", "Status Color Name", "Status Color Row"} },// FIXME: outside cg_draw_hud
+	{ HUDF(fireteam),           CG_DrawFireTeamOverlay,           0.20f,  { "Latched Class", "No Header",    "Colorless Name", "Status Color Name", "Status Color Row", "Spawn Point", "Minor Spawn Point"} },// FIXME: outside cg_draw_hud
 	{ HUDF(popupmessages),      CG_DrawPM,                        0.22f,  { "No Connect",    "No TeamJoin",  "No Mission",     "No Pickup", "No Death", "Weapon Icon", "Alt Weap Icons", "Swap V<->K", "Force Colors", "Scroll Down"} }, // FIXME: outside cg_draw_hud
 	{ HUDF(popupmessages2),     CG_DrawPM,                        0.22f,  { "No Connect",    "No TeamJoin",  "No Mission",     "No Pickup", "No Death", "Weapon Icon", "Alt Weap Icons", "Swap V<->K", "Force Colors", "Scroll Down"} }, // FIXME: outside cg_draw_hud
 	{ HUDF(popupmessages3),     CG_DrawPM,                        0.22f,  { "No Connect",    "No TeamJoin",  "No Mission",     "No Pickup", "No Death", "Weapon Icon", "Alt Weap Icons", "Swap V<->K", "Force Colors", "Scroll Down"} }, // FIXME: outside cg_draw_hud

--- a/src/cgame/cg_fireteamoverlay.c
+++ b/src/cgame/cg_fireteamoverlay.c
@@ -521,7 +521,7 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 			}
 			if (comp->style & BIT(6))
 			{
-				spawnPtStr[i] = va("^7%s", Q_CleanStr(CG_GetLocationMsg(ci->clientNum, cgs.majorSpawnpointEnt[ci->spawnpt - 1].origin)));
+				spawnPtStr[i] = va("%s", Q_CleanStr(CG_GetLocationMsg(ci->clientNum, cgs.majorSpawnpointEnt[ci->spawnpt - 1].origin)));
 				if (cg_locationMaxChars.integer)
 				{
 					spawnwidth  = spacing;
@@ -842,8 +842,6 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 		x += spacing;
 		float widthLocationLeft = w - (x - comp->location.x) - spacing;
 		float charWidth         = CG_Text_Width_Ext_Float("A", scale, 0, FONT_TEXT);
-
-		// paint
 		if (cg_locations.integer & LOC_FTEAM)
 		{
 			float locWidthLocationLeft = widthLocationLeft;
@@ -879,6 +877,22 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 		}
 		if (comp->style & BIT(5))
 		{
+			vec4_t *spawnPtColor;
+			float  timeDiff = cg.time - ci->spawnChangedTime;
+			if (timeDiff < 1500.0f)
+			{
+				float t = timeDiff / 1500.0f;
+				spawnPtColor = (vec4_t[]) { { colorOrange[0] + (colorWhite[0] - colorOrange[0]) * t,
+											  colorOrange[1] + (colorWhite[1] - colorOrange[1]) * t,
+											  colorOrange[2] + (colorWhite[2] - colorOrange[2]) * t,
+											  colorOrange[3] + (colorWhite[3] - colorOrange[3]) * t } };
+			}
+			else
+			{
+				spawnPtColor = colorWhite;
+			}
+
+
 			if (cg_locations.integer & LOC_FTEAM)
 			{
 				widthLocationLeft = widthLocationLeft / 2;
@@ -890,24 +904,24 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 				{
 					if (comp->alignText == ITEM_ALIGN_RIGHT) // right align
 					{
-						CG_Text_Paint_RightAligned_Ext(x + widthLocationLeft, y + heightTextOffset, scale, scale, comp->colorMain, spawnPtStr[i], 0, lim, comp->styleText, FONT_TEXT);
+						CG_Text_Paint_RightAligned_Ext(x + widthLocationLeft, y + heightTextOffset, scale, scale, spawnPtColor, spawnPtStr[i], 0, lim, comp->styleText, FONT_TEXT);
 					}
 					else if (comp->alignText == ITEM_ALIGN_LEFT)
 					{
-						CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, comp->colorMain, spawnPtStr[i], 0, lim, comp->styleText, FONT_TEXT);
+						CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, spawnPtColor, spawnPtStr[i], 0, lim, comp->styleText, FONT_TEXT);
 					}
 					else    // center
 					{
-						CG_Text_Paint_Centred_Ext(x + widthLocationLeft * 0.5, y + heightTextOffset, scale, scale, comp->colorMain, spawnPtStr[i], 0, lim, comp->styleText, FONT_TEXT);
+						CG_Text_Paint_Centred_Ext(x + widthLocationLeft * 0.5, y + heightTextOffset, scale, scale, spawnPtColor, spawnPtStr[i], 0, lim, comp->styleText, FONT_TEXT);
 					}
 				}
 			}
 			else
 			{
-				CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, comp->colorMain, Q_TruncateStr(spawnPtStr[i], 0), 0, 0, comp->styleText, FONT_TEXT);
+				CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, *spawnPtColor, Q_TruncateStr(spawnPtStr[i], 0), 0, 0, comp->styleText, FONT_TEXT);
 				if (comp->style & BIT(7) && ci->mspawnpt > 0)
 				{
-					CG_Text_Paint_Ext(x + charWidth, y + heightTextOffset, scale / 1.5, scale / 1.5, comp->colorMain, va("%i", ci->mspawnpt), 0, 0, comp->styleText, FONT_TEXT);
+					CG_Text_Paint_Ext(x + charWidth, y + heightTextOffset, scale / 1.5, scale / 1.5, *spawnPtColor, va("%i", ci->mspawnpt), 0, 0, comp->styleText, FONT_TEXT);
 				}
 
 			}

--- a/src/cgame/cg_fireteamoverlay.c
+++ b/src/cgame/cg_fireteamoverlay.c
@@ -33,6 +33,7 @@
  */
 
 #include "cg_local.h"
+#include "../game/g_local.h"
 
 static int sortedFireTeamClients[MAX_CLIENTS];
 
@@ -683,6 +684,17 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 		trap_R_SetColor(iconColor);
 		CG_DrawPic(x, y + heightIconsOffset, iconsSize, iconsSize, cgs.media.skillPics[SkillNumForClass(ci->cls)]);
 		x += iconsSize;
+		if (comp->style & BIT(5))
+		{
+			CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, comp->colorMain, va("%i", ci->spawnpt), 0, 0, comp->styleText, FONT_TEXT);
+			x += spacing * 1;
+			if (comp->style & BIT(6) && ci->mspawnpt > 0)
+			{
+				char* mspawnpt = va(".%i", ci->mspawnpt);
+				CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, comp->colorMain, mspawnpt, 0, 0, comp->styleText, FONT_TEXT);
+				x += spacing * 2;
+			}
+		}
 
 		if (comp->style & 1)
 		{

--- a/src/cgame/cg_fireteamoverlay.c
+++ b/src/cgame/cg_fireteamoverlay.c
@@ -33,7 +33,6 @@
  */
 
 #include "cg_local.h"
-#include "../game/g_local.h"
 
 static int sortedFireTeamClients[MAX_CLIENTS];
 
@@ -684,17 +683,6 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 		trap_R_SetColor(iconColor);
 		CG_DrawPic(x, y + heightIconsOffset, iconsSize, iconsSize, cgs.media.skillPics[SkillNumForClass(ci->cls)]);
 		x += iconsSize;
-		if (comp->style & BIT(5))
-		{
-			CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, comp->colorMain, va("%i", ci->spawnpt), 0, 0, comp->styleText, FONT_TEXT);
-			x += spacing * 1;
-			if (comp->style & BIT(6) && ci->mspawnpt > 0)
-			{
-				char* mspawnpt = va(".%i", ci->mspawnpt);
-				CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, comp->colorMain, mspawnpt, 0, 0, comp->styleText, FONT_TEXT);
-				x += spacing * 2;
-			}
-		}
 
 		if (comp->style & 1)
 		{
@@ -744,6 +732,12 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 			//if (ci->rank > 0) CG_DrawPic( x, y, heightTextOffset, heightTextOffset, rankicons[ ci->rank ][  ci->team == TEAM_AXIS ? 1 : 0 ][0].shader );
 			//x += 14;
 			puwidth = 0;
+		}
+
+		if (comp->style & BIT(5))
+		{
+			CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, comp->colorMain, va("%i", ci->spawnpt), 0, 0, comp->styleText, FONT_TEXT);
+			x += spacing;
 		}
 
 		x += spacing;

--- a/src/cgame/cg_fireteamoverlay.c
+++ b/src/cgame/cg_fireteamoverlay.c
@@ -843,9 +843,10 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 		float widthLocationLeft = w - (x - comp->location.x) - spacing;
 		float charWidth         = CG_Text_Width_Ext_Float("A", scale, 0, FONT_TEXT);
 		int   lim;
+		float locWidthLocationLeft;
 		if (cg_locations.integer & LOC_FTEAM)
 		{
-			float locWidthLocationLeft = widthLocationLeft;
+			locWidthLocationLeft = widthLocationLeft;
 			if (comp->style & BIT(5))
 			{
 				if (comp->style & BIT(6))

--- a/src/cgame/cg_fireteamoverlay.c
+++ b/src/cgame/cg_fireteamoverlay.c
@@ -515,7 +515,7 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 		if (comp->style & BIT(5))
 		{
 			spawnPtStr[i] = va("%i", ci->spawnpt);
-			if (comp->style & BIT(7) && cg.supportsMinorSpawnPoints == qtrue && ci->mspawnpt > 0)
+			if (comp->style & BIT(7) && cg.hasMinorSpawnPoints == qtrue && ci->mspawnpt > 0)
 			{
 				spawnPtStr[i] = va("%s%i", spawnPtStr[i], ci->mspawnpt);
 			}
@@ -842,6 +842,7 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 		x += spacing;
 		float widthLocationLeft = w - (x - comp->location.x) - spacing;
 		float charWidth         = CG_Text_Width_Ext_Float("A", scale, 0, FONT_TEXT);
+		int   lim;
 		if (cg_locations.integer & LOC_FTEAM)
 		{
 			float locWidthLocationLeft = widthLocationLeft;
@@ -856,7 +857,7 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 					locWidthLocationLeft -= bestSpawnWidth + spacing;
 				}
 			}
-			int lim = locWidthLocationLeft / charWidth;
+			lim = locWidthLocationLeft / charWidth;
 			if (lim > 0)
 			{
 				if (comp->alignText == ITEM_ALIGN_RIGHT) // right align
@@ -877,21 +878,15 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 		}
 		if (comp->style & BIT(5))
 		{
-			vec4_t *spawnPtColor;
-			float  timeDiff = cg.time - ci->spawnChangedTime;
+			const float timeDiff = cg.time - ci->spawnChangedTime;
+			vec4_t      spawnPtColor;
+			Vector4Copy(colorWhite, spawnPtColor);
+
 			if (timeDiff < 1500.0f)
 			{
-				float t = timeDiff / 1500.0f;
-				spawnPtColor = (vec4_t[]) { { colorOrange[0] + (colorWhite[0] - colorOrange[0]) * t,
-											  colorOrange[1] + (colorWhite[1] - colorOrange[1]) * t,
-											  colorOrange[2] + (colorWhite[2] - colorOrange[2]) * t,
-											  colorOrange[3] + (colorWhite[3] - colorOrange[3]) * t } };
+				const float t = timeDiff / 1500.0f;
+				LerpColor(colorOrange, colorWhite, spawnPtColor, t);
 			}
-			else
-			{
-				spawnPtColor = colorWhite;
-			}
-
 
 			if (cg_locations.integer & LOC_FTEAM)
 			{
@@ -899,7 +894,7 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 			}
 			if (comp->style & BIT(6))
 			{
-				int lim = widthLocationLeft / charWidth;
+				lim = widthLocationLeft / charWidth;
 				if (lim > 0)
 				{
 					if (comp->alignText == ITEM_ALIGN_RIGHT) // right align
@@ -918,12 +913,11 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 			}
 			else
 			{
-				CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, *spawnPtColor, Q_TruncateStr(spawnPtStr[i], 0), 0, 0, comp->styleText, FONT_TEXT);
+				CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, spawnPtColor, Q_TruncateStr(spawnPtStr[i], 0), 0, 0, comp->styleText, FONT_TEXT);
 				if (comp->style & BIT(7) && ci->mspawnpt > 0)
 				{
-					CG_Text_Paint_Ext(x + charWidth, y + heightTextOffset, scale / 1.5, scale / 1.5, *spawnPtColor, va("%i", ci->mspawnpt), 0, 0, comp->styleText, FONT_TEXT);
+					CG_Text_Paint_Ext(x + charWidth, y + heightTextOffset, scale / 1.5, scale / 1.5, spawnPtColor, va("%i", ci->mspawnpt), 0, 0, comp->styleText, FONT_TEXT);
 				}
-
 			}
 		}
 	}

--- a/src/cgame/cg_fireteamoverlay.c
+++ b/src/cgame/cg_fireteamoverlay.c
@@ -517,12 +517,7 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 			spawnPtStr[i] = va("%i", ci->spawnpt);
 			if (comp->style & BIT(7) && cg.supportsMinorSpawnPoints == qtrue && ci->mspawnpt > 0)
 			{
-				char *mspawnpt = va("%i", ci->mspawnpt);
-				spawnPtStr[i] = va("%s%c", spawnPtStr[i], 0x2080 + mspawnpt[0]);
-				if (ci->mspawnpt > 9)
-				{
-					spawnPtStr[i] = va("%s%c", spawnPtStr[i], 0x2080 + mspawnpt[1]);
-				}
+				spawnPtStr[i] = va("%s%i", spawnPtStr[i], ci->mspawnpt);
 			}
 			if (comp->style & BIT(6))
 			{
@@ -909,7 +904,12 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 			}
 			else
 			{
-				CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, comp->colorMain, spawnPtStr[i], 0, 0, comp->styleText, FONT_TEXT);
+				CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, comp->colorMain, Q_TruncateStr(spawnPtStr[i], 0), 0, 0, comp->styleText, FONT_TEXT);
+				if (comp->style & BIT(7) && ci->mspawnpt > 0)
+				{
+					CG_Text_Paint_Ext(x + charWidth, y + heightTextOffset, scale / 1.5, scale / 1.5, comp->colorMain, va("%i", ci->mspawnpt), 0, 0, comp->styleText, FONT_TEXT);
+				}
+
 			}
 		}
 	}

--- a/src/cgame/cg_fireteamoverlay.c
+++ b/src/cgame/cg_fireteamoverlay.c
@@ -419,6 +419,8 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 	int            nameMaxLen;
 	float          scale;
 	float          spacing;
+	float          widthLocationLeft;
+
 
 	// colors and fonts for overlays
 	vec4_t FT_select                = { 0.5f, 0.5f, 0.2f, 0.3f }; // selected member
@@ -674,7 +676,6 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 	}
 
 	lineX = (int)x;
-
 	for (i = 0; i < MAX_FIRETEAM_MEMBERS; i++)
 	{
 		x = lineX;
@@ -839,17 +840,15 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 		}
 
 		// set hard limit on width
-		x += spacing;
-		float widthLocationLeft = w - (x - comp->location.x) - spacing;
-		float charWidth         = CG_Text_Width_Ext_Float("A", scale, 0, FONT_TEXT);
-		int   lim;
-		float locWidthLocationLeft;
+		x                += spacing;
+		widthLocationLeft = w - (x - comp->location.x) - spacing;
 		if (cg_locations.integer & LOC_FTEAM)
 		{
-			locWidthLocationLeft = widthLocationLeft;
-			if (comp->style & BIT(5))
+			int   lim;
+			float locWidthLocationLeft = widthLocationLeft;
+			if (comp->style & BIT(5)) // spawn points
 			{
-				if (comp->style & BIT(6))
+				if (comp->style & BIT(6)) // spawn locations
 				{
 					locWidthLocationLeft = (widthLocationLeft - spacing) / 2;
 				}
@@ -858,7 +857,7 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 					locWidthLocationLeft -= bestSpawnWidth + spacing;
 				}
 			}
-			lim = locWidthLocationLeft / charWidth;
+			lim = locWidthLocationLeft / spacing;
 			if (lim > 0)
 			{
 				if (comp->alignText == ITEM_ALIGN_RIGHT) // right align
@@ -877,7 +876,7 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 				x += locWidthLocationLeft;
 			}
 		}
-		if (comp->style & BIT(5))
+		if (comp->style & BIT(5)) // spawn points
 		{
 			const float timeDiff = cg.time - ci->spawnChangedTime;
 			vec4_t      spawnPtColor;
@@ -893,9 +892,9 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 			{
 				widthLocationLeft = widthLocationLeft / 2;
 			}
-			if (comp->style & BIT(6))
+			if (comp->style & BIT(6)) // spawn locations
 			{
-				lim = widthLocationLeft / charWidth;
+				int lim = widthLocationLeft / spacing;
 				if (lim > 0)
 				{
 					if (comp->alignText == ITEM_ALIGN_RIGHT) // right align
@@ -915,9 +914,9 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 			else
 			{
 				CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, spawnPtColor, Q_TruncateStr(spawnPtStr[i], 0), 0, 0, comp->styleText, FONT_TEXT);
-				if (comp->style & BIT(7) && ci->mspawnpt > 0)
+				if (comp->style & BIT(7) && ci->mspawnpt > 0) // minor spawn points
 				{
-					CG_Text_Paint_Ext(x + charWidth, y + heightTextOffset, scale / 1.5, scale / 1.5, spawnPtColor, va("%i", ci->mspawnpt), 0, 0, comp->styleText, FONT_TEXT);
+					CG_Text_Paint_Ext(x + spacing, y + heightTextOffset, scale / 1.5, scale / 1.5, spawnPtColor, va("%i", ci->mspawnpt), 0, 0, comp->styleText, FONT_TEXT);
 				}
 			}
 		}

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -650,7 +650,6 @@ typedef struct clientInfo_s
 	int cls;
 	int latchedcls;
 	int spawnpt;
-	int mspawnpt;
 	int ping;
 
 	int rank;

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -649,6 +649,8 @@ typedef struct clientInfo_s
 	int breathPuffTime;
 	int cls;
 	int latchedcls;
+	int spawnpt;
+	int mspawnpt;
 	int ping;
 
 	int rank;

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -651,6 +651,7 @@ typedef struct clientInfo_s
 	int latchedcls;
 	int spawnpt;
 	int mspawnpt;
+	int spawnChangedTime;
 	int ping;
 
 	int rank;

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1423,7 +1423,7 @@ typedef struct
 	int numSpawnpointEnts;
 	int numMajorSpawnpointEnts;
 
-	qboolean supportsMinorSpawnPoints;
+	qboolean hasMinorSpawnPoints;
 
 	qboolean showCampaignBriefing;
 	qboolean showGameView;

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -650,6 +650,7 @@ typedef struct clientInfo_s
 	int cls;
 	int latchedcls;
 	int spawnpt;
+	int mspawnpt;
 	int ping;
 
 	int rank;
@@ -1419,6 +1420,9 @@ typedef struct
 	int numMiscGameModels;
 	int numCoronas;
 	int numSpawnpointEnts;
+	int numMajorSpawnpointEnts;
+
+	qboolean supportsMinorSpawnPoints;
 
 	qboolean showCampaignBriefing;
 	qboolean showGameView;
@@ -2609,6 +2613,7 @@ typedef struct cgs_s
 	cg_gamemodel_t miscGameModels[MAX_STATIC_GAMEMODELS];
 	cg_corona_t corona[MAX_GAMECORONAS];
 	cg_spawnpoint_t spawnpointEnt[MAX_GENTITIES];
+	cg_spawnpoint_t majorSpawnpointEnt[MAX_GENTITIES];
 
 	vec2_t ccMenuPos;
 	qboolean ccMenuShowing;

--- a/src/cgame/cg_players.c
+++ b/src/cgame/cg_players.c
@@ -222,8 +222,11 @@ void CG_NewClientInfo(int clientNum)
 	v                  = Info_ValueForKey(configstring, "lc");
 	newInfo.latchedcls = Q_atoi(v);
 
-	v                  = Info_ValueForKey(configstring, "sp");
+	v               = Info_ValueForKey(configstring, "sp");
 	newInfo.spawnpt = Q_atoi(v);
+
+	v                = Info_ValueForKey(configstring, "msp");
+	newInfo.mspawnpt = Q_atoi(v);
 
 	// rank
 	v            = Info_ValueForKey(configstring, "r");

--- a/src/cgame/cg_players.c
+++ b/src/cgame/cg_players.c
@@ -222,6 +222,12 @@ void CG_NewClientInfo(int clientNum)
 	v                  = Info_ValueForKey(configstring, "lc");
 	newInfo.latchedcls = Q_atoi(v);
 
+	v                  = Info_ValueForKey(configstring, "sp");
+	newInfo.spawnpt = Q_atoi(v);
+
+	v                  = Info_ValueForKey(configstring, "msp");
+	newInfo.mspawnpt = Q_atoi(v);
+
 	// rank
 	v            = Info_ValueForKey(configstring, "r");
 	newInfo.rank = Q_atoi(v);

--- a/src/cgame/cg_players.c
+++ b/src/cgame/cg_players.c
@@ -496,6 +496,11 @@ void CG_NewClientInfo(int clientNum)
 		CG_ToggleShoutcasterMode(newInfo.shoutcaster);
 	}
 
+	if (newInfo.spawnpt != ci->spawnpt || newInfo.mspawnpt != ci->mspawnpt)
+	{
+		newInfo.spawnChangedTime = cg.time;
+	}
+
 	// passing the clientNum since that's all we need, and we
 	// can't calculate it properly from the clientinfo
 	CG_LoadClientInfo(clientNum);

--- a/src/cgame/cg_players.c
+++ b/src/cgame/cg_players.c
@@ -225,9 +225,6 @@ void CG_NewClientInfo(int clientNum)
 	v                  = Info_ValueForKey(configstring, "sp");
 	newInfo.spawnpt = Q_atoi(v);
 
-	v                  = Info_ValueForKey(configstring, "msp");
-	newInfo.mspawnpt = Q_atoi(v);
-
 	// rank
 	v            = Info_ValueForKey(configstring, "r");
 	newInfo.rank = Q_atoi(v);

--- a/src/cgame/cg_spawn.c
+++ b/src/cgame/cg_spawn.c
@@ -386,6 +386,10 @@ void CG_Spawnpoint(void)
 
 	CG_SpawnVector("origin", "0 0 0", spawnpoint->origin);
 	CG_SpawnInt("id", "", &spawnpoint->id);
+	if (spawnpoint->id != 0)
+	{
+		cg.supportsMinorSpawnPoints = qtrue;
+	}
 
 }
 
@@ -400,6 +404,7 @@ void SP_team_WOLF_objective(void)
 	CG_SpawnString("description", "WARNING: No objective description set", &desc);
 	Q_strncpyz(spawnpoint->name, desc, sizeof(spawnpoint->name));
 	CG_SpawnVector("origin", "0 0 0", spawnpoint->origin);
+	cgs.majorSpawnpointEnt[cg.numMajorSpawnpointEnts++] = *spawnpoint;
 }
 
 typedef struct
@@ -738,11 +743,13 @@ void SP_worldspawn(void)
 void CG_ParseEntitiesFromString(void)
 {
 	// allow calls to CG_Spawn*()
-	cg.spawning          = qtrue;
-	cg.numSpawnVars      = 0;
-	cg.numMiscGameModels = 0;
-	cg.numCoronas        = 0;
-	cg.numSpawnpointEnts = 0;
+	cg.spawning                 = qtrue;
+	cg.numSpawnVars             = 0;
+	cg.numMiscGameModels        = 0;
+	cg.numCoronas               = 0;
+	cg.numSpawnpointEnts        = 0;
+	cg.numMajorSpawnpointEnts   = 0;
+	cg.supportsMinorSpawnPoints = qfalse;
 
 	// the worldspawn is not an actual entity, but it still
 	// has a "spawn" function to perform any global setup

--- a/src/cgame/cg_spawn.c
+++ b/src/cgame/cg_spawn.c
@@ -388,7 +388,7 @@ void CG_Spawnpoint(void)
 	CG_SpawnInt("id", "", &spawnpoint->id);
 	if (spawnpoint->id != 0)
 	{
-		cg.supportsMinorSpawnPoints = qtrue;
+		cg.hasMinorSpawnPoints = qtrue;
 	}
 
 }
@@ -743,13 +743,13 @@ void SP_worldspawn(void)
 void CG_ParseEntitiesFromString(void)
 {
 	// allow calls to CG_Spawn*()
-	cg.spawning                 = qtrue;
-	cg.numSpawnVars             = 0;
-	cg.numMiscGameModels        = 0;
-	cg.numCoronas               = 0;
-	cg.numSpawnpointEnts        = 0;
-	cg.numMajorSpawnpointEnts   = 0;
-	cg.supportsMinorSpawnPoints = qfalse;
+	cg.spawning               = qtrue;
+	cg.numSpawnVars           = 0;
+	cg.numMiscGameModels      = 0;
+	cg.numCoronas             = 0;
+	cg.numSpawnpointEnts      = 0;
+	cg.numMajorSpawnpointEnts = 0;
+	cg.hasMinorSpawnPoints    = qfalse;
 
 	// the worldspawn is not an actual entity, but it still
 	// has a "spawn" function to perform any global setup

--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -1992,13 +1992,12 @@ void ClientUserinfoChanged(int clientNum)
 	*/
 
 	infoLen = sizeof(configStr);
-	len     = snprintf(configStr, infoLen - len, "n\\%s\\t\\%i\\c\\%i\\lc\\%i\\sp\\%i\\msp\\%i\\r\\%i\\m\\%s\\s\\%s",
+	len     = snprintf(configStr, infoLen - len, "n\\%s\\t\\%i\\c\\%i\\lc\\%i\\sp\\%i\\r\\%i\\m\\%s\\s\\%s",
 	                   client->pers.netname,
 	                   client->sess.sessionTeam,
 	                   client->sess.playerType,
 	                   client->sess.latchPlayerType,
 	                   client->sess.userSpawnPointValue,
-	                   client->sess.userMinorSpawnPointValue,
 	                   client->sess.rank,
 	                   medalStr,
 	                   skillStr

--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -1990,14 +1990,14 @@ void ClientUserinfoChanged(int clientNum)
 	               client->sess.uci
 	               );
 	*/
-
 	infoLen = sizeof(configStr);
-	len     = snprintf(configStr, infoLen - len, "n\\%s\\t\\%i\\c\\%i\\lc\\%i\\sp\\%i\\r\\%i\\m\\%s\\s\\%s",
+	len     = snprintf(configStr, infoLen - len, "n\\%s\\t\\%i\\c\\%i\\lc\\%i\\sp\\%i\\msp\\%i\\r\\%i\\m\\%s\\s\\%s",
 	                   client->pers.netname,
 	                   client->sess.sessionTeam,
 	                   client->sess.playerType,
 	                   client->sess.latchPlayerType,
-	                   client->sess.userSpawnPointValue,
+	                   Com_Clamp(0, (level.numSpawnPoints - 1), ent->client->sess.resolvedSpawnPointIndex) + 1,
+	                   client->sess.userMinorSpawnPointValue,
 	                   client->sess.rank,
 	                   medalStr,
 	                   skillStr

--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -1992,11 +1992,13 @@ void ClientUserinfoChanged(int clientNum)
 	*/
 
 	infoLen = sizeof(configStr);
-	len     = snprintf(configStr, infoLen - len, "n\\%s\\t\\%i\\c\\%i\\lc\\%i\\r\\%i\\m\\%s\\s\\%s",
+	len     = snprintf(configStr, infoLen - len, "n\\%s\\t\\%i\\c\\%i\\lc\\%i\\sp\\%i\\msp\\%i\\r\\%i\\m\\%s\\s\\%s",
 	                   client->pers.netname,
 	                   client->sess.sessionTeam,
 	                   client->sess.playerType,
 	                   client->sess.latchPlayerType,
+	                   client->sess.userSpawnPointValue,
+	                   client->sess.userMinorSpawnPointValue,
 	                   client->sess.rank,
 	                   medalStr,
 	                   skillStr

--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -4614,6 +4614,7 @@ void SetPlayerSpawn(gentity_t *ent, int majorSpawn, int minorSpawn, qboolean upd
 	if (update)
 	{
 		G_UpdateSpawnPointStatePlayerCounts();
+		ClientUserinfoChanged(ent - g_entities);
 	}
 
 	resolvedSpawnPoint = Com_Clamp(0, (level.numSpawnPoints - 1), ent->client->sess.resolvedSpawnPointIndex);

--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -4614,7 +4614,6 @@ void SetPlayerSpawn(gentity_t *ent, int majorSpawn, int minorSpawn, qboolean upd
 	if (update)
 	{
 		G_UpdateSpawnPointStatePlayerCounts();
-		ClientUserinfoChanged(ent - g_entities);
 	}
 
 	resolvedSpawnPoint = Com_Clamp(0, (level.numSpawnPoints - 1), ent->client->sess.resolvedSpawnPointIndex);

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -641,6 +641,7 @@ typedef struct
 	int userSpawnPointValue;                            ///< index of objective to spawn nearest to (returned from UI)
 	int userMinorSpawnPointValue;                       ///< index of minor spawnpoint to spawn nearest to
 	int resolvedSpawnPointIndex;                        ///< most possible objective to spawn nearest to
+	int previousUserMinorSpawnPointValue;               ///< keeps track if minor spawn changed since last time
 	int latchPlayerType;                                ///< latched class
 	weapon_t latchPlayerWeapon;                         ///< latched primary weapon
 	weapon_t latchPlayerWeapon2;                        ///< latched secondary weapon

--- a/src/game/g_team.c
+++ b/src/game/g_team.c
@@ -2222,8 +2222,15 @@ void G_UpdateSpawnPointStatePlayerCounts()
 				continue;
 			}
 		}
-		playerCounts[resolvedSpawnPt]       += 1;
+		playerCounts[resolvedSpawnPt] += 1;
+		int oldResolvedSpawnPt = client->sess.resolvedSpawnPointIndex;
 		client->sess.resolvedSpawnPointIndex = resolvedSpawnPt;
+		if (oldResolvedSpawnPt != resolvedSpawnPt ||
+		    client->sess.userMinorSpawnPointValue != client->sess.previousUserMinorSpawnPointValue)
+		{
+			client->sess.previousUserMinorSpawnPointValue = client->sess.userMinorSpawnPointValue;
+			ClientUserinfoChanged(client - level.clients);
+		}
 	}
 	// update configstring, if necessary
 	for (i = 0; i < level.numSpawnPoints; i++)

--- a/src/game/g_team.c
+++ b/src/game/g_team.c
@@ -2195,7 +2195,7 @@ void G_UpdateSpawnPointStatePlayerCounts()
 		G_ResolveSpawnPointIndex(TEAM_AXIS,   level.axisAutoSpawn),
 		G_ResolveSpawnPointIndex(TEAM_ALLIES, level.alliesAutoSpawn)
 	};
-	int i, teamAutoSpawnPt, resolvedSpawnPt;
+	int i, teamAutoSpawnPt, resolvedSpawnPt, oldResolvedSpawnPt;
 	// check updates
 	for (i = 0; i < level.numConnectedClients; i++)
 	{
@@ -2222,8 +2222,8 @@ void G_UpdateSpawnPointStatePlayerCounts()
 				continue;
 			}
 		}
-		playerCounts[resolvedSpawnPt] += 1;
-		int oldResolvedSpawnPt = client->sess.resolvedSpawnPointIndex;
+		playerCounts[resolvedSpawnPt]       += 1;
+		oldResolvedSpawnPt                   = client->sess.resolvedSpawnPointIndex;
 		client->sess.resolvedSpawnPointIndex = resolvedSpawnPt;
 		if (oldResolvedSpawnPt != resolvedSpawnPt ||
 		    client->sess.userMinorSpawnPointValue != client->sess.previousUserMinorSpawnPointValue)


### PR DESCRIPTION
After LAN I noticed multiple times people still struggling with spawnpoints. The spawnmenu should already help with this. But for people still using binds I think a tool that can help them is seeing who in their team has what spawnpoint. I was playing around with latchedSpawnPt and minorSpawnPt, but I think its best to keep it simple by using only majorspawnpt.

I have added the following:
- A entry for the fireteam hud component
- A entry in the clientInfo string
- A call to update client info when changing spawnpt
- Showing the spawnpt in front of the name in the fireteam under a hudcomponent check

See: https://streamable.com/nj76a8

I am not sure if I need to add anything for hud versioning.