### PR TITLE
general: fix off by one error in Q_TruncateStr

### DIFF
--- a/src/cgame/cg_fireteamoverlay.c
+++ b/src/cgame/cg_fireteamoverlay.c
@@ -524,7 +524,7 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 		if (cg_fireteamNameMaxChars.integer)
 		{
 			nameMaxLen = Com_Clamp(0, MAX_NAME_LENGTH - 1, cg_fireteamNameMaxChars.integer);
-			Q_strncpyz(name[i], Q_TruncateStr(name[i], nameMaxLen), sizeof(name[i]));
+			Q_TruncateStr(name[i], nameMaxLen);
 
 			// if alignment is requested, keep a static width
 			if (cg_fireteamNameAlign.integer)

--- a/src/cgame/cg_locations.c
+++ b/src/cgame/cg_locations.c
@@ -372,8 +372,8 @@ location_t *CG_GetLocation(int client, vec3_t origin)
 	if (ISVALIDCLIENTNUM(client) && cgs.clientLocation[client].lastLocation)
 	{
 		if (cgs.clientLocation[client].lastX == origin[0]
-		     && cgs.clientLocation[client].lastY == origin[1]
-		     && cgs.clientLocation[client].lastZ == origin[2])
+		    && cgs.clientLocation[client].lastY == origin[1]
+		    && cgs.clientLocation[client].lastZ == origin[2])
 		{
 			return &cgs.location[cgs.clientLocation[client].lastLocation];
 		}
@@ -476,7 +476,7 @@ char *CG_BuildLocationString(int clientNum, vec3_t origin, int flag)
 			if (cg_locationMaxChars.integer)
 			{
 				locMaxLen = Com_Clamp(0, 128, cg_locationMaxChars.integer); // 128 is max location length
-				locStr    = Q_TruncateStr(locStr, locMaxLen);
+				Q_TruncateStr(locStr, locMaxLen);
 			}
 		}
 

--- a/src/qcommon/q_shared.c
+++ b/src/qcommon/q_shared.c
@@ -1853,8 +1853,8 @@ int Q_PrintStrlen(const char *string)
 }
 
 /**
- * @brief Q_TruncateStr
- * @param[in] string
+ * @brief Truncates string to a given length, ignoring color codes
+ * @param[in,out] string
  * @param[in] limit
  * @return
  */
@@ -1862,21 +1862,21 @@ char *Q_TruncateStr(char *string, int limit)
 {
 	char *p;
 	char *s;
-	int  i, len;
+	int  i;
 
 	if (!string)
 	{
-		return 0;
+		return NULL;
 	}
 
-	len = Q_PrintStrlen(string);
-	if (len <= limit)
+	if (strlen(string) <= limit || Q_PrintStrlen(string) <= limit)
 	{
 		return string;
 	}
 
 	p = string;
 	s = string;
+
 	for (i = 0; i < limit; i++)
 	{
 		if (Q_IsColorString(p))
@@ -1886,13 +1886,12 @@ char *Q_TruncateStr(char *string, int limit)
 			i++;
 			continue;
 		}
+
 		p++;
 	}
 
-	limit++; // for null byte
 	s[limit] = '\0';
-
-	return s;
+	return string;
 }
 
 /**


### PR DESCRIPTION
This also fixes incorrect usage of the function in fireteam overlay name truncation, which caused an assertion fail if the players' name was shorter than the requested name length limit.

refs #1707 