### PR TITLE
cgame: fix buffer size for remapshader timeOffset

### DIFF
--- a/src/cgame/cg_servercmds.c
+++ b/src/cgame/cg_servercmds.c
@@ -906,7 +906,7 @@ void CG_ShaderStateChanged(void)
 			o = strstr(t, "@");
 			if (o)
 			{
-				Q_strncpyz(timeOffset, t, o - t);
+				Q_strncpyz(timeOffset, t, MIN(o - t + 1, sizeof(timeOffset)));
 				o++;
 				trap_R_RemapShader(cgs.gameShaderNames[atoi(originalShader)],
 				                   cgs.gameShaderNames[atoi(newShader)],


### PR DESCRIPTION
Buffer needs +1 size like old/new shader buffers, which was initially missing when `strncpy` -> `Q_strncpyz` change was done.