### PR TITLE
cgame: offset minor spawn ID's slightly off the ground

### DIFF
--- a/src/cgame/cg_view.c
+++ b/src/cgame/cg_view.c
@@ -2156,6 +2156,9 @@ static void CG_DrawSpawnpoints(void)
 			// draw id if the spawnpoint is assigned one
 			if (spawnpoint->id)
 			{
+				// offset this a bit more from the ground in case the spawnpoint is on an uneven ground,
+				// otherwise the text origin might be inside solid, which causes it to not draw
+				trace.endpos[2] += 8;
 				CG_AddOnScreenText(va("%i", spawnpoint->id), trace.endpos, qfalse);
 			}
 		}


### PR DESCRIPTION
In some maps which have spawnpoints on uneven ground, the spawn blob draw origin might be inside a solid, which causes the minor ID text to not draw. Offset the text drawing a bit up to work around this.

refs #2179