### PR TITLE
general: enabled loongarch64 support. closes #3193

### DIFF
--- a/src/qcommon/q_platform.h
+++ b/src/qcommon/q_platform.h
@@ -202,6 +202,8 @@
 #undef idx64
 #define idx64 1
 #define ARCH_STRING "x86_64"
+#elif defined __loongarch64
+#define ARCH_STRING "loongarch64"
 #elif defined __powerpc64__
 #if BYTE_ORDER == BIG_ENDIAN
 #define ARCH_STRING "ppc64"

--- a/src/qcommon/vm.c
+++ b/src/qcommon/vm.c
@@ -338,7 +338,7 @@ void VM_LoadSymbols(vm_t *vm)
  */
 intptr_t QDECL VM_DllSyscall(intptr_t arg, ...)
 {
-#if defined(__x86_64__) || defined (_WIN64) || defined (__llvm__) || defined(__ANDROID__) || defined(__aarch64__) || ((defined __linux__) && (defined __powerpc__))
+#if defined(__loongarch64) || defined(__x86_64__) || defined (_WIN64) || defined (__llvm__) || defined(__ANDROID__) || defined(__aarch64__) || ((defined __linux__) && (defined __powerpc__))
 	// rcg010206 - see commentary above
 	intptr_t args[VM_SYSCALL_ARGS] = { 0 };
 	int      i;


### PR DESCRIPTION
Now the game builds and runs on loongarch64. The change to `q_platform.h` enables the game to build properly, and the change to `vm.c` allows the game to actually run (without that change, the cvar table was getting clobbered with a return value of the wrong size and making the game segfault during UI initialization).

I tested this on `6.16.7+deb14-loong64` with `gcc 15.2.0` and the system versions of all the dependencies. I built it with `./easybuild.sh -64 -debug -systemlib -noextras --prefix=/such/and/such`.