### PR TITLE
cgame: don't enforce sv_cvars in demo playback

### DIFF
--- a/src/cgame/cg_view.c
+++ b/src/cgame/cg_view.c
@@ -2325,7 +2325,10 @@ void CG_DrawActiveFrame(int serverTime, qboolean demoPlayback)
 	cg.time -= snapshotDelayTime;
 #endif // FAKELAG
 
-	CG_ProcessCvars();
+	if (!demoPlayback)
+	{
+		CG_ProcessCvars();
+	}
 
 #ifdef DEBUGTIME_ENABLED
 	CG_Printf("\n");


### PR DESCRIPTION
Should be obvious that this doesn't make sense.

fixes #3195 