### PR TITLE
ui: Fix ctype usage.

### DIFF
--- a/src/ui/ui_shared.c
+++ b/src/ui/ui_shared.c
@@ -176,7 +176,7 @@ static long hashForString(const char *str)
 
 	while (str[i] != '\0')
 	{
-		letter = (char)tolower(str[i]);
+		letter = (char)tolower((unsigned char)str[i]);
 		hash  += (long)(letter) * (i + 119);
 		i++;
 	}


### PR DESCRIPTION
The argument of these functions is of type int, but only a very restricted subset of values are actually valid.  The argument must either be the value of the macro EOF (which has a negative value), or must be a non-negative value within the range representable as unsigned char.

Passing invalid (negative char) values leads to undefined behavior.

This fixes a segfault on startup on NetBSD 11.