### PR TITLE
cgame: fixes to coronas

### DIFF
--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -4607,9 +4607,10 @@ void CG_DrawSprite(const vec3_t origin, float radius, qhandle_t shader, byte col
 }
 
 /**
- * @brief CG_Coronas
+ * @brief CG_DrawClientCoronas
+ * @brief Handles drawing client side coronas
  */
-void CG_Coronas(void)
+static void CG_DrawClientCoronas(void)
 {
 	if (cg_coronas.integer == 0)
 	{
@@ -4761,7 +4762,7 @@ void CG_DrawActive()
 	CG_ShakeCamera();
 	CG_PB_RenderPolyBuffers();
 	CG_DrawMiscGamemodels();
-	CG_Coronas();
+	CG_DrawClientCoronas();
 
 	if (!(cg.limboEndCinematicTime > cg.time && cg.showGameView))
 	{
@@ -4847,7 +4848,7 @@ void CG_DrawMissileCamera(hudComponent_t *comp)
 		CG_AddTrails();        // this must come last, so the trails dropped this frame get drawn
 		CG_PB_RenderPolyBuffers();
 		CG_DrawMiscGamemodels();
-		CG_Coronas();
+		CG_DrawClientCoronas();
 	}
 
 	refdef.time = cg.time;

--- a/src/cgame/cg_ents.c
+++ b/src/cgame/cg_ents.c
@@ -1560,7 +1560,8 @@ static void CG_Corona(centity_t *cent)
 {
 	float    r, g, b;
 	int      dli;
-	float    dot, dist;
+	float    dist;
+	float    fov;
 	vec3_t   dir;
 	qboolean behind = qfalse, toofar = qfalse;
 
@@ -1584,14 +1585,12 @@ static void CG_Corona(centity_t *cent)
 		toofar = qtrue;
 	}
 
-	dot = DotProduct(dir, cg.refdef_current->viewaxis[0]);
-	if (dot >= -0.6f)         // assumes ~90 deg fov - changed value to 0.6 (screen corner at 90 fov)
-	{
-		behind = qtrue;     // use the dot to at least do trivial removal of those behind you.
-	}
-	// yeah, I could calc side planes to clip against, but would that be worth it? (much better than dumb dot>= thing?)
 
-	//CG_Printf("dot: %f\n", dot);
+	fov = cosf((cg.refdef_current->fov_x / 2) * (float)(M_PI / 180));
+	if (DotProduct(dir, cg.refdef_current->viewaxis[0]) >= -fov)
+	{
+		behind = qtrue;
+	}
 
 	if (cg_coronas.integer == 2)       // if set to '2' trace everything
 	{

--- a/src/cgame/cg_ents.c
+++ b/src/cgame/cg_ents.c
@@ -1554,6 +1554,7 @@ static void CG_Trap(centity_t *cent)
 
 /**
  * @brief CG_Corona
+ * @brief This handles server side coronas only
  * @param[in] cent
  */
 static void CG_Corona(centity_t *cent)

--- a/src/cgame/cg_spawn.c
+++ b/src/cgame/cg_spawn.c
@@ -207,7 +207,7 @@ void SP_info_train_spline_main(void)
 /**
  * @brief CG_corona
  */
-void CG_corona(void)
+void SP_corona(void)
 {
 	cg_corona_t *corona;
 	float       scale;
@@ -412,7 +412,7 @@ spawn_t spawns[] =
 
 	{ "trigger_objective_info",    SP_trigger_objective_info },
 	{ "misc_gamemodel",            SP_misc_gamemodel         },
-	{ "corona",                    CG_corona                 },
+	{ "corona",                    SP_corona                 },
 	{ "team_CTF_redspawn",         CG_Spawnpoint             },
 	{ "team_CTF_bluespawn",        CG_Spawnpoint             },
 	{ "team_WOLF_objective",       SP_team_WOLF_objective    },


### PR DESCRIPTION
* Fix client side coronas not replicating wrapping behavior for `color` and `scale` like server side coronas do, resulting in mismatched visuals for same parameters depending on whether the corona was client or server sided
* Fix server side coronas culling too early from view on widescreen aspect ratios (already fixed this for client side coronas ~year ago but didn't notice server side coronas use a different function for drawing...)
* Cleanup corona related function names to be less confusing

This should probably be rebased.
refs #255 
refs #2538 