### PR TITLE
cgame: fix demo playback issues, refs #696

### DIFF
--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -4219,6 +4219,7 @@ static void CG_Draw2D(void)
 	if (cg.snap->ps.pm_type == PM_INTERMISSION)
 	{
 		CG_DrawIntermission();
+		CG_DrawDemoOverlay();
 		return;
 	}
 

--- a/src/cgame/cg_info.c
+++ b/src/cgame/cg_info.c
@@ -194,17 +194,17 @@ static qboolean CG_DemoControlButtonDown(panel_button_t *button, int key)
 
 		offset = offset / button->rect.w;
 		result = (int)(cg.demoinfo->firstTime + ((cg.demoinfo->lastTime - cg.demoinfo->firstTime) * offset));
-		trap_SendConsoleCommand(va("seekservertime %i", result));
+		trap_SendConsoleCommand(va("seekservertime %i\n", result));
 	}
 	break;
 	case 1:
-		trap_SendConsoleCommand("rewind 5");
+		trap_SendConsoleCommand("rewind 5\n");
 		break;
 	case 2:
-		trap_SendConsoleCommand("pausedemo");
+		trap_SendConsoleCommand("pausedemo\n");
 		break;
 	case 3:
-		trap_SendConsoleCommand("fastforward 5");
+		trap_SendConsoleCommand("fastforward 5\n");
 		break;
 	default:
 		break;
@@ -581,7 +581,7 @@ void CG_DemoClick(int key, qboolean down)
 	case K_SPACE: // most everyone's favorite jump key, :x
 		if (!down)
 		{
-			trap_SendConsoleCommand("pausedemo");
+			trap_SendConsoleCommand("pausedemo\n");
 		}
 		return;
 
@@ -753,7 +753,7 @@ void CG_DemoClick(int key, qboolean down)
 	case K_F11:
 		if (!down)
 		{
-			trap_SendConsoleCommand("screenshot");
+			trap_SendConsoleCommand("screenshot\n");
 		}
 		return;
 	case K_F12:

--- a/src/cgame/cg_info.c
+++ b/src/cgame/cg_info.c
@@ -298,6 +298,12 @@ void CG_DemoClick(int key, qboolean down)
 {
 	int milli = trap_Milliseconds();
 
+	// we don't want these duplicate key presses
+	if (key & K_CHAR_FLAG)
+	{
+		return;
+	}
+
 	// Avoid active console keypress issues
 	if (!down && !cgs.fKeyPressed[key])
 	{

--- a/src/cgame/cg_info.c
+++ b/src/cgame/cg_info.c
@@ -2073,6 +2073,14 @@ void CG_DrawOverlays(void)
 #ifdef FEATURE_MULTIVIEW
 	CG_SpecHelpDraw();
 #endif
+	CG_DrawDemoOverlay();
+}
+
+/**
+ * @brief CG_DrawDemoOverlay
+ */
+void CG_DrawDemoOverlay(void)
+{
 #ifdef FEATURE_EDV
 	if (cg.demoPlayback && cg_predefineddemokeys.integer)
 #else

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -3263,6 +3263,7 @@ void CG_ShowHelp_On(int *status);
 #ifdef FEATURE_MULTIVIEW
 qboolean CG_ViewingDraw(void);
 #endif
+void CG_DrawDemoOverlay(void);
 
 // cg_scoreboard.c
 qboolean CG_DrawScoreboard(void);

--- a/src/cgame/cg_view.c
+++ b/src/cgame/cg_view.c
@@ -2020,6 +2020,22 @@ static void CG_DemoRewindFixEffects(void)
 		}
 	}
 
+	for (i = 0; i < cg.snap->numEntities; i++)
+	{
+		centity_t *cent = &cg_entities[cg.snap->entities[i].number];
+
+		if (cent->currentState.number < MAX_CLIENTS)
+		{
+			continue;
+		}
+
+		// reset time for landmine flag
+		if (cent->currentState.weapon == WP_LANDMINE)
+		{
+			cent->lerpFrame.frameTime = cg.time;
+		}
+	}
+
 	CG_DemoRewindFixLocalEntities();
 
 	// lazy fix, ideally every time based event should be adjusted individually not simply deleted

--- a/src/client/cl_cvars.c
+++ b/src/client/cl_cvars.c
@@ -140,7 +140,7 @@ void CL_InitCvars()
 	cl_showServerCommands = Cvar_Get("cl_showServerCommands", "0", 0);
 	cl_showSend           = Cvar_Get("cl_showSend", "0", CVAR_TEMP);
 	cl_showTimeDelta      = Cvar_Get("cl_showTimeDelta", "0", CVAR_TEMP);
-	cl_freezeDemo         = Cvar_Get("cl_freezeDemo", "0", CVAR_TEMP);
+	cl_freezeDemo         = Cvar_Get("cl_freezeDemo", "0", CVAR_ROM);
 	rcon_client_password  = Cvar_Get("rconPassword", "", CVAR_TEMP);
 	cl_activeAction       = Cvar_Get("activeAction", "", CVAR_TEMP);
 	cl_autorecord         = Cvar_Get("cl_autorecord", "0", CVAR_TEMP);

--- a/src/client/cl_demo.c
+++ b/src/client/cl_demo.c
@@ -454,6 +454,7 @@ static void CL_DemoFastForward(double wantedTime)
 
 	cl.serverTime      = (int)(floor(wantedTime));
 	cls.realtime       = (int)(floor(wantedTime));
+	clc.lastPacketTime = cls.realtime;
 	di.Overf           = wantedTime - floor(wantedTime);
 	cl.serverTimeDelta = 0;
 

--- a/src/client/cl_demo.c
+++ b/src/client/cl_demo.c
@@ -54,6 +54,10 @@
 #define NEW_DEMOFUNC 1
 
 #if NEW_DEMOFUNC
+static int demoPauseTime = 0;
+#endif
+
+#if NEW_DEMOFUNC
 typedef struct
 {
 	int numSnaps;
@@ -454,6 +458,11 @@ static void CL_DemoFastForward(double wantedTime)
 	clc.lastPacketTime = cls.realtime;
 	di.Overf           = wantedTime - floor(wantedTime);
 	cl.serverTimeDelta = 0;
+
+	if (cl_freezeDemo->integer)
+	{
+		demoPauseTime = cls.realtime;
+	}
 
 	// TODO: fix this
 	//VM_Call(cgvm, CG_TIME_CHANGE, cl.serverTime, (int)(Overf * SUBTIME_RESOLUTION));
@@ -1895,10 +1904,6 @@ void CL_SeekPrev_f(void)
  */
 void CL_PauseDemo_f(void)
 {
-#if NEW_DEMOFUNC
-	static int pauseTime = 0;
-#endif
-
 	if (!clc.demo.playing)
 	{
 		return;
@@ -1913,12 +1918,11 @@ void CL_PauseDemo_f(void)
 #if NEW_DEMOFUNC
 	if (!cl_freezeDemo->integer)
 	{
-		pauseTime = cl.serverTime;
+		demoPauseTime = cls.realtime;
 	}
 	else
 	{
-		// TODO: this is just a hack, actually fix the cl_freezeDemo instead of this
-		CL_DemoSeekMs(0, pauseTime);
+		cls.realtime = demoPauseTime;
 	}
 #endif
 


### PR DESCRIPTION
- cgame: fix landmines flag breaking on demo rewind
- cgame: fix out of bound access
It was causing visual glitches when 'W' key got pressed on map sw_goldrush_te around the lighthouse after the tank passed the tank barrier.
- client: fix demo timeout when rewinding
- client: fix gamestate not updating on demo rewind in some cases
- cgame: fix missing endline on send console command
- client: allow rewinding/fast-forwarding when demo is paused
- cgame: draw demo overlay/help window during intermission

refs #696