### PR TITLE
server: direct http file downloads

### DIFF
--- a/misc/etmain/etl_server.cfg
+++ b/misc/etmain/etl_server.cfg
@@ -57,6 +57,13 @@ set sv_wwwBaseURL ""                            // base URL for redirection
 set sv_wwwDlDisconnected "0"                    // tell clients to perform their downloads while disconnected from the server
 set sv_wwwFallbackURL ""                        // URL to send to if an http/ftp fails or is refused client side
 
+// HTTP SERVER - Embedded HTTP server for serving game files
+set sv_httpEnable "1"                           // enable/disable embedded HTTP server (requires restart)
+set sv_httpMaxClients "16"                      // maximum simultaneous HTTP client connections (max: 32)
+set sv_httpAutoConfig "1"                       // automatically configure sv_wwwBaseURL using detected server IP
+set sv_httpTimeout "30"                         // connection timeout for idle HTTP clients in seconds
+set sv_httpMaxBytesPerFrame "65536"             // bandwidth throttling - max bytes per frame (64KB default)
+
 // LOGGING & PROTECTION
 
 set logfile "2"                                 // enable console logging - 'etconsole.log' (1: enabled 2: enabled and synchronized)

--- a/misc/etmain/etl_server_comp.cfg
+++ b/misc/etmain/etl_server_comp.cfg
@@ -52,6 +52,13 @@ set sv_wwwBaseURL ""                            // base URL for redirection
 set sv_wwwDlDisconnected "0"                    // tell clients to perform their downloads while disconnected from the server
 set sv_wwwFallbackURL ""                        // URL to send to if an http/ftp fails or is refused client side
 
+// HTTP SERVER - Embedded HTTP server for serving game files
+set sv_httpEnable "1"                           // enable/disable embedded HTTP server (requires restart)
+set sv_httpMaxClients "16"                      // maximum simultaneous HTTP client connections (max: 32)
+set sv_httpAutoConfig "1"                       // automatically configure sv_wwwBaseURL using detected server IP
+set sv_httpTimeout "30"                         // connection timeout for idle HTTP clients in seconds
+set sv_httpMaxBytesPerFrame "65536"             // bandwidth throttling - max bytes per frame (64KB default)
+
 // LOGGING & PROTECTION
 
 set logfile "1"                                 // enable console logging - 'etconsole.log' (1: enabled 2: enabled and synchronized)

--- a/src/qcommon/common.c
+++ b/src/qcommon/common.c
@@ -3136,6 +3136,14 @@ void Com_Init(char *commandLine)
 	}
 #endif
 
+#ifdef DEDICATED
+	// Initialize embedded HTTP server after network initialization is complete
+	if (com_dedicated->integer)
+	{
+		HTTP_Init();
+	}
+#endif
+
 	com_fullyInitialized = qtrue;
 	Com_Printf("----- Common Initialized -------\n");
 }

--- a/src/qcommon/net_ip.c
+++ b/src/qcommon/net_ip.c
@@ -32,6 +32,12 @@
  * @file net_ip.c
  */
 
+// Define feature test macros before any system includes
+#ifndef _WIN32
+#define _DEFAULT_SOURCE 1
+#define _BSD_SOURCE 1
+#endif
+
 #include "q_shared.h"
 #include "qcommon.h"
 
@@ -1113,7 +1119,7 @@ int NET_IPSocket(const char *net_interface, int port, int *err)
 {
 	SOCKET             newsocket;
 	struct sockaddr_in address;
-	u_long             _true = 1;
+	unsigned long      _true = 1;
 	int                i     = 1;
 
 	struct timeval timeout;
@@ -1209,7 +1215,7 @@ int NET_IP6Socket(const char *net_interface, int port, struct sockaddr_in6 *bind
 {
 	SOCKET              newsocket;
 	struct sockaddr_in6 address;
-	u_long              _true = 1;
+	unsigned long       _true = 1;
 
 	*err = 0;
 

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -46,6 +46,10 @@
 	#include "../irc/irc_client.h"
 #endif
 
+#ifdef DEDICATED
+	#include "sv_http.h"
+#endif
+
 #define PERS_SCORE              0   ///< !!! MUST NOT CHANGE, SERVER AND GAME BOTH REFERENCE !!!
 
 // advert control

--- a/src/server/sv_cvars.c
+++ b/src/server/sv_cvars.c
@@ -77,6 +77,13 @@ cvar_t *sv_wwwBaseURL;          // base URL for redirect
 cvar_t *sv_wwwDlDisconnected;
 cvar_t *sv_wwwFallbackURL; // URL to send to if an http/ftp fails or is refused client side
 
+// HTTP server
+cvar_t *sv_httpEnable;           // enable/disable embedded HTTP server
+cvar_t *sv_httpMaxClients;       // maximum simultaneous HTTP client connections
+cvar_t *sv_httpAutoConfig;       // automatically configure sv_wwwBaseURL using detected IP
+cvar_t *sv_httpTimeout;          // connection timeout for idle HTTP clients (seconds)
+cvar_t *sv_httpMaxBytesPerFrame; // bandwidth throttling - max bytes per frame
+
 cvar_t *sv_cheats;
 cvar_t *sv_packetloss;
 cvar_t *sv_packetdelay;

--- a/src/server/sv_cvars.h
+++ b/src/server/sv_cvars.h
@@ -89,6 +89,13 @@ extern cvar_t *sv_wwwBaseURL;  ///< the base URL of all the files
 extern cvar_t *sv_wwwDlDisconnected;
 extern cvar_t *sv_wwwFallbackURL;
 
+/// HTTP server
+extern cvar_t *sv_httpEnable;           ///< enable/disable embedded HTTP server
+extern cvar_t *sv_httpMaxClients;       ///< maximum simultaneous HTTP client connections
+extern cvar_t *sv_httpAutoConfig;       ///< automatically configure sv_wwwBaseURL using detected IP
+extern cvar_t *sv_httpTimeout;          ///< connection timeout for idle HTTP clients (seconds)
+extern cvar_t *sv_httpMaxBytesPerFrame; ///< bandwidth throttling - max bytes per frame
+
 extern cvar_t *sv_cheats;
 extern cvar_t *sv_packetloss;
 extern cvar_t *sv_packetdelay;

--- a/src/server/sv_http.h
+++ b/src/server/sv_http.h
@@ -1,0 +1,343 @@
+/*
+ * Wolfenstein: Enemy Territory GPL Source Code
+ * Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company.
+ *
+ * ET: Legacy
+ * Copyright (C) 2012-2024 ET:Legacy team <mail@etlegacy.com>
+ *
+ * This file is part of ET: Legacy - http://www.etlegacy.com
+ *
+ * ET: Legacy is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ET: Legacy is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ET: Legacy. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * In addition, Wolfenstein: Enemy Territory GPL Source Code is also
+ * subject to certain additional terms. You should have received a copy
+ * of these additional terms immediately following the terms and conditions
+ * of the GNU General Public License which accompanied the source code.
+ * If not, please request a copy in writing from id Software at the address below.
+ *
+ * id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, Maryland 20850 USA.
+ */
+/**
+ * @file sv_http.h
+ * @brief Embedded HTTP server for serving game files
+ */
+
+#ifndef INCLUDE_SV_HTTP_H
+#define INCLUDE_SV_HTTP_H
+
+#include "../qcommon/q_shared.h"
+#include "../qcommon/qcommon.h"
+
+// Maximum number of simultaneous HTTP client connections
+#define MAX_HTTP_CLIENTS        32
+
+// Buffer sizes
+#define HTTP_REQUEST_BUFFER     16384   // 16KB for request headers
+#define HTTP_RESPONSE_BUFFER    4096    // 4KB for response headers
+#define HTTP_FILE_CHUNK         32768   // 32KB for file chunks
+
+// HTTP request method
+typedef enum
+{
+	HTTP_METHOD_NONE,
+	HTTP_METHOD_GET,
+	HTTP_METHOD_HEAD
+} httpMethod_t;
+
+// HTTP client connection state
+typedef enum
+{
+	HTTP_STATE_FREE,            // Client slot is free
+	HTTP_STATE_CONNECTED,       // Client connected, waiting for request
+	HTTP_STATE_RECEIVING,       // Receiving request data
+	HTTP_STATE_PROCESSING,      // Processing request
+	HTTP_STATE_SENDING_HEADERS, // Sending response headers
+	HTTP_STATE_SENDING_FILE,    // Sending file data
+	HTTP_STATE_CLOSING          // Closing connection
+} httpState_t;
+
+/**
+ * @struct httpClient_s
+ * @typedef httpClient_t
+ * @brief HTTP client connection structure
+ */
+typedef struct httpClient_s
+{
+	httpState_t state;          // Connection state
+	int socket;                 // Client socket descriptor
+	netadr_t address;           // Client address
+	int lastActivity;           // Time of last activity (msec)
+
+	// Request data
+	char requestBuffer[HTTP_REQUEST_BUFFER];    // Request buffer
+	int requestLength;                          // Current request length
+	httpMethod_t method;                        // HTTP method
+	char path[MAX_QPATH];                       // Requested path
+	char httpVersion[16];                       // HTTP version string
+
+	// Request headers
+	char userAgent[256];                        // User-Agent header
+	char referer[256];                          // Referer header
+
+	// Range request support
+	qboolean hasRange;                          // Has Range header
+	int rangeStart;                             // Range start position
+	int rangeEnd;                               // Range end position
+
+	// Response data
+	char responseBuffer[HTTP_RESPONSE_BUFFER]; // Response header buffer
+	int responseLength;                         // Response header length
+	int bytesSent;                              // Bytes sent so far
+
+	// File serving
+	fileHandle_t fileHandle;                    // Open file handle
+	int fileSize;                               // Total file size
+	int filePosition;                           // Current position in file
+	int fileBytesToSend;                        // Bytes remaining to send
+} httpClient_t;
+
+/**
+ * @struct httpServer_s
+ * @typedef httpServer_t
+ * @brief HTTP server state structure
+ */
+typedef struct httpServer_s
+{
+	qboolean initialized;       // Server initialized
+	qboolean enabled;           // Server enabled
+	int socket;                 // Listening socket descriptor
+	int port;                   // Listening port
+	int maxClients;             // Maximum clients
+
+	httpClient_t clients[MAX_HTTP_CLIENTS]; // Client pool
+	int activeClients;          // Number of active clients
+
+	// Performance tracking
+	int frameBytesSent;         // Bytes sent in current frame
+	int frameStartTime;         // Frame start time (msec)
+
+	// Statistics
+	int totalConnections;       // Total connections accepted
+	int totalBytesSent;         // Total bytes sent
+	int totalRequests;          // Total requests processed
+} httpServer_t;
+
+// Public API
+
+/**
+ * @brief Get the external IP address of the server
+ * @param[out] ipBuffer Buffer to store the IP address string
+ * @param[in] ipBufferSize Size of the IP address buffer
+ */
+qboolean HTTP_GetExternalIP(char *ipBuffer, int ipBufferSize);
+
+/**
+ * @brief Initialize the HTTP server subsystem
+ */
+void HTTP_Init(void);
+
+/**
+ * @brief Shutdown the HTTP server subsystem
+ */
+void HTTP_Shutdown(void);
+
+/**
+ * @brief Process HTTP server events (called each frame)
+ */
+void HTTP_Frame(void);
+
+/**
+ * @brief Open the HTTP server listening port
+ * @param[in] port Port number to listen on
+ * @return qtrue on success, qfalse on failure
+ */
+qboolean HTTP_OpenPort(int port);
+
+/**
+ * @brief Close the HTTP server listening port
+ */
+void HTTP_ClosePort(void);
+
+/**
+ * @brief Automatically configure sv_wwwBaseURL for HTTP downloads
+ * @return qtrue on success, qfalse on failure
+ */
+qboolean HTTP_AutoConfigureBaseURL(void);
+
+/**
+ * @brief Accept new incoming TCP connections
+ */
+void HTTP_AcceptConnections(void);
+
+/**
+ * @brief Allocate a free client structure
+ * @return Pointer to client structure or NULL if none available
+ */
+httpClient_t *HTTP_AllocClient(void);
+
+/**
+ * @brief Free a client structure back to the pool
+ * @param[in] client Client to free
+ */
+void HTTP_FreeClient(httpClient_t *client);
+
+/**
+ * @brief Close a client connection
+ * @param[in] client Client to close
+ */
+void HTTP_CloseClient(httpClient_t *client);
+
+/**
+ * @brief Timeout idle client connections
+ */
+void HTTP_TimeoutClients(void);
+
+// Request parsing functions
+
+/**
+ * @brief Parse HTTP request from client buffer
+ * @param[in] client Client to parse request for
+ * @return qtrue on success, qfalse on parse error
+ */
+qboolean HTTP_ParseRequest(httpClient_t *client);
+
+/**
+ * @brief Parse HTTP request line (method, path, version)
+ * @param[in] client Client to parse for
+ * @param[in] line Request line string
+ * @return qtrue on success, qfalse on parse error
+ */
+qboolean HTTP_ParseRequestLine(httpClient_t *client, const char *line);
+
+/**
+ * @brief Parse HTTP headers from request
+ * @param[in] client Client to parse for
+ * @param[in] headers Headers string (after request line)
+ * @return qtrue on success, qfalse on parse error
+ */
+qboolean HTTP_ParseHeaders(httpClient_t *client, const char *headers);
+
+/**
+ * @brief Parse Range header for partial content requests
+ * @param[in] client Client to parse for
+ * @param[in] value Range header value
+ * @return qtrue on success, qfalse on parse error
+ */
+qboolean HTTP_ParseRangeHeader(httpClient_t *client, const char *value);
+
+// Response generation functions
+
+/**
+ * @brief Get HTTP status text for status code
+ * @param[in] statusCode HTTP status code
+ * @return Status text string
+ */
+const char *HTTP_GetStatusText(int statusCode);
+
+/**
+ * @brief Determine MIME type from file extension
+ * @param[in] path File path
+ * @return MIME type string
+ */
+const char *HTTP_GetMimeType(const char *path);
+
+/**
+ * @brief Build response headers for a given status code
+ * @param[in] client Client to build headers for
+ * @param[in] statusCode HTTP status code
+ * @param[in] contentType Content-Type header value
+ * @param[in] contentLength Content-Length value (-1 for no Content-Length)
+ * @return qtrue on success, qfalse on error
+ */
+qboolean HTTP_BuildResponseHeaders(httpClient_t *client, int statusCode, const char *contentType, int contentLength);
+
+/**
+ * @brief Send response headers to client
+ * @param[in] client Client to send to
+ * @return qtrue if headers sent or in progress, qfalse on error
+ */
+qboolean HTTP_SendHeaders(httpClient_t *client);
+
+/**
+ * @brief Send error response to client
+ * @param[in] client Client to send error to
+ * @param[in] statusCode HTTP status code
+ * @param[in] message Error message
+ */
+void HTTP_SendErrorResponse(httpClient_t *client, int statusCode, const char *message);
+
+/**
+ * @brief Process response sending state
+ * @param[in] client Client to process
+ * @return qtrue if processing should continue, qfalse if done or error
+ */
+qboolean HTTP_ProcessResponseSending(httpClient_t *client);
+
+// File operations functions
+
+/**
+ * @brief Validate requested path for security
+ * @param[in] path Requested path from HTTP request
+ * @return qtrue if path is valid and safe, qfalse otherwise
+ */
+qboolean HTTP_ValidatePath(const char *path);
+
+/**
+ * @brief Open file for serving over HTTP using secure filesystem
+ * @param[in] path Game-relative path to file (e.g., "etmain/pak0.pk3")
+ * @param[out] fileHandle Pointer to store file handle
+ * @param[out] fileSize Pointer to store file size
+ * @return qtrue if file opened successfully, qfalse otherwise
+ */
+qboolean HTTP_OpenFileForServing(const char *path, fileHandle_t *fileHandle, int *fileSize);
+
+/**
+ * @brief Close open file
+ * @param[in] fileHandle File handle to close
+ */
+void HTTP_CloseFile(fileHandle_t fileHandle);
+
+/**
+ * @brief Read chunk of data from file
+ * @param[in] fileHandle Open file handle
+ * @param[out] buffer Buffer to read data into
+ * @param[in] bufferSize Size of buffer
+ * @return Number of bytes read, or -1 on error
+ */
+int HTTP_ReadFileChunk(fileHandle_t fileHandle, void *buffer, int bufferSize);
+
+/**
+ * @brief Seek to position in file
+ * @param[in] fileHandle Open file handle
+ * @param[in] offset Offset to seek to
+ * @param[in] whence Seek mode (FS_SEEK_SET, FS_SEEK_CUR, FS_SEEK_END)
+ * @return qtrue on success, qfalse on error
+ */
+qboolean HTTP_SeekFile(fileHandle_t fileHandle, int offset, int whence);
+
+/**
+ * @brief Send file response to client (initiate file transfer)
+ * @param[in] client Client to send file to
+ * @return qtrue on success, qfalse on error
+ */
+qboolean HTTP_SendFileResponse(httpClient_t *client);
+
+/**
+ * @brief Send file data chunk to client
+ * @param[in] client Client to send chunk to
+ * @return qtrue if more data to send, qfalse if complete or error
+ */
+qboolean HTTP_SendFileChunk(httpClient_t *client);
+
+#endif // INCLUDE_SV_HTTP_H

--- a/src/server/sv_http_file.c
+++ b/src/server/sv_http_file.c
@@ -1,0 +1,230 @@
+/*
+ * Wolfenstein: Enemy Territory GPL Source Code
+ * Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company.
+ *
+ * ET: Legacy
+ * Copyright (C) 2012-2024 ET:Legacy team <mail@etlegacy.com>
+ *
+ * This file is part of ET: Legacy - http://www.etlegacy.com
+ *
+ * ET: Legacy is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ET: Legacy is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ET: Legacy. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * In addition, Wolfenstein: Enemy Territory GPL Source Code is also
+ * subject to certain additional terms. You should have received a copy
+ * of these additional terms immediately following the terms and conditions
+ * of the GNU General Public License which accompanied the source code.
+ * If not, please request a copy in writing from id Software at the address below.
+ *
+ * id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, Maryland 20850 USA.
+ */
+/**
+ * @file sv_http_file.c
+ * @brief HTTP file operations - validation, location, and serving
+ */
+
+#include "server.h"
+#include "sv_http.h"
+
+/**
+ * @brief Validate requested path for security
+ * @param[in] path Requested path from HTTP request
+ * @return qtrue if path is valid and safe, qfalse otherwise
+ *
+ * @note This validation mirrors the security checks used in SV_WriteDownloadToClient
+ *       to ensure HTTP file serving has the same security as the regular download system
+ */
+qboolean HTTP_ValidatePath(const char *path)
+{
+	const char *cleanPath;
+	const char *ext;
+
+	if (!path || !path[0])
+	{
+		Com_DPrintf("HTTP: Empty path rejected\n");
+		return qfalse;
+	}
+
+	// Skip leading slash if present
+	cleanPath = path;
+	if (cleanPath[0] == '/')
+	{
+		cleanPath++;
+	}
+
+	// Empty after removing slash
+	if (!cleanPath[0])
+	{
+		Com_DPrintf("HTTP: Empty path after normalization rejected\n");
+		return qfalse;
+	}
+
+	// Use existing filesystem security check for path traversal
+	if (FS_CheckDirTraversal(cleanPath))
+	{
+		Com_DPrintf("HTTP: Path traversal attempt rejected: %s\n", cleanPath);
+		return qfalse;
+	}
+
+	// Only allow .pk3 files
+	ext = strrchr(cleanPath, '.');
+	if (!ext || Q_stricmp(ext, ".pk3") != 0)
+	{
+		Com_DPrintf("HTTP: Non-pk3 file rejected: %s\n", cleanPath);
+		return qfalse;
+	}
+
+	// Check if downloads are allowed (same as SV_CheckDownloadAllowed)
+	if (!sv_allowDownload->integer)
+	{
+		Com_DPrintf("HTTP: Downloads disabled on server: %s\n", cleanPath);
+		return qfalse;
+	}
+
+	// Check if this is an official id pak (same check as SV_CheckDownloadAllowed)
+	// Note: FS_idPak expects path WITHOUT .pk3 extension
+	{
+		char pathWithoutExt[MAX_QPATH];
+		Q_strncpyz(pathWithoutExt, cleanPath, sizeof(pathWithoutExt));
+		COM_StripExtension(pathWithoutExt, pathWithoutExt, sizeof(pathWithoutExt));
+
+		if (FS_idPak(pathWithoutExt, BASEGAME))
+		{
+			Com_DPrintf("HTTP: Cannot download official id pak: %s\n", cleanPath);
+			return qfalse;
+		}
+	}
+
+	// CRITICAL: Verify the pak is in the loaded pak list (CVE-2006-2082 protection)
+	// This ensures we only serve files that are already registered in the filesystem
+	if (!FS_VerifyPak(cleanPath))
+	{
+		Com_DPrintf("HTTP: Pak not in loaded pak list (CVE-2006-2082): %s\n", cleanPath);
+		return qfalse;
+	}
+
+	// Path is valid and safe
+	Com_DPrintf("HTTP: Path validated: %s\n", cleanPath);
+	return qtrue;
+}
+
+/**
+ * @brief Open file for serving over HTTP using secure filesystem
+ * @param[in] path Game-relative path to file (e.g., "etmain/pak0.pk3")
+ * @param[out] fileHandle Pointer to store file handle
+ * @param[out] fileSize Pointer to store file size
+ * @return qtrue if file opened successfully, qfalse otherwise
+ *
+ * @note This should only be called after HTTP_ValidatePath has approved the path
+ */
+qboolean HTTP_OpenFileForServing(const char *path, fileHandle_t *fileHandle, int *fileSize)
+{
+	long       size;
+	const char *cleanPath;
+
+	if (!path || !path[0] || !fileHandle || !fileSize)
+	{
+		return qfalse;
+	}
+
+	// Skip leading slash if present
+	cleanPath = path;
+	if (cleanPath[0] == '/')
+	{
+		cleanPath++;
+	}
+
+	// Use secure server filesystem function that:
+	// - Searches homepath and basepath automatically
+	// - Returns file size
+	// - Opens the file handle
+	// - Uses proper security checks
+	size = FS_SV_FOpenFileRead(cleanPath, fileHandle);
+
+	if (size <= 0 || !*fileHandle)
+	{
+		Com_DPrintf("HTTP: Failed to open file: %s\n", cleanPath);
+		return qfalse;
+	}
+
+	*fileSize = (int)size;
+	Com_DPrintf("HTTP: File opened: %s (handle: %d, size: %d bytes)\n", cleanPath, *fileHandle, *fileSize);
+	return qtrue;
+}
+
+/**
+ * @brief Close open file
+ * @param[in] fileHandle File handle to close
+ */
+void HTTP_CloseFile(fileHandle_t fileHandle)
+{
+	if (fileHandle)
+	{
+		FS_FCloseFile(fileHandle);
+		Com_DPrintf("HTTP: File closed (handle: %d)\n", fileHandle);
+	}
+}
+
+/**
+ * @brief Read chunk of data from file
+ * @param[in] fileHandle Open file handle
+ * @param[out] buffer Buffer to read data into
+ * @param[in] bufferSize Size of buffer
+ * @return Number of bytes read, or -1 on error
+ */
+int HTTP_ReadFileChunk(fileHandle_t fileHandle, void *buffer, int bufferSize)
+{
+	int bytesRead;
+
+	if (!fileHandle || !buffer || bufferSize <= 0)
+	{
+		return -1;
+	}
+
+	bytesRead = FS_Read(buffer, bufferSize, fileHandle);
+	if (bytesRead < 0)
+	{
+		Com_DPrintf("HTTP: File read error\n");
+		return -1;
+	}
+
+	Com_DPrintf("HTTP: Read %d bytes from file\n", bytesRead);
+	return bytesRead;
+}
+
+/**
+ * @brief Seek to position in file
+ * @param[in] fileHandle Open file handle
+ * @param[in] offset Offset to seek to
+ * @param[in] whence Seek mode (FS_SEEK_SET, FS_SEEK_CUR, FS_SEEK_END)
+ * @return qtrue on success, qfalse on error
+ */
+qboolean HTTP_SeekFile(fileHandle_t fileHandle, int offset, int whence)
+{
+	int result;
+
+	if (!fileHandle)
+	{
+		return qfalse;
+	}
+
+	result = FS_Seek(fileHandle, offset, whence);
+	if (result != 0)
+	{
+		Com_DPrintf("HTTP: File seek failed\n");
+		return qfalse;
+	}
+
+	Com_DPrintf("HTTP: Seeked to offset %d\n", offset);
+	return qtrue;
+}

--- a/src/server/sv_http_ipresolve.c
+++ b/src/server/sv_http_ipresolve.c
@@ -39,6 +39,7 @@
 #include <netdb.h>
 #include <unistd.h>
 #include <errno.h>
+#include <sys/time.h>
 typedef int SOCKET;
 #define closesocket close
 #define INVALID_SOCKET -1
@@ -91,6 +92,7 @@ qboolean HTTP_GetExternalIP(char *ipBuffer, int ipBufferSize)
 		struct timeval          tv;
 		int                     len;
 		int                     j;
+		unsigned int            seed;
 
 		Com_Memset(&hints, 0, sizeof(hints));
 		hints.ai_family   = AF_INET;
@@ -116,7 +118,7 @@ qboolean HTTP_GetExternalIP(char *ipBuffer, int ipBufferSize)
 		*(unsigned short *)&request[0] = htons(0x0001);
 		*(unsigned short *)&request[2] = htons(0x0000);
 		*(unsigned int *)&request[4]   = htonl(0x2112A442);
-		unsigned int seed = Sys_Milliseconds();
+		seed = Sys_Milliseconds();
 		for (j = 8; j < 20; j++)
 		{
 			request[j] = (rand() ^ (seed >> ((j - 8) % 4))) & 0xFF;

--- a/src/server/sv_http_ipresolve.c
+++ b/src/server/sv_http_ipresolve.c
@@ -113,13 +113,13 @@ qboolean HTTP_GetExternalIP(char *ipBuffer, int ipBufferSize)
 
 		// STUN request packet
 		Com_Memset(request, 0, sizeof(request));
-		*(unsigned short *)&request[0] = htons(0x0001); // Binding Request
-		*(unsigned short *)&request[2] = htons(0x0000); // Message Length
-		*(unsigned int *)&request[4]   = htonl(0x2112A442); // Magic Cookie
-		// Transaction ID (12 bytes) - can be random
+		*(unsigned short *)&request[0] = htons(0x0001);
+		*(unsigned short *)&request[2] = htons(0x0000);
+		*(unsigned int *)&request[4]   = htonl(0x2112A442);
+		unsigned int seed = Sys_Milliseconds();
 		for (j = 8; j < 20; j++)
 		{
-			request[j] = rand() & 0xFF;
+			request[j] = (rand() ^ (seed >> ((j - 8) % 4))) & 0xFF;
 		}
 
 		if (sendto(sock, (const char *)request, sizeof(request), 0, res->ai_addr, res->ai_addrlen) == SOCKET_ERROR)

--- a/src/server/sv_http_ipresolve.c
+++ b/src/server/sv_http_ipresolve.c
@@ -91,8 +91,6 @@ qboolean HTTP_GetExternalIP(char *ipBuffer, int ipBufferSize)
 		socklen_t               fromlen;
 		struct timeval          tv;
 		int                     len;
-		int                     j;
-		unsigned int            seed;
 
 		Com_Memset(&hints, 0, sizeof(hints));
 		hints.ai_family   = AF_INET;
@@ -118,11 +116,8 @@ qboolean HTTP_GetExternalIP(char *ipBuffer, int ipBufferSize)
 		*(unsigned short *)&request[0] = htons(0x0001);
 		*(unsigned short *)&request[2] = htons(0x0000);
 		*(unsigned int *)&request[4]   = htonl(0x2112A442);
-		seed = Sys_Milliseconds();
-		for (j = 8; j < 20; j++)
-		{
-			request[j] = (rand() ^ (seed >> ((j - 8) % 4))) & 0xFF;
-		}
+		// Generate 12 random bytes for transaction ID (bytes 8-19)
+		Com_RandomBytes(&request[8], 12);
 
 		if (sendto(sock, (const char *)request, sizeof(request), 0, res->ai_addr, res->ai_addrlen) == SOCKET_ERROR)
 		{

--- a/src/server/sv_http_ipresolve.c
+++ b/src/server/sv_http_ipresolve.c
@@ -1,0 +1,183 @@
+/*
+ * Wolfenstein: Enemy Territory GPL Source Code
+ * Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company.
+ *
+ * ET: Legacy
+ * Copyright (C) 2012-2024 ET:Legacy team <mail@etlegacy.com>
+ *
+ * This file is part of ET: Legacy - http://www.etlegacy.com
+ *
+ * ET: Legacy is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ET: Legacy is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ET: Legacy. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file sv_http_ipresolve.c
+ * @brief IP address resolution for the HTTP server
+ */
+
+#include "server.h"
+#include "sv_http.h"
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <unistd.h>
+#include <errno.h>
+typedef int SOCKET;
+#define closesocket close
+#define INVALID_SOCKET -1
+#define SOCKET_ERROR -1
+#endif
+
+/**
+ * @brief Get the external IP address using STUN
+ * @param[out] ipBuffer Buffer to store IP address string
+ * @param[in] ipBufferSize Size of IP buffer
+ * @return qtrue if the external IP was found, qfalse otherwise
+ */
+qboolean HTTP_GetExternalIP(char *ipBuffer, int ipBufferSize)
+{
+	// A list of prominent STUN servers.
+	const char *stun_servers[] =
+	{
+		"stun.l.google.com",
+		"stun1.l.google.com",
+		"stun2.l.google.com",
+		"stun3.l.google.com",
+		"stun4.l.google.com",
+		"stun.ekiga.net",
+		"stun.ideasip.com",
+		"stun.schlund.de",
+		"stun.stunprotocol.org",
+		"stun.voiparound.com",
+		"stun.voipbuster.com",
+		"stun.voipstunt.com",
+		"stun.voxgratia.org",
+		NULL
+	};
+
+	SOCKET sock = INVALID_SOCKET;
+	int    i;
+
+	if (!ipBuffer || ipBufferSize < 16)
+	{
+		return qfalse;
+	}
+
+	for (i = 0; stun_servers[i] != NULL; i++)
+	{
+		struct addrinfo         hints, *res = NULL;
+		int                     err;
+		unsigned char           request[20];
+		unsigned char           response[2048];
+		struct sockaddr_storage from;
+		socklen_t               fromlen;
+		struct timeval          tv;
+		int                     len;
+		int                     j;
+
+		Com_Memset(&hints, 0, sizeof(hints));
+		hints.ai_family   = AF_INET;
+		hints.ai_socktype = SOCK_DGRAM;
+
+		err = getaddrinfo(stun_servers[i], "3478", &hints, &res);
+		if (err != 0)
+		{
+			Com_Printf("HTTP_GetExternalIP: getaddrinfo for %s failed: %s\n", stun_servers[i], gai_strerror(err));
+			continue;
+		}
+
+		sock = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+		if (sock == INVALID_SOCKET)
+		{
+			freeaddrinfo(res);
+			Com_Printf("HTTP_GetExternalIP: socket creation failed\n");
+			continue;
+		}
+
+		// STUN request packet
+		Com_Memset(request, 0, sizeof(request));
+		*(unsigned short *)&request[0] = htons(0x0001); // Binding Request
+		*(unsigned short *)&request[2] = htons(0x0000); // Message Length
+		*(unsigned int *)&request[4]   = htonl(0x2112A442); // Magic Cookie
+		// Transaction ID (12 bytes) - can be random
+		for (j = 8; j < 20; j++)
+		{
+			request[j] = rand() & 0xFF;
+		}
+
+		if (sendto(sock, (const char *)request, sizeof(request), 0, res->ai_addr, res->ai_addrlen) == SOCKET_ERROR)
+		{
+			Com_Printf("HTTP_GetExternalIP: sendto failed\n");
+			closesocket(sock);
+			freeaddrinfo(res);
+			continue;
+		}
+
+		fromlen = sizeof(from);
+
+		// Set a timeout for recvfrom
+		tv.tv_sec  = 2; // 2 second timeout
+		tv.tv_usec = 0;
+		setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const char *)&tv, sizeof(tv));
+
+		len = recvfrom(sock, (char *)response, sizeof(response), 0, (struct sockaddr *)&from, &fromlen);
+
+		closesocket(sock);
+		freeaddrinfo(res);
+
+		if (len > 0)
+		{
+			// Basic STUN response parsing
+			if (len >= 20 && ntohs(*(unsigned short *)&response[0]) == 0x0101) // Binding Success Response
+			{
+				int pos = 20;
+				while (pos + 4 <= len)
+				{
+					unsigned short attr_type = ntohs(*(unsigned short *)&response[pos]);
+					unsigned short attr_len  = ntohs(*(unsigned short *)&response[pos + 2]);
+					pos += 4;
+
+					if (attr_type == 0x0001) // MAPPED-ADDRESS
+					{
+						if (attr_len >= 8 && response[pos + 1] == 0x01) // IPv4
+						{
+							struct in_addr addr;
+							addr.s_addr = *(unsigned int *)&response[pos + 4];
+							Q_strncpyz(ipBuffer, inet_ntoa(addr), ipBufferSize);
+							return qtrue;
+						}
+					}
+					pos += attr_len;
+					// Align to 4-byte boundary
+					if (pos % 4 != 0)
+					{
+						pos += 4 - (pos % 4);
+					}
+				}
+			}
+		}
+		else
+		{
+			Com_Printf("HTTP_GetExternalIP: recvfrom failed or timed out for %s\n", stun_servers[i]);
+		}
+	}
+
+	return qfalse;
+}

--- a/src/server/sv_http_request.c
+++ b/src/server/sv_http_request.c
@@ -1,0 +1,345 @@
+/*
+ * Wolfenstein: Enemy Territory GPL Source Code
+ * Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company.
+ *
+ * ET: Legacy
+ * Copyright (C) 2012-2024 ET:Legacy team <mail@etlegacy.com>
+ *
+ * This file is part of ET: Legacy - http://www.etlegacy.com
+ *
+ * ET: Legacy is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ET: Legacy is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ET: Legacy. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * In addition, Wolfenstein: Enemy Territory GPL Source Code is also
+ * subject to certain additional terms. You should have received a copy
+ * of these additional terms immediately following the terms and conditions
+ * of the GNU General Public License which accompanied the source code.
+ * If not, please request a copy in writing from id Software at the address below.
+ *
+ * id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, Maryland 20850 USA.
+ */
+/**
+ * @file sv_http_request.c
+ * @brief HTTP request parsing implementation
+ */
+
+#include "server.h"
+#include "sv_http.h"
+
+/**
+ * @brief Parse HTTP request line (method, path, version)
+ * @param[in] client Client to parse for
+ * @param[in] line Request line string
+ * @return qtrue on success, qfalse on parse error
+ */
+qboolean HTTP_ParseRequestLine(httpClient_t *client, const char *line)
+{
+	char method[16];
+	char path[MAX_QPATH];
+	char version[16];
+	int  result;
+
+	if (!client || !line)
+	{
+		return qfalse;
+	}
+
+	// Parse request line: "METHOD /path HTTP/version"
+	result = sscanf(line, "%15s %255s %15s", method, path, version);
+	if (result != 3)
+	{
+		Com_DPrintf("HTTP: Malformed request line: %s\n", line);
+		return qfalse;
+	}
+
+	// Parse HTTP method
+	if (!Q_stricmp(method, "GET"))
+	{
+		client->method = HTTP_METHOD_GET;
+	}
+	else if (!Q_stricmp(method, "HEAD"))
+	{
+		client->method = HTTP_METHOD_HEAD;
+	}
+	else
+	{
+		Com_DPrintf("HTTP: Unsupported method: %s\n", method);
+		return qfalse;
+	}
+
+	// Validate HTTP version (accept HTTP/1.0 and HTTP/1.1)
+	if (Q_stricmp(version, "HTTP/1.0") && Q_stricmp(version, "HTTP/1.1"))
+	{
+		Com_DPrintf("HTTP: Unsupported HTTP version: %s\n", version);
+		return qfalse;
+	}
+
+	// Copy parsed values
+	Q_strncpyz(client->path, path, sizeof(client->path));
+	Q_strncpyz(client->httpVersion, version, sizeof(client->httpVersion));
+
+	Com_DPrintf("HTTP: Request: %s %s %s\n", method, client->path, client->httpVersion);
+
+	return qtrue;
+}
+
+/**
+ * @brief Parse Range header for partial content requests
+ * @param[in] client Client to parse for
+ * @param[in] value Range header value (e.g., "bytes=1024-2047")
+ * @return qtrue on success, qfalse on parse error
+ */
+qboolean HTTP_ParseRangeHeader(httpClient_t *client, const char *value)
+{
+	int start = -1;
+	int end   = -1;
+	int result;
+
+	if (!client || !value)
+	{
+		return qfalse;
+	}
+
+	// Parse "bytes=start-end" format
+	if (Q_stricmpn(value, "bytes=", 6) != 0)
+	{
+		Com_DPrintf("HTTP: Invalid Range header format: %s\n", value);
+		return qfalse;
+	}
+
+	value += 6; // Skip "bytes="
+
+	// Try to parse both start and end
+	result = sscanf(value, "%d-%d", &start, &end);
+
+	if (result == 2)
+	{
+		// Both start and end specified: "bytes=1024-2047"
+		if (start < 0 || end < start)
+		{
+			Com_DPrintf("HTTP: Invalid range: %d-%d\n", start, end);
+			return qfalse;
+		}
+		client->hasRange   = qtrue;
+		client->rangeStart = start;
+		client->rangeEnd   = end;
+	}
+	else if (result == 1 && start >= 0)
+	{
+		// Only start specified: "bytes=1024-" (open-ended)
+		client->hasRange   = qtrue;
+		client->rangeStart = start;
+		client->rangeEnd   = -1; // Will be set to file size later
+	}
+	else
+	{
+		Com_DPrintf("HTTP: Failed to parse range: %s\n", value);
+		return qfalse;
+	}
+
+	Com_DPrintf("HTTP: Range request: bytes=%d-%d\n", client->rangeStart, client->rangeEnd);
+
+	return qtrue;
+}
+
+/**
+ * @brief Parse HTTP headers from request
+ * @param[in] client Client to parse for
+ * @param[in] headers Headers string (after request line)
+ * @return qtrue on success, qfalse on parse error
+ */
+qboolean HTTP_ParseHeaders(httpClient_t *client, const char *headers)
+{
+	const char *line;
+	const char *next;
+	char       headerLine[1024];
+	char       headerName[256];
+	char       headerValue[768];
+	qboolean   hasHost = qfalse;
+	size_t     lineLen;
+	const char *colon;
+	size_t     nameLen;
+	const char *valueStart;
+
+	if (!client || !headers)
+	{
+		return qfalse;
+	}
+
+	// Initialize default values
+	client->hasRange = qfalse;
+
+	// Parse each header line
+	line = headers;
+	while (*line)
+	{
+		// Find end of line
+		next = strstr(line, "\r\n");
+		if (!next)
+		{
+			break; // No more lines
+		}
+
+		// Copy line to buffer
+		lineLen = next - line;
+		if (lineLen >= sizeof(headerLine))
+		{
+			lineLen = sizeof(headerLine) - 1;
+		}
+		Q_strncpyz(headerLine, line, lineLen + 1);
+
+		// Skip empty lines (end of headers)
+		if (headerLine[0] == '\0')
+		{
+			break;
+		}
+
+		// Parse header: "Name: Value"
+		colon = strchr(headerLine, ':');
+		if (!colon)
+		{
+			// Skip malformed header
+			line = next + 2;
+			continue;
+		}
+
+		// Extract header name
+		nameLen = colon - headerLine;
+		if (nameLen >= sizeof(headerName))
+		{
+			nameLen = sizeof(headerName) - 1;
+		}
+		Q_strncpyz(headerName, headerLine, nameLen + 1);
+
+		// Extract header value (skip leading whitespace)
+		valueStart = colon + 1;
+		while (*valueStart == ' ' || *valueStart == '\t')
+		{
+			valueStart++;
+		}
+		Q_strncpyz(headerValue, valueStart, sizeof(headerValue));
+
+		// Process known headers
+		if (!Q_stricmp(headerName, "Host"))
+		{
+			hasHost = qtrue;
+			Com_DPrintf("HTTP: Host: %s\n", headerValue);
+		}
+		else if (!Q_stricmp(headerName, "User-Agent"))
+		{
+			Q_strncpyz(client->userAgent, headerValue, sizeof(client->userAgent));
+			Com_DPrintf("HTTP: User-Agent: %s\n", client->userAgent);
+		}
+		else if (!Q_stricmp(headerName, "Referer"))
+		{
+			Q_strncpyz(client->referer, headerValue, sizeof(client->referer));
+			Com_DPrintf("HTTP: Referer: %s\n", client->referer);
+		}
+		else if (!Q_stricmp(headerName, "Range"))
+		{
+			if (!HTTP_ParseRangeHeader(client, headerValue))
+			{
+				Com_DPrintf("HTTP: Failed to parse Range header\n");
+			}
+		}
+
+		// Move to next line
+		line = next + 2;
+	}
+
+	// HTTP/1.1 requires Host header
+	if (!Q_stricmp(client->httpVersion, "HTTP/1.1") && !hasHost)
+	{
+		Com_DPrintf("HTTP: Missing required Host header for HTTP/1.1\n");
+		return qfalse;
+	}
+
+	return qtrue;
+}
+
+/**
+ * @brief Parse HTTP request from client buffer
+ * @param[in] client Client to parse request for
+ * @return qtrue on success, qfalse on parse error
+ */
+qboolean HTTP_ParseRequest(httpClient_t *client)
+{
+	const char *requestEnd;
+	const char *headersStart;
+	char       requestLine[1024];
+	size_t     lineLen;
+
+	if (!client)
+	{
+		return qfalse;
+	}
+
+	// Check if request is complete (ends with \r\n\r\n)
+	requestEnd = strstr(client->requestBuffer, "\r\n\r\n");
+	if (!requestEnd)
+	{
+		// Request not complete yet
+		return qfalse;
+	}
+
+	// Find end of first line (request line)
+	headersStart = strstr(client->requestBuffer, "\r\n");
+	if (!headersStart)
+	{
+		Com_DPrintf("HTTP: Malformed request (no request line)\n");
+		return qfalse;
+	}
+
+	// Extract request line
+	lineLen = headersStart - client->requestBuffer;
+	if (lineLen >= sizeof(requestLine))
+	{
+		Com_DPrintf("HTTP: Request line too long\n");
+		return qfalse;
+	}
+	Q_strncpyz(requestLine, client->requestBuffer, lineLen + 1);
+
+	// Parse request line
+	if (!HTTP_ParseRequestLine(client, requestLine))
+	{
+		return qfalse;
+	}
+
+	// Parse headers (skip \r\n after request line)
+	headersStart += 2;
+	if (!HTTP_ParseHeaders(client, headersStart))
+	{
+		return qfalse;
+	}
+
+	// Validate ET 2.60b client compatibility
+	// Accept "ID_DOWNLOAD/2.0" user agent
+	if (client->userAgent[0] != '\0')
+	{
+		if (strstr(client->userAgent, "ID_DOWNLOAD"))
+		{
+			Com_DPrintf("HTTP: ET 2.60b client detected\n");
+		}
+	}
+
+	// Accept ET:// referer format
+	if (client->referer[0] != '\0')
+	{
+		if (Q_stricmpn(client->referer, "et://", 5) == 0)
+		{
+			Com_DPrintf("HTTP: ET:// referer format detected\n");
+		}
+	}
+
+	return qtrue;
+}

--- a/src/server/sv_http_response.c
+++ b/src/server/sv_http_response.c
@@ -48,7 +48,6 @@
 
 // External access to server state for bandwidth throttling
 extern httpServer_t httpServer;
-extern cvar_t       *sv_httpMaxBytesPerFrame;
 
 /**
  * @brief Get HTTP status text for status code

--- a/src/server/sv_http_response.c
+++ b/src/server/sv_http_response.c
@@ -1,0 +1,687 @@
+/*
+ * Wolfenstein: Enemy Territory GPL Source Code
+ * Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company.
+ *
+ * ET: Legacy
+ * Copyright (C) 2012-2024 ET:Legacy team <mail@etlegacy.com>
+ *
+ * This file is part of ET: Legacy - http://www.etlegacy.com
+ *
+ * ET: Legacy is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ET: Legacy is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ET: Legacy. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * In addition, Wolfenstein: Enemy Territory GPL Source Code is also
+ * subject to certain additional terms. You should have received a copy
+ * of these additional terms immediately following the terms and conditions
+ * of the GNU General Public License which accompanied the source code.
+ * If not, please request a copy in writing from id Software at the address below.
+ *
+ * id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, Maryland 20850 USA.
+ */
+/**
+ * @file sv_http_response.c
+ * @brief HTTP response generation and transmission
+ */
+
+#include "server.h"
+#include "sv_http.h"
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <sys/socket.h>
+#include <errno.h>
+#define INVALID_SOCKET -1
+#define SOCKET_ERROR -1
+#endif
+
+// External access to server state for bandwidth throttling
+extern httpServer_t httpServer;
+extern cvar_t       *sv_httpMaxBytesPerFrame;
+
+/**
+ * @brief Get HTTP status text for status code
+ * @param[in] statusCode HTTP status code
+ * @return Status text string
+ */
+const char *HTTP_GetStatusText(int statusCode)
+{
+	switch (statusCode)
+	{
+	case 200:
+		return "OK";
+	case 206:
+		return "Partial Content";
+	case 400:
+		return "Bad Request";
+	case 404:
+		return "Not Found";
+	case 416:
+		return "Range Not Satisfiable";
+	case 500:
+		return "Internal Server Error";
+	case 503:
+		return "Service Unavailable";
+	default:
+		return "Unknown";
+	}
+}
+
+/**
+ * @brief Determine MIME type from file extension
+ * @param[in] path File path
+ * @return MIME type string
+ */
+const char *HTTP_GetMimeType(const char *path)
+{
+	const char *ext;
+
+	if (!path)
+	{
+		return "application/octet-stream";
+	}
+
+	// Find file extension
+	ext = strrchr(path, '.');
+	if (!ext)
+	{
+		return "application/octet-stream";
+	}
+
+	ext++; // Skip the dot
+
+	// Check known extensions
+	if (!Q_stricmp(ext, "pk3"))
+	{
+		return "application/octet-stream";
+	}
+	else if (!Q_stricmp(ext, "txt"))
+	{
+		return "text/plain";
+	}
+	else if (!Q_stricmp(ext, "html") || !Q_stricmp(ext, "htm"))
+	{
+		return "text/html";
+	}
+
+	// Default to binary
+	return "application/octet-stream";
+}
+
+/**
+ * @brief Build response headers for a given status code
+ * @param[in] client Client to build headers for
+ * @param[in] statusCode HTTP status code
+ * @param[in] contentType Content-Type header value
+ * @param[in] contentLength Content-Length value
+ * @return qtrue on success, qfalse on error
+ */
+qboolean HTTP_BuildResponseHeaders(httpClient_t *client, int statusCode, const char *contentType, int contentLength)
+{
+	int len;
+
+	if (!client)
+	{
+		return qfalse;
+	}
+
+	// Start with status line
+	len = Com_sprintf(client->responseBuffer, sizeof(client->responseBuffer),
+	                  "HTTP/1.1 %d %s\r\n", statusCode, HTTP_GetStatusText(statusCode));
+
+	// Add Server header
+	len += Com_sprintf(client->responseBuffer + len, sizeof(client->responseBuffer) - len,
+	                   "Server: ETLegacy/%s\r\n", Q3_VERSION);
+
+	// Add Content-Type header
+	if (contentType && contentType[0])
+	{
+		len += Com_sprintf(client->responseBuffer + len, sizeof(client->responseBuffer) - len,
+		                   "Content-Type: %s\r\n", contentType);
+	}
+
+	// Add Content-Length header
+	if (contentLength >= 0)
+	{
+		len += Com_sprintf(client->responseBuffer + len, sizeof(client->responseBuffer) - len,
+		                   "Content-Length: %d\r\n", contentLength);
+	}
+
+	// Add Accept-Ranges header for file responses
+	if (statusCode == 200 || statusCode == 206)
+	{
+		len += Com_sprintf(client->responseBuffer + len, sizeof(client->responseBuffer) - len,
+		                   "Accept-Ranges: bytes\r\n");
+	}
+
+	// Add Content-Range header for partial content
+	if (statusCode == 206 && client->hasRange)
+	{
+		int rangeEnd = client->rangeEnd;
+		if (rangeEnd < 0 || rangeEnd >= client->fileSize)
+		{
+			rangeEnd = client->fileSize - 1;
+		}
+
+		len += Com_sprintf(client->responseBuffer + len, sizeof(client->responseBuffer) - len,
+		                   "Content-Range: bytes %d-%d/%d\r\n",
+		                   client->rangeStart, rangeEnd, client->fileSize);
+	}
+
+	// Add Connection header (always close for now)
+	len += Com_sprintf(client->responseBuffer + len, sizeof(client->responseBuffer) - len,
+	                   "Connection: close\r\n");
+
+	// End headers with blank line
+	len += Com_sprintf(client->responseBuffer + len, sizeof(client->responseBuffer) - len, "\r\n");
+
+	// Check for overflow
+	if (len >= sizeof(client->responseBuffer))
+	{
+		Com_Printf("HTTP: Response header buffer overflow\n");
+		return qfalse;
+	}
+
+	client->responseLength = len;
+
+	Com_DPrintf("HTTP: Built response headers (%d bytes):\n%s", len, client->responseBuffer);
+
+	return qtrue;
+}
+
+/**
+ * @brief Send response headers to client
+ * @param[in] client Client to send to
+ * @return qtrue if headers fully sent, qfalse if would block or error
+ * Implements bandwidth throttling
+ */
+qboolean HTTP_SendHeaders(httpClient_t *client)
+{
+	int bytesSent;
+	int bytesToSend;
+	int maxBytesPerFrame;
+	int bytesAvailableThisFrame;
+
+	if (!client || client->socket == INVALID_SOCKET)
+	{
+		return qfalse;
+	}
+
+	// Calculate how much to send
+	bytesToSend = client->responseLength - client->bytesSent;
+	if (bytesToSend <= 0)
+	{
+		// Headers already sent
+		return qtrue;
+	}
+
+	// Check bandwidth throttling
+	if (sv_httpMaxBytesPerFrame && sv_httpMaxBytesPerFrame->integer > 0)
+	{
+		maxBytesPerFrame        = sv_httpMaxBytesPerFrame->integer;
+		bytesAvailableThisFrame = maxBytesPerFrame - httpServer.frameBytesSent;
+
+		if (bytesAvailableThisFrame <= 0)
+		{
+			// Bandwidth limit reached for this frame, defer to next frame
+			Com_DPrintf("HTTP: Bandwidth limit reached, deferring header send\n");
+			return qtrue; // Return true to avoid closing connection
+		}
+
+		// Limit bytes to send this frame
+		if (bytesToSend > bytesAvailableThisFrame)
+		{
+			bytesToSend = bytesAvailableThisFrame;
+		}
+	}
+
+	// Send data
+	bytesSent = send(client->socket,
+	                 client->responseBuffer + client->bytesSent,
+	                 bytesToSend,
+	                 0);
+
+	if (bytesSent > 0)
+	{
+		client->bytesSent         += bytesSent;
+		client->lastActivity       = Sys_Milliseconds();
+		httpServer.frameBytesSent += bytesSent;      // Track frame bytes
+		httpServer.totalBytesSent += bytesSent;       // Update total stats
+
+		Com_DPrintf("HTTP: Sent %d header bytes to %s (%d/%d)\n",
+		            bytesSent, NET_AdrToString(&client->address),
+		            client->bytesSent, client->responseLength);
+
+		// Check if all headers sent
+		if (client->bytesSent >= client->responseLength)
+		{
+			Com_DPrintf("HTTP: Headers fully sent to %s\n", NET_AdrToString(&client->address));
+			return qtrue;
+		}
+
+		// More to send, but return true to continue
+		return qtrue;
+	}
+	else if (bytesSent == 0)
+	{
+		// Connection closed
+		Com_DPrintf("HTTP: Connection closed while sending headers to %s\n",
+		            NET_AdrToString(&client->address));
+		return qfalse;
+	}
+	else
+	{
+		// Error or would block
+#ifdef _WIN32
+		int err = WSAGetLastError();
+		if (err == WSAEWOULDBLOCK)
+		{
+			// Would block - try again next frame
+			return qtrue;
+		}
+		Com_DPrintf("HTTP: Send error to %s: %d\n", NET_AdrToString(&client->address), err);
+#else
+		if (errno == EAGAIN || errno == EWOULDBLOCK)
+		{
+			// Would block - try again next frame
+			return qtrue;
+		}
+		Com_DPrintf("HTTP: Send error to %s: %s\n", NET_AdrToString(&client->address), strerror(errno));
+#endif
+		return qfalse;
+	}
+}
+
+/**
+ * @brief Send error response to client
+ * @param[in] client Client to send error to
+ * @param[in] statusCode HTTP status code
+ * @param[in] message Error message
+ */
+void HTTP_SendErrorResponse(httpClient_t *client, int statusCode, const char *message)
+{
+	char body[1024];
+	int  bodyLen;
+
+	if (!client)
+	{
+		return;
+	}
+
+	// Build error body
+	bodyLen = Com_sprintf(body, sizeof(body),
+	                      "<html><head><title>%d %s</title></head>\n"
+	                      "<body><h1>%d %s</h1>\n"
+	                      "<p>%s</p>\n"
+	                      "<hr><p>ETLegacy/%s</p>\n"
+	                      "</body></html>\n",
+	                      statusCode, HTTP_GetStatusText(statusCode),
+	                      statusCode, HTTP_GetStatusText(statusCode),
+	                      message ? message : HTTP_GetStatusText(statusCode),
+	                      Q3_VERSION);
+
+	// Build response headers
+	if (!HTTP_BuildResponseHeaders(client, statusCode, "text/html", bodyLen))
+	{
+		HTTP_CloseClient(client);
+		return;
+	}
+
+	// Append body to response buffer if there's space
+	if (client->responseLength + bodyLen <= sizeof(client->responseBuffer))
+	{
+		memcpy(client->responseBuffer + client->responseLength, body, bodyLen);
+		client->responseLength += bodyLen;
+	}
+
+	// Reset send counter
+	client->bytesSent = 0;
+	client->state     = HTTP_STATE_SENDING_HEADERS;
+
+	Com_DPrintf("HTTP: Sending error response %d to %s: %s\n",
+	            statusCode, NET_AdrToString(&client->address), message ? message : "");
+
+	// Try to send immediately
+	if (HTTP_SendHeaders(client))
+	{
+		if (client->bytesSent >= client->responseLength)
+		{
+			// All sent, close connection
+			client->state = HTTP_STATE_CLOSING;
+		}
+	}
+	else
+	{
+		// Send failed, close connection
+		client->state = HTTP_STATE_CLOSING;
+	}
+}
+
+/**
+ * @brief Process response sending state (headers only or complete response)
+ * @param[in] client Client to process
+ * @return qtrue if processing should continue, qfalse if done or error
+ */
+qboolean HTTP_ProcessResponseSending(httpClient_t *client)
+{
+	if (!client)
+	{
+		return qfalse;
+	}
+
+	if (client->state != HTTP_STATE_SENDING_HEADERS)
+	{
+		return qtrue;
+	}
+
+	// Send headers
+	if (!HTTP_SendHeaders(client))
+	{
+		// Error sending headers
+		client->state = HTTP_STATE_CLOSING;
+		return qfalse;
+	}
+
+	// Check if all data sent
+	if (client->bytesSent >= client->responseLength)
+	{
+		// All sent, close connection (for now, no keep-alive)
+		Com_DPrintf("HTTP: Response fully sent to %s\n", NET_AdrToString(&client->address));
+		client->state = HTTP_STATE_CLOSING;
+		return qfalse;
+	}
+
+	// Still sending, continue next frame
+	return qtrue;
+}
+
+/**
+ * @brief Send file response to client (initiate file transfer)
+ * @param[in] client Client to send file to
+ * @return qtrue on success, qfalse on error
+ */
+qboolean HTTP_SendFileResponse(httpClient_t *client)
+{
+	int        statusCode;
+	int        contentLength;
+	const char *mimeType;
+
+	if (!client)
+	{
+		return qfalse;
+	}
+
+	// Validate path for security
+	if (!HTTP_ValidatePath(client->path))
+	{
+		HTTP_SendErrorResponse(client, 400, "Invalid file path");
+		return qfalse;
+	}
+
+	// Open file using secure filesystem (validates existence, opens file, gets size)
+	if (!HTTP_OpenFileForServing(client->path, &client->fileHandle, &client->fileSize))
+	{
+		HTTP_SendErrorResponse(client, 404, "File not found");
+		return qfalse;
+	}
+
+	// Handle range requests
+	if (client->hasRange)
+	{
+		// Validate range
+		if (client->rangeStart < 0 || client->rangeStart >= client->fileSize)
+		{
+			HTTP_CloseFile(client->fileHandle);
+			client->fileHandle = 0;
+			HTTP_SendErrorResponse(client, 416, "Range not satisfiable");
+			return qfalse;
+		}
+
+		// Adjust range end if needed
+		if (client->rangeEnd < 0 || client->rangeEnd >= client->fileSize)
+		{
+			client->rangeEnd = client->fileSize - 1;
+		}
+
+		// Seek to start position
+		if (!HTTP_SeekFile(client->fileHandle, client->rangeStart, FS_SEEK_SET))
+		{
+			HTTP_CloseFile(client->fileHandle);
+			client->fileHandle = 0;
+			HTTP_SendErrorResponse(client, 500, "Failed to seek file");
+			return qfalse;
+		}
+
+		// Calculate bytes to send
+		contentLength           = client->rangeEnd - client->rangeStart + 1;
+		client->fileBytesToSend = contentLength;
+		client->filePosition    = client->rangeStart;
+		statusCode              = 206; // Partial Content
+
+		Com_Printf("HTTP: Sending partial file: %s (bytes %d-%d/%d) to %s\n",
+		           client->path, client->rangeStart, client->rangeEnd,
+		           client->fileSize, NET_AdrToString(&client->address));
+	}
+	else
+	{
+		// Send entire file
+		contentLength           = client->fileSize;
+		client->fileBytesToSend = client->fileSize;
+		client->filePosition    = 0;
+		statusCode              = 200; // OK
+
+		Com_Printf("HTTP: Sending file: %s (%d bytes) to %s\n",
+		           client->path, client->fileSize, NET_AdrToString(&client->address));
+	}
+
+	// Determine MIME type
+	mimeType = HTTP_GetMimeType(client->path);
+
+	// Build response headers
+	if (!HTTP_BuildResponseHeaders(client, statusCode, mimeType, contentLength))
+	{
+		HTTP_CloseFile(client->fileHandle);
+		client->fileHandle = 0;
+		return qfalse;
+	}
+
+	// Reset counters
+	client->bytesSent = 0;
+	client->state     = HTTP_STATE_SENDING_HEADERS;
+
+	// Try to send headers immediately
+	if (HTTP_SendHeaders(client))
+	{
+		// Check if headers fully sent
+		if (client->bytesSent >= client->responseLength)
+		{
+			// Headers sent, move to file sending state
+			client->state     = HTTP_STATE_SENDING_FILE;
+			client->bytesSent = 0; // Reset for file data
+			Com_DPrintf("HTTP: Headers sent, beginning file transfer\n");
+		}
+	}
+	else
+	{
+		// Send failed, close
+		HTTP_CloseFile(client->fileHandle);
+		client->fileHandle = 0;
+		client->state      = HTTP_STATE_CLOSING;
+		return qfalse;
+	}
+
+	return qtrue;
+}
+
+/**
+ * @brief Send file data chunk to client
+ * @param[in] client Client to send chunk to
+ * @return qtrue if more data to send, qfalse if complete or error
+ * Implements bandwidth throttling
+ */
+qboolean HTTP_SendFileChunk(httpClient_t *client)
+{
+	static char fileChunkBuffer[HTTP_FILE_CHUNK];
+	int         bytesToRead;
+	int         bytesRead;
+	int         bytesSent;
+	int         totalSent;
+	int         maxBytesPerFrame;
+	int         bytesAvailableThisFrame;
+
+	if (!client || !client->fileHandle)
+	{
+		return qfalse;
+	}
+
+	// Check bandwidth throttling before reading
+	if (sv_httpMaxBytesPerFrame && sv_httpMaxBytesPerFrame->integer > 0)
+	{
+		maxBytesPerFrame        = sv_httpMaxBytesPerFrame->integer;
+		bytesAvailableThisFrame = maxBytesPerFrame - httpServer.frameBytesSent;
+
+		if (bytesAvailableThisFrame <= 0)
+		{
+			// Bandwidth limit reached for this frame, defer to next frame
+			Com_DPrintf("HTTP: Bandwidth limit reached, deferring file chunk send\n");
+			return qtrue; // Return true to continue next frame
+		}
+	}
+	else
+	{
+		bytesAvailableThisFrame = HTTP_FILE_CHUNK; // No limit
+	}
+
+	// Calculate how much to read this chunk
+	bytesToRead = client->fileBytesToSend;
+	if (bytesToRead > HTTP_FILE_CHUNK)
+	{
+		bytesToRead = HTTP_FILE_CHUNK;
+	}
+
+	// Limit by available bandwidth this frame
+	if (bytesToRead > bytesAvailableThisFrame)
+	{
+		bytesToRead = bytesAvailableThisFrame;
+	}
+
+	if (bytesToRead <= 0)
+	{
+		// No more data to send
+		Com_Printf("HTTP: File transfer complete: %d bytes sent to %s\n",
+		           client->filePosition, NET_AdrToString(&client->address));
+		HTTP_CloseFile(client->fileHandle);
+		client->fileHandle = 0;
+		client->state      = HTTP_STATE_CLOSING;
+		return qfalse;
+	}
+
+	// Read chunk from file
+	bytesRead = HTTP_ReadFileChunk(client->fileHandle, fileChunkBuffer, bytesToRead);
+	if (bytesRead <= 0)
+	{
+		// Read error or EOF
+		Com_DPrintf("HTTP: File read error or EOF\n");
+		HTTP_CloseFile(client->fileHandle);
+		client->fileHandle = 0;
+		client->state      = HTTP_STATE_CLOSING;
+		return qfalse;
+	}
+
+	// Send chunk to client
+	totalSent = 0;
+	while (totalSent < bytesRead)
+	{
+		bytesSent = send(client->socket,
+		                 fileChunkBuffer + totalSent,
+		                 bytesRead - totalSent,
+		                 0);
+
+		if (bytesSent > 0)
+		{
+			totalSent           += bytesSent;
+			client->lastActivity = Sys_Milliseconds();
+		}
+		else if (bytesSent == 0)
+		{
+			// Connection closed
+			Com_DPrintf("HTTP: Connection closed while sending file\n");
+			HTTP_CloseFile(client->fileHandle);
+			client->fileHandle = 0;
+			client->state      = HTTP_STATE_CLOSING;
+			return qfalse;
+		}
+		else
+		{
+			// Error or would block
+#ifdef _WIN32
+			int err = WSAGetLastError();
+			if (err == WSAEWOULDBLOCK)
+			{
+				// Would block - continue next frame
+				// Seek back to where we were
+				if (totalSent < bytesRead)
+				{
+					int seekBack = -(bytesRead - totalSent);
+					FS_Seek(client->fileHandle, seekBack, FS_SEEK_CUR);
+				}
+				return qtrue;
+			}
+			Com_DPrintf("HTTP: Send error: %d\n", err);
+#else
+			if (errno == EAGAIN || errno == EWOULDBLOCK)
+			{
+				// Would block - continue next frame
+				// Seek back to where we were
+				if (totalSent < bytesRead)
+				{
+					int seekBack = -(bytesRead - totalSent);
+					FS_Seek(client->fileHandle, seekBack, FS_SEEK_CUR);
+				}
+				return qtrue;
+			}
+			Com_DPrintf("HTTP: Send error: %s\n", strerror(errno));
+#endif
+			HTTP_CloseFile(client->fileHandle);
+			client->fileHandle = 0;
+			client->state      = HTTP_STATE_CLOSING;
+			return qfalse;
+		}
+	}
+
+	// Update counters
+	client->filePosition      += totalSent;
+	client->fileBytesToSend   -= totalSent;
+	client->bytesSent         += totalSent;
+	httpServer.frameBytesSent += totalSent;  // Track frame bytes
+	httpServer.totalBytesSent += totalSent;   // Update total stats
+
+	Com_DPrintf("HTTP: Sent %d bytes to %s (total: %d, remaining: %d)\n",
+	            totalSent, NET_AdrToString(&client->address),
+	            client->filePosition, client->fileBytesToSend);
+
+	// Check if we're done
+	if (client->fileBytesToSend <= 0)
+	{
+		Com_Printf("HTTP: File transfer complete: %d bytes sent to %s\n",
+		           client->filePosition, NET_AdrToString(&client->address));
+		HTTP_CloseFile(client->fileHandle);
+		client->fileHandle = 0;
+		client->state      = HTTP_STATE_CLOSING;
+		return qfalse;
+	}
+
+	// More data to send next frame
+	return qtrue;
+}

--- a/src/server/sv_http_server.c
+++ b/src/server/sv_http_server.c
@@ -1,0 +1,848 @@
+/*
+ * Wolfenstein: Enemy Territory GPL Source Code
+ * Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company.
+ *
+ * ET: Legacy
+ * Copyright (C) 2012-2024 ET:Legacy team <mail@etlegacy.com>
+ *
+ * This file is part of ET: Legacy - http://www.etlegacy.com
+ *
+ * ET: Legacy is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ET: Legacy is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ET: Legacy. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * In addition, Wolfenstein: Enemy Territory GPL Source Code is also
+ * subject to certain additional terms. You should have received a copy
+ * of these additional terms immediately following the terms and conditions
+ * of the GNU General Public License which accompanied the source code.
+ * If not, please request a copy in writing from id Software at the address below.
+ *
+ * id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, Maryland 20850 USA.
+ */
+/**
+ * @file sv_http_server.c
+ * @brief Embedded HTTP server implementation
+ */
+
+#include "server.h"
+#include "sv_http.h"
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+typedef int socklen_t;
+#else
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#define closesocket close
+#define INVALID_SOCKET -1
+#define SOCKET_ERROR -1
+#endif
+
+// Global HTTP server state
+httpServer_t httpServer; // Non-static for bandwidth throttling access
+
+// CVARs
+static cvar_t *sv_httpEnable;
+static cvar_t *sv_httpMaxClients;
+static cvar_t *sv_httpAutoConfig;
+static cvar_t *sv_httpTimeout;          // Connection timeout
+cvar_t        *sv_httpMaxBytesPerFrame; // Non-static for bandwidth throttling access
+
+/**
+ * @brief Set socket to non-blocking mode
+ * @param[in] sock Socket descriptor
+ * @return qtrue on success, qfalse on failure
+ */
+static qboolean HTTP_SetNonBlocking(int sock)
+{
+#ifdef _WIN32
+	u_long mode = 1;
+	if (ioctlsocket(sock, FIONBIO, &mode) != 0)
+	{
+		Com_Printf("HTTP: Failed to set non-blocking mode: %d\n", WSAGetLastError());
+		return qfalse;
+	}
+#else
+	int flags = fcntl(sock, F_GETFL, 0);
+	if (flags == -1)
+	{
+		Com_Printf("HTTP: Failed to get socket flags: %s\n", strerror(errno));
+		return qfalse;
+	}
+	if (fcntl(sock, F_SETFL, flags | O_NONBLOCK) == -1)
+	{
+		Com_Printf("HTTP: Failed to set non-blocking mode: %s\n", strerror(errno));
+		return qfalse;
+	}
+#endif
+	return qtrue;
+}
+
+/**
+ * @brief Get string representation of socket error
+ * @return Error string
+ */
+static const char *HTTP_GetSocketError(void)
+{
+#ifdef _WIN32
+	static char buf[256];
+	int         err = WSAGetLastError();
+	Com_sprintf(buf, sizeof(buf), "error %d", err);
+	return buf;
+#else
+	return strerror(errno);
+#endif
+}
+
+/**
+ * @brief Open the HTTP server listening port
+ * @param[in] port Port number to listen on
+ * @return qtrue on success, qfalse on failure
+ */
+qboolean HTTP_OpenPort(int port)
+{
+	struct sockaddr_in address;
+	int                sock;
+	int                optval = 1;
+
+	if (httpServer.socket != INVALID_SOCKET)
+	{
+		Com_Printf("HTTP: Server already listening on port %d\n", httpServer.port);
+		return qtrue;
+	}
+
+	// Create TCP socket
+	sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+	if (sock == INVALID_SOCKET)
+	{
+		Com_Printf("HTTP: Failed to create socket: %s\n", HTTP_GetSocketError());
+		return qfalse;
+	}
+
+	// Set SO_REUSEADDR to allow binding to same port as UDP socket
+	if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (const char *)&optval, sizeof(optval)) == SOCKET_ERROR)
+	{
+		Com_Printf("HTTP: Failed to set SO_REUSEADDR: %s\n", HTTP_GetSocketError());
+		closesocket(sock);
+		return qfalse;
+	}
+
+#ifdef SO_REUSEPORT
+	// Set SO_REUSEPORT on platforms that support it
+	if (setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, (const char *)&optval, sizeof(optval)) == SOCKET_ERROR)
+	{
+		Com_DPrintf("HTTP: Failed to set SO_REUSEPORT: %s (not critical)\n", HTTP_GetSocketError());
+	}
+#endif
+
+	// Bind to port
+	memset(&address, 0, sizeof(address));
+	address.sin_family      = AF_INET;
+	address.sin_addr.s_addr = INADDR_ANY;
+	address.sin_port        = htons(port);
+
+	if (bind(sock, (struct sockaddr *)&address, sizeof(address)) == SOCKET_ERROR)
+	{
+		Com_Printf("HTTP: Failed to bind to port %d: %s\n", port, HTTP_GetSocketError());
+		closesocket(sock);
+		return qfalse;
+	}
+
+	// Listen with backlog of 16 connections
+	if (listen(sock, 16) == SOCKET_ERROR)
+	{
+		Com_Printf("HTTP: Failed to listen on port %d: %s\n", port, HTTP_GetSocketError());
+		closesocket(sock);
+		return qfalse;
+	}
+
+	// Set non-blocking mode
+	if (!HTTP_SetNonBlocking(sock))
+	{
+		closesocket(sock);
+		return qfalse;
+	}
+
+	httpServer.socket = sock;
+	httpServer.port   = port;
+
+	Com_Printf("HTTP: Server started on port %d\n", port);
+	return qtrue;
+}
+
+/**
+ * @brief Close the HTTP server listening port
+ */
+void HTTP_ClosePort(void)
+{
+	if (httpServer.socket != INVALID_SOCKET)
+	{
+		closesocket(httpServer.socket);
+		httpServer.socket = INVALID_SOCKET;
+		Com_Printf("HTTP: Server stopped\n");
+	}
+}
+
+/**
+ * @brief Detect server IP address for HTTP URL generation
+ * @param[out] ipBuffer Buffer to store IP address string
+ * @param[in] ipBufferSize Size of IP buffer
+ * @return qtrue on success, qfalse on failure
+ */
+static qboolean HTTP_DetectServerIP(char *ipBuffer, int ipBufferSize)
+{
+	cvar_t *net_ip;
+
+	if (!ipBuffer || ipBufferSize < 16)
+	{
+		return qfalse;
+	}
+
+	// First check if net_ip is manually set
+	net_ip = Cvar_Get("net_ip", "0.0.0.0", CVAR_LATCH);
+	if (net_ip && net_ip->string[0] && Q_stricmp(net_ip->string, "0.0.0.0") != 0 &&
+	    Q_stricmp(net_ip->string, "localhost") != 0)
+	{
+		Q_strncpyz(ipBuffer, net_ip->string, ipBufferSize);
+		Com_DPrintf("HTTP: Using net_ip cvar: %s\n", ipBuffer);
+		return qtrue;
+	}
+
+	// Try to get the external ip
+	if (HTTP_GetExternalIP(ipBuffer, ipBufferSize))
+	{
+		Com_DPrintf("HTTP: Using detected local IP: %s\n", ipBuffer);
+		return qtrue;
+	}
+
+	// Fallback to 0.0.0.0 which means clients will use their connection IP
+	// This is the recommended approach for most server setups as it works
+	// correctly even behind NAT or with multiple network interfaces
+	Q_strncpyz(ipBuffer, "0.0.0.0", ipBufferSize);
+	Com_DPrintf("HTTP: Using fallback IP: 0.0.0.0 (clients will use actual connection IP)\n");
+	return qtrue;
+}
+
+/**
+ * @brief Automatically configure sv_wwwBaseURL for HTTP downloads
+ * @return qtrue on success, qfalse on failure
+ */
+qboolean HTTP_AutoConfigureBaseURL(void)
+{
+	char   ipAddress[64];
+	char   baseURL[256];
+	cvar_t *sv_wwwBaseURL;
+	cvar_t *sv_wwwDownload;
+	int    port;
+
+	if (!httpServer.initialized || !httpServer.enabled)
+	{
+		Com_DPrintf("HTTP: Cannot auto-configure - server not initialized\n");
+		return qfalse;
+	}
+
+	// Get sv_wwwBaseURL cvar
+	sv_wwwBaseURL = Cvar_Get("sv_wwwBaseURL", "", CVAR_ARCHIVE);
+
+	// Check if auto-configuration should be used
+	if (!sv_httpAutoConfig->integer)
+	{
+		// Auto-config disabled, check if manual URL is set
+		if (sv_wwwBaseURL && sv_wwwBaseURL->string[0])
+		{
+			Com_Printf("HTTP: Using manually configured sv_wwwBaseURL = %s\n", sv_wwwBaseURL->string);
+			return qtrue;
+		}
+		Com_DPrintf("HTTP: Auto-configuration disabled and no manual sv_wwwBaseURL set\n");
+		return qfalse;
+	}
+
+	// Auto-config enabled OR sv_wwwBaseURL is empty - proceed with auto-configuration
+	if (sv_wwwBaseURL && sv_wwwBaseURL->string[0] && !sv_httpAutoConfig->integer)
+	{
+		Com_Printf("HTTP: Using manually configured sv_wwwBaseURL = %s\n", sv_wwwBaseURL->string);
+		return qtrue;
+	}
+
+	// Detect server IP
+	if (!HTTP_DetectServerIP(ipAddress, sizeof(ipAddress)))
+	{
+		Com_Printf("HTTP: Failed to detect server IP address\n");
+		return qfalse;
+	}
+
+	// Get server port
+	port = httpServer.port;
+	if (port <= 0 || port > 65535)
+	{
+		Com_Printf("HTTP: Invalid port %d\n", port);
+		return qfalse;
+	}
+
+	// Build base URL
+	Com_sprintf(baseURL, sizeof(baseURL), "http://%s:%d", ipAddress, port);
+
+	// Set sv_wwwBaseURL cvar
+	Cvar_Set("sv_wwwBaseURL", baseURL);
+	Com_Printf("HTTP: Auto-configured sv_wwwBaseURL = %s\n", baseURL);
+
+	// Enable sv_wwwDownload
+	sv_wwwDownload = Cvar_Get("sv_wwwDownload", "0", CVAR_ARCHIVE);
+	if (sv_wwwDownload && !sv_wwwDownload->integer)
+	{
+		Cvar_Set("sv_wwwDownload", "1");
+		Com_Printf("HTTP: Enabled sv_wwwDownload\n");
+	}
+
+	return qtrue;
+}
+
+/**
+ * @brief Allocate a free client structure
+ * @return Pointer to client structure or NULL if none available
+ */
+httpClient_t *HTTP_AllocClient(void)
+{
+	int i;
+
+	for (i = 0; i < httpServer.maxClients; i++)
+	{
+		if (httpServer.clients[i].state == HTTP_STATE_FREE)
+		{
+			memset(&httpServer.clients[i], 0, sizeof(httpClient_t));
+			httpServer.clients[i].state        = HTTP_STATE_CONNECTED;
+			httpServer.clients[i].socket       = INVALID_SOCKET;
+			httpServer.clients[i].fileHandle   = 0;
+			httpServer.clients[i].lastActivity = Sys_Milliseconds();
+			httpServer.activeClients++;
+			return &httpServer.clients[i];
+		}
+	}
+
+	return NULL;
+}
+
+/**
+ * @brief Free a client structure back to the pool
+ * @param[in] client Client to free
+ */
+void HTTP_FreeClient(httpClient_t *client)
+{
+	if (!client)
+	{
+		return;
+	}
+
+	if (client->state != HTTP_STATE_FREE)
+	{
+		memset(client, 0, sizeof(httpClient_t));
+		client->state  = HTTP_STATE_FREE;
+		client->socket = INVALID_SOCKET;
+		httpServer.activeClients--;
+	}
+}
+
+/**
+ * @brief Close a client connection
+ * @param[in] client Client to close
+ */
+void HTTP_CloseClient(httpClient_t *client)
+{
+	if (!client)
+	{
+		return;
+	}
+
+	// Close file if open
+	if (client->fileHandle)
+	{
+		FS_FCloseFile(client->fileHandle);
+		client->fileHandle = 0;
+	}
+
+	// Close socket
+	if (client->socket != INVALID_SOCKET)
+	{
+		Com_DPrintf("HTTP: Client disconnected: %s\n", NET_AdrToString(&client->address));
+		closesocket(client->socket);
+		client->socket = INVALID_SOCKET;
+	}
+
+	// Free client structure
+	HTTP_FreeClient(client);
+}
+
+/**
+ * @brief Timeout idle client connections
+ */
+void HTTP_TimeoutClients(void)
+{
+	int i;
+	int currentTime;
+	int timeout;
+
+	if (!sv_httpTimeout)
+	{
+		return;
+	}
+
+	timeout = sv_httpTimeout->integer * 1000; // Convert seconds to milliseconds
+	if (timeout <= 0)
+	{
+		return; // Timeout disabled
+	}
+
+	currentTime = Sys_Milliseconds();
+
+	for (i = 0; i < httpServer.maxClients; i++)
+	{
+		httpClient_t *client = &httpServer.clients[i];
+
+		if (client->state == HTTP_STATE_FREE)
+		{
+			continue;
+		}
+
+		// Check if client has been idle too long
+		if (currentTime - client->lastActivity > timeout)
+		{
+			Com_DPrintf("HTTP: Client timeout: %s (idle for %d ms)\n",
+			            NET_AdrToString(&client->address),
+			            currentTime - client->lastActivity);
+			HTTP_CloseClient(client);
+		}
+	}
+}
+
+/**
+ * @brief Accept new incoming TCP connections
+ */
+void HTTP_AcceptConnections(void)
+{
+	struct sockaddr_in clientAddr;
+	socklen_t          addrLen;
+	int                clientSock;
+	httpClient_t       *client;
+
+	if (httpServer.socket == INVALID_SOCKET)
+	{
+		return;
+	}
+
+	// Accept all pending connections
+	while (1)
+	{
+		addrLen    = sizeof(clientAddr);
+		clientSock = accept(httpServer.socket, (struct sockaddr *)&clientAddr, &addrLen);
+
+		if (clientSock == INVALID_SOCKET)
+		{
+#ifdef _WIN32
+			int err = WSAGetLastError();
+			if (err == WSAEWOULDBLOCK)
+			{
+				break; // No more connections
+			}
+			Com_DPrintf("HTTP: Accept failed: %s\n", HTTP_GetSocketError());
+#else
+			if (errno == EAGAIN || errno == EWOULDBLOCK)
+			{
+				break; // No more connections
+			}
+			Com_DPrintf("HTTP: Accept failed: %s\n", HTTP_GetSocketError());
+#endif
+			break;
+		}
+
+		// Allocate client structure
+		client = HTTP_AllocClient();
+		if (!client)
+		{
+			Com_Printf("HTTP: Maximum clients reached, rejecting connection\n");
+			closesocket(clientSock);
+			continue;
+		}
+
+		// Set non-blocking mode
+		if (!HTTP_SetNonBlocking(clientSock))
+		{
+			HTTP_FreeClient(client);
+			closesocket(clientSock);
+			continue;
+		}
+
+		// Initialize client
+		client->socket        = clientSock;
+		client->address.type  = NA_IP;
+		client->address.ip[0] = clientAddr.sin_addr.s_addr & 0xFF;
+		client->address.ip[1] = (clientAddr.sin_addr.s_addr >> 8) & 0xFF;
+		client->address.ip[2] = (clientAddr.sin_addr.s_addr >> 16) & 0xFF;
+		client->address.ip[3] = (clientAddr.sin_addr.s_addr >> 24) & 0xFF;
+		client->address.port  = ntohs(clientAddr.sin_port);
+		client->state         = HTTP_STATE_CONNECTED;
+		client->lastActivity  = Sys_Milliseconds();
+
+		httpServer.totalConnections++;
+
+		Com_Printf("HTTP: Client connected: %s\n", NET_AdrToString(&client->address));
+		Com_DPrintf("HTTP: Active clients: %d/%d\n", httpServer.activeClients, httpServer.maxClients);
+	}
+}
+
+/**
+ * @brief Initialize the HTTP server subsystem
+ */
+void HTTP_Init(void)
+{
+	int port;
+
+	Com_Printf("------- HTTP_Init -------\n");
+
+	// Initialize server structure
+	memset(&httpServer, 0, sizeof(httpServer));
+	httpServer.socket = INVALID_SOCKET;
+
+	// Register CVARs
+	sv_httpEnable     = Cvar_Get("sv_httpEnable", "1", CVAR_ARCHIVE | CVAR_LATCH);
+	sv_httpMaxClients = Cvar_Get("sv_httpMaxClients", "16", CVAR_ARCHIVE);
+	sv_httpAutoConfig = Cvar_Get("sv_httpAutoConfig", "1", CVAR_ARCHIVE);
+	// Performance optimization CVARs
+	sv_httpTimeout          = Cvar_Get("sv_httpTimeout", "30", CVAR_ARCHIVE);
+	sv_httpMaxBytesPerFrame = Cvar_Get("sv_httpMaxBytesPerFrame", "65536", CVAR_ARCHIVE);
+
+	// Check if HTTP server is enabled
+	if (!sv_httpEnable->integer)
+	{
+		Com_Printf("HTTP: Server disabled\n");
+		return;
+	}
+
+	// Get port from net_port cvar
+	port = Cvar_VariableIntegerValue("net_port");
+	if (port <= 0 || port > 65535)
+	{
+		Com_Printf("HTTP: Invalid port %d\n", port);
+		return;
+	}
+
+	// Set max clients
+	httpServer.maxClients = sv_httpMaxClients->integer;
+	if (httpServer.maxClients < 1)
+	{
+		httpServer.maxClients = 1;
+	}
+	else if (httpServer.maxClients > MAX_HTTP_CLIENTS)
+	{
+		httpServer.maxClients = MAX_HTTP_CLIENTS;
+	}
+
+	// Open listening port
+	if (HTTP_OpenPort(port))
+	{
+		httpServer.initialized = qtrue;
+		httpServer.enabled     = qtrue;
+
+		// Auto-configure base URL if enabled
+		HTTP_AutoConfigureBaseURL();
+	}
+	else
+	{
+		Com_Printf("HTTP: Failed to initialize server\n");
+	}
+}
+
+/**
+ * @brief Shutdown the HTTP server subsystem
+ */
+void HTTP_Shutdown(void)
+{
+	int i;
+
+	if (!httpServer.initialized)
+	{
+		return;
+	}
+
+	Com_Printf("HTTP: Shutting down...\n");
+
+	// Close all client connections
+	for (i = 0; i < MAX_HTTP_CLIENTS; i++)
+	{
+		if (httpServer.clients[i].state != HTTP_STATE_FREE)
+		{
+			HTTP_CloseClient(&httpServer.clients[i]);
+		}
+	}
+
+	// Close listening socket
+	HTTP_ClosePort();
+
+	// Print statistics
+	Com_Printf("HTTP: Total connections: %d\n", httpServer.totalConnections);
+	Com_Printf("HTTP: Total bytes sent: %d\n", httpServer.totalBytesSent);
+	Com_Printf("HTTP: Total requests: %d\n", httpServer.totalRequests);
+
+	// Clear server structure
+	memset(&httpServer, 0, sizeof(httpServer));
+	httpServer.socket = INVALID_SOCKET;
+}
+
+/**
+ * @brief Receive data from a client into request buffer
+ * @param[in] client Client to receive data from
+ * @return qtrue if data received, qfalse on error or no data
+ */
+static qboolean HTTP_ReceiveClientData(httpClient_t *client)
+{
+	int bytesReceived;
+	int bufferSpace;
+
+	if (!client || client->socket == INVALID_SOCKET)
+	{
+		return qfalse;
+	}
+
+	// Calculate available buffer space
+	bufferSpace = HTTP_REQUEST_BUFFER - client->requestLength - 1;
+	if (bufferSpace <= 0)
+	{
+		Com_DPrintf("HTTP: Request buffer full for client %s\n", NET_AdrToString(&client->address));
+		return qfalse;
+	}
+
+	// Receive data into buffer
+	bytesReceived = recv(client->socket,
+	                     client->requestBuffer + client->requestLength,
+	                     bufferSpace,
+	                     0);
+
+	if (bytesReceived > 0)
+	{
+		// Data received successfully
+		client->requestLength                       += bytesReceived;
+		client->requestBuffer[client->requestLength] = '\0'; // Null terminate
+		client->lastActivity                         = Sys_Milliseconds();
+
+		Com_DPrintf("HTTP: Received %d bytes from %s (total: %d)\n",
+		            bytesReceived, NET_AdrToString(&client->address), client->requestLength);
+
+		return qtrue;
+	}
+	else if (bytesReceived == 0)
+	{
+		// Connection closed by client
+		Com_DPrintf("HTTP: Connection closed by client %s\n", NET_AdrToString(&client->address));
+		return qfalse;
+	}
+	else
+	{
+		// Error or would block
+#ifdef _WIN32
+		int err = WSAGetLastError();
+		if (err != WSAEWOULDBLOCK)
+		{
+			Com_DPrintf("HTTP: Recv error from %s: %s\n",
+			            NET_AdrToString(&client->address), HTTP_GetSocketError());
+			return qfalse;
+		}
+#else
+		if (errno != EAGAIN && errno != EWOULDBLOCK)
+		{
+			Com_DPrintf("HTTP: Recv error from %s: %s\n",
+			            NET_AdrToString(&client->address), HTTP_GetSocketError());
+			return qfalse;
+		}
+#endif
+		// Would block - no data available right now
+		return qtrue;
+	}
+}
+
+/**
+ * @brief Check if client request is complete
+ * @param[in] client Client to check
+ * @return qtrue if request is complete (ends with \r\n\r\n)
+ */
+static qboolean HTTP_IsRequestComplete(httpClient_t *client)
+{
+	if (!client)
+	{
+		return qfalse;
+	}
+
+	// Check for end of headers marker
+	return (strstr(client->requestBuffer, "\r\n\r\n") != NULL);
+}
+
+/**
+ * @brief Process client requests
+ * @param[in] client Client to process
+ */
+static void HTTP_ProcessClient(httpClient_t *client)
+{
+	if (!client)
+	{
+		return;
+	}
+
+	switch (client->state)
+	{
+	case HTTP_STATE_CONNECTED:
+	case HTTP_STATE_RECEIVING:
+		// Receive data from client
+		if (!HTTP_ReceiveClientData(client))
+		{
+			// Error or connection closed
+			if (client->requestLength == 0 ||
+			    client->requestBuffer[0] == '\0' ||
+			    recv(client->socket, client->requestBuffer, 1, MSG_PEEK) == 0)
+			{
+				// Connection closed or error
+				HTTP_CloseClient(client);
+				return;
+			}
+			// Check if buffer is full without valid request - prevent buffer exhaustion DoS
+			if (client->requestLength >= HTTP_REQUEST_BUFFER - 1 && !HTTP_IsRequestComplete(client))
+			{
+				Com_DPrintf("HTTP: Request buffer exhausted without valid request from %s\n",
+				            NET_AdrToString(&client->address));
+				HTTP_SendErrorResponse(client, 400, "Request too large");
+				return;
+			}
+		}
+
+		// Update state
+		if (client->requestLength > 0)
+		{
+			client->state = HTTP_STATE_RECEIVING;
+		}
+
+		// Check if request is complete
+		if (HTTP_IsRequestComplete(client))
+		{
+			// Parse the request
+			if (HTTP_ParseRequest(client))
+			{
+				client->state = HTTP_STATE_PROCESSING;
+				Com_Printf("HTTP: Request from %s: %s %s\n",
+				           NET_AdrToString(&client->address),
+				           (client->method == HTTP_METHOD_GET) ? "GET" : "HEAD",
+				           client->path);
+			}
+			else
+			{
+				// Parse error - send 400 Bad Request
+				Com_DPrintf("HTTP: Parse error for client %s\n", NET_AdrToString(&client->address));
+				HTTP_SendErrorResponse(client, 400, "Malformed HTTP request");
+			}
+		}
+		break;
+
+	case HTTP_STATE_PROCESSING:
+		// Process request and prepare response
+		// Initiate file transfer
+		HTTP_SendFileResponse(client);
+		break;
+
+	case HTTP_STATE_SENDING_HEADERS:
+		// Send response headers
+		if (!HTTP_ProcessResponseSending(client))
+		{
+			// Sending complete or error - close connection
+			if (client->state != HTTP_STATE_CLOSING)
+			{
+				client->state = HTTP_STATE_CLOSING;
+			}
+		}
+		// Check if headers are fully sent and we should start sending file
+		else if (client->state == HTTP_STATE_SENDING_HEADERS &&
+		         client->bytesSent >= client->responseLength &&
+		         client->fileHandle)
+		{
+			// Headers sent, move to file sending
+			client->state     = HTTP_STATE_SENDING_FILE;
+			client->bytesSent = 0;
+			Com_DPrintf("HTTP: Headers complete, starting file transfer\n");
+		}
+		break;
+
+	case HTTP_STATE_SENDING_FILE:
+		// Send file data chunks
+		if (!HTTP_SendFileChunk(client))
+		{
+			// Transfer complete or error - close connection
+			if (client->state != HTTP_STATE_CLOSING)
+			{
+				client->state = HTTP_STATE_CLOSING;
+			}
+		}
+		break;
+
+	case HTTP_STATE_CLOSING:
+		HTTP_CloseClient(client);
+		break;
+
+	default:
+		break;
+	}
+}
+
+/**
+ * @brief Process HTTP server events (called each frame)
+ * Implements frame time budget and bandwidth throttling
+ */
+void HTTP_Frame(void)
+{
+	int       i;
+	int       currentTime;
+	int       elapsedTime;
+	const int FRAME_TIME_BUDGET_MS = 5; // 5ms budget per frame
+
+	if (!httpServer.initialized || !httpServer.enabled)
+	{
+		return;
+	}
+
+	// Track frame start time and reset frame byte counter
+	httpServer.frameStartTime = Sys_Milliseconds();
+	httpServer.frameBytesSent = 0;
+
+	// Accept new connections
+	HTTP_AcceptConnections();
+
+	// Timeout idle clients
+	HTTP_TimeoutClients();
+
+	// Process existing client connections
+	for (i = 0; i < httpServer.maxClients; i++)
+	{
+		if (httpServer.clients[i].state != HTTP_STATE_FREE)
+		{
+			HTTP_ProcessClient(&httpServer.clients[i]);
+
+			// Check frame time budget
+			currentTime = Sys_Milliseconds();
+			elapsedTime = currentTime - httpServer.frameStartTime;
+			if (elapsedTime >= FRAME_TIME_BUDGET_MS)
+			{
+				Com_DPrintf("HTTP: Frame time budget exceeded (%d ms), deferring remaining clients\n", elapsedTime);
+				break; // Continue next frame
+			}
+		}
+	}
+}

--- a/src/server/sv_http_server.c
+++ b/src/server/sv_http_server.c
@@ -240,6 +240,7 @@ qboolean HTTP_AutoConfigureBaseURL(void)
 	cvar_t *sv_wwwBaseURL;
 	cvar_t *sv_wwwDownload;
 	int    port;
+	const char *protocol;
 
 	if (!httpServer.initialized || !httpServer.enabled)
 	{
@@ -281,8 +282,8 @@ qboolean HTTP_AutoConfigureBaseURL(void)
 		return qfalse;
 	}
 
-	// Build base URL
-	Com_sprintf(baseURL, sizeof(baseURL), "http://%s:%d", ipAddress, port);
+	protocol = "http";
+	Com_sprintf(baseURL, sizeof(baseURL), "%s://%s:%d", protocol, ipAddress, port);
 
 	// Set sv_wwwBaseURL cvar
 	Cvar_Set("sv_wwwBaseURL", baseURL);
@@ -421,7 +422,7 @@ void HTTP_TimeoutClients(void)
  */
 void HTTP_AcceptConnections(void)
 {
-	struct sockaddr_in clientAddr;
+	struct sockaddr_in clientAddr = {0};
 	socklen_t          addrLen;
 	int                clientSock;
 	httpClient_t       *client;

--- a/src/server/sv_http_server.c
+++ b/src/server/sv_http_server.c
@@ -223,11 +223,9 @@ static qboolean HTTP_DetectServerIP(char *ipBuffer, int ipBufferSize)
 		return qtrue;
 	}
 
-	// Fallback to 0.0.0.0 which means clients will use their connection IP
-	// This is the recommended approach for most server setups as it works
-	// correctly even behind NAT or with multiple network interfaces
-	Q_strncpyz(ipBuffer, "0.0.0.0", ipBufferSize);
-	Com_DPrintf("HTTP: Using fallback IP: 0.0.0.0 (clients will use actual connection IP)\n");
+	// Fallback to 127.0.0.1
+	Q_strncpyz(ipBuffer, "127.0.0.1", ipBufferSize);
+	Com_DPrintf("HTTP: Using fallback IP: 127.0.0.1 (clients will use local IP)\n");
 	return qtrue;
 }
 

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -1203,6 +1203,13 @@ void SV_Init(void)
 	sv_wwwDlDisconnected = Cvar_Get("sv_wwwDlDisconnected", "0", CVAR_ARCHIVE);
 	sv_wwwFallbackURL    = Cvar_Get("sv_wwwFallbackURL", "", CVAR_ARCHIVE);
 
+	// HTTP server cvars
+	sv_httpEnable           = Cvar_Get("sv_httpEnable", "1", CVAR_ARCHIVE | CVAR_LATCH);
+	sv_httpMaxClients       = Cvar_Get("sv_httpMaxClients", "16", CVAR_ARCHIVE);
+	sv_httpAutoConfig       = Cvar_Get("sv_httpAutoConfig", "1", CVAR_ARCHIVE);
+	sv_httpTimeout          = Cvar_Get("sv_httpTimeout", "30", CVAR_ARCHIVE);
+	sv_httpMaxBytesPerFrame = Cvar_Get("sv_httpMaxBytesPerFrame", "65536", CVAR_ARCHIVE);
+
 	sv_packetloss  = Cvar_Get("sv_packetloss", "0", CVAR_CHEAT);
 	sv_packetdelay = Cvar_Get("sv_packetdelay", "0", CVAR_CHEAT);
 

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -38,6 +38,10 @@
 #include "sv_tracker.h"
 #endif
 
+#ifdef DEDICATED
+#include "sv_http.h"
+#endif
+
 // Attack log file is started when server is init (!= sv_running 1!)
 // we even log attacks when the server is waiting for rcon and doesn't run a map
 int attHandle = 0; // server attack log file handle
@@ -1360,6 +1364,10 @@ void SV_Shutdown(const char *finalmsg)
 
 	// disconnect any local clients
 	CL_Disconnect(qfalse);
+
+#ifdef DEDICATED
+	HTTP_Shutdown();
+#endif
 
 #ifdef FEATURE_TRACKER
 	Tracker_ServerStop();

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -38,6 +38,10 @@
 #include "sv_tracker.h"
 #endif
 
+#ifdef DEDICATED
+#include "sv_http.h"
+#endif
+
 serverStatic_t       svs;             // persistant server info
 server_t             sv;              // local server
 svclientActive_t     svcl;
@@ -1825,6 +1829,10 @@ void SV_Frame(int msec)
 			Com_Printf(S_COLOR_YELLOW "WARNING: Average frame time has reached a critical value of %ims\n", (int) svs.stats.avg);
 		}
 	}
+
+#ifdef DEDICATED
+	HTTP_Frame();
+#endif
 }
 
 /**


### PR DESCRIPTION
This PR embeds a custom HTTP server to enable faster downloading without a second http service.

Both game server (UDP) and http server (TCP) are served through the same port.

**Security**

- The configurable HTTP server is a minimal implementation with only read (GET) functionality.
- It uses the same security logic as traditional UDP file downloads (FS_VerifyPak & FS_idPak) to prevent exploiting.
- There are configurations with sensible defaults to handle connection limits and timeouts.

It's designed as an improvement requiring zero configuration and backwards compatibility for 2.60b.
When no `sv_wwwBaseURL` is provided, it checks the `net_ip` cvar and falls back to querying prominent STUN servers to determine the external ip and then passes that to the client as the default `sv_wwwBaseURL`.

I wanted to keep the http server code as isolated as possible from the rest of the code.