### PR TITLE
cgame: fix typo in trap_R_RegisterShaderNoMip debug print

### DIFF
--- a/src/cgame/cg_syscalls.c
+++ b/src/cgame/cg_syscalls.c
@@ -1702,7 +1702,7 @@ qhandle_t trap_R_RegisterShaderNoMip(const char *name)
 	{
 		CG_DPrintf("^2trap_R_RegisterShaderNoMip: register shader no mip: '%s'\n", name);
 	}
-	DEBUG_REGISTERPROFILE_EXEC("trap_R_RegisterShaderNpMip", name);
+	DEBUG_REGISTERPROFILE_EXEC("trap_R_RegisterShaderNoMip", name);
 	return handle;
 }
 


### PR DESCRIPTION
This should use `__func__` realistically, but I'm not 100% sure if the build machine has new enough compiler(s) to support it on C89/90, as it only became standard in C99, with newer compilers backporting support to C89/90 too.