### PR TITLE
Don't process triggers during pause

### DIFF
--- a/src/game/g_active.c
+++ b/src/game/g_active.c
@@ -2357,7 +2357,11 @@ void ClientEndFrame(gentity_t *ent)
 	// run touch functions here too, so movers don't have to wait
 	// until the next ClientThink, which will be too late for some map
 	// scripts (railgun)
-	G_TouchTriggers(ent);
+	// Don't process triggers during pause to prevent damage from barbed wire, etc.
+	if (level.match_pause == PAUSE_NONE)
+	{
+		G_TouchTriggers(ent);
+	}
 
 	// run entity scripting
 	G_Script_ScriptRun(ent);


### PR DESCRIPTION
We found a bug during a competitive match where one player was touching barbed wire during pause and he go killed by it.
He kept receiving damage during the pause until he died.

This PR tells the engine not to process triggers during pause to prevent damage from barbed wire, etc.

This needs to be tested.