### PR TITLE
game: fix corpses floating 1u off ground when player died on ground

### DIFF
--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -630,7 +630,7 @@ void CopyToBodyQue(gentity_t *ent)
 
 		body->r.currentOrigin[0] = origin[0] - offset[0];
 		body->r.currentOrigin[1] = origin[1] - offset[1];
-		body->r.currentOrigin[2] = origin[2] + 1;           // make sure it is off ground
+		body->r.currentOrigin[2] = origin[2];
 
 		// ok set it und Fertig!
 		VectorCopy(body->r.currentOrigin, body->s.pos.trBase);


### PR DESCRIPTION
Unsure why this was done, undoing this can possibly cause the corpses to stutter slightly in some scenarios I guess (based off the referenced issue that the commit that added this was referring to), but that is a purely visual issue, while this has consequences on gameplay.

fixes #3212
refs #1385