### PR TITLE
cgame: fix needle bar placement in HUD for certain combinations

### DIFF
--- a/src/cgame/cg_drawtools.c
+++ b/src/cgame/cg_drawtools.c
@@ -310,7 +310,15 @@ void CG_FilledBar(float x, float y, float w, float h, float *startColor, float *
 
 		if (needleFrac > 0.f && flags & BAR_NEEDLE)
 		{
-			CG_FillRect(x3, y3 + (h * (1 - needleFrac)) + 0.0, w, 1.0, backgroundcolor);
+			if (flags & BAR_LEFT)
+			{
+				y3 += h * (1.0f - needleFrac);
+			}
+			else
+			{
+				y3 += h * needleFrac;
+			}
+			CG_FillRect(x3, y3, w, 1.0f, backgroundcolor);
 		}
 
 		if (flags & BAR_DECOR)
@@ -368,7 +376,15 @@ void CG_FilledBar(float x, float y, float w, float h, float *startColor, float *
 
 		if (needleFrac > 0.f && flags & BAR_NEEDLE)
 		{
-			CG_FillRect(x3 + (w * (1 - needleFrac)) - 0.0, y3, 1.0, h, backgroundcolor);
+			if (flags & BAR_LEFT)
+			{
+				x3 += w * (1.0f - needleFrac);
+			}
+			else
+			{
+				x3 += w * needleFrac;
+			}
+			CG_FillRect(x3, y3, 1.0f, h, backgroundcolor);
 		}
 
 		if (flags & BAR_DECOR)


### PR DESCRIPTION
Hey, position of needle bar is incorrect when LEFT checkbox is unticked.

<img width="1149" height="484" alt="image" src="https://github.com/user-attachments/assets/194566f3-e4aa-4fd1-9be3-f804e3aaa0bb" />

Below is after fix:
<img width="1543" height="804" alt="image" src="https://github.com/user-attachments/assets/993d69ab-be61-4961-a6e1-5245611c2155" />
