### PR TITLE
etmain: add shader scripts for cm_flagshadow so that its not drawn ou…

### DIFF
--- a/etmain/materials/legacy.shader
+++ b/etmain/materials/legacy.shader
@@ -478,6 +478,20 @@ gfx/limbo/cm_flagaxis
 	}
 }
 
+gfx/limbo/cm_flagshadow
+{
+	nopicmip
+	nocompress
+	nomipmaps
+	{
+		map gfx/limbo/cm_flagshadow
+		depthFunc equal
+		blendfunc blend
+		rgbGen vertex
+		alphaGen vertex
+	}
+}
+
 gfx/limbo/cm_fuel
 {
 	nopicmip

--- a/etmain/scripts/legacy_gfx_limbo.shader
+++ b/etmain/scripts/legacy_gfx_limbo.shader
@@ -262,6 +262,21 @@ gfx/limbo/cm_flagaxis
 	}
 }
 
+
+gfx/limbo/cm_flagshadow
+{
+	nopicmip
+	nocompress
+	nomipmaps
+	{
+		map gfx/limbo/cm_flagshadow
+		depthFunc equal
+		blendfunc blend
+		rgbGen vertex
+		alphaGen vertex
+	}
+}
+
 gfx/limbo/cm_fuel
 {
 	nopicmip


### PR DESCRIPTION
…tside of compass

I figured it should have same shader script as allies/axis flags (as this is basically an extension of flag).

Screen that shows how it was before fix:
<img width="938" height="874" alt="image" src="https://github.com/user-attachments/assets/5711a948-04f7-4163-af98-6c0cb6991d24" />


And screen that shows how it is after:
<img width="804" height="799" alt="image" src="https://github.com/user-attachments/assets/325d9071-cc5e-4cff-a3fe-1b1d5cde5080" />
