### PR TITLE
cgame: fireteam overlay refactor, fixes and improvements

### DIFF
--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -180,6 +180,19 @@ int CG_Text_Width(const char *text, float scale, int limit)
  */
 int CG_Text_Height_Ext(const char *text, float scale, int limit, fontHelper_t *font)
 {
+	return (int)CG_Text_Height_Ext_Float(text, scale, limit, font);
+}
+
+/**
+ * @brief CG_Text_Height_Ext_Float
+ * @param[in] text
+ * @param[in] scale
+ * @param[in] limit
+ * @param[in] font
+ * @return
+ */
+float CG_Text_Height_Ext_Float(const char *text, float scale, int limit, fontHelper_t *font)
+{
 	float max = 0;
 
 	if (text)
@@ -1206,7 +1219,7 @@ void CG_PriorityCenterPrint(const char *str, int priority)
 	scale = CG_ComputeScale(&CG_GetActiveHUD()->centerprint /*CG_GetActiveHUD()->centerprint.location.h, CG_GetActiveHUD()->centerprint.scale, &cgs.media.limboFont2*/);
 	w     = CG_GetActiveHUD()->centerprint.location.w;
 
-	maxLineChars = CG_GetMaxCharsPerLine(str, scale, &cgs.media.limboFont2, w);
+	maxLineChars = CG_MaxCharsForWidth(str, scale, &cgs.media.limboFont2, w);
 
 	CG_WordWrapString(CG_TranslateString(str), maxLineChars, cg.centerPrint, sizeof(cg.centerPrint), NULL);
 	cg.centerPrintPriority = priority;
@@ -3750,7 +3763,7 @@ void CG_ObjectivePrint(const char *str)
 	scale = CG_ComputeScale(&CG_GetActiveHUD()->objectivetext /*CG_GetActiveHUD()->objectivetext.location.h, CG_GetActiveHUD()->objectivetext.scale, &cgs.media.limboFont2*/);
 	w     = CG_GetActiveHUD()->objectivetext.location.w;
 
-	maxLineChars = CG_GetMaxCharsPerLine(str, scale, &cgs.media.limboFont2, w);
+	maxLineChars = CG_MaxCharsForWidth(str, scale, &cgs.media.limboFont2, w);
 	CG_WordWrapString(CG_TranslateString(str), maxLineChars, cg.oidPrint, sizeof(cg.oidPrint), NULL);
 	cg.oidPrintTime = cg.time;
 }

--- a/src/cgame/cg_drawtools.c
+++ b/src/cgame/cg_drawtools.c
@@ -1092,31 +1092,33 @@ void CG_AddOnScreenBar(float fraction, vec4_t colorStart, vec4_t colorEnd, vec4_
  * @param[in]  textScale
  * @param[in]  font
  * @param[in]  width
- * @param[out] maxLineChars
+ * @param[out] maxChars
  */
-int CG_GetMaxCharsPerLine(const char *str, float textScale, fontHelper_t *font, float width)
+int CG_MaxCharsForWidth(const char *str, float textScale, fontHelper_t *font, float width)
 {
-	int maxLineChars = 0;
-	int limit        = 0;
+	int maxChars = 0;
+	int limit    = 0;
 
 	while (str != NULL)
 	{
-		if (CG_Text_Width_Ext_Float(str, textScale, 0, font) < width)
+		if (CG_Text_Width_Ext_Float(str, textScale, 0, font) <= width)
 		{
-			maxLineChars = Q_PrintStrlen(str);
+			maxChars = Q_PrintStrlen(str);
 			break;
 		}
 
 		limit++;
-		maxLineChars++;
+		maxChars++;
 
 		if (CG_Text_Width_Ext_Float(str, textScale, limit, font) > width)
 		{
+			// we went over the limit, so reduce 'maxChars' by 1
+			maxChars--;
 			break;
 		}
 	}
 
-	return maxLineChars;
+	return maxChars;
 }
 
 /**

--- a/src/cgame/cg_fireteamoverlay.c
+++ b/src/cgame/cg_fireteamoverlay.c
@@ -39,6 +39,71 @@ static int sortedFireTeamClients[MAX_CLIENTS];
 #define FONT_HEADER         &cgs.media.limboFont1
 #define FONT_TEXT           &cgs.media.limboFont2
 
+// HUD editor flags
+// TODO: move these elsewhere (and probably rename)
+#define FT_LATCHED_CLASS        (BIT(0))
+#define FT_NO_HEADER            (BIT(1))
+#define FT_COLORLESS_NAME       (BIT(2))
+#define FT_STATUS_COLOR_NAME    (BIT(3))
+#define FT_STATUS_COLOR_ROW     (BIT(4))
+#define FT_SPAWN_POINT          (BIT(5))
+#define FT_SPAWN_POINT_LOC      (BIT(6))
+#define FT_SPAWN_POINT_MINOR    (BIT(7))
+
+typedef struct fireteamOverlay_s
+{
+	float x;
+	float y;
+	float w;
+	float h;
+
+	float textScale;
+	float textScaleMinorSpawn;
+
+	float spacerInner; // spacing between elements on a row
+	float spacerOuter; // spacer at the outer edges of a row
+
+	float textHeight;
+	float iconSize;
+	float weaponIconSize;
+	float powerupWidth;
+
+	float textHeightOffset;
+	float iconHeightOffset;
+	float weaponIconHeightOffset;
+
+	float classIconWidth;
+	float healthWidth;
+
+	float bestNameWidth; // includes powerup icon width if present
+	float bestLocWidth;
+	float bestWeaponIconWidthScale;
+	float bestSpawnWidth;
+
+	float maxLocWidth;
+	float maxSpawnWidth;
+
+	int currentWeapon;
+
+	clientInfo_t *ci;
+	fireteamData_t *ftData;
+
+	char locStr[MAX_FIRETEAM_MEMBERS][MAX_LOC_LEN];
+	char spawnPtStr[MAX_FIRETEAM_MEMBERS][MAX_LOC_LEN];
+	char name[MAX_FIRETEAM_MEMBERS][MAX_NAME_LENGTH];
+
+	vec4_t selectedMemberColor;
+	vec4_t iconColor;
+	vec4_t iconColorAlt;    // for weapon icon that isn't updated (teammate out of PVS)
+	vec4_t textWhite;       // normal text
+	vec4_t textYellow;      // for health drawing
+	vec4_t textRed;         // for health drawing
+	vec4_t textOrange;      // for connection issues
+	vec4_t nameColor;
+} fireteamOverlay_t;
+
+static fireteamOverlay_t ftOverlay;
+
 /**
  * @brief CG_SortFireTeam
  * @param[in] a
@@ -393,55 +458,567 @@ static ID_INLINE int CG_FireTeamClientCurrentWeapon(clientInfo_t *ci)
 	}
 }
 
-/**
- * @brief Draw FireTeam overlay
- * @param[in] rect
- */
+static void CG_FTOverlay_NoiseGen(fireteamOverlay_t *fto, hudComponent_t *comp)
+{
+	const char *info       = "Please join a real Fireteam!";
+	float      titleHeight = 0;
+
+	// draw the box
+	fto->w = comp->location.w;
+	fto->h = comp->location.h;
+	CG_FillRect(fto->x, fto->y, fto->w, fto->h, comp->colorBackground);
+	CG_DrawRect_FixedBorder(fto->x, fto->y, fto->w, fto->h, 1, comp->colorBorder);
+	CG_FillRect(fto->x + 1, fto->y + 1, fto->w - 2, fto->h - 2, comp->colorSecondary);
+
+	// draw a text info on it
+	fto->textScale = CG_ComputeScale(comp);
+	titleHeight    = CG_Text_Height_Ext(info, fto->textScale, 0, FONT_HEADER);
+	CG_Text_Paint_Ext(fto->x + 4, comp->location.y + ((titleHeight + fto->h) * 0.5f), fto->textScale, fto->textScale,
+	                  comp->colorMain, info, 0, 0, comp->styleText, FONT_TEXT);
+}
+
+static void CG_FTOverlay_SetColors(fireteamOverlay_t *fto, const float alpha)
+{
+	Vector4Set(fto->selectedMemberColor, 0.5f, 0.5f, 0.2f, 0.3f);
+	Vector4Set(fto->iconColor, 1.0f, 1.0f, 1.0f, 1.0f);
+	Vector4Set(fto->iconColorAlt, 1.0f, 1.0f, 1.0f, 0.5f);
+	Vector4Set(fto->textWhite, 1.0f, 1.0f, 1.0f, 1.0f);
+	Vector4Set(fto->textYellow, 1.0f, 1.0f, 0.0f, 1.0f);
+	Vector4Set(fto->textRed, 1.0f, 0.0f, 0.0f, 1.0f);
+	Vector4Set(fto->textOrange, 1.0f, 0.6f, 0.0f, 1.0f);
+	Vector4Set(fto->nameColor, 1.0f, 1.0f, 1.0f, 1.0f);
+
+	fto->selectedMemberColor[3] *= alpha;
+	fto->iconColor[3]           *= alpha;
+	fto->iconColorAlt[3]        *= alpha;
+	fto->textWhite[3]           *= alpha;
+	fto->textYellow[3]          *= alpha;
+	fto->textRed[3]             *= alpha;
+	fto->textOrange[3]          *= alpha;
+	fto->nameColor[3]           *= alpha;
+}
+
+static void CG_FTOverlay_StorePlayerName(fireteamOverlay_t *fto, const int row, const hudComponent_t *comp)
+{
+	if (comp->style & FT_COLORLESS_NAME || (comp->style & FT_STATUS_COLOR_NAME && (fto->ci->health <= 0 || fto->ci->ping >= 999)))
+	{
+		char escapedName[MAX_NAME_LENGTH];
+
+		// use NULL color here rather than 'fto->ci->cleanname' directly,
+		// to make sure that a name with visible carets in it doesn't get colorized when drawing,
+		// and works as expected with colorless names/status colored names
+		Q_ColorizeString('*', fto->ci->cleanname, escapedName, sizeof(escapedName));
+		Q_strncpyz(fto->name[row], escapedName, sizeof(fto->name[row]));
+	}
+	else
+	{
+		Q_strncpyz(fto->name[row], fto->ci->name, sizeof(fto->name[row]));
+	}
+
+	// truncate name if max chars is set
+	if (cg_fireteamNameMaxChars.integer > 0)
+	{
+		const int nameMaxLen = Com_Clamp(0, MAX_NAME_LENGTH - 1, cg_fireteamNameMaxChars.integer);
+		Q_TruncateStr(fto->name[row], nameMaxLen);
+	}
+}
+
+static void CG_FTOverlay_StoreLocationString(fireteamOverlay_t *fto, const int row)
+{
+	const char *locStr;
+
+	if (!(cg_locations.integer & LOC_FTEAM))
+	{
+		return;
+	}
+
+	locStr = CG_BuildLocationString(fto->ci->clientNum, fto->ci->location, LOC_FTEAM);
+
+	// CG_BuildLocationString should always return a valid string!
+	etl_assert(locStr != NULL);
+
+	// store the location name so we don't need to rebuild it later for drawing
+	Q_strncpyz(fto->locStr[row], locStr, sizeof(fto->locStr[row]));
+}
+
+static void CG_FTOverlay_StoreSpawnpointString(fireteamOverlay_t *fto, const int row, const hudComponent_t *comp)
+{
+	if (!(comp->style & FT_SPAWN_POINT_LOC))
+	{
+		return;
+	}
+
+	Q_strncpyz(fto->spawnPtStr[row],
+	           Q_CleanStr(CG_GetLocationMsg(fto->ci->clientNum, cgs.majorSpawnpointEnt[fto->ci->spawnpt - 1].origin)),
+	           sizeof(fto->spawnPtStr[row]));
+
+}
+
+#define HEALTH_WIDTH (CG_Text_Width_Ext_Float("999", fto->textScale, 0, FONT_TEXT))
+#define CLASS_ICON_ARROW_WIDTH (CG_Text_Width_Ext_Float("->", fto->textScale, 0, FONT_TEXT))
+// slightly wider than the icon size, to leave a bit of margin between the icon and name
+#define POWERUP_WIDTH (fto->iconSize * 1.25f)
+#define MAJOR_SPAWN_NUMBER_WIDTH_SCALE ((comp->style & FT_SPAWN_POINT_MINOR) ? 1.25f : 1.0f)
+
+static float CG_FTOverlay_ClassIconWidth(const fireteamOverlay_t *fto, const hudComponent_t *comp)
+{
+	if (comp->style & FT_LATCHED_CLASS)
+	{
+		return (fto->iconSize * 2) + CLASS_ICON_ARROW_WIDTH;
+	}
+
+	return fto->iconSize;
+}
+
+static float CG_FTOverlay_NameWidth(fireteamOverlay_t *fto, const int row)
+{
+	float nameWidth = 0;
+	int   limit     = 0;
+
+	// names should be stored before calling this!
+	etl_assert(fto->name[row][0] != '\0');
+
+	if (cg_fireteamNameMaxChars.integer > 0)
+	{
+		limit = Com_Clamp(0, MAX_NAME_LENGTH, cg_fireteamNameMaxChars.integer);
+
+		// if alignment is requested, keep a static width
+		if (cg_fireteamNameAlign.integer)
+		{
+			// NOTE: use clean name for counting the padding here - we're counting visible padding!
+			nameWidth = CG_Text_Width_Ext_Float(va("%*s", limit, &fto->ci->cleanname[row]), fto->textScale, limit, FONT_TEXT);
+		}
+		else
+		{
+			nameWidth = CG_Text_Width_Ext_Float(fto->name[row], fto->textScale, limit, FONT_TEXT);
+		}
+	}
+	else
+	{
+		nameWidth = CG_Text_Width_Ext_Float(fto->name[row], fto->textScale, limit, FONT_TEXT);
+	}
+
+	// reserve more space if the player is holding an objective or is disguised,
+	// as that gets placed in front of the player's name, shifting it to right
+	if (fto->ci->powerups & ((1 << PW_REDFLAG) | (1 << PW_BLUEFLAG) | (1 << PW_OPS_DISGUISED)))
+	{
+		nameWidth += POWERUP_WIDTH;
+	}
+
+	return nameWidth;
+}
+
+static float CG_FTOverlay_WeaponIconWidthScale(fireteamOverlay_t *fto)
+{
+	fto->currentWeapon = CG_FireTeamClientCurrentWeapon(fto->ci);
+
+	// ensure we actually have a valid weapon (should always be the case)
+	if (IS_VALID_WEAPON(fto->currentWeapon) &&
+	    (cg_weapons[fto->currentWeapon].weaponIcon[0] || cg_weapons[fto->currentWeapon].weaponIcon[1]))
+	{
+		return cg_weapons[fto->currentWeapon].weaponIconScale;
+	}
+
+	return 1.0f;
+}
+
+
+// pretty useless, but it's clearer intention to call a function named this,
+// rather than to just write out the value
+static ID_INLINE float CG_FTOverlay_HealthWidth(const fireteamOverlay_t *fto)
+{
+	return HEALTH_WIDTH;
+}
+
+static float CG_FTOverlay_LocationWidth(const fireteamOverlay_t *fto, const int row)
+{
+	float locWidth = 0.0f;
+	int   limit    = 0;
+
+	if (!(cg_locations.integer & LOC_FTEAM))
+	{
+		return locWidth;
+	}
+
+	// location names should be stored before calling this!
+	etl_assert(fto->locStr[row][0] != '\0');
+
+	if (cg_locationMaxChars.integer > 0)
+	{
+		// we need to use clean string here since we're counting printf padding
+		char cleanLocStr[MAX_LOC_LEN];
+		Q_strncpyz(cleanLocStr, fto->locStr[row], sizeof(cleanLocStr));
+		Q_CleanStr(cleanLocStr);
+
+		limit    = Com_Clamp(0, MAX_LOC_LEN, cg_locationMaxChars.integer);
+		locWidth = CG_Text_Width_Ext_Float(va("%*s", limit, cleanLocStr), fto->textScale, limit, FONT_TEXT);
+	}
+	else
+	{
+		locWidth = CG_Text_Width_Ext_Float(fto->locStr[row], fto->textScale, limit, FONT_TEXT);
+	}
+
+	return locWidth;
+}
+
+static float CG_FTOverlay_SpawnpointWidth(const fireteamOverlay_t *fto, const int row, const hudComponent_t *comp)
+{
+	float spawnWidth = 0;
+	int   limit      = 0;
+
+	if (!(comp->style & FT_SPAWN_POINT) && !(comp->style & FT_SPAWN_POINT_LOC))
+	{
+		return spawnWidth;
+	}
+
+	// text location takes precedence over numbers, if both are set
+	if (comp->style & FT_SPAWN_POINT_LOC)
+	{
+		// spawnpoint names should be stored before calling this!
+		etl_assert(fto->spawnPtStr[row][0] != '\0');
+
+		if (cg_locationMaxChars.integer > 0)
+		{
+			limit = Com_Clamp(0, MAX_LOC_LEN, cg_locationMaxChars.integer);
+			// spawnpoint strings are cleaned from color codes, we can use that to count padding
+			spawnWidth = CG_Text_Width_Ext_Float(va("%*s", limit, fto->spawnPtStr[row]), fto->textScale, limit, FONT_TEXT);
+		}
+		else
+		{
+			spawnWidth = CG_Text_Width_Ext_Float(fto->spawnPtStr[row], fto->textScale, limit, FONT_TEXT);
+		}
+	}
+	else if (comp->style & FT_SPAWN_POINT)
+	{
+		spawnWidth = CG_Text_Width_Ext_Float(va("%i", fto->ci->spawnpt), fto->textScale, 0, FONT_TEXT) * MAJOR_SPAWN_NUMBER_WIDTH_SCALE;
+
+		if (comp->style & FT_SPAWN_POINT_MINOR && cg.hasMinorSpawnPoints && fto->ci->mspawnpt > 0)
+		{
+			spawnWidth += CG_Text_Width_Ext_Float(va("%i", fto->ci->mspawnpt), fto->textScaleMinorSpawn, 0, FONT_TEXT);
+		}
+	}
+
+	return spawnWidth;
+}
+
+static void CG_FTOverlay_DrawHeader(fireteamOverlay_t *fto, hudComponent_t *comp)
+{
+	const char *header     = CG_TranslateString(va("%sFireteam", fto->ftData->priv ? "Private " : ""));
+	float      titleHeight = 0;
+	char       buf[64];
+
+	CG_FillRect(fto->x + 1, fto->y + 1, fto->w - 2, fto->h - 1, comp->colorSecondary);
+
+	Com_sprintf(buf, sizeof(buf), "%s: %s", header, cgs.clientinfo[cg.clientNum].team == TEAM_AXIS
+	                                                                ? bg_fireteamNamesAxis[fto->ftData->ident]
+	                                                                : bg_fireteamNamesAllies[fto->ftData->ident]);
+	Q_strupr(buf);
+	titleHeight = CG_Text_Height_Ext_Float(buf, fto->textScale, 0, FONT_HEADER);
+
+	CG_Text_Paint_Ext(fto->x + fto->spacerOuter, comp->location.y + ((titleHeight + fto->h) * 0.5f), fto->textScale, fto->textScale,
+	                  comp->colorMain, buf, 0, 0, comp->styleText, FONT_HEADER);
+
+	fto->y += fto->h;
+}
+
+static void CG_FTOverlay_DrawClassIcon(fireteamOverlay_t *fto, hudComponent_t *comp)
+{
+	trap_R_SetColor(fto->iconColor);
+	CG_DrawPic(fto->x, fto->y + fto->iconHeightOffset, fto->iconSize, fto->iconSize,
+	           cgs.media.skillPics[SkillNumForClass(fto->ci->cls)]);
+
+	fto->x += fto->iconSize;
+
+	if (comp->style & FT_LATCHED_CLASS)
+	{
+		const float arrowWidth = CLASS_ICON_ARROW_WIDTH;
+
+		if (fto->ci->cls != fto->ci->latchedcls)
+		{
+			CG_Text_Paint_Ext(fto->x, fto->y + fto->textHeightOffset, fto->textScale, fto->textScale,
+			                  comp->colorMain, "^3->", 0, 0, comp->styleText, FONT_TEXT);
+
+			fto->x += arrowWidth;
+
+			CG_DrawPic(fto->x, fto->y + fto->iconHeightOffset, fto->iconSize, fto->iconSize,
+			           cgs.media.skillPics[SkillNumForClass(fto->ci->latchedcls)]);
+
+			fto->x += fto->iconSize;
+		}
+		else
+		{
+			fto->x += fto->iconSize + arrowWidth;
+		}
+	}
+
+	fto->x += fto->spacerInner;
+}
+
+static void CG_FTOverlay_DrawPowerupIcon(fireteamOverlay_t *fto)
+{
+	if (fto->ci->powerups & ((1 << PW_REDFLAG) | (1 << PW_BLUEFLAG)))
+	{
+		trap_R_SetColor(fto->iconColor);
+		CG_DrawPic(fto->x, fto->y + fto->iconHeightOffset, fto->iconSize, fto->iconSize, cgs.media.objectiveShader);
+
+		fto->powerupWidth = POWERUP_WIDTH;
+		fto->x           += POWERUP_WIDTH;
+	}
+	else if (fto->ci->powerups & (1 << PW_OPS_DISGUISED))
+	{
+		trap_R_SetColor(fto->iconColor);
+		CG_DrawPic(fto->x, fto->y + fto->iconHeightOffset, fto->iconSize, fto->iconSize,
+		           fto->ci->team == TEAM_AXIS ? cgs.media.alliedUniformShader : cgs.media.axisUniformShader);
+
+		fto->powerupWidth = POWERUP_WIDTH;
+		fto->x           += POWERUP_WIDTH;
+	}
+	else
+	{
+		fto->powerupWidth = 0;
+	}
+}
+
+static void CG_FTOverlay_DrawName(fireteamOverlay_t *fto, const int row, const hudComponent_t *comp)
+{
+	// first draw the icon for any powerups, as that influences the position of the name
+	CG_FTOverlay_DrawPowerupIcon(fto);
+
+	// right aligned?
+	if (cg_fireteamNameAlign.integer > 0)
+	{
+		CG_Text_Paint_RightAligned_Ext(fto->x + fto->bestNameWidth - fto->powerupWidth, fto->y + fto->textHeightOffset, fto->textScale, fto->textScale,
+		                               fto->nameColor, fto->name[row], 0, 0, comp->styleText, FONT_TEXT);
+	}
+	else
+	{
+		CG_Text_Paint_Ext(fto->x, fto->y + fto->textHeightOffset, fto->textScale, fto->textScale,
+		                  fto->nameColor, fto->name[row], 0, 0, comp->styleText, FONT_TEXT);
+	}
+
+	// fto->bestNameWidth already accounts for potential obj/disguise icon for max width calculations,
+	// so subtract it here - otherwise we shift the position to the right too much
+	fto->x += fto->bestNameWidth - fto->powerupWidth + fto->spacerInner;
+}
+
+static void CG_FTOverlay_DrawWeaponIcon(fireteamOverlay_t *fto)
+{
+	fto->currentWeapon = CG_FireTeamClientCurrentWeapon(fto->ci);
+
+	if (IS_VALID_WEAPON(fto->currentWeapon))
+	{
+		const qhandle_t shader = cg_weapons[fto->currentWeapon].weaponIcon[0]
+		    ? cg_weapons[fto->currentWeapon].weaponIcon[0]
+		    : cg_weapons[fto->currentWeapon].weaponIcon[1];
+
+		if (shader)
+		{
+			trap_R_SetColor((cg_entities[fto->ci->clientNum].currentValid || fto->ci->clientNum == cg.clientNum)
+			       ? fto->iconColor
+			       : fto->iconColorAlt);
+			CG_DrawPic(fto->x, fto->y + fto->weaponIconHeightOffset,
+			           cg_weapons[fto->currentWeapon].weaponIconScale * fto->weaponIconSize, fto->weaponIconSize, shader);
+		}
+	}
+
+	fto->x += (fto->bestWeaponIconWidthScale * fto->weaponIconSize) + fto->spacerInner;
+}
+
+#define FT_HEALTH_NORMAL 80
+#define FT_HEALTH_YELLOW 10
+
+static void CG_FTOverlay_DrawHealth(fireteamOverlay_t *fto, const hudComponent_t *comp)
+{
+	const int  health      = fto->ci->health;
+	const int  healthWidth = HEALTH_WIDTH;
+	vec4_t     color;
+	const char *text;
+
+	if (health > FT_HEALTH_NORMAL)
+	{
+		Vector4Copy(comp->colorMain, color);
+		text = va("%i", health);
+	}
+	else if (health >= FT_HEALTH_YELLOW)
+	{
+		Vector4Copy(fto->textYellow, color);
+		text = va("%i", health);
+	}
+	else if (health > 0)
+	{
+		Vector4Copy(fto->textRed, color);
+		text = va("%i", health);
+	}
+	// wounded
+	else if (health == 0)
+	{
+		Vector4Copy(fto->textWhite, color);
+		text = va("%s*%s%i",
+		          ((cg.time % 500) > 250) ? "^7" : "^1",
+		          ((cg.time % 500) > 250) ? "^1" : "^7",
+		          health);
+	}
+	// limbo (-1 health)
+	else
+	{
+		Vector4Copy(fto->textRed, color);
+		text = "0";
+	}
+
+	CG_Text_Paint_RightAligned_Ext(fto->x + healthWidth, fto->y + fto->textHeightOffset, fto->textScale, fto->textScale,
+	                               color, text, 0, 0, comp->styleText, FONT_TEXT);
+
+	// always use static size, regardless of actual text being drawn
+	fto->x += healthWidth + fto->spacerInner;
+}
+
+void CG_FTOverlay_DrawLocation(fireteamOverlay_t *fto, const int row, hudComponent_t *comp)
+{
+	int limit;
+
+	if (!(cg_locations.integer & LOC_FTEAM))
+	{
+		return;
+	}
+
+	limit = fto->bestLocWidth > fto->maxLocWidth
+	    ? CG_MaxCharsForWidth(fto->locStr[row], fto->textScale, FONT_TEXT, fto->maxLocWidth)
+	    : 0;
+
+	if (comp->alignText == ITEM_ALIGN_RIGHT)
+	{
+		CG_Text_Paint_RightAligned_Ext(fto->x + fto->maxLocWidth, fto->y + fto->textHeightOffset, fto->textScale, fto->textScale,
+		                               comp->colorMain, fto->locStr[row], 0, limit, comp->styleText, FONT_TEXT);
+	}
+	else if (comp->alignText == ITEM_ALIGN_LEFT)
+	{
+		CG_Text_Paint_Ext(fto->x, fto->y + fto->textHeightOffset, fto->textScale, fto->textScale,
+		                  comp->colorMain, fto->locStr[row], 0, limit, comp->styleText, FONT_TEXT);
+	}
+	else
+	{
+		CG_Text_Paint_Centred_Ext(fto->x + (fto->maxLocWidth * 0.5f), fto->y + fto->textHeightOffset, fto->textScale, fto->textScale,
+		                          comp->colorMain, fto->locStr[row], 0, limit, comp->styleText, FONT_TEXT);
+	}
+
+	fto->x += fto->maxLocWidth + fto->spacerInner;
+}
+
+static void CG_FTOverlay_DrawSpawnpoint(fireteamOverlay_t *fto, const int row, const hudComponent_t *comp)
+{
+	const float timeDiff = cg.time - fto->ci->spawnChangedTime;
+	vec4_t      spawnPtColor;
+
+	if (!(comp->style & FT_SPAWN_POINT) && !(comp->style & FT_SPAWN_POINT_LOC))
+	{
+		return;
+	}
+
+	Vector4Copy(fto->textWhite, spawnPtColor);
+
+	// lerp color for 1.5s after spawn is changed
+	if (timeDiff < 1500)
+	{
+		const float t = timeDiff / 1500.0f;
+		LerpColor(fto->textOrange, fto->textWhite, spawnPtColor, t);
+	}
+
+	if (comp->style & FT_SPAWN_POINT_LOC)
+	{
+		// 'fto->maxLocWidth' isn't set if 'cg_locations' does not enable fireteam locations
+		const int limit = (fto->maxSpawnWidth == fto->maxLocWidth || fto->maxSpawnWidth < fto->bestSpawnWidth)
+		    ? CG_MaxCharsForWidth(fto->spawnPtStr[row], fto->textScale, FONT_TEXT, fto->maxSpawnWidth)
+		    : 0;
+
+		if (comp->alignText == ITEM_ALIGN_RIGHT)
+		{
+			CG_Text_Paint_RightAligned_Ext(fto->x + fto->maxSpawnWidth, fto->y + fto->textHeightOffset, fto->textScale, fto->textScale,
+			                               spawnPtColor, fto->spawnPtStr[row], 0, limit, comp->styleText, FONT_TEXT);
+		}
+		else if (comp->alignText == ITEM_ALIGN_LEFT)
+		{
+			CG_Text_Paint_Ext(fto->x, fto->y + fto->textHeightOffset, fto->textScale, fto->textScale,
+			                  spawnPtColor, fto->spawnPtStr[row], 0, limit, comp->styleText, FONT_TEXT);
+		}
+		else
+		{
+			CG_Text_Paint_Centred_Ext(fto->x + (fto->maxSpawnWidth * 0.5f), fto->y + fto->textHeightOffset, fto->textScale, fto->textScale,
+			                          spawnPtColor, fto->spawnPtStr[row], 0, limit, comp->styleText, FONT_TEXT);
+		}
+
+		fto->x += fto->maxSpawnWidth;
+	}
+	else
+	{
+		const char *spawnPtStr = va("%i", fto->ci->spawnpt);
+		CG_Text_Paint_Ext(fto->x, fto->y + fto->textHeightOffset, fto->textScale, fto->textScale,
+		                  spawnPtColor, spawnPtStr, 0, 0, comp->styleText, FONT_TEXT);
+
+		fto->x += CG_Text_Width_Ext_Float(spawnPtStr, fto->textScale, 0, FONT_TEXT) * MAJOR_SPAWN_NUMBER_WIDTH_SCALE;
+
+		if (comp->style & FT_SPAWN_POINT_MINOR && cg.hasMinorSpawnPoints && fto->ci->mspawnpt > 0)
+		{
+			const char *minorSpawnPtStr = va("%i", fto->ci->mspawnpt);
+			CG_Text_Paint_Ext(fto->x, fto->y + fto->textHeightOffset, fto->textScaleMinorSpawn, fto->textScaleMinorSpawn,
+			                  spawnPtColor, minorSpawnPtStr, 0, 0, comp->styleText, FONT_TEXT);
+
+			fto->x += CG_Text_Width_Ext_Float(minorSpawnPtStr, fto->textScaleMinorSpawn, 0, FONT_TEXT);
+		}
+	}
+
+	fto->x += fto->spacerInner;
+}
+
+static void CG_FTOverlay_ComputeLocLimits(fireteamOverlay_t *fto, float fixedElementsWidth, const hudComponent_t *comp)
+{
+	int remainingWidth;
+	int maxWidth;
+
+	// 'fto->w' should already be capped to comp max width at this point!
+	etl_assert(fto->w == comp->location.w);
+
+	maxWidth       = fto->w - (fto->spacerOuter * 2);
+	remainingWidth = maxWidth - fixedElementsWidth;
+
+	// if we're drawing locations, and using spawn point location strings,
+	// divide the remaining space equally between them
+	if (cg_locations.integer & LOC_FTEAM && comp->style & FT_SPAWN_POINT_LOC)
+	{
+		fto->maxLocWidth   = (remainingWidth - fto->spacerInner) / 2;
+		fto->maxSpawnWidth = fto->maxLocWidth;
+	}
+	// locations are off, but spawn point is still drawn with a location string
+	else if (comp->style & FT_SPAWN_POINT_LOC)
+	{
+		fto->maxSpawnWidth = remainingWidth;
+	}
+	// nothing else requires space, numbered spawn point display is reserved as fixed width
+	else
+	{
+		fto->maxLocWidth   = remainingWidth;
+		fto->maxSpawnWidth = fto->bestSpawnWidth;
+	}
+}
+
 void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 {
-	float          x = comp->location.x;
-	float          y = comp->location.y;
-	float          locwidth, namewidth, weapIconWidthScale, spawnwidth;
-	int            i, puwidth, lineX;
-	int            bestNameWidth          = -1;
-	int            bestLocWidth           = -1;
-	int            bestWeapIconWidthScale = -1;
-	int            bestSpawnWidth         = -1;
-	char           buffer[64];
-	float          w, computedWidth, h;
-	float          heighTitle, heightText, iconsSize, weaponIconSize, heightTextOffset, heightIconsOffset, heightWeaponIconOffset;
-	clientInfo_t   *ci = NULL;
-	fireteamData_t *f  = NULL;
-	char           *locStr[MAX_FIRETEAM_MEMBERS];
-	char           *spawnPtStr[MAX_FIRETEAM_MEMBERS];
-	int            curWeap;
-	char           name[MAX_FIRETEAM_MEMBERS][MAX_NAME_LENGTH];
-	int            nameMaxLen;
-	float          scale;
-	float          spacing;
-	float          widthLocationLeft;
-	float          minorSpawnTextScale;
+	fireteamOverlay_t *fto                  = &ftOverlay;
+	float             fixedElementsWidth    = 0;
+	float             flexibleElementsWidth = 0;
+	float             nameWidth, weaponIconWidthScale, locationWidth, spawnWidth;
+	float             baseX;
+	int               i;
+	qboolean          drawHeader;
 
+	Com_Memset(fto, 0, sizeof(fireteamOverlay_t));
 
-	// colors and fonts for overlays
-	vec4_t FT_select                = { 0.5f, 0.5f, 0.2f, 0.3f }; // selected member
-	vec4_t iconColor                = { 1.0f, 1.0f, 1.0f, 1.0f }; // icon "color", used for alpha adjustments
-	vec4_t iconColorSemitransparent = { 1.0f, 1.0f, 1.0f, 0.5f };
-	vec4_t textWhite                = { 1.0f, 1.0f, 1.0f, 1.0f }; // regular text
-	vec4_t textYellow               = { 1.0f, 1.0f, 0.0f, 1.0f }; // yellow text for health drawing
-	vec4_t textRed                  = { 1.0f, 0.0f, 0.0f, 1.0f }; // red text for health drawing
-	vec4_t textOrange               = { 1.0f, 0.6f, 0.0f, 1.0f }; // orange text for ping issues
-	vec4_t nameColor                = { 1.0f, 1.0f, 1.0f, 1.0f };
+	fto->x = comp->location.x;
+	fto->y = comp->location.y;
 
-	// early exits
-	if (
-		// we are a shoutcaster
-		cgs.clientinfo[cg.clientNum].shoutcaster
-		// or we are not on a fireteam
-		|| !CG_IsOnFireteam(cg.clientNum)
-		// or assign fireteam data, and early out if not on one
-		|| !(f = CG_IsOnFireteam(cg.clientNum))
-		)
+	fto->ftData = CG_IsOnFireteam(cg.clientNum);
+
+	// early exit
+	if (cgs.clientinfo[cg.clientNum].shoutcaster || !fto->ftData)
 	{
 		// XXX : TODO : we currently don't generate any noise for the
 		// fireteamoverlay, as it's pretty involved - so we do the minimum here,
@@ -449,492 +1026,220 @@ void CG_DrawFireTeamOverlay(hudComponent_t *comp)
 		// mentions this fact
 		if (cg.generatingNoiseHud)
 		{
-			const char *info = "Please join a real Fireteam!";
-			int        i     = 0;
-
-			// draw the box
-			w = comp->location.w;
-			h = comp->location.h;
-			CG_FillRect(x, y, w, h * (i + 1), comp->colorBackground);
-			CG_DrawRect_FixedBorder(x, y, w, h * (i + 1), 1, comp->colorBorder);
-			CG_FillRect(x + 1, y + 1, w - 2, h - 1, comp->colorSecondary);
-
-			// draw a text info on it
-			scale      = CG_ComputeScale(comp /* h, comp->scale, FONT_TEXT*/);
-			heighTitle = CG_Text_Height_Ext(info, scale, 0, FONT_HEADER);
-			CG_Text_Paint_Ext(x + 4, comp->location.y + ((heighTitle + h) * 0.5), scale, scale, comp->colorMain, info, 0, 0, 0, FONT_TEXT);
+			CG_FTOverlay_NoiseGen(fto, comp);
 		}
 
 		return;
 	}
 
-	Com_Memset(locStr, 0, sizeof(char *) * MAX_FIRETEAM_MEMBERS);
-	Com_Memset(spawnPtStr, 0, sizeof(char *) * MAX_FIRETEAM_MEMBERS);
+	fto->textScale           = CG_ComputeScale(comp);
+	fto->textScaleMinorSpawn = fto->textScale / 1.5f;
 
+	fto->h = comp->location.h / (MAX_FIRETEAM_MEMBERS + 1);
+
+	fto->textHeight     = CG_Text_Height_Ext_Float("A", fto->textScale, 0, FONT_TEXT);
+	fto->spacerOuter    = CG_Text_Width_Ext_Float("A", fto->textScale, 0, FONT_TEXT);
+	fto->spacerInner    = fto->textHeight * 1.5f;
+	fto->iconSize       = fto->textHeight * 2.0f;
+	fto->weaponIconSize = fto->textHeight * 2.0f;
+
+	fto->textHeightOffset       = (fto->h + fto->textHeight) * 0.5f;
+	fto->iconHeightOffset       = (fto->h - fto->iconSize) * 0.5f;
+	fto->weaponIconHeightOffset = (fto->h - (fto->textHeight * 2)) * 0.5f;
+
+	// first, get the width for all the elements
+	// the width does *NOT* contain the spacer required between each element,
+	// as some of them are not necessarily drawn (location/spawnpoint)
+	// we also store all the names, locations and spawn points (if using string display) here
 	for (i = 0; i < MAX_FIRETEAM_MEMBERS; i++)
 	{
-		Com_Memset(name[i], 0, sizeof(char) * (MAX_NAME_LENGTH));
-	}
+		fto->ci = CG_SortedFireTeamPlayerForPosition(i);
 
-	h = comp->location.h / (MAX_FIRETEAM_MEMBERS + 1);
-
-	scale               = CG_ComputeScale(comp /* h, comp->scale, FONT_TEXT*/);
-	spacing             = CG_Text_Width_Ext_Float("_", scale, 0, FONT_TEXT);
-	minorSpawnTextScale = scale / 1.5f;
-
-	// First get name and location width, also store location names
-	for (i = 0; i < MAX_FIRETEAM_MEMBERS; i++)
-	{
-		ci = CG_SortedFireTeamPlayerForPosition(i);
-
-		// Make sure it's valid
-		if (!ci)
+		if (!fto->ci)
 		{
 			break;
 		}
 
-		if (cg_locations.integer & LOC_FTEAM)
-		{
-			locStr[i] = CG_BuildLocationString(ci->clientNum, ci->location, LOC_FTEAM);
+		CG_FTOverlay_StorePlayerName(fto, i, comp);
+		CG_FTOverlay_StoreLocationString(fto, i);
+		CG_FTOverlay_StoreSpawnpointString(fto, i, comp);
 
-			if (!locStr[i][1] || !*locStr[i])
-			{
-				locStr[i] = 0;
-			}
+		nameWidth            = CG_FTOverlay_NameWidth(fto, i);
+		weaponIconWidthScale = CG_FTOverlay_WeaponIconWidthScale(fto);
+		locationWidth        = CG_FTOverlay_LocationWidth(fto, i);
+		spawnWidth           = CG_FTOverlay_SpawnpointWidth(fto, i, comp);
 
-			// cap max location length?
-			if (cg_locationMaxChars.integer)
-			{
-				locwidth  = spacing;
-				locwidth *= Com_Clamp(0, 128, cg_locationMaxChars.integer);     // 128 is max location length
-			}
-			else
-			{
-				locwidth = CG_Text_Width_Ext(locStr[i], scale, 0, FONT_TEXT);
-			}
-		}
-		else
+		if (nameWidth > fto->bestNameWidth)
 		{
-			locwidth = 0;
+			fto->bestNameWidth = nameWidth;
 		}
 
-		if (comp->style & BIT(5) || comp->style & BIT(6))
+		if (weaponIconWidthScale > fto->bestWeaponIconWidthScale)
 		{
-			// spawnpoint as a location string
-			if (comp->style & BIT(6))
-			{
-				spawnPtStr[i] = va("%s", Q_CleanStr(CG_GetLocationMsg(ci->clientNum, cgs.majorSpawnpointEnt[ci->spawnpt - 1].origin)));
-
-				if (cg_locationMaxChars.integer)
-				{
-					spawnwidth  = spacing;
-					spawnwidth *= Com_Clamp(0, 128, cg_locationMaxChars.integer);     // 128 is max location length
-				}
-				else
-				{
-					spawnwidth = CG_Text_Width_Ext(spawnPtStr[i], scale, 0, FONT_TEXT);
-				}
-			}
-			// spawnpoint as number(s)
-			else
-			{
-				spawnwidth = CG_Text_Width_Ext(va("%i", ci->spawnpt), scale, 0, FONT_TEXT);
-
-				if (comp->style & BIT(7) && cg.hasMinorSpawnPoints && ci->mspawnpt > 0)
-				{
-					spawnwidth += CG_Text_Width_Ext(va("%i", ci->mspawnpt), minorSpawnTextScale, 0, FONT_TEXT);
-				}
-
-			}
-		}
-		else
-		{
-			spawnwidth = 0;
+			fto->bestWeaponIconWidthScale = weaponIconWidthScale;
 		}
 
-		if (comp->style & BIT(2) || (comp->style & BIT(3) && (ci->health <= 0 || ci->ping >= 999)))
+		if (locationWidth > fto->bestLocWidth)
 		{
-			Q_strncpyz(name[i], ci->cleanname, sizeof(name[i]));
-		}
-		else
-		{
-			Q_strncpyz(name[i], ci->name, sizeof(name[i]));
+			fto->bestLocWidth = locationWidth;
 		}
 
-
-		// truncate name if max chars is set
-		if (cg_fireteamNameMaxChars.integer)
+		if (spawnWidth > fto->bestSpawnWidth)
 		{
-			nameMaxLen = Com_Clamp(0, MAX_NAME_LENGTH - 1, cg_fireteamNameMaxChars.integer);
-			Q_TruncateStr(name[i], nameMaxLen);
-
-			// if alignment is requested, keep a static width
-			if (cg_fireteamNameAlign.integer)
-			{
-				namewidth  = spacing;
-				namewidth *= Com_Clamp(0, MAX_NAME_LENGTH, cg_fireteamNameMaxChars.integer);
-			}
-			else
-			{
-				namewidth = CG_Text_Width_Ext(name[i], scale, 0, FONT_TEXT);
-			}
-		}
-		else
-		{
-			namewidth = CG_Text_Width_Ext(name[i], scale, 0, FONT_TEXT);
-		}
-
-		if (ci->powerups & ((1 << PW_REDFLAG) | (1 << PW_BLUEFLAG) | (1 << PW_OPS_DISGUISED)))
-		{
-			namewidth += 14;
-		}
-
-		// find the widest weapons icons
-		curWeap = CG_FireTeamClientCurrentWeapon(ci);
-
-		if (IS_VALID_WEAPON(curWeap) && (cg_weapons[curWeap].weaponIcon[0] || cg_weapons[curWeap].weaponIcon[1]))     // do not try to draw nothing
-		{
-			weapIconWidthScale = cg_weapons[curWeap].weaponIconScale;
-		}
-		else
-		{
-			weapIconWidthScale = 1;
-		}
-
-		if (namewidth > bestNameWidth)
-		{
-			bestNameWidth = namewidth;
-		}
-
-		if (locwidth > bestLocWidth)
-		{
-			bestLocWidth = locwidth;
-		}
-
-		if (spawnwidth > bestSpawnWidth)
-		{
-			bestSpawnWidth = spawnwidth;
-		}
-
-		if (weapIconWidthScale > bestWeapIconWidthScale)
-		{
-			bestWeapIconWidthScale = weapIconWidthScale;
+			fto->bestSpawnWidth = spawnWidth;
 		}
 	}
 
-	heightText             = CG_Text_Height_Ext("A", scale, 0, FONT_TEXT);
-	iconsSize              = heightText * 2.5f;
-	weaponIconSize         = heightText * 2;
-	heightTextOffset       = (h + heightText) * 0.5f;
-	heightIconsOffset      = (h - iconsSize) * 0.5f;
-	heightWeaponIconOffset = (h - heightText * 2) * 0.5f;
+	// these are always static width and just depend on fireteam overlay settings,
+	// no need to compute them inside a loop for each member
+	fto->classIconWidth = CG_FTOverlay_ClassIconWidth(fto, comp);
+	fto->healthWidth    = CG_FTOverlay_HealthWidth(fto);
 
-	// NOTE: terrible way to do it ... but work
-	computedWidth = spacing
-	                + iconsSize                                         // class icons
-	                + spacing * 2 + iconsSize + spacing                 // latched class
-	                + iconsSize + spacing                               // objective icon
-	                + spacing * 2 + bestNameWidth                       // player name
-	                + bestWeapIconWidthScale * weaponIconSize + spacing // weapon icons
-	                + spacing * 3 + spacing                             // health points
-	                + bestLocWidth + spacing                            // location name
-	                + bestSpawnWidth;                                   // spawn location/point
+	fixedElementsWidth = fto->classIconWidth + fto->spacerInner
+	                     + fto->bestNameWidth + fto->spacerInner
+	                     + (fto->weaponIconSize * fto->bestWeaponIconWidthScale) + fto->spacerInner
+	                     + fto->healthWidth;
 
-	// keep the best fit for the location text
-	w = MIN(computedWidth, comp->location.w);
+	// Figure out the remaining space. This is a bit complicated with locations
+	// and spawnpoint being so complicated with their possible combinations,
+	// but the general idea is this:
+	//
+	// * if spawn point is drawn with numbers, it's *always* fixed width
+	// * if 'cg_locations' enables fireteam locations:
+	//   * location string is "flexible" width and can be truncated
+	//   * if spawn point is drawn with a location string, it's flexible width
+	//     and will be truncated equally with location string to fit
+	// * if 'cg_locations' is *NOT* enabled for fireteam:
+	//   * if spawnpoint is drawn with a location string, it's flexible width
+	//
+	// There is one unaccounted issue with this, which is that the fireteam
+	// requires a minimum width to display all the fixed width information.
+	// This is not currently handled, and it's up to the user to make sure that
+	// their fireteam comp is wide enough to have everything visible.
+	// The game doesn't crash or anything if the comp is too narrow,
+	// all the alignments simply break. This really isn't a high priority issue
+	// though, as players will likely want to make the fireteam wide enough
+	// anyway to display enough relevant information for any given element.
 
-	// fireteam alpha adjustments
+	// if locations are enabled, add the location string(s) to flexible elements
+	if (cg_locations.integer & LOC_FTEAM || comp->style & FT_SPAWN_POINT_LOC)
+	{
+		fixedElementsWidth += fto->spacerInner;
 
-	// set background alpha first
-	FT_select[3]  *= comp->colorMain[3];
-	iconColor[3]  *= comp->colorMain[3];
-	textWhite[3]  *= comp->colorMain[3];
-	textYellow[3] *= comp->colorMain[3];
-	textRed[3]    *= comp->colorMain[3];
-	textOrange[3] *= comp->colorMain[3];
-	nameColor[3]  *= comp->colorMain[3];
+		// both location string and spawn point string are flexible
+		if (comp->style & FT_SPAWN_POINT_LOC)
+		{
+			// don't add an extra spacer if we're *NOT* drawing locations
+			flexibleElementsWidth += (cg_locations.integer & LOC_FTEAM)
+			    ? fto->bestLocWidth + fto->spacerInner + fto->bestSpawnWidth
+			    : fto->bestSpawnWidth;
+		}
+		// only location string is flexible, spawnpoint is drawn with a number
+		else if (comp->style & FT_SPAWN_POINT)
+		{
+			flexibleElementsWidth = fto->bestLocWidth;
+			fixedElementsWidth   += fto->spacerInner + fto->bestSpawnWidth;
+		}
+		// spawnpoint drawing is off, only location is flexible
+		else
+		{
+			flexibleElementsWidth += fto->bestLocWidth;
+		}
+	}
+	// location string(s) are off, spawnpoint is drawn with a number
+	else if (comp->style & FT_SPAWN_POINT)
+	{
+		fixedElementsWidth += fto->spacerInner + fto->bestSpawnWidth;
+	}
+
+	// if we're overflowing the comp width after adding location,
+	// figure out how much space we have left for location(s)
+	if (fixedElementsWidth + flexibleElementsWidth > (comp->location.w - (fto->spacerOuter * 2)))
+	{
+		fto->w = comp->location.w;
+		CG_FTOverlay_ComputeLocLimits(fto, fixedElementsWidth, comp);
+	}
+	else
+	{
+		fto->w             = fixedElementsWidth + flexibleElementsWidth + (fto->spacerOuter * 2);
+		fto->maxLocWidth   = fto->bestLocWidth;
+		fto->maxSpawnWidth = fto->bestSpawnWidth;
+	}
+
+	CG_FTOverlay_SetColors(fto, comp->colorMain[3]);
+
+	drawHeader = !(comp->style & FT_NO_HEADER);
 
 	if (comp->showBackGround)
 	{
-		CG_FillRect(x, y, w, h * (i + 1), comp->colorBackground);
+		CG_FillRect(fto->x, fto->y, fto->w, fto->h * (i + (drawHeader ? 1 : 0)), comp->colorBackground);
 	}
 
 	if (comp->showBorder)
 	{
-		CG_DrawRect_FixedBorder(x, y, w, h * (i + 1), 1, comp->colorBorder);
+		CG_DrawRect_FixedBorder(fto->x, fto->y, fto->w, fto->h * (i + (drawHeader ? 1 : 0)), 1, comp->colorBorder);
 	}
 
-
-	if (!(comp->style & BIT(1)))
+	if (drawHeader)
 	{
-		CG_FillRect(x + 1, y + 1, w - 2, h - 1, comp->colorSecondary);
-
-		if (f->priv)
-		{
-			Com_sprintf(buffer, 64, CG_TranslateString("Private Fireteam: %s"), cgs.clientinfo[cg.clientNum].team == TEAM_AXIS ? bg_fireteamNamesAxis[f->ident] : bg_fireteamNamesAllies[f->ident]);
-		}
-		else
-		{
-			Com_sprintf(buffer, 64, CG_TranslateString("Fireteam: %s"), cgs.clientinfo[cg.clientNum].team == TEAM_AXIS ? bg_fireteamNamesAxis[f->ident] : bg_fireteamNamesAllies[f->ident]);
-		}
-
-		Q_strupr(buffer);
-		heighTitle = CG_Text_Height_Ext(buffer, scale, 0, FONT_HEADER);
-		CG_Text_Paint_Ext(x + 4, comp->location.y + ((heighTitle + h) * 0.5), scale, scale, comp->colorMain, buffer, 0, 0, 0, FONT_HEADER);
+		CG_FTOverlay_DrawHeader(fto, comp);
 	}
 
-	lineX = (int)x;
+	baseX = fto->x;
+
 	for (i = 0; i < MAX_FIRETEAM_MEMBERS; i++)
 	{
-		x = lineX;
+		fto->x  = baseX;
+		fto->ci = CG_SortedFireTeamPlayerForPosition(i);
 
-		if (i != 0 || !(comp->style & BIT(1)))
-		{
-			y += h;
-		}
-		// grab a pointer to the current player
-		ci = CG_SortedFireTeamPlayerForPosition(i);
-
-		// make sure it's valid
-		if (!ci)
+		if (!fto->ci)
 		{
 			break;
 		}
 
-		if (comp->style & BIT(3) || comp->style & BIT(4))
+		if (comp->style & FT_STATUS_COLOR_NAME || comp->style & FT_STATUS_COLOR_ROW)
 		{
-			fireteamMemberStatusEnum_t status = CG_FireTeamMemberStatus(ci);
-			vec3_copy(*CG_FireTeamNameColor(status), nameColor);
-			if (comp->style & BIT(4) && status != NONE)
+			fireteamMemberStatusEnum_t status = CG_FireTeamMemberStatus(fto->ci);
+			VectorCopy(*CG_FireTeamNameColor(status), fto->nameColor);
+
+			if (comp->style & FT_STATUS_COLOR_ROW && status != NONE)
 			{
 				vec4_t rowColor;
-				vec4_copy(nameColor, rowColor);
+				Vector4Copy(fto->nameColor, rowColor);
 				rowColor[3] = comp->colorBackground[3];
-				CG_FillRect(x, y, w, h, rowColor);
+
+				CG_FillRect(fto->x, fto->y, fto->w, fto->h, rowColor);
 			}
 		}
 		else
 		{
-			vec4_copy(textWhite, nameColor);
+			Vector4Copy(fto->textWhite, fto->nameColor);
 		}
 
-		if (ci->selected)
+		if (fto->ci->selected)
 		{
-			// highlight selected players
-			CG_FillRect(x, y, w, h, FT_select);
+			CG_FillRect(fto->x, fto->y, fto->w, fto->h, fto->selectedMemberColor);
 		}
 
-		x += spacing;
+		fto->x += fto->spacerOuter;
 
-		// draw class icon in fireteam overlay
-		trap_R_SetColor(iconColor);
-		CG_DrawPic(x, y + heightIconsOffset, iconsSize, iconsSize, cgs.media.skillPics[SkillNumForClass(ci->cls)]);
-		x += iconsSize;
+		// All of the element draw functions adjust the x position such that
+		// once they have finished executing, the position is shifted
+		// to the right, to the correct position for the next element.
+		// Any potential new elements should adhere to this,
+		// to keep this functioning as expected.
+		// This means that it's possible to reorder the elements in any way desired,
+		// without messing up layout - the elements are simply drawn
+		// left to right, in the order that their draw functions are called.
 
-		if (comp->style & 1)
-		{
-			if (ci->cls != ci->latchedcls)
-			{
-				// draw the yellow arrow
-				CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, comp->colorMain, "^3->", 0, 0, comp->styleText, FONT_TEXT);
-				x += spacing * 2;
-				// draw latched class icon in fireteam overlay
-				trap_R_SetColor(iconColor);
-				CG_DrawPic(x, y + heightIconsOffset, iconsSize, iconsSize, cgs.media.skillPics[SkillNumForClass(ci->latchedcls)]);
-				x += iconsSize;
-			}
-			else
-			{
-				x += spacing * 2 + iconsSize;
-			}
-		}
+		CG_FTOverlay_DrawClassIcon(fto, comp);
+		CG_FTOverlay_DrawName(fto, i, comp);
+		CG_FTOverlay_DrawWeaponIcon(fto);
+		CG_FTOverlay_DrawHealth(fto, comp);
+		CG_FTOverlay_DrawLocation(fto, i, comp);
+		CG_FTOverlay_DrawSpawnpoint(fto, i, comp);
 
-		x += spacing;
-
-		// draw the mute-icon in the fireteam overlay..
-		//if ( ci->muted ) {
-		//	CG_DrawPic( x, y, heightTextOffset, heightTextOffset, cgs.media.muteIcon );
-		//	x += 14;
-		//} else if
-
-		// draw objective icon (if they are carrying one) in fireteam overlay
-		if (ci->powerups & ((1 << PW_REDFLAG) | (1 << PW_BLUEFLAG)))
-		{
-			trap_R_SetColor(iconColor);
-			CG_DrawPic(x, y + heightIconsOffset, iconsSize, iconsSize, cgs.media.objectiveShader);
-			x      += iconsSize;
-			puwidth = iconsSize;
-		}
-		// or else draw the disguised icon in fireteam overlay
-		else if (ci->powerups & (1 << PW_OPS_DISGUISED))
-		{
-			trap_R_SetColor(iconColor);
-			CG_DrawPic(x, y + heightIconsOffset, iconsSize, iconsSize, ci->team == TEAM_AXIS ? cgs.media.alliedUniformShader : cgs.media.axisUniformShader);
-			x      += iconsSize;
-			puwidth = iconsSize;
-		}
-		// otherwise draw rank icon in fireteam overlay
-		else
-		{
-			//if (ci->rank > 0) CG_DrawPic( x, y, heightTextOffset, heightTextOffset, rankicons[ ci->rank ][  ci->team == TEAM_AXIS ? 1 : 0 ][0].shader );
-			//x += 14;
-			puwidth = 0;
-		}
-
-		x += spacing;
-
-		// draw the player's name
-		// right align?
-		if (cg_fireteamNameAlign.integer > 0)
-		{
-			CG_Text_Paint_RightAligned_Ext(x + bestNameWidth - puwidth, y + heightTextOffset, scale, scale, nameColor, name[i], 0, 0, comp->styleText, FONT_TEXT);
-		}
-		else
-		{
-			CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, nameColor, name[i], 0, 0, ITEM_TEXTSTYLE_SHADOWED, FONT_TEXT);
-		}
-
-		// add space
-		x += spacing * 2 + bestNameWidth - puwidth;
-
-		// draw the player's weapon icon
-		curWeap = CG_FireTeamClientCurrentWeapon(ci);
-
-		// note: WP_NONE is excluded
-		if (IS_VALID_WEAPON(curWeap) && cg_weapons[curWeap].weaponIcon[0])     // do not try to draw nothing
-		{
-			trap_R_SetColor((cg_entities[ci->clientNum].currentValid || ci->clientNum == cg.clientNum) ? iconColor : iconColorSemitransparent);  // semitransparent white for weapon that is not currently being updated
-			CG_DrawPic(x, y + heightWeaponIconOffset, cg_weapons[curWeap].weaponIconScale * weaponIconSize, weaponIconSize, cg_weapons[curWeap].weaponIcon[0]);
-		}
-		else if (IS_VALID_WEAPON(curWeap) && cg_weapons[curWeap].weaponIcon[1])
-		{
-			trap_R_SetColor(iconColor);
-			CG_DrawPic(x, y + heightWeaponIconOffset, cg_weapons[curWeap].weaponIconScale * weaponIconSize, weaponIconSize, cg_weapons[curWeap].weaponIcon[1]);
-		}
-
-		x += bestWeapIconWidthScale * heightText * 2 + spacing;
-
-		// draw the player's health
-		if (ci->health >= 100)
-		{
-			CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, comp->colorMain, va("%i", ci->health), 0, 0, comp->styleText, FONT_TEXT);
-			x += spacing * 3;
-		}
-		else if (ci->health >= 10)
-		{
-			x += spacing;
-			CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, ci->health > 80 ? comp->colorMain : textYellow, va("%i", ci->health), 0, 0, comp->styleText, FONT_TEXT);
-			x += spacing * 2;
-		}
-		else if (ci->health > 0)
-		{
-			x += spacing * 2;
-			CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, textYellow, va("%i", ci->health), 0, 0, comp->styleText, FONT_TEXT);
-			x += spacing;
-		}
-		else if (ci->health == 0)
-		{
-			x += spacing;
-			CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, ((cg.time % 500) > 250)  ? textWhite : textRed, "*", 0, 0, comp->styleText, FONT_TEXT);
-			x += spacing;
-			CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, ((cg.time % 500) > 250)  ? textRed : textWhite, "0", 0, 0, comp->styleText, FONT_TEXT);
-			x += spacing;
-		}
-		else
-		{
-			x += spacing * 2;
-			CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, textRed, "0", 0, 0, comp->styleText, FONT_TEXT);
-			x += spacing;
-		}
-
-		// set hard limit on width
-		x                += spacing;
-		widthLocationLeft = w - (x - comp->location.x) - spacing;
-		if (cg_locations.integer & LOC_FTEAM)
-		{
-			int   lim;
-			float locWidthLocationLeft = widthLocationLeft;
-
-			if (comp->style & BIT(5) || comp->style & BIT(6)) // spawn points
-			{
-				if (comp->style & BIT(6)) // spawn locations
-				{
-					locWidthLocationLeft = (widthLocationLeft - spacing) / 2;
-				}
-				else
-				{
-					locWidthLocationLeft -= bestSpawnWidth + spacing;
-				}
-			}
-
-			lim = locWidthLocationLeft / spacing;
-
-			if (lim > 0)
-			{
-				if (comp->alignText == ITEM_ALIGN_RIGHT) // right align
-				{
-					CG_Text_Paint_RightAligned_Ext(x + locWidthLocationLeft, y + heightTextOffset, scale, scale, comp->colorMain, locStr[i], 0, lim, comp->styleText, FONT_TEXT);
-				}
-				else if (comp->alignText == ITEM_ALIGN_LEFT)
-				{
-					CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, comp->colorMain, locStr[i], 0, lim, comp->styleText, FONT_TEXT);
-				}
-				else    // center
-				{
-					CG_Text_Paint_Centred_Ext(x + locWidthLocationLeft * 0.5, y + heightTextOffset, scale, scale, comp->colorMain, locStr[i], 0, lim, comp->styleText, FONT_TEXT);
-				}
-				x += spacing;
-				x += locWidthLocationLeft;
-			}
-		}
-
-		if (comp->style & BIT(5) || comp->style & BIT(6)) // spawn points
-		{
-			const float timeDiff = cg.time - ci->spawnChangedTime;
-			vec4_t      spawnPtColor;
-			Vector4Copy(colorWhite, spawnPtColor);
-
-			if (timeDiff < 1500.0f)
-			{
-				const float t = timeDiff / 1500.0f;
-				LerpColor(colorOrange, colorWhite, spawnPtColor, t);
-			}
-
-			if (cg_locations.integer & LOC_FTEAM)
-			{
-				widthLocationLeft = widthLocationLeft / 2;
-			}
-
-			if (comp->style & BIT(6)) // spawn locations
-			{
-				int lim = widthLocationLeft / spacing;
-
-				if (lim > 0)
-				{
-					if (comp->alignText == ITEM_ALIGN_RIGHT) // right align
-					{
-						CG_Text_Paint_RightAligned_Ext(x + widthLocationLeft, y + heightTextOffset, scale, scale, spawnPtColor, spawnPtStr[i], 0, lim, comp->styleText, FONT_TEXT);
-					}
-					else if (comp->alignText == ITEM_ALIGN_LEFT)
-					{
-						CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, spawnPtColor, spawnPtStr[i], 0, lim, comp->styleText, FONT_TEXT);
-					}
-					else    // center
-					{
-						CG_Text_Paint_Centred_Ext(x + widthLocationLeft * 0.5, y + heightTextOffset, scale, scale, spawnPtColor, spawnPtStr[i], 0, lim, comp->styleText, FONT_TEXT);
-					}
-				}
-			}
-			else
-			{
-				CG_Text_Paint_Ext(x, y + heightTextOffset, scale, scale, spawnPtColor, va("%i", ci->spawnpt), 0, 0, comp->styleText, FONT_TEXT);
-
-				if (comp->style & BIT(7) && ci->mspawnpt > 0) // minor spawn points
-				{
-					CG_Text_Paint_Ext(x + spacing, y + heightTextOffset, minorSpawnTextScale, minorSpawnTextScale, spawnPtColor, va("%i", ci->mspawnpt), 0, 0, comp->styleText, FONT_TEXT);
-				}
-			}
-		}
+		fto->y += fto->h;
 	}
 
 	trap_R_SetColor(NULL);

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2227,7 +2227,7 @@ enum
 	COMPASS_CARDINAL_POINTS      = BIT(6),
 	COMPASS_ALWAYS_DRAW          = BIT(7),
 	COMPASS_POINT_TOWARD_NORTH   = BIT(8),
-    COMPASS_DRAW_ICONS_INSIDE    = BIT(9),
+	COMPASS_DRAW_ICONS_INSIDE    = BIT(9),
 };
 
 // Follow filters
@@ -2238,6 +2238,7 @@ enum
 
 /// Locations
 #define MAX_C_LOCATIONS 1024
+#define MAX_LOC_LEN 128
 
 // locations draw bits and cvar
 /*
@@ -2309,7 +2310,7 @@ typedef struct location_s
 {
 	int index;
 	vec3_t origin;
-	char message[128];
+	char message[MAX_LOC_LEN];
 } location_t;
 
 /**
@@ -2924,7 +2925,7 @@ qboolean CG_WorldCoordToScreenCoordFloat(vec3_t point, float *x, float *y);
 void CG_AddOnScreenText(const char *text, vec3_t origin, qboolean fade);
 void CG_AddOnScreenBar(float fraction, vec4_t colorStart, vec4_t colorEnd, vec4_t colorBack, vec3_t origin);
 
-int CG_GetMaxCharsPerLine(const char *str, float textScale, fontHelper_t *font, float width);
+int CG_MaxCharsForWidth(const char *str, float textScale, fontHelper_t *font, float width);
 // string word wrapper
 char *CG_WordWrapString(const char *input, int maxLineChars, char *output, int maxOutputSize, int *numLineOutput);
 // draws multiline strings
@@ -2964,6 +2965,7 @@ float CG_Text_Width_Ext_Float(const char *text, float scale, int limit, fontHelp
 float CG_Text_Line_Width_Ext_Float(const char *text, float scale, fontHelper_t *font);
 int CG_Text_Width(const char *text, float scale, int limit);
 int CG_Text_Height_Ext(const char *text, float scale, int limit, fontHelper_t *font);
+float CG_Text_Height_Ext_Float(const char *text, float scale, int limit, fontHelper_t *font);
 int CG_Text_Height(const char *text, float scale, int limit);
 float CG_GetValue(int ownerDraw, int type);   // 'type' is relative or absolute (fractional-'0.5' or absolute- '50' health)
 qboolean CG_OwnerDrawVisible(int flags);

--- a/src/cgame/cg_locations.c
+++ b/src/cgame/cg_locations.c
@@ -475,7 +475,7 @@ char *CG_BuildLocationString(int clientNum, vec3_t origin, int flag)
 			// truncate location string if max chars is set
 			if (cg_locationMaxChars.integer)
 			{
-				locMaxLen = Com_Clamp(0, 128, cg_locationMaxChars.integer); // 128 is max location length
+				locMaxLen = Com_Clamp(0, MAX_LOC_LEN, cg_locationMaxChars.integer);
 				Q_TruncateStr(locStr, locMaxLen);
 			}
 		}

--- a/src/cgame/cg_popupmessages.c
+++ b/src/cgame/cg_popupmessages.c
@@ -782,7 +782,7 @@ static qboolean CG_DrawPMItems(hudComponent_t *comp, pmListItem_t *listItem, flo
 	}
 
 	w = comp->location.w - size * 2;
-	CG_WordWrapString(buffer, CG_GetMaxCharsPerLine(buffer, scale, &cgs.media.limboFont2, w), buffer, sizeof(buffer), &lineNumber);
+	CG_WordWrapString(buffer, CG_MaxCharsForWidth(buffer, scale, &cgs.media.limboFont2, w), buffer, sizeof(buffer), &lineNumber);
 
 	// we reach the comp border, don't print the line
 	if (scrollDown)
@@ -1060,7 +1060,7 @@ static qboolean CG_DrawPMXPItems(hudComponent_t *comp, pmListItem_t *listItem, f
 	}
 
 	w = comp->location.w - size * 2;
-	CG_WordWrapString(buffer, CG_GetMaxCharsPerLine(buffer, scale * 0.75, &cgs.media.limboFont2, w), buffer, sizeof(buffer), &lineNumber);
+	CG_WordWrapString(buffer, CG_MaxCharsForWidth(buffer, scale * 0.75, &cgs.media.limboFont2, w), buffer, sizeof(buffer), &lineNumber);
 
 	// we reach the comp border, don't print the line
 	if (scrollDown)

--- a/src/cgame/cg_servercmds.c
+++ b/src/cgame/cg_servercmds.c
@@ -3043,7 +3043,7 @@ void CG_AddToBannerPrint(const char *str)
 	scale = CG_ComputeScale(&CG_GetActiveHUD()->banner /*CG_GetActiveHUD()->banner.location.h, CG_GetActiveHUD()->banner.scale, &cgs.media.limboFont2*/);
 	w     = CG_GetActiveHUD()->banner.location.w;
 
-	maxLineChars = CG_GetMaxCharsPerLine(str, scale, &cgs.media.limboFont2, w);
+	maxLineChars = CG_MaxCharsForWidth(str, scale, &cgs.media.limboFont2, w);
 	CG_WordWrapString(str, maxLineChars, cg.bannerPrint, sizeof(cg.bannerPrint), NULL);
 	cg.bannerPrintTime = cg.time;
 }
@@ -3228,7 +3228,7 @@ static void CG_ServerCommand(void)
 		{
 			pmType = iconnumber;
 		}
-        
+
 		CG_AddPMItem(pmType, CG_LocalizeServerCommand(CG_Argv(1)), " ", cgs.media.pmImages[iconnumber], 0, 0, colorWhite);
 		return;
 	}


### PR DESCRIPTION
Rewrote most of fireteam overlay code to be more modular, extendable and maintainable. During this, several fixes and improvements were made.

* fixed general bad scaling/positioning of various elements due to usage of integer size/positions, everything is now using floats to move/scale more accurately
* fixed `No header` option always forcing minimum of 2 lines to be drawn even if fireteam only contained 1 member
* fixed locations/spawn point locations not cropping properly when comp max width was reached, both are now equally cropped if max width is reached
* fixed numeric spawn point display being too close to location string
* fixed colorless name and status colored name not working correctly if player name contained a caret
* fixed powerup icon next to names drawing too much to the left, and using hardcoded width offset instead of respecting text scaling option of the comp
* fixed fireteam header ignoring comp text style options
* fixed fireteam names ignoring comp text style options, unless names were right-algined
* added ability to draw names left-aligned with fixed width, by setting `cg_fireteamNameAlign -1`