### PR TITLE
cgame: add cg_bloodForcePuffsForDamage

### DIFF
--- a/src/cgame/cg_cvars.c
+++ b/src/cgame/cg_cvars.c
@@ -150,6 +150,7 @@ vmCvar_t cg_autoReload;
 vmCvar_t cg_bloodDamageBlend;
 vmCvar_t cg_bloodFlash;
 vmCvar_t cg_bloodFlashTime;
+vmCvar_t cg_bloodForcePuffsForDamage;
 vmCvar_t cg_noAmmoAutoSwitch;
 vmCvar_t cg_printObjectiveInfo;
 #ifdef FEATURE_MULTIVIEW
@@ -457,6 +458,7 @@ static cvarTable_t cvarTable[] =
 	{ &cg_bloodDamageBlend,                   "cg_bloodDamageBlend",                   "1.0",         CVAR_ARCHIVE,                 0 },
 	{ &cg_bloodFlash,                         "cg_bloodFlash",                         "1.0",         CVAR_ARCHIVE,                 0 },
 	{ &cg_bloodFlashTime,                     "cg_bloodFlashTime",                     "1500",        CVAR_ARCHIVE,                 0 },
+	{ &cg_bloodForcePuffsForDamage,           "cg_bloodForcePuffsForDamage",           "1",           CVAR_ARCHIVE,                 0 },
 	{ &cg_noAmmoAutoSwitch,                   "cg_noAmmoAutoSwitch",                   "1",           CVAR_ARCHIVE,                 0 },
 	{ &cg_printObjectiveInfo,                 "cg_printObjectiveInfo",                 "1",           CVAR_ARCHIVE,                 0 },
 #ifdef FEATURE_MULTIVIEW

--- a/src/cgame/cg_cvars.h
+++ b/src/cgame/cg_cvars.h
@@ -151,6 +151,7 @@ extern vmCvar_t cg_autoReload;
 extern vmCvar_t cg_bloodDamageBlend;
 extern vmCvar_t cg_bloodFlash;
 extern vmCvar_t cg_bloodFlashTime;
+extern vmCvar_t cg_bloodForcePuffsForDamage;
 extern vmCvar_t cg_noAmmoAutoSwitch;
 extern vmCvar_t cg_printObjectiveInfo;
 #ifdef FEATURE_MULTIVIEW

--- a/src/cgame/cg_weapons.c
+++ b/src/cgame/cg_weapons.c
@@ -5339,7 +5339,7 @@ static void CG_AddFleshImpact(vec3_t end, vec3_t dir, int fleshEntityNum)
 	vec3_t    tmpv, tmpv2;
 	int       i, headshot;
 	centity_t *cent  = &cg_entities[fleshEntityNum];
-	qhandle_t shader = !cg_blood.integer || (cent->currentState.powerups & (1 << PW_INVULNERABLE))
+	qhandle_t shader = ((!cg_bloodForcePuffsForDamage.integer) || (cent->currentState.powerups & (1 << PW_INVULNERABLE)))
 	    ? cgs.media.smokePuffShader
 	    : cgs.media.fleshSmokePuffShader;
 


### PR DESCRIPTION
Default "1" - if enabled always shows smoke puffs for shooting
invulnerable players (spawn prot, rez shield) otherwise always shows
blood puffs.
