### PR TITLE
cgame: fix cursor timeout when interacting with demo UI

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2608,7 +2608,7 @@ typedef struct cgs_s
 
 	int aviDemoRate;                                    ///< Demo playback recording
 	int aReinfOffset[TEAM_NUM_TEAMS];                   ///< Team reinforcement offsets
-	int cursorUpdate;                                   ///< Timeout for mouse pointer view
+	int cursorTimeout;                                  ///< Timestamp where mouse cursor disappears on demo/multiview
 	fileHandle_t dumpStatsFile;                         ///< File to dump stats
 	char *dumpStatsFileName;                            ///< Name of file to dump stats
 	int dumpStatsTime;                                  ///< Next stats command that comes back will be written to a logfile

--- a/src/cgame/cg_newDraw.c
+++ b/src/cgame/cg_newDraw.c
@@ -622,7 +622,7 @@ void CG_MouseEvent(int x, int y)
 	case CGAME_EVENT_MULTIVIEW:
 		if (x != 0 || y != 0)
 		{
-			cgs.cursorUpdate = cg.time + 5000;
+			cgs.cursorTimeout = cg.time + 5000;
 		} // fall through
 	case CGAME_EVENT_SPEAKEREDITOR:
 	case CGAME_EVENT_CAMERAEDITOR:
@@ -804,7 +804,7 @@ void CG_EventHandling(int type, qboolean fForced)
 	case CGAME_EVENT_DEMO:
 		cgs.fResize         = qfalse;
 		cgs.fSelect         = qfalse;
-		cgs.cursorUpdate    = cg.time + 10000;
+		cgs.cursorTimeout   = cg.time + 10000;
 		cgs.timescaleUpdate = cg.time + 4000;
 		CG_ScoresUp_f();
 		CG_HudEditorReset();

--- a/src/cgame/cg_view.c
+++ b/src/cgame/cg_view.c
@@ -2381,10 +2381,13 @@ void CG_DrawActiveFrame(int serverTime, qboolean demoPlayback)
 
 	DEBUGTIME
 
-	// demo rewind happend, fix time based effects
+	// demo rewind happened, fix time based effects
 	if (demoPlayback && cg.time - cg.oldTime < 0)
 	{
 		CG_DemoRewindFixEffects();
+
+		// reset cursor timeout
+		cgs.cursorTimeout = cg.time + 5000;
 	}
 
 	DEBUGTIME

--- a/src/cgame/cg_window.c
+++ b/src/cgame/cg_window.c
@@ -491,7 +491,7 @@ void CG_windowDraw(void)
 
 #ifdef FEATURE_MULTIVIEW
 	// Mouse cursor lays on top of everything
-	if (cg.mvTotalClients > 0 && cg.time < cgs.cursorUpdate && fAllowMV)
+	if (cg.mvTotalClients > 0 && cg.time < cgs.cursorTimeout && fAllowMV)
 	{
 		CG_DrawCursor(cgDC.cursorx, cgDC.cursory);
 	}


### PR DESCRIPTION
Cursor timeout wasn't correctly accounting for the timestamp changes that happened as a result of rewind/fast-forward/seek, resulting in interacting with the UI making the cursor disappear until it was moved again. This only works while interacting with the UI and not when inputting commands in console, as the commands are implemented in engine, so cgame doesn't know about them. They should probably be part of cgame at some point, because the whole rewind stuff is only supported in legacy mod demos anyway.