### PR TITLE
Update macOS runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,7 +145,7 @@ jobs:
           if-no-files-found: error
 
   osx-mod:
-    runs-on: macos-13
+    runs-on: macos-14
     needs: pre-build
     steps:
       - uses: actions/checkout@v4
@@ -541,7 +541,7 @@ jobs:
           if-no-files-found: error
 
   osx:
-    runs-on: macos-13
+    runs-on: macos-14
     needs: [pre-build, mod-merger]
     env:
       CI_ETL_DESCRIBE: ${{needs.pre-build.outputs.describe}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
         run: cpack
 
   osx:
-    runs-on: macos-13
+    runs-on: macos-14
     needs: [pre-build]
     env:
       CI_ETL_DESCRIBE: ${{needs.pre-build.outputs.describe}}


### PR DESCRIPTION
No further actions should be required, none of the tooling is deprecated from macos-13