### PR TITLE
cgame: disable zoom sway for binocs

### DIFF
--- a/src/cgame/cg_view.c
+++ b/src/cgame/cg_view.c
@@ -561,6 +561,11 @@ static void CG_ZoomSway(void)
 		return;
 	}
 
+	if (cg.zoomedBinoc)        // no sway on binoculars
+	{
+		return;
+	}
+
 	if ((cg.snap->ps.eFlags & EF_MG42_ACTIVE) || (cg.snap->ps.eFlags & EF_AAGUN_ACTIVE))     // don't draw when on mg_42
 	{
 		return;


### PR DESCRIPTION
there's multiple issues fixed here:

1. most players who do fff have a binding to just drop it where the crosshair is

2. the spot that would call an arty would never be affected by the sway at all - changing this would potentially break the above binding accuracy

therefore the easiest and most sane option forward here is to just disable binoc sway completely - this will make calling arty behave like expected when using binocs