### PR TITLE
mod: cleanup getspawnpt & limbo spawnpoint drawing

### DIFF
--- a/src/cgame/cg_commandmap.c
+++ b/src/cgame/cg_commandmap.c
@@ -2052,8 +2052,11 @@ void CG_DrawAutoMap(float basex, float basey, float basew, float baseh, int styl
  */
 static void CG_DrawSpawnPointInfoFlag(int i, float size, vec2_t point)
 {
+	const team_t team = cgs.clientinfo[cg.clientNum].team;
+
 	// render flag shadow if spawn point is the one that is currently resolved
-	if (i == cgs.ccResolvedSpawnPoint + 1)
+	// skip drawing if we're spectating, or during intermission, as the data is wrong anyway
+	if (team != TEAM_SPECTATOR && teamOrder[cgs.ccSelectedTeam] == team && cg.snap->ps.pm_type != PM_INTERMISSION && i == cgs.ccResolvedSpawnPoint + 1)
 	{
 		float offsetSize = size * 1.3;
 

--- a/src/cgame/cg_limbopanel.c
+++ b/src/cgame/cg_limbopanel.c
@@ -42,7 +42,7 @@
 
 void CG_DrawBorder(float x, float y, float w, float h, qboolean fill, qboolean drawMouseOver);
 
-static team_t teamOrder[3] =
+const team_t teamOrder[3] =
 {
 	TEAM_AXIS,
 	TEAM_ALLIES,
@@ -3580,8 +3580,11 @@ void CG_LimboPanel_Setup(void)
 	trap_Cvar_VariableStringBuffer("name", buffer, 256);
 	trap_Cvar_Set("limboname", buffer);
 
-	// refresh resolved spawnpoint
-	trap_SendClientCommand("getspawnpt");
+	// refresh resolved spawnpoint, unless we're on intermission or spectating
+	if (cgs.clientinfo[cg.clientNum].team != TEAM_SPECTATOR && cg.snap->ps.pm_type != PM_INTERMISSION)
+	{
+		trap_SendClientCommand("getspawnpt");
+	}
 
 	if (cgs.ccLayers)
 	{

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1118,6 +1118,9 @@ typedef struct
 	team_t team;
 } mapEntityData_t;
 
+// limbo menu team order
+extern const team_t teamOrder[3];
+
 /**
  * @enum showView_t
  * @brief
@@ -2635,7 +2638,7 @@ typedef struct cgs_s
 	int ccSelectedObjective;
 	int ccSelectedSpawnPoint;
 	int ccResolvedSpawnPoint;
-	int ccSelectedTeam;                                 ///< ( 1 = ALLIES, 0 = AXIS )
+	int ccSelectedTeam;                                 ///< ( 0 = AXIS, 1 = ALLIES, 2 = SPECTATOR )
 	int ccSelectedWeaponSlot;                           ///< ( 0 = secondary, 1 = primary)
 	int ccSelectedClass;
 	weapon_t ccSelectedPrimaryWeapon;                   ///< Selected primary weapon from limbo panel

--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -4566,6 +4566,11 @@ void Cmd_Activate2_f(gentity_t *ent)
 
 void Cmd_GetSpawnPoint_f(gentity_t *ent, unsigned int dwCommand, int value)
 {
+	if (ent->client->sess.sessionTeam == TEAM_SPECTATOR)
+	{
+		return;
+	}
+
 	trap_SendServerCommand((int)(ent - g_entities), va("getspawnpt \"%d\" \"%d\" \"%d\"",
 	                                                   ent->client->sess.userSpawnPointValue,
 	                                                   ent->client->sess.userMinorSpawnPointValue,


### PR DESCRIPTION
* Don't draw the selected spawnpoint indicator if we're spectating, have different team selected, or intermission is active
* Don't send `getspawnpt` during intermission, or if we're spectating, when limbo menu is opened
* Don't respond to `getspawnpt` commands from spectators

refs #3039