### PR TITLE
cgame: fix spawnpoint drawing pos on fallback path

### DIFF
--- a/src/cgame/cg_view.c
+++ b/src/cgame/cg_view.c
@@ -2125,6 +2125,7 @@ static void CG_DrawSpawnpoints(void)
 			if (trace.fraction == 1.0f)
 			{
 				VectorCopy(spawnpoint->origin, trace.endpos);
+				trace.endpos[2] += cg.snap->ps.mins[2];
 			}
 			else
 			{


### PR DESCRIPTION
When trace fails to find a groundplane, offset the position to the player feet level instead of displaying at the spawnpoint origin.

refs #2179