### PR TITLE
cgame: fix customcrosshair positioning in HUD editor

### DIFF
--- a/src/cgame/cg_customcrosshair.c
+++ b/src/cgame/cg_customcrosshair.c
@@ -117,6 +117,12 @@ void CG_DrawCustomCrosshair(qboolean withSpread)
 	x = (float)cgs.glconfig.vidWidth / 2 + cg_crosshairX.value;
 	y = (float)cgs.glconfig.vidHeight / 2 + cg_crosshairY.value;
 
+	if (cg.editingHud)
+	{
+		x /= HUD_EDITOR_SIZE_COEFF;
+		y /= HUD_EDITOR_SIZE_COEFF;
+	}
+
 	if (withSpread)
 	{
 		crossSpread = CG_CustomCrosshairCalcSpread();


### PR DESCRIPTION
Since this draws on real screen pixel coordinates for some reason, it doesn't get automatically adjusted to HUD editor adjusted viewport.

refs #2964 