### PR TITLE
qcommon: fix es->number typedef size

### DIFF
--- a/src/qcommon/q_shared.h
+++ b/src/qcommon/q_shared.h
@@ -1657,7 +1657,7 @@ typedef enum ETL_DEMO_EXTEND
  */
 typedef struct ETL_260B_NOEDIT entityState_s
 {
-	net_uint8_t number;             ///< entity index
+	net_uint10_t number;             ///< entity index
 	entityType_t eType;     ///< entityType_t
 	net_uint24_t eFlags;
 


### PR DESCRIPTION
This obviously matches `GENTITYNUM_BITS`, otherwise entitynumbers > 255 would not work.

refs #3166 