### PR TITLE
etmain: skip single option menus in classmenu

### DIFF
--- a/etmain/ui/wm_class.menu
+++ b/etmain/ui/wm_class.menu
@@ -107,7 +107,7 @@ QM_MENU_START( "wm_class_soldier" )
 QM_MENU_END
 
 QM_MENU_START( "wm_class_soldier_p1_s1" )
-	QM_MENU_ITEM_TEAM(	"P. Pistol",			exec "class s 1 1";	close wm_class_soldier_p1_s1,		"p", 0 )
+	onOpen { exec "class s 1 1";	close wm_class_soldier_p1_s1 }
 QM_MENU_END
 
 QM_MENU_START( "wm_class_soldier_p1_s2" )
@@ -116,7 +116,7 @@ QM_MENU_START( "wm_class_soldier_p1_s2" )
 QM_MENU_END
 
 QM_MENU_START( "wm_class_soldier_p2_s1" )
-	QM_MENU_ITEM_TEAM(	"P. Pistol",			exec "class s 2 1";	close wm_class_soldier_p2_s1,		"p", 0 )
+	onOpen { exec "class s 2 1";	close wm_class_soldier_p2_s1 }
 QM_MENU_END
 
 QM_MENU_START( "wm_class_soldier_p2_s2" )
@@ -125,7 +125,7 @@ QM_MENU_START( "wm_class_soldier_p2_s2" )
 QM_MENU_END
 
 QM_MENU_START( "wm_class_soldier_p3_s1" )
-	QM_MENU_ITEM_TEAM(	"P. Pistol",			exec "class s 3 1";	close wm_class_soldier_p3_s1,		"p", 0 )
+	onOpen { exec "class s 3 1";	close wm_class_soldier_p3_s1 }
 QM_MENU_END
 
 QM_MENU_START( "wm_class_soldier_p3_s2" )
@@ -134,7 +134,7 @@ QM_MENU_START( "wm_class_soldier_p3_s2" )
 QM_MENU_END
 
 QM_MENU_START( "wm_class_soldier_p4_s1" )
-	QM_MENU_ITEM_TEAM(	"P. Pistol",			exec "class s 4 1";	close wm_class_soldier_p4_s1,		"p", 0 )
+	onOpen { exec "class s 4 1";	close wm_class_soldier_p4_s1 }
 QM_MENU_END
 
 QM_MENU_START( "wm_class_soldier_p4_s2" )
@@ -143,7 +143,7 @@ QM_MENU_START( "wm_class_soldier_p4_s2" )
 QM_MENU_END
 
 QM_MENU_START( "wm_class_soldier_p5_s1" )
-	QM_MENU_ITEM_TEAM(	"P. Pistol",			exec "class s 5 1";	close wm_class_soldier_p5_s1,		"p", 0 )
+	onOpen { exec "class s 5 1";	close wm_class_soldier_p5_s1 }
 QM_MENU_END
 
 QM_MENU_START( "wm_class_soldier_p5_s2" )
@@ -214,13 +214,13 @@ QM_MENU_START( "wm_class_soldier_p5_s4" )
 QM_MENU_END
 
 QM_MENU_START( "wm_class_medic" )
-	QM_MENU_ITEM_TEAM(	"S. SMG",				uiScript clientCheckSecondaryWeapon ; conditionalscript cg_ui_secondary_lw 0
-												( "close wm_class_medic ; open wm_class_medic_p1_s2" )
-												( "close wm_class_medic ; open wm_class_medic_p1_s1" ),	"s", 0 )
+    onOpen { uiScript clientCheckSecondaryWeapon ; conditionalscript cg_ui_secondary_lw 0
+             ( "close wm_class_medic ; open wm_class_medic_p1_s2" )
+             ( "close wm_class_medic ; open wm_class_medic_p1_s1" ) }
 QM_MENU_END
 
 QM_MENU_START( "wm_class_medic_p1_s1" )
-	QM_MENU_ITEM_TEAM(	"P. Pistol",			exec "class m 1 1";	close wm_class_medic_p1_s1,		"p", 0 )
+	onOpen { exec "class m 1 1";	close wm_class_medic_p1_s1 }
 QM_MENU_END
 
 QM_MENU_START( "wm_class_medic_p1_s2" )
@@ -238,7 +238,7 @@ QM_MENU_START( "wm_class_engineer" )
 QM_MENU_END
 
 QM_MENU_START( "wm_class_engineer_p1_s1" )
-	QM_MENU_ITEM_TEAM(	"P. Pistol",			exec "class e 1 1";	close wm_class_engineer_p1_s1,		"p", 0 )
+	onOpen { exec "class e 1 1";	close wm_class_engineer_p1_s1 }
 QM_MENU_END
 
 QM_MENU_START( "wm_class_engineer_p1_s2" )
@@ -247,7 +247,7 @@ QM_MENU_START( "wm_class_engineer_p1_s2" )
 QM_MENU_END
 
 QM_MENU_START( "wm_class_engineer_p2_s1" )
-	QM_MENU_ITEM_TEAM(	"P. Pistol",			exec "class e 2 1";	close wm_class_engineer_p2_s1,		"p", 0 )
+	onOpen { exec "class e 2 1";	close wm_class_engineer_p2_s1 }
 QM_MENU_END
 
 QM_MENU_START( "wm_class_engineer_p2_s2" )
@@ -256,13 +256,13 @@ QM_MENU_START( "wm_class_engineer_p2_s2" )
 QM_MENU_END
 
 QM_MENU_START( "wm_class_fieldops" )
-	QM_MENU_ITEM_TEAM(	"S. SMG",				uiScript clientCheckSecondaryWeapon ; conditionalscript cg_ui_secondary_lw 0
-												( "close wm_class_fieldops ; open wm_class_fieldops_p1_s2" )
-												( "close wm_class_fieldops ; open wm_class_fieldops_p1_s1" ),	"s", 0 )
+   onOpen { uiScript clientCheckSecondaryWeapon ; conditionalscript cg_ui_secondary_lw 0
+            ( "close wm_class_fieldops ; open wm_class_fieldops_p1_s2" )
+            ( "close wm_class_fieldops ; open wm_class_fieldops_p1_s1" ) }
 QM_MENU_END
 
 QM_MENU_START( "wm_class_fieldops_p1_s1" )
-	QM_MENU_ITEM_TEAM(	"P. Pistol",			exec "class f 1 1";	close wm_class_fieldops_p1_s1,		"p", 0 )
+	onOpen { exec "class f 1 1";	close wm_class_fieldops_p1_s1 }
 QM_MENU_END
 
 QM_MENU_START( "wm_class_fieldops_p1_s2" )
@@ -283,7 +283,7 @@ QM_MENU_START( "wm_class_covertops" )
 QM_MENU_END
 
 QM_MENU_START( "wm_class_covertops_p1_s1" )
-	QM_MENU_ITEM_TEAM(	"P. Silenced Pistol",	exec "class c 1 1";	close wm_class_covertops_p1_s1,		"p", 0 )
+	onOpen { exec "class c 1 1";	close wm_class_covertops_p1_s1 }
 QM_MENU_END
 
 QM_MENU_START( "wm_class_covertops_p1_s2" )
@@ -292,7 +292,7 @@ QM_MENU_START( "wm_class_covertops_p1_s2" )
 QM_MENU_END
 
 QM_MENU_START( "wm_class_covertops_p2_s1" )
-	QM_MENU_ITEM_TEAM(	"P. Silenced Pistol",	exec "class c 2 1";	close wm_class_covertops_p2_s1,		"p", 0 )
+	onOpen { exec "class c 2 1";	close wm_class_covertops_p2_s1 }
 QM_MENU_END
 
 QM_MENU_START( "wm_class_covertops_p2_s2" )
@@ -301,7 +301,7 @@ QM_MENU_START( "wm_class_covertops_p2_s2" )
 QM_MENU_END
 
 QM_MENU_START( "wm_class_covertops_p3_s1" )
-	QM_MENU_ITEM_TEAM(	"P. Silenced Pistol",	exec "class c 3 1";	close wm_class_covertops_p3_s1,		"p", 0 )
+	onOpen { exec "class c 3 1";	close wm_class_covertops_p3_s1 }
 QM_MENU_END
 
 QM_MENU_START( "wm_class_covertops_p3_s2" )

--- a/etmain/ui/wm_classAlt.menu
+++ b/etmain/ui/wm_classAlt.menu
@@ -107,7 +107,7 @@ QM_MENU_START( "wm_class_soldieralt" )
 QM_MENU_END
 
 QM_MENU_START( "wm_class_soldieralt_p1_s1" )
-	QM_MENU_ITEM_TEAM(	"1. Pistol",			exec "class s 1 1";	close wm_class_soldieralt_p1_s1,		"1", 0 )
+	onOpen { exec "class s 1 1"; close wm_class_soldieralt_p1_s1 }
 QM_MENU_END
 
 QM_MENU_START( "wm_class_soldieralt_p1_s2" )
@@ -116,7 +116,7 @@ QM_MENU_START( "wm_class_soldieralt_p1_s2" )
 QM_MENU_END
 
 QM_MENU_START( "wm_class_soldieralt_p2_s1" )
-	QM_MENU_ITEM_TEAM(	"1. Pistol",			exec "class s 2 1";	close wm_class_soldieralt_p2_s1,		"1", 0 )
+	onOpen { exec "class s 2 1";	close wm_class_soldieralt_p2_s1 }
 QM_MENU_END
 
 QM_MENU_START( "wm_class_soldieralt_p2_s2" )
@@ -125,7 +125,7 @@ QM_MENU_START( "wm_class_soldieralt_p2_s2" )
 QM_MENU_END
 
 QM_MENU_START( "wm_class_soldieralt_p3_s1" )
-	QM_MENU_ITEM_TEAM(	"1. Pistol",			exec "class s 3 1";	close wm_class_soldieralt_p3_s1,		"1", 0 )
+	onOpen { exec "class s 3 1";	close wm_class_soldieralt_p3_s1 }
 QM_MENU_END
 
 QM_MENU_START( "wm_class_soldieralt_p3_s2" )
@@ -134,7 +134,7 @@ QM_MENU_START( "wm_class_soldieralt_p3_s2" )
 QM_MENU_END
 
 QM_MENU_START( "wm_class_soldieralt_p4_s1" )
-	QM_MENU_ITEM_TEAM(	"1. Pistol",			exec "class s 4 1";	close wm_class_soldieralt_p4_s1,		"1", 0 )
+	onOpen { exec "class s 4 1";	close wm_class_soldieralt_p4_s1 }
 QM_MENU_END
 
 QM_MENU_START( "wm_class_soldieralt_p4_s2" )
@@ -143,7 +143,7 @@ QM_MENU_START( "wm_class_soldieralt_p4_s2" )
 QM_MENU_END
 
 QM_MENU_START( "wm_class_soldieralt_p5_s1" )
-	QM_MENU_ITEM_TEAM(	"1. Pistol",			exec "class s 5 1";	close wm_class_soldieralt_p5_s1,		"1", 0 )
+	onOpen { exec "class s 5 1";	close wm_class_soldieralt_p5_s1 }
 QM_MENU_END
 
 QM_MENU_START( "wm_class_soldieralt_p5_s2" )
@@ -214,13 +214,14 @@ QM_MENU_START( "wm_class_soldieralt_p5_s4" )
 QM_MENU_END
 
 QM_MENU_START( "wm_class_medicalt" )
-	QM_MENU_ITEM_TEAM(	"1. SMG",				uiScript clientCheckSecondaryWeapon ; conditionalscript cg_ui_secondary_lw 0
-												( "close wm_class_medicalt ; open wm_class_medicalt_p1_s2" )
-												( "close wm_class_medicalt ; open wm_class_medicalt_p1_s1" ),	"1", 0 )
+	onOpen { uiScript clientCheckSecondaryWeapon ; conditionalscript cg_ui_secondary_lw 0
+             ( "close wm_class_medicalt ; open wm_class_medicalt_p1_s2" )
+             ( "close wm_class_medicalt ; open wm_class_medicalt_p1_s1" ) }
+
 QM_MENU_END
 
 QM_MENU_START( "wm_class_medicalt_p1_s1" )
-	QM_MENU_ITEM_TEAM(	"1. Pistol",			exec "class m 1 1";	close wm_class_medicalt_p1_s1,		"1", 0 )
+	onOpen {exec "class m 1 1";	close wm_class_medicalt_p1_s1}
 QM_MENU_END
 
 QM_MENU_START( "wm_class_medicalt_p1_s2" )
@@ -238,7 +239,7 @@ QM_MENU_START( "wm_class_engineeralt" )
 QM_MENU_END
 
 QM_MENU_START( "wm_class_engineeralt_p1_s1" )
-	QM_MENU_ITEM_TEAM(	"1. Pistol",			exec "class e 1 1";	close wm_class_engineeralt_p1_s1,		"1", 0 )
+	onOpen { exec "class e 1 1"; close wm_class_engineeralt_p1_s1 }
 QM_MENU_END
 
 QM_MENU_START( "wm_class_engineeralt_p1_s2" )
@@ -247,7 +248,7 @@ QM_MENU_START( "wm_class_engineeralt_p1_s2" )
 QM_MENU_END
 
 QM_MENU_START( "wm_class_engineeralt_p2_s1" )
-	QM_MENU_ITEM_TEAM(	"1. Pistol",			exec "class e 2 1";	close wm_class_engineeralt_p2_s1,		"1", 0 )
+	onOpen { exec "class e 2 1"; close wm_class_engineeralt_p2_s1 }
 QM_MENU_END
 
 QM_MENU_START( "wm_class_engineeralt_p2_s2" )
@@ -256,13 +257,13 @@ QM_MENU_START( "wm_class_engineeralt_p2_s2" )
 QM_MENU_END
 
 QM_MENU_START( "wm_class_fieldopsalt" )
-	QM_MENU_ITEM_TEAM(	"1. SMG",				uiScript clientCheckSecondaryWeapon ; conditionalscript cg_ui_secondary_lw 0
-												( "close wm_class_fieldopsalt ; open wm_class_fieldopsalt_p1_s2" )
-												( "close wm_class_fieldopsalt ; open wm_class_fieldopsalt_p1_s1" ),	"1", 0 )
+    onOpen { uiScript clientCheckSecondaryWeapon ; conditionalscript cg_ui_secondary_lw 0
+             ( "close wm_class_fieldopsalt ; open wm_class_fieldopsalt_p1_s2" )
+             ( "close wm_class_fieldopsalt ; open wm_class_fieldopsalt_p1_s1" ) }
 QM_MENU_END
 
 QM_MENU_START( "wm_class_fieldopsalt_p1_s1" )
-	QM_MENU_ITEM_TEAM(	"1. Pistol",			exec "class f 1 1";	close wm_class_fieldopsalt_p1_s1,		"1", 0 )
+	onOpen { exec "class f 1 1";	close wm_class_fieldopsalt_p1_s1 }
 QM_MENU_END
 
 QM_MENU_START( "wm_class_fieldopsalt_p1_s2" )
@@ -283,7 +284,7 @@ QM_MENU_START( "wm_class_covertopsalt" )
 QM_MENU_END
 
 QM_MENU_START( "wm_class_covertopsalt_p1_s1" )
-	QM_MENU_ITEM_TEAM(	"1. Silenced Pistol",	exec "class c 1 1";	close wm_class_covertopsalt_p1_s1,		"1", 0 )
+	onOpen { exec "class c 1 1";	close wm_class_covertopsalt_p1_s1 }
 QM_MENU_END
 
 QM_MENU_START( "wm_class_covertopsalt_p1_s2" )
@@ -292,7 +293,7 @@ QM_MENU_START( "wm_class_covertopsalt_p1_s2" )
 QM_MENU_END
 
 QM_MENU_START( "wm_class_covertopsalt_p2_s1" )
-	QM_MENU_ITEM_TEAM(	"1. Silenced Pistol",	exec "class c 2 1";	close wm_class_covertopsalt_p2_s1,		"1", 0 )
+	onOpen { exec "class c 2 1";	close wm_class_covertopsalt_p2_s1 }
 QM_MENU_END
 
 QM_MENU_START( "wm_class_covertopsalt_p2_s2" )
@@ -301,7 +302,7 @@ QM_MENU_START( "wm_class_covertopsalt_p2_s2" )
 QM_MENU_END
 
 QM_MENU_START( "wm_class_covertopsalt_p3_s1" )
-	QM_MENU_ITEM_TEAM(	"1. Silenced Pistol",	exec "class c 3 1";	close wm_class_covertopsalt_p3_s1,		"1", 0 )
+	onOpen { exec "class c 3 1";	close wm_class_covertopsalt_p3_s1 }
 QM_MENU_END
 
 QM_MENU_START( "wm_class_covertopsalt_p3_s2" )


### PR DESCRIPTION
Currently classmenu displays options to player even when there is only one option to choose from.

In such cases there is no point waiting for player selection. This improvement is especially useful in gathers setting as it reduces clicks required to change to medic from 4 to 2.

I've made the code edits using onOpen, hoping it's an ok solution. I've tried to maintain previous structure of code to make reviewing and updating easier.

Disclaimer: Similar improvement CANNOT be done for spawnptmenu as there we sometimes want to select 'unselectable' spawnpts.