### PR TITLE
cgame: increase splatter blood decal size

### DIFF
--- a/src/cgame/cg_effects.c
+++ b/src/cgame/cg_effects.c
@@ -729,7 +729,7 @@ void CG_GibPlayer(centity_t *cent, vec3_t playerOrigin, vec3_t gdir, int damage)
 			if (trace.fraction < 1.0f)
 			{
 
-				CG_ProjectBloodDecal((vec3_t *)trace.endpos, 10.0f);
+				CG_ProjectBloodDecal((vec3_t *)trace.endpos, 20.0f);
 
 				if (count++ > GIB_BLOOD_DOTS)
 				{


### PR DESCRIPTION
was 30 initially, reduced to 10, now back to 20