### PR TITLE
cgame: display revivable bodies of fireteam members in command map ev…

### DIFF
--- a/src/cgame/cg_commandmap.c
+++ b/src/cgame/cg_commandmap.c
@@ -854,8 +854,8 @@ static void CG_DrawMapEntity(mapEntityData_t *mEnt, float x, float y, float w, f
 		}
 		else
 		{
-			// only see revivables for own team, unless shoutcaster
-			if (mEnt->type == ME_PLAYER_REVIVE && !CG_IsShoutcaster())
+			// only see revivables for own team, unless shoutcaster or in same fireteam
+			if (mEnt->type == ME_PLAYER_REVIVE && !CG_IsShoutcaster() && !CG_IsOnSameFireteam(cg.clientNum, mEnt->data))
 			{
 				return;
 			}


### PR DESCRIPTION
…en when they're outside of pvs.

This change shouldn't have any influence on public servers and if you decide to join same fireteam with some1 on public then Id say it's an improvement for public as well.

But the main reason I would like this to be added is of course gathers. Currently ur teammate can be revivable 10m next to you but you have no way of telling where they are because they are outside of pvs.
Furthermore location information is already sent to fireteam hud element so imo this logic makes sense even more.

I really think this change is non controversial and an improvement.
