### PR TITLE
game: default 'g_complaintlimit' to '0'

### DIFF
--- a/src/game/g_cvars.c
+++ b/src/game/g_cvars.c
@@ -442,7 +442,7 @@ cvarTable_t gameCvarTable[] =
 
 	{ &voteFlags,                         "voteFlags",                         "0",                          CVAR_TEMP | CVAR_ROM | CVAR_SERVERINFO,          0, qfalse, qfalse },
 
-	{ &g_complaintlimit,                  "g_complaintlimit",                  "6",                          CVAR_ARCHIVE,                                    0, qtrue,  qfalse },
+	{ &g_complaintlimit,                  "g_complaintlimit",                  "0",                          CVAR_ARCHIVE,                                    0, qtrue,  qfalse },
 	{ &g_teambleedComplaint,              "g_teambleedComplaint",              "50",                         CVAR_ARCHIVE,                                    0, qtrue,  qfalse },
 	{ &g_ipcomplaintlimit,                "g_ipcomplaintlimit",                "3",                          CVAR_ARCHIVE,                                    0, qtrue,  qfalse },
 	{ &g_filtercams,                      "g_filtercams",                      "0",                          CVAR_ARCHIVE,                                    0, qfalse, qfalse },


### PR DESCRIPTION
Complaint popups are primarily clutter and on almost all servers have no effect anyhow.

For pub servers tracking team damage/kicking is the way to go; on Comp servers it's particularly pointless.