### PR TITLE
Fix SMG pickup selection drop

### DIFF
--- a/src/cgame/cg_event.c
+++ b/src/cgame/cg_event.c
@@ -459,11 +459,23 @@ static void CG_ItemPickup(int itemNum)
 	// see if it should be the grabbed weapon
 	if (item->giType == IT_WEAPON)
 	{
+		qboolean selectedWeaponDropped = qfalse;
+
 		// we just drop current weapon
 		if (!COM_BitCheck(cg.snap->ps.weapons, cg.weaponSelect))
 		{
 			cg.weaponSelect             = WP_NONE;
 			cg.weaponSelectDuringFiring = (cg.snap->ps.weaponstate == WEAPON_FIRING) ? cg.time : 0;
+			selectedWeaponDropped       = qtrue;
+		}
+
+		// Keep a valid active weapon when a pickup replaces the currently selected one
+		// (for example MP40 -> Thompson swap). This must not depend on cg_autoswitch.
+		if (selectedWeaponDropped && itemid != WP_AMMO)
+		{
+			cg.weaponSelectTime         = cg.time;
+			cg.weaponSelect             = itemid;
+			cg.weaponSelectDuringFiring = (cg.predictedPlayerState.weaponstate == WEAPON_FIRING) ? cg.time : 0;
 		}
 
 		if (!cg_autoswitch.integer || cg.predictedPlayerState.weaponstate == WEAPON_RELOADING)


### PR DESCRIPTION
When picking up a weapon that replaces the currently selected weapon, the pickup path in CG_ItemPickup() cleared cg.weaponSelect if the previous selection bit disappeared from ps.weapons.

With cg_autoswitch set to 0, the function then returned early and never selected the replacement pickup weapon, leaving the client with no active weapon selection until the player manually switched banks.

This change tracks when the selected weapon was dropped by the pickup and immediately selects the picked-up primary weapon (excluding WP_AMMO). That preserves a valid active selection for replacement swaps such as MP40 -> Thompson while keeping existing autoswitch behavior for all other cases unchanged.