### PR TITLE
cgame: fix cursorHintBar upgrade compatibility

### DIFF
--- a/src/cgame/cg_hud_io.c
+++ b/src/cgame/cg_hud_io.c
@@ -1740,7 +1740,7 @@ static hudStucture_t *CG_ReadHudJsonObject(cJSON *hud, hudFileUpgrades_t *upgr, 
 
 		if (!parentHud || (tmpHud->cursorhintsbar.style != parentHud->cursorhintsbar.style))
 		{
-			tmpHud->cursorhintsbar.barStyle = tmpHud->healthbar.style;
+			tmpHud->cursorhintsbar.barStyle = tmpHud->cursorhintsbar.style;
 			tmpHud->cursorhintsbar.style    = 0;    // clear all
 		}
 


### PR DESCRIPTION
C&P issue to to the usage of healtbar  isntead of cursorhintbar as comp for style upgrade compatibility