### PR TITLE
cgame: fix comps draw behind HUD Editor panel

### DIFF
--- a/src/cgame/cg_hud_editor.c
+++ b/src/cgame/cg_hud_editor.c
@@ -3754,8 +3754,9 @@ static panel_button_t ** CG_HudEditor_GetSelectedTab()
 */
 void CG_DrawHudEditor(void)
 {
-	static int altHud = -1;
-	qboolean   skip;
+	static const vec4_t HUD_Background = { 0.16f, 0.2f, 0.17f, 1.0f };
+	static int          altHud         = -1;
+	qboolean            skip;
 
 	panel_button_t **buttons = hudComponentsPanel;
 	panel_button_t *button;
@@ -3766,6 +3767,10 @@ void CG_DrawHudEditor(void)
 		trap_Cvar_Set(hudEditorHudName.text, hudData.active->name);
 		altHud = hudData.active->hudnumber;
 	}
+
+	// draw background panals, otherwise HUD elements will draw behind panel elements and keep visible
+	CG_FillRect(HUDEditorX, 0, HUDEditorWidth, SCREEN_HEIGHT_SAFE * HUD_EDITOR_SIZE_COEFF, HUD_Background);
+	CG_FillRect(0, SCREEN_HEIGHT_SAFE, HUDEditorX, (SCREEN_HEIGHT_SAFE * HUD_EDITOR_SIZE_COEFF) - SCREEN_HEIGHT_SAFE, HUD_Background);
 
 	CG_HudEditor_GridDraw();
 	BG_PanelButtonsRender(hudComponentsPanel);

--- a/src/cgame/cg_weapons.c
+++ b/src/cgame/cg_weapons.c
@@ -101,7 +101,7 @@ static void CG_Transform(refEntity_t *ref, float scale, float trnsl1, float trns
 	static vec3_t vec1, vec2, vec3;
 
 	// scale
-	if (scale != 0.0 || scale != 1.0)
+	if (scale != 0.0 && scale != 1.0)
 	{
 		VectorScale(ref->axis[0], scale, ref->axis[0]);
 		VectorScale(ref->axis[1], scale, ref->axis[1]);

--- a/src/client/cl_cgame.c
+++ b/src/client/cl_cgame.c
@@ -221,14 +221,15 @@ static void CL_InterpolationCheckRange(void)
 		return;
 	}
 
-	snaps      = Cvar_VariableValue("snaps");
-	updateRate = snaps < cl.sv_fps ? 1000 / snaps : 1000 / cl.sv_fps;
+	snaps = (int)Cvar_VariableValue("snaps");
+
+	updateRate = snaps && (snaps < cl.sv_fps) ? 1000 / snaps : 1000 / cl.sv_fps;
 	buffer     = (FRAMETIME / 2) / updateRate - 1;
 
 	if (cl_interpolation->integer > buffer)
 	{
 		Com_Printf(S_COLOR_YELLOW "WARNING: cvar '%s' is over allowed buffer (%d > %d), setting to %d\n", cl_interpolation->name, cl_interpolation->integer, buffer, buffer);
-		Cvar_SetValue(cl_interpolation->name, buffer);
+		Cvar_SetValue(cl_interpolation->name, (float)buffer);
 	}
 }
 

--- a/src/game/g_xp_saver.c
+++ b/src/game/g_xp_saver.c
@@ -458,10 +458,16 @@ void G_XPCheck_Expiration(xpData_t *xp_data)
 
 	if (!level.database.initialized)
 	{
-		G_Printf("G_XPSaver_Read: access to non-initialized database\n");
+		G_Printf("G_XPCheck_Expiration: access to non-initialized database\n");
 	}
 
 	result = sqlite3_prepare(level.database.db, va(XPUSERS_SQLWRAP_SELECT, xp_data->guid), -1, &sqlstmt, NULL);
+
+	if (result != SQLITE_OK)
+	{
+		G_Printf("G_XPCheck_Expiration: sqlite3_prepare failed\n");
+		return;
+	}
 
 	result = sqlite3_step(sqlstmt);
 
@@ -497,10 +503,7 @@ void G_XPCheck_Expiration(xpData_t *xp_data)
 		{
 			G_Printf("^3%s (%i): failed: %s\n", __func__, __LINE__, err);
 		}
-		sqlite3_finalize(sqlstmt);
 	}
-
-	result = sqlite3_finalize(sqlstmt);
 
 	if (age > g_xpSaverMaxAge.integer)
 	{
@@ -509,6 +512,12 @@ void G_XPCheck_Expiration(xpData_t *xp_data)
 		G_XPSaver_Write(xp_data);
 	}
 
+	result = sqlite3_finalize(sqlstmt);
+
+	if (result != SQLITE_OK)
+	{
+		G_Printf("G_XPCheck_Expiration: sqlite3_finalize failed\n");
+	}
 }
 
 /**

--- a/src/game/g_xp_saver.c
+++ b/src/game/g_xp_saver.c
@@ -736,6 +736,7 @@ void G_XPImportAll_IntoDatabase()
 		{
 			if (G_XPSaver_Write(&xp_data))
 			{
+				Com_Dealloc((void *)xp_data.guid);
 				continue;
 			}
 

--- a/src/game/g_xp_saver.c
+++ b/src/game/g_xp_saver.c
@@ -432,8 +432,10 @@ void G_XPCheck_Expiration(xpData_t *xp_data)
 	const char   *err;
 	sqlite3_stmt *sqlstmt;
 	const char   *updated;
-	int          age = 0, len;
-	int          t, t2 = 0;
+	int          len;
+	time_t       age = 0;
+	time_t       t;
+	time_t       t2 = 0;
 	qtime_t      ct;
 	struct tm    tm;
 
@@ -452,7 +454,7 @@ void G_XPCheck_Expiration(xpData_t *xp_data)
 	tm.tm_yday  = ct.tm_yday;
 	tm.tm_isdst = ct.tm_isdst;
 	// Perform the conversion and return
-	t = (int) mktime(&tm);
+	t = mktime(&tm);
 
 	if (!level.database.initialized)
 	{
@@ -482,7 +484,7 @@ void G_XPCheck_Expiration(xpData_t *xp_data)
 				tm_old.tm_min  = mm;
 				tm_old.tm_sec  = ss;
 
-				t2 = (int)mktime(&tm_old);
+				t2 = mktime(&tm_old);
 			}
 		}
 		age = t - t2;

--- a/src/qcommon/qcommon.h
+++ b/src/qcommon/qcommon.h
@@ -1327,7 +1327,7 @@ void SV_Shutdown(const char *finalmsg);
 void SV_Frame(int msec);
 void SV_PacketEvent(const netadr_t *from, msg_t *msg);
 qboolean SV_GameCommand(void);
-int SV_FrameMsec();
+int64_t SV_FrameMsec();
 int SV_SendQueuedPackets();
 void SV_CheckTimeouts(void);
 

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -1500,7 +1500,7 @@ static qboolean SV_CheckPaused(void)
 /**
  * @brief Return time in millseconds until processing of the next server frame.
  */
-int SV_FrameMsec()
+int64_t SV_FrameMsec()
 {
 	if (svcls.isTVGame)
 	{
@@ -1509,21 +1509,17 @@ int SV_FrameMsec()
 
 	if (sv_fps)
 	{
-		int frameMsec = (int)(1000.0f / sv_fps->value);
+		int64_t frameMsec = (int64_t)(1000.0f / sv_fps->value);
 
 		if (frameMsec < sv.timeResidual)
 		{
 			return 0;
 		}
-		else
-		{
-			return frameMsec - sv.timeResidual;
-		}
+
+		return frameMsec - sv.timeResidual;
 	}
-	else
-	{
-		return 1;
-	}
+
+	return 1;
 }
 
 /**


### PR DESCRIPTION
Fix an issue when comp element are draw on right and bottom HUD Editor panel they keep visible and generate visual noise into the panels.