### PR TITLE
cgame: fix and adjust fireteam containt 

### DIFF
--- a/src/cgame/cg_consolecmds.c
+++ b/src/cgame/cg_consolecmds.c
@@ -1704,7 +1704,7 @@ static void CG_ShareTimer_f(void)
 	qtime_t ct;
 	char    *cmd, *stChar, text[MAX_SAY_TEXT];
 	int     st, limboTime, nextSpawn;
-	stChar = CG_SpawnTimerText();
+	stChar = CG_SpawnTimerText(qfalse);
 
 	if (stChar == NULL)
 	{

--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -3131,7 +3131,7 @@ void CG_DrawFPS(hudComponent_t *comp)
  * @brief CG_SpawnTimerText red colored spawn time text in reinforcement time HUD element.
  * @return red colored text or NULL when its not supposed to be rendered
 */
-char *CG_SpawnTimerText()
+char *CG_SpawnTimerText(qboolean isDoubleDigits)
 {
 	int msec = (cgs.timelimit * 60000.f) - (cg.time - cgs.levelStartTime);
 	int seconds;
@@ -3146,7 +3146,7 @@ char *CG_SpawnTimerText()
 			{
 				seconds     = msec / 1000;
 				secondsThen = ((cgs.timelimit * 60000.f) - cg_spawnTimer_set.integer) / 1000;
-				return va("%02i", period + (seconds - secondsThen) % period);
+				return va(isDoubleDigits ? "%02i" : "%0i", period + (seconds - secondsThen) % period);
 			}
 		}
 	}
@@ -3183,7 +3183,7 @@ static qboolean CG_SpawnTimersText(char **s, char **rt, qboolean isDoubleDigits)
 		}
 
 		*rt = va(isDoubleDigits ? "%02i" : "%0i", limbotimeEnemy / 1000);
-		*s  = (cgs.gametype == GT_WOLF_LMS && !cgs.clientinfo[cg.clientNum].shoutcaster) ? va("%s", CG_TranslateString("WARMUP")) : va("%02i", limbotimeOwn / 1000);
+		*s  = (cgs.gametype == GT_WOLF_LMS && !cgs.clientinfo[cg.clientNum].shoutcaster) ? va("%s", CG_TranslateString("WARMUP")) : va(isDoubleDigits ? "%02i" : "%0i", limbotimeOwn / 1000);
 
 		// if hud editor is up, return qfalse since we want to see text style changes
 		return !cg.generatingNoiseHud;
@@ -3198,7 +3198,7 @@ static qboolean CG_SpawnTimersText(char **s, char **rt, qboolean isDoubleDigits)
 		else if (cgs.clientinfo[cg.clientNum].team != TEAM_SPECTATOR || (cg.snap->ps.pm_flags & PMF_FOLLOW))
 		{
 			*s  = va(isDoubleDigits ? "%02i" : "%0i", CG_GetReinfTime(qfalse));
-			*rt = CG_SpawnTimerText();
+			*rt = CG_SpawnTimerText(isDoubleDigits);
 		}
 	}
 	return qfalse;

--- a/src/cgame/cg_fireteamoverlay.c
+++ b/src/cgame/cg_fireteamoverlay.c
@@ -1268,22 +1268,23 @@ static fireteamMemberStatusEnum_t CG_FireTeamMemberStatus(clientInfo_t *ci)
 	{
 		return TIMEOUT;
 	}
-	else if (ci->powerups & (1 << PW_INVULNERABLE))
+
+	if (ci->powerups & (1 << PW_INVULNERABLE))
 	{
 		return INVULNERABLE;
 	}
-	else if (ci->health == 0)
+
+	if (ci->health == 0)
 	{
 		return WOUNDED;
 	}
-	else if (ci->health < 0)
+
+	if (ci->health < 0)
 	{
 		return DEAD;
 	}
-	else
-	{
-		return NONE;
-	}
+
+    return NONE;
 }
 
 static vec4_t * CG_FireTeamNameColor(fireteamMemberStatusEnum_t status)
@@ -1306,24 +1307,23 @@ static vec4_t * CG_FireTeamNameColor(fireteamMemberStatusEnum_t status)
 
 static vec4_t * CG_FireTeamHealthColor(clientInfo_t *ci, hudComponent_t *comp)
 {
-	if (ci->powerups & (1 << PW_INVULNERABLE))
-	{
-		return &colorMdCyan;
-	}
-	else if (ci->health > FT_HEALTH_NORMAL)
+	if (ci->health > FT_HEALTH_NORMAL)
 	{
 		return &comp->colorMain;
 	}
-	else if (ci->health >= FT_HEALTH_YELLOW)
+
+	if (ci->health >= FT_HEALTH_YELLOW)
 	{
 		return &colorYellow;
 	}
-	else if (ci->health > 0)
+
+	if (ci->health > 0)
 	{
 		return &colorRed;
 	}
+
 	// wounded
-	else if (ci->health == 0)
+	if (ci->health == 0)
 	{
 		return (cg.time % 500) > 250 ? &colorWhite : &colorRed;
 	}

--- a/src/cgame/cg_fireteamoverlay.c
+++ b/src/cgame/cg_fireteamoverlay.c
@@ -835,8 +835,19 @@ static void CG_FTOverlay_DrawHealth(fireteamOverlay_t *fto, hudComponent_t *comp
 
 	if (comp->style & FT_HEALTH_TEXT)
 	{
+        const char *asterisk;
+
+        if (fto->ci->health == 0)
+        {
+            asterisk = va("*^%c", (cg.time % 500) > 250 ? '1' : '7');
+        }
+        else
+        {
+            asterisk = "";
+        }
+
 		CG_Text_Paint_RightAligned_Ext(fto->x + healthTextWidth, fto->y + fto->textHeightOffset, fto->textScale, fto->textScale,
-		                               color, va("%i", MAX(health, 0)), 0, 0, comp->styleText, FONT_TEXT);
+		                               color, va("%s%i", asterisk, MAX(health, 0)), 0, 0, comp->styleText, FONT_TEXT);
 
 		// always use static size, regardless of actual text being drawn
 		fto->x += healthTextWidth + fto->spacerInner;
@@ -1314,7 +1325,7 @@ static vec4_t * CG_FireTeamHealthColor(clientInfo_t *ci, hudComponent_t *comp)
 	// wounded
 	else if (ci->health == 0)
 	{
-		return (cg.time % 500) > 250 ? &colorYellow : &colorRed;
+		return (cg.time % 500) > 250 ? &colorWhite : &colorRed;
 	}
 
 	// limbo (-1 health)

--- a/src/cgame/cg_fireteamoverlay.c
+++ b/src/cgame/cg_fireteamoverlay.c
@@ -820,10 +820,10 @@ static void CG_FTOverlay_DrawWeaponIcon(fireteamOverlay_t *fto)
 
 static void CG_FTOverlay_DrawHealth(fireteamOverlay_t *fto, hudComponent_t *comp)
 {
-	const int  health          = fto->ci->health;
-	const int  healthTextWidth = HEALTH_TEXT_WIDTH;
-	int        maxHealth;
-	vec4_t     color;
+	const int health          = fto->ci->health;
+	const int healthTextWidth = HEALTH_TEXT_WIDTH;
+	int       maxHealth;
+	vec4_t    color;
 
 	if (!(comp->style & FT_HEALTH_TEXT) && !(comp->style & FT_MINI_HEALTH_BAR))
 	{
@@ -835,16 +835,16 @@ static void CG_FTOverlay_DrawHealth(fireteamOverlay_t *fto, hudComponent_t *comp
 
 	if (comp->style & FT_HEALTH_TEXT)
 	{
-        const char *asterisk;
+		const char *asterisk;
 
-        if (fto->ci->health == 0)
-        {
-            asterisk = va("*^%c", (cg.time % 500) > 250 ? '1' : '7');
-        }
-        else
-        {
-            asterisk = "";
-        }
+		if (fto->ci->health == 0)
+		{
+			asterisk = va("*^%c", (cg.time % 500) > 250 ? '1' : '7');
+		}
+		else
+		{
+			asterisk = "";
+		}
 
 		CG_Text_Paint_RightAligned_Ext(fto->x + healthTextWidth, fto->y + fto->textHeightOffset, fto->textScale, fto->textScale,
 		                               color, va("%s%i", asterisk, MAX(health, 0)), 0, 0, comp->styleText, FONT_TEXT);
@@ -1284,7 +1284,7 @@ static fireteamMemberStatusEnum_t CG_FireTeamMemberStatus(clientInfo_t *ci)
 		return DEAD;
 	}
 
-    return NONE;
+	return NONE;
 }
 
 static vec4_t * CG_FireTeamNameColor(fireteamMemberStatusEnum_t status)

--- a/src/cgame/cg_fireteamoverlay.c
+++ b/src/cgame/cg_fireteamoverlay.c
@@ -761,7 +761,7 @@ static void CG_FTOverlay_DrawPowerupIcon(fireteamOverlay_t *fto)
 	}
 	else if (fto->ci->health <= 0)
 	{
-		icon = fto->ci->health == 0 ? cgs.media.medicIcon : cgs.media.scoreEliminatedShader;
+		icon = fto->ci->health == 0 ? cgs.media.medicReviveShader2 : cgs.media.scoreEliminatedShader;
 	}
 
 	if (icon != -1)

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -3336,7 +3336,7 @@ void CG_LoadRankIcons(void);
 
 void CG_ParseFireteams(void);
 void CG_ParseOIDInfos(void);
-char *CG_SpawnTimerText(void);
+char *CG_SpawnTimerText(qboolean isDoubleDigits);
 //oidInfo_t *CG_OIDInfoForEntityNum(int num);
 
 // cg_consolecmds.c


### PR DESCRIPTION
* Use revive icon instead of need medic icon for wounded player in fireteam comp
* Fix missing asterisk prefixing HP text 
* Change back wounded bliking color from yellow/red to white/red
* Remove middle cyan color status for invulnerable player from HP elements (text / bar / row)