### PR TITLE
game: add g_legacyRevives CVAR

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2787,6 +2787,7 @@ typedef struct cgs_s
 	int fixedphysics;
 	int fixedphysicsfps;
 	int pronedelay;
+	int legacyRevives;
 #ifdef FEATURE_RATING
 	int skillRating;
 	float mapProb;

--- a/src/cgame/cg_servercmds.c
+++ b/src/cgame/cg_servercmds.c
@@ -402,6 +402,7 @@ void CG_ParseModInfo(void)
 	cgs.fixedphysics    = Q_atoi(Info_ValueForKey(info, "fp"));
 	cgs.fixedphysicsfps = Q_atoi(Info_ValueForKey(info, "fpv"));
 	cgs.pronedelay      = Q_atoi(Info_ValueForKey(info, "pd"));
+	cgs.legacyRevives   = Q_atoi(Info_ValueForKey(info, "lr"));
 }
 
 /**
@@ -1256,6 +1257,7 @@ void CG_AddToTeamChat(const char *str, int clientnum) // FIXME: add disguise?
 			cgs.teamChatPos++;
 
 			cgs.teamChatStartLine[cgs.teamChatPos % chatHeight] = qfalse;
+
 			p    = cgs.teamChatMsgs[cgs.teamChatPos % chatHeight];
 			*p   = 0;
 			*p++ = Q_COLOR_ESCAPE;

--- a/src/game/g_combat.c
+++ b/src/game/g_combat.c
@@ -717,6 +717,9 @@ void player_die(gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int 
 
 	self->client->limboDropWeapon = self->s.weapon; // store this so it can be dropped in limbo
 
+	// Keep the exact viewangles from the downed moment so legacy revive mode can restore them.
+	VectorCopy(self->client->ps.viewangles, self->client->downedViewAngles);
+
 	LookAtKiller(self, inflictor, attacker);
 	self->client->ps.viewangles[0] = 0;
 	self->client->ps.viewangles[2] = 0;

--- a/src/game/g_cvars.c
+++ b/src/game/g_cvars.c
@@ -100,6 +100,7 @@ vmCvar_t g_voiceChatsAllowed;
 vmCvar_t g_alliedmaxlives;
 vmCvar_t g_axismaxlives;
 vmCvar_t g_fastres;
+vmCvar_t g_legacyRevives;
 vmCvar_t g_syringeHealing;
 vmCvar_t g_enforcemaxlives;
 
@@ -454,6 +455,7 @@ cvarTable_t gameCvarTable[] =
 	{ &g_alliedmaxlives,                  "g_alliedmaxlives",                  "0",                          CVAR_LATCH | CVAR_SERVERINFO,                    0, qtrue,  qfalse },
 	{ &g_axismaxlives,                    "g_axismaxlives",                    "0",                          CVAR_LATCH | CVAR_SERVERINFO,                    0, qtrue,  qfalse },
 	{ &g_fastres,                         "g_fastres",                         "0",                          CVAR_ARCHIVE,                                    0, qtrue,  qtrue  },     // Fast Medic Resing
+	{ &g_legacyRevives,                   "g_legacyRevives",                   "1",                          CVAR_ARCHIVE,                                    0, qtrue,  qtrue  }, // Always look at where you looked when being downed AND no crouch/prone during standup
 	{ &g_syringeHealing,                  "g_syringeHealing",                  "0",                          CVAR_ARCHIVE,                                    0, qtrue,  qtrue  }, // Enable syringe healing on alive teammates
 	{ &g_enforcemaxlives,                 "g_enforcemaxlives",                 "1",                          CVAR_ARCHIVE,                                    0, qtrue,  qfalse },     // Gestapo enforce maxlives stuff by temp banning
 
@@ -944,6 +946,7 @@ void G_UpdateCvars(void)
 					Info_SetValueForKey(cs, "fp", va("%i", g_fixedphysics.integer));
 					Info_SetValueForKey(cs, "fpv", va("%i", g_fixedphysicsfps.integer));
 					Info_SetValueForKey(cs, "pd", va("%i", g_pronedelay.integer));
+					Info_SetValueForKey(cs, "lr", va("%i", g_legacyRevives.integer));
 
 
 					trap_SetConfigstring(CS_MODINFO, cs);

--- a/src/game/g_cvars.h
+++ b/src/game/g_cvars.h
@@ -87,6 +87,7 @@ extern vmCvar_t g_voiceChatsAllowed;        ///< number before spam control
 extern vmCvar_t g_alliedmaxlives;
 extern vmCvar_t g_axismaxlives;
 extern vmCvar_t g_fastres;                  ///< Fast medic res'ing
+extern vmCvar_t g_legacyRevives;            ///< Always look at where you looked when being downed AND no crouch/prone during standup
 extern vmCvar_t g_syringeHealing;           ///< Allow syringe healing for low-health teammates
 extern vmCvar_t g_enforcemaxlives;          ///< Temp ban with maxlives between rounds
 

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1055,6 +1055,7 @@ struct gclient_s
 	int deathAnimTime;                      ///< time when anim ends
 
 	int deathTime;                          ///< if we are dead, when did we die
+	vec3_t downedViewAngles;                ///< viewangles to restore on revive when legacy revive behavior is enabled
 
 	int disguiseClientNum;
 


### PR DESCRIPTION
When enabled:

- Crouch and prone input are blocked while PMF_TIME_LOCKPLAYER is active during stand-up animation, preventing crouch/prone while standing up.

- Revived players now always restore facing from their downed viewangles instead of using command-derived yaw, fixing first-revive random rotation and keeping revive orientation deterministic across repeated revives.