### PR TITLE
game: add g_legacyRevives

### DIFF
--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -3394,6 +3394,12 @@ void CG_DrawWarmupText(hudComponent_t *comp)
 {
 	const char *s = NULL, *s1 = NULL, *s2 = NULL;
 
+	if (cg.cursorHintIcon == HINT_NO_DARM_FIRST_REVIVE)
+	{
+		CG_DrawCompMultilineText(comp, "^9No ^zDynamite ^9Arm/Disarm\n^z1st^9 Revive per Spawn\n\n ", comp->colorMain, comp->alignText, comp->styleText, &cgs.media.limboFont2);
+		return;
+	}
+
 	if (!cg.warmup || cg.generatingNoiseHud)
 	{
 		if ((!(cgs.gamestate == GS_WARMUP && !cg.warmup) && cgs.gamestate != GS_WAITING_FOR_PLAYERS) && !cg.generatingNoiseHud)

--- a/src/cgame/cg_newDraw.c
+++ b/src/cgame/cg_newDraw.c
@@ -393,6 +393,9 @@ void CG_DrawCursorhint(hudComponent_t *comp)
 	case HINT_RESTRICTED:
 		cg.lastUsedHintIcon = cgs.media.friendShader;
 		break;
+	case HINT_NO_DARM_FIRST_REVIVE:
+		cg.lastUsedHintIcon = cgs.media.doorLockHintShader;
+		break;
 	case HINT_ACTIVATE:
 	case HINT_BAD_USER:
 	default:

--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -2121,8 +2121,9 @@ typedef enum
 
 	HINT_BAD_USER,              ///< invisible user with no target
 	HINT_COMPLETED,
+	HINT_NO_DARM_FIRST_REVIVE,  ///< first-revive restriction icon for explosive arm/disarm interactions
 
-	HINT_NUM_HINTS = 51,
+	HINT_NUM_HINTS = 52,
 } hintType_t;
 
 void BG_EvaluateTrajectory(const trajectory_t *tr, int atTime, vec3_t result, qboolean isAngle, int splinePath);

--- a/src/game/g_combat.c
+++ b/src/game/g_combat.c
@@ -716,6 +716,9 @@ void player_die(gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int 
 	self->s.loopSound = 0;
 
 	self->client->limboDropWeapon = self->s.weapon; // store this so it can be dropped in limbo
+	                                                //
+	// Capture the exact downed look direction before the death orientation is forced.
+	G_LegacyRevive_RecordDownedViewAngles(self);
 
 	LookAtKiller(self, inflictor, attacker);
 	self->client->ps.viewangles[0] = 0;

--- a/src/game/g_cvars.c
+++ b/src/game/g_cvars.c
@@ -101,6 +101,7 @@ vmCvar_t g_alliedmaxlives;
 vmCvar_t g_axismaxlives;
 vmCvar_t g_fastres;
 vmCvar_t g_syringeHealing;
+vmCvar_t g_legacyRevives;
 vmCvar_t g_enforcemaxlives;
 
 vmCvar_t g_needpass;
@@ -455,6 +456,7 @@ cvarTable_t gameCvarTable[] =
 	{ &g_axismaxlives,                    "g_axismaxlives",                    "0",                          CVAR_LATCH | CVAR_SERVERINFO,                    0, qtrue,  qfalse },
 	{ &g_fastres,                         "g_fastres",                         "0",                          CVAR_ARCHIVE,                                    0, qtrue,  qtrue  },     // Fast Medic Resing
 	{ &g_syringeHealing,                  "g_syringeHealing",                  "0",                          CVAR_ARCHIVE,                                    0, qtrue,  qtrue  }, // Enable syringe healing on alive teammates
+	{ &g_legacyRevives,                   "g_legacyRevives",                   "1",                          CVAR_ARCHIVE,                                    0, qtrue,  qtrue  }, // Legacy ET revive behavior compatibility
 	{ &g_enforcemaxlives,                 "g_enforcemaxlives",                 "1",                          CVAR_ARCHIVE,                                    0, qtrue,  qfalse },     // Gestapo enforce maxlives stuff by temp banning
 
 	{ &g_developer,                       "developer",                         "0",                          CVAR_TEMP,                                       0, qfalse, qfalse },

--- a/src/game/g_cvars.h
+++ b/src/game/g_cvars.h
@@ -88,6 +88,7 @@ extern vmCvar_t g_alliedmaxlives;
 extern vmCvar_t g_axismaxlives;
 extern vmCvar_t g_fastres;                  ///< Fast medic res'ing
 extern vmCvar_t g_syringeHealing;           ///< Allow syringe healing for low-health teammates
+extern vmCvar_t g_legacyRevives;            ///< Enable ET:Legacy revive compatibility mode
 extern vmCvar_t g_enforcemaxlives;          ///< Temp ban with maxlives between rounds
 
 extern vmCvar_t g_needpass;

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1083,6 +1083,11 @@ struct gclient_s
 	damageReceivedStats_t dmgReceivedSts[MAX_CLIENTS];
 
 	int isSpawnInvulnerability;
+
+	// Legacy revive compatibility state.
+	vec3_t legacyDownedViewAngles;            ///< View direction at the moment player got downed.
+	qboolean legacyDownedViewAnglesValid;     ///< True when downed angles are valid for revive restore.
+	int legacyRevivesSinceRespawn;            ///< Number of revives since last full respawn.
 };
 
 /**
@@ -1739,6 +1744,10 @@ void respawn(gentity_t *ent);
 void BeginIntermission(void);
 void InitBodyQue(void);
 void ClientSpawn(gentity_t *ent, qboolean revived, qboolean teamChange, qboolean restoreHealth, qboolean toggleTeleport);
+void G_LegacyRevive_RecordDownedViewAngles(gentity_t *ent);
+void G_LegacyRevive_OnClientSpawn(gentity_t *ent, qboolean revived);
+qboolean G_LegacyRevive_GetReviveViewAngles(gentity_t *ent, vec3_t outViewAngles);
+qboolean G_LegacyRevive_IsFirstReviveRestricted(gentity_t *ent);
 void player_die(gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int damage, meansOfDeath_t meansOfDeath);
 void AddKillScore(gentity_t *ent, int score);
 void CalculateRanks(void);

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -931,23 +931,32 @@ void G_CheckForCursorHints(gentity_t *ent)
 				if (ps->stats[STAT_PLAYER_CLASS] == PC_ENGINEER)
 				{
 					hintDist = CH_BREAKABLE_DIST;
-					hintType = HINT_DISARM;
-					hintVal  = checkEnt->health;            // also send health to client for visualization
-					if (hintVal > 255)
+					if (checkEnt->methodOfDeath == MOD_DYNAMITE && G_LegacyRevive_IsFirstReviveRestricted(ent))
 					{
-						hintVal = 255;
+						// During the first revive stand-up, only dynamite arm/disarm is blocked.
+						hintType = HINT_NO_DARM_FIRST_REVIVE;
+						hintVal  = 0;
+					}
+					else
+					{
+						hintType = HINT_DISARM;
+						hintVal  = checkEnt->health;            // also send health to client for visualization
+						if (hintVal > 255)
+						{
+							hintVal = 255;
+						}
 					}
 				}
 
 				// hint icon specified in entity (and proper contact was made, so hintType was set)
 				// first try the checkent...
-				if (checkEnt->s.dmgFlags && hintType)
+				if (hintType != HINT_NO_DARM_FIRST_REVIVE && checkEnt->s.dmgFlags && hintType)
 				{
 					hintType = checkEnt->s.dmgFlags;
 				}
 
 				// then the traceent
-				if (traceEnt->s.dmgFlags && hintType)
+				if (hintType != HINT_NO_DARM_FIRST_REVIVE && traceEnt->s.dmgFlags && hintType)
 				{
 					hintType = traceEnt->s.dmgFlags;
 				}

--- a/src/game/g_mover.c
+++ b/src/game/g_mover.c
@@ -94,6 +94,7 @@ const char *hintStrings[HINT_NUM_HINTS] =
 
 	"HINT_BAD_USER",
 	"HINT_COMPLETED",
+	"HINT_NO_DARM_FIRST_REVIVE",
 };
 
 /*


### PR DESCRIPTION
When g_legacyRevives is 0, revive behavior remains unchanged to 2.60b.

When g_legacyRevives is 1:
- Revived players are always reoriented to the view direction recorded when they were downed.
- The first revive per respawn blocks all pliers interactions (dynamite, mines, constructibles etc.) - visually shown via an icon.

This way the intention is to keep the current meta while making the viewangles consistent and the mechanic self-evident (via the visual icon).