### PR TITLE
cgame: draw custom crosshair smallcross for no-spread weapons

### DIFF
--- a/src/cgame/cg_customcrosshair.c
+++ b/src/cgame/cg_customcrosshair.c
@@ -171,9 +171,7 @@ void CG_DrawCustomCrosshair(qboolean withSpread)
 
 		// draw small cross
 		if (
-			(cg_customCrosshair.integer == CUSTOMCROSSHAIR_DOT_WITH_SMALLCROSS || cg_customCrosshair.integer == CUSTOMCROSSHAIR_SMALLCROSS) &&
-			withSpread
-			)
+			(cg_customCrosshair.integer == CUSTOMCROSSHAIR_DOT_WITH_SMALLCROSS && withSpread) || cg_customCrosshair.integer == CUSTOMCROSSHAIR_SMALLCROSS)
 		{
 			innerWidth       = cg_customCrosshairCrossWidth.value;
 			innerWidthOffset = innerWidth / 2;


### PR DESCRIPTION
so when cg_customCrosshair = 3 and cg_customCrosshairDotWidth = 0 player can always see the cross

related conversation: https://discord.com/channels/260750790203932672/260750790203932672/1476652997298880624