### PR TITLE
cgame: remove FPS sample rate cvar for measurement

### DIFF
--- a/src/cgame/cg_cvars.c
+++ b/src/cgame/cg_cvars.c
@@ -37,7 +37,6 @@ vmCvar_t cg_swingSpeed;
 vmCvar_t cg_shadows;
 vmCvar_t cg_gibs;
 vmCvar_t cg_draw2D;
-vmCvar_t cg_drawFPS;
 vmCvar_t cg_drawCrosshair;
 vmCvar_t cg_drawCrosshairFade;
 vmCvar_t cg_crosshairHintsLinger;
@@ -353,7 +352,6 @@ static cvarTable_t cvarTable[] =
 	{ &cg_draw2D,                             "cg_draw2D",                             "1",           CVAR_ARCHIVE,                 0 },
 	{ &cg_railTrailTime,                      "cg_railTrailTime",                      "750",         CVAR_ARCHIVE,                 0 },
 	{ &cg_drawStatus,                         "cg_drawStatus",                         "0",           CVAR_CHEAT,                   0 },
-	{ &cg_drawFPS,                            "cg_drawFPS",                            "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_drawCrosshair,                      "cg_drawCrosshair",                      "1",           CVAR_ARCHIVE,                 0 },
 	{ &cg_drawCrosshairFade,                  "cg_drawCrosshairFade",                  "250",         CVAR_ARCHIVE,                 0 },
 	{ &cg_crosshairHintsLinger,               "cg_crosshairHintsLinger",               "100",         CVAR_ARCHIVE,                 0 },

--- a/src/cgame/cg_cvars.h
+++ b/src/cgame/cg_cvars.h
@@ -41,7 +41,6 @@ extern vmCvar_t cg_swingSpeed;
 extern vmCvar_t cg_shadows;
 extern vmCvar_t cg_gibs;
 extern vmCvar_t cg_draw2D;
-extern vmCvar_t cg_drawFPS;
 extern vmCvar_t cg_drawCrosshair;
 extern vmCvar_t cg_drawCrosshairFade;
 extern vmCvar_t cg_crosshairHintsLinger;

--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -3071,51 +3071,35 @@ void CG_DrawSpeed(hudComponent_t *comp)
  */
 void CG_DrawFPS(hudComponent_t *comp)
 {
-	static int previousTimes[MAX_FPS_FRAMES];
-	static int previous;
-	static int index;
-	static int oldSamples;
-	const char *s;
-	int        t;
-	int        frameTime;
-	int        samples = cg_drawFPS.integer;
+	static int          previousTimes[MAX_FPS_FRAMES];
+	static int          previous;
+	static unsigned int index;
+	const char          *s;
+	int                 t;
+	int                 frameTime;
 
 	t = trap_Milliseconds(); // don't use serverTime, because that will be drifting to correct for internet lag changes, timescales, timedemos, etc
 
 	frameTime = t - previous;
 	previous  = t;
 
-	if (samples < 4)
-	{
-		samples = 4;
-	}
-	if (samples > MAX_FPS_FRAMES)
-	{
-		samples = MAX_FPS_FRAMES;
-	}
-	if (samples != oldSamples)
-	{
-		index = 0;
-	}
-
-	oldSamples                     = samples;
-	previousTimes[index % samples] = frameTime;
+	previousTimes[index % MAX_FPS_FRAMES] = frameTime;
 	index++;
 
-	if (index > samples)
+	if (index > MAX_FPS_FRAMES)
 	{
 		int i, fps;
 		// average multiple frames together to smooth changes out a bit
 		int total = 0;
 
-		for (i = 0 ; i < samples ; ++i)
+		for (i = 0 ; i < MAX_FPS_FRAMES ; ++i)
 		{
 			total += previousTimes[i];
 		}
 
 		total = total ? total : 1;
 
-		fps = 1000 * samples / total;
+		fps = 1000 * MAX_FPS_FRAMES / total;
 
 		s = va("%i FPS", fps);
 	}


### PR DESCRIPTION
There is no reason to let the player customized the measurement samples rate. Hard coding it to MAX_FPS_FRAMES samples (currently 500).