### PR TITLE
cgame: change cg_centertime unit from s to ms

### DIFF
--- a/src/cgame/cg_cvars.c
+++ b/src/cgame/cg_cvars.c
@@ -371,7 +371,7 @@ static cvarTable_t cvarTable[] =
 	{ &cg_gun_x,                              "cg_gunX",                               "0",           CVAR_TEMP,                    0 },
 	{ &cg_gun_y,                              "cg_gunY",                               "0",           CVAR_TEMP,                    0 },
 	{ &cg_gun_z,                              "cg_gunZ",                               "0",           CVAR_TEMP,                    0 },
-	{ &cg_centertime,                         "cg_centertime",                         "5",           CVAR_ARCHIVE,                 0 }, // changed from 3 to 5
+	{ &cg_centertime,                         "cg_centertime",                         "5000",        CVAR_ARCHIVE,                 0 }, // changed from 3 to 5
 	{ &cg_bobbing,                            "cg_bobbing",                            "0.0",         CVAR_ARCHIVE,                 0 },
 	{ &cg_drawEnvAwareness,                   "cg_drawEnvAwareness",                   "7",           CVAR_ARCHIVE,                 0 },
 	{ &cg_drawEnvAwarenessScale,              "cg_drawEnvAwarenessScale",              "0.80",        CVAR_ARCHIVE,                 0 },

--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -1245,7 +1245,7 @@ void CG_DrawCenterString(hudComponent_t *comp)
 	}
 
 	Vector4Copy(comp->colorMain, textColor);
-	color = CG_FadeColor_Ext(cg.centerPrintTime, (int)(1000 * cg_centertime.value), textColor[3]);
+	color = CG_FadeColor_Ext(cg.centerPrintTime, cg_centertime.integer, textColor[3]);
 	if (!color)
 	{
 		cg.centerPrintTime     = 0;


### PR DESCRIPTION
Consistencies with other cvar using millisecond for duration unit