### PR TITLE
game: fix gibs spawning at incorrect locations

### DIFF
--- a/src/game/g_combat.c
+++ b/src/game/g_combat.c
@@ -248,7 +248,7 @@ void GibEntity(gentity_t *self, int killer, int damage)
 	}
 
 	te                   = G_TempEntity(self->r.currentOrigin, EV_GIB_PLAYER);
-	te->s.otherEntityNum = self->s.clientNum;
+	te->s.otherEntityNum = self->s.number;
 	te->s.eventParm      = DirToByte(dir);
 	te->s.effect3Time    = damage;
 


### PR DESCRIPTION
`EV_GIB_PLAYER` was using `s.clientNum` to send the corpse entity number as part of the event, which is incorrect for corpses as that is the clientNum of the player who's corpse it is. This caused gibs to spawn in the location of the player whenever their corpse was gibbed, instead of at the location of the corpse.

refs #3244 