### PR TITLE
game: fix delete not working correctly with g_corpses 1

### DIFF
--- a/src/game/g_script_actions.c
+++ b/src/game/g_script_actions.c
@@ -5099,7 +5099,7 @@ qboolean G_ScriptAction_Delete(gentity_t *ent, char *params)
 	}
 
 	// now delete the entities that passed all tests..
-	for (i = ENTITYNUM_MAX_NORMAL - 1; i >= MAX_CLIENTS + BODY_QUEUE_SIZE; i--)
+	for (i = ENTITYNUM_MAX_NORMAL - 1; i >= MAX_CLIENTS; i--)
 	{
 		if (pass[i] == count)
 		{

--- a/src/game/g_script_actions.c
+++ b/src/game/g_script_actions.c
@@ -5095,7 +5095,7 @@ qboolean G_ScriptAction_Delete(gentity_t *ent, char *params)
 	// did we find any key/value pairs in the params at all?..
 	if (count == 0)
 	{
-		return qfalse;
+		return qtrue;
 	}
 
 	// now delete the entities that passed all tests..
@@ -5113,7 +5113,6 @@ qboolean G_ScriptAction_Delete(gentity_t *ent, char *params)
 	if (deleted == 0)
 	{
 		G_Printf("G_ScriptAction_Delete(): no entities found (%s)\n", params);
-		return qfalse;
 	}
 
 	return qtrue;


### PR DESCRIPTION
The loop that iterated and deleted the entities was stopping it's iteration at `MAX_CLIENTS + BODY_QUEUE_SIZE`, which caused any entity with a number 64-72 to not be able to be targeted by `delete` when `g_corpses` was set to 1, because these entity slots were no longer reserved for corpses.

refs #2864 