### PR TITLE
game: fix formatting for scores table if names contain ^ chars

### DIFF
--- a/src/game/g_match.c
+++ b/src/game/g_match.c
@@ -821,6 +821,9 @@ void G_printMatchInfo(gentity_t *ent)
 	char      *ref;
 	char      guid[MAX_GUID_LENGTH + 1];
 	char      n2[MAX_STRING_CHARS];
+	int       namePadding;
+
+#define SCORES_NAME_MAX_LEN 15
 
 	ent->client->scoresIndex = ent->client->scoresCount = 0;
 
@@ -880,8 +883,10 @@ void G_printMatchInfo(gentity_t *ent)
 			}
 
 			Q_strncpyz(n2, cl->pers.netname, sizeof(n2));
+			Q_TruncateStr(n2, SCORES_NAME_MAX_LEN);
 			Q_CleanStr(n2);
-			n2[15] = 0;
+			Q_EscapeColorCodes(n2, '3');
+			namePadding = Q_CountPaddingWithColor(n2, SCORES_NAME_MAX_LEN);
 
 			ref = "^7";
 			tot_timex += cl->sess.time_axis;
@@ -918,14 +923,14 @@ void G_printMatchInfo(gentity_t *ent)
 
 			cnt++;
 #ifdef FEATURE_RATING
-			G_SaveMatchInfo(ent, va("sc \"%-9s %-14s %s%-15s^1%4d^$%4d^7%s%4d^3%4d%4d%4d%4d%4d%4d%4d%s%4d^2%6d^1%6d^6%5d^$%5d^3%7d^8%8.2f^5%+7.2f\n\"",
+			G_SaveMatchInfo(ent, va("sc \"%-9s %-14s %s%-*s^1%4d^$%4d^7%s%4d^3%4d%4d%4d%4d%4d%4d%4d%s%4d^2%6d^1%6d^6%5d^$%5d^3%7d^8%8.2f^5%+7.2f\n\"",
 #else
-			G_SaveMatchInfo(ent, va("sc \"%-9s %-14s %s%-15s^1%4d^$%4d^7%s%4d^3%4d%4d%4d%4d%4d%4d%4d%s%4d^2%6d^1%6d^6%5d^$%5d^3%7d\n\"",
+			G_SaveMatchInfo(ent, va("sc \"%-9s %-14s %s%-*s^1%4d^$%4d^7%s%4d^3%4d%4d%4d%4d%4d%4d%4d%s%4d^2%6d^1%6d^6%5d^$%5d^3%7d\n\"",
 #endif
 			                        guid,
 			                        aTeams[i],
 			                        ref,
-			                        n2,
+			                        namePadding, n2,
 			                        cl->sess.time_axis / 60000,
 			                        cl->sess.time_allies / 60000,
 			                        ref,

--- a/src/qcommon/q_shared.c
+++ b/src/qcommon/q_shared.c
@@ -1964,6 +1964,51 @@ char *Q_CleanStr(char *string)
 }
 
 /**
+ * @brief Takes a string and escapes any color codes found in it, so that the text can
+ * be printed "as is", without the color codes being interpreted as actual color codes.
+ * This is useful when you want to print clean strings that contain '^' characters,
+ * without them being automatically interpreted as color codes.
+ *
+ * Example use case:
+ * We want to print a player's name to the console without color codes, and their name is:
+ * ^1Foo^2^^3Bar
+ *
+ * After color codes are removed, the remaining string is:
+ * Foo^Bar
+ *
+ * Printing this will interpret the '^B' as a color code, resulting output 'Fooar'.
+ *
+ * After cleaning, running the string through this function with '7' as 'escapeChar'
+ * will instead turn the string into this:
+ * Foo^^7Bar
+ *
+ * This can now be printed as plain white text, while preserving the caret character.
+ *
+ * NOTE: This function potentially grows the string size by 3x!
+ * Ensure the buffer holding the string is large enough to accommodate this!
+ *
+ * @param[in] string
+ * @param[in] escapeColor
+ */
+void Q_EscapeColorCodes(char *string, char escapeColor)
+{
+	size_t len = strlen(string);
+	size_t i;
+
+	for (i = 0; i < len; i++)
+	{
+		if (Q_IsColorString(string + i) && len > i + 2)
+		{
+			len += 2;
+			memmove(string + i + 3, string + i + 1, len - i - 2);
+			string[i + 1] = Q_COLOR_ESCAPE;
+			string[i + 2] = escapeColor;
+			i            += 2;
+		}
+	}
+}
+
+/**
  * @brief Takes a plain "un-colored" string, and then colorizes it so the string is displayed in the given color.
  * If given a string such as "Bob" and asked to colorize to '1' (red)', the output would be "^1Bob". If given
  * "John^^7Candy" the output is "^1John^^1^^17Candy"  -- Note that when drawn, this would literally show

--- a/src/qcommon/q_shared.h
+++ b/src/qcommon/q_shared.h
@@ -932,6 +932,17 @@ static ID_INLINE qboolean Q_IsAcceleratorString(const char *p)
 /// removes color sequences from string
 char *Q_CleanStr(char *string);
 
+// escapes any color codes in a string so it can be printed "as is"
+// with the color determined by 'escapeColor'
+void Q_EscapeColorCodes(char *string, char escapeColor);
+
+// returns the padding required to reach 'targetPadding' for printf
+// formatting, when a string has color codes in it
+static ID_INLINE int Q_CountPaddingWithColor(const char *string, int targetPadding)
+{
+	return targetPadding + strlen(string) - Q_PrintStrlen(string);
+}
+
 /// removes color sequences from string using multiple passes
 void Q_StripColor(char *string);
 


### PR DESCRIPTION
Fixes scores printing interpreting `^` characters as color codes when it tries to strip color codes and print the player names as plain yellow text. The print will now correctly escape any `^` characters in player names and retains the correct formatting for the table.

fixes #3353 