### PR TITLE
cgame: fix riflegrenade switch exploit with cg_weapaltSwitches 0

### DIFF
--- a/src/cgame/cg_weapons.c
+++ b/src/cgame/cg_weapons.c
@@ -3347,7 +3347,9 @@ void CG_FinishWeaponChange(int lastWeapon, int newWeapon)
 
 	cg.mortarImpactTime = -2;
 
-	if (cg_weapaltSwitches.integer && lastWeapon != GetWeaponTableData(newWeapon)->weapAlts)
+	// Always keep selected weapon in sync with attachment/silencer state.
+	// This prevents bypassing alt attach/detach animations via wheel switching.
+	if (lastWeapon != GetWeaponTableData(newWeapon)->weapAlts)
 	{
 		if (((GetWeaponTableData(newWeapon)->type & WEAPON_TYPE_PISTOL) && !(GetWeaponTableData(newWeapon)->attributes & WEAPON_ATTRIBUT_SILENCED) && (cg.pmext.silencedSideArm & 1))
 		    || ((GetWeaponTableData(newWeapon)->type & WEAPON_TYPE_PISTOL) && (GetWeaponTableData(newWeapon)->attributes & WEAPON_ATTRIBUT_SILENCED) && !(cg.pmext.silencedSideArm & 1))


### PR DESCRIPTION
The previous change in ca86ce23985902d815ec289b8168e67d5a397884 made the attachment/silencer state correction in CG_FinishWeaponChange conditional on cg_weapaltSwitches.

In practice, an engineer could switch away from rifle and back and end up on riflegrenade without the required attach animation, enabling rapid repeated grenade shots.