### PR TITLE
game: fix riflenade detach bypass during raise

### DIFF
--- a/src/cgame/cg_weapons.c
+++ b/src/cgame/cg_weapons.c
@@ -3620,6 +3620,13 @@ void CG_AltWeapon_f(void)
 		return;
 	}
 
+	// Match server-side PM lock: prevent alt toggles while the weapon is still raising
+	// from a regular switch, otherwise predicted select state can desync briefly.
+	if (cg.snap->ps.weaponstate == WEAPON_RAISING)
+	{
+		return;
+	}
+
 	// don't allow alt weapon switch till we have switched to selected weapon
 	if (cg.snap->ps.weapon != cg.weaponSelect || (cg.snap->ps.nextWeapon && cg.snap->ps.weapon != cg.snap->ps.nextWeapon))
 	{

--- a/src/cgame/cg_weapons.c
+++ b/src/cgame/cg_weapons.c
@@ -3620,9 +3620,12 @@ void CG_AltWeapon_f(void)
 		return;
 	}
 
-	// Match server-side PM lock: prevent alt toggles while the weapon is still raising
-	// from a regular switch, otherwise predicted select state can desync briefly.
-	if (cg.snap->ps.weaponstate == WEAPON_RAISING)
+	// Match server-side PM lock, but only for rifle grenade attach/detach.
+	// Scope/silencer alt modes are intentionally not blocked here.
+	if (cg.snap->ps.weaponstate == WEAPON_RAISING
+	    && (((GetWeaponTableData(cg.weaponSelect)->type & WEAPON_TYPE_RIFLE)
+	         && (GetWeaponTableData(GetWeaponTableData(cg.weaponSelect)->weapAlts)->type & WEAPON_TYPE_RIFLENADE))
+	        || (GetWeaponTableData(cg.weaponSelect)->type & WEAPON_TYPE_RIFLENADE)))
 	{
 		return;
 	}

--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -2603,10 +2603,14 @@ static void PM_BeginWeaponChange(weapon_t oldWeapon, weapon_t newWeapon, qboolea
 		return;
 	}
 
-	// Keep alt attachment toggles locked while a weapon is still raising from a regular switch.
-	// Without this guard, a fast re-select + altweap can bypass the detach animation timing.
+	// Keep rifle grenade toggles locked while a weapon is still raising from a regular switch.
+	// Without this guard, a fast re-select + altweap can bypass detach timing for rifle grenades.
+	// Scope/silencer alt modes are intentionally excluded.
 	if (pm->ps->weaponstate == WEAPON_RAISING &&
-	    (newWeapon == GetWeaponTableData(oldWeapon)->weapAlts || oldWeapon == GetWeaponTableData(newWeapon)->weapAlts))
+	    (((GetWeaponTableData(oldWeapon)->type & WEAPON_TYPE_RIFLE) && (GetWeaponTableData(newWeapon)->type & WEAPON_TYPE_RIFLENADE)
+	      && newWeapon == GetWeaponTableData(oldWeapon)->weapAlts)
+	     || ((GetWeaponTableData(oldWeapon)->type & WEAPON_TYPE_RIFLENADE) && (GetWeaponTableData(newWeapon)->type & WEAPON_TYPE_RIFLE)
+	         && oldWeapon == GetWeaponTableData(newWeapon)->weapAlts)))
 	{
 		return;
 	}
@@ -2736,6 +2740,16 @@ static void PM_FinishWeaponChange(void)
 	// doesn't happen too often (player switched weapons away then back very quickly)
 	if (oldWeapon == newWeapon)
 	{
+		// Keep rifle/riflegrenade transitions from collapsing into a zero-time raise
+		// when a quick switch gets canceled back to the same weapon.
+		if (((GetWeaponTableData(newWeapon)->type & WEAPON_TYPE_RIFLENADE)
+		     || ((GetWeaponTableData(newWeapon)->type & WEAPON_TYPE_RIFLE)
+		         && (GetWeaponTableData(GetWeaponTableData(newWeapon)->weapAlts)->type & WEAPON_TYPE_RIFLENADE))))
+		{
+			PM_StartWeaponAnim(WEAP_RAISE);
+			pm->ps->weaponTime += GetWeaponTableData(newWeapon)->switchTimeFinish;
+		}
+
 		return;
 	}
 

--- a/src/game/bg_pmove.c
+++ b/src/game/bg_pmove.c
@@ -2603,6 +2603,14 @@ static void PM_BeginWeaponChange(weapon_t oldWeapon, weapon_t newWeapon, qboolea
 		return;
 	}
 
+	// Keep alt attachment toggles locked while a weapon is still raising from a regular switch.
+	// Without this guard, a fast re-select + altweap can bypass the detach animation timing.
+	if (pm->ps->weaponstate == WEAPON_RAISING &&
+	    (newWeapon == GetWeaponTableData(oldWeapon)->weapAlts || oldWeapon == GetWeaponTableData(newWeapon)->weapAlts))
+	{
+		return;
+	}
+
 	// don't allow change during spinup
 	if (pm->ps->weaponDelay)
 	{


### PR DESCRIPTION
Block alt-weapon toggles while a weapon is in WEAPON_RAISING when the request is an alt-pair transition (rifle<->riflenade, scoped/unscope, silencer pairs). This closes a timing window where players could fast-switch away/back and trigger altweap before raise completion, bypassing expected detach timing/animation flow.

The server-side lock is in PM_BeginWeaponChange so authoritative simulation no longer accepts this sequence. A matching client-side check in CG_AltWeapon_f keeps prediction and local selection state aligned with the server and avoids transient desync behavior.