### PR TITLE
cgame: add cg_disableComplaints cvar

### DIFF
--- a/src/cgame/cg_cvars.c
+++ b/src/cgame/cg_cvars.c
@@ -103,6 +103,7 @@ vmCvar_t cg_synchronousClients;
 #endif // ALLOW_GSYNC
 vmCvar_t cg_teamChatTime;
 vmCvar_t cg_teamChatMention;
+vmCvar_t cg_disableComplaints;
 vmCvar_t cg_stats;
 vmCvar_t cg_buildScript;
 vmCvar_t cg_coronafardist;
@@ -422,6 +423,7 @@ static cvarTable_t cvarTable[] =
 	{ &cg_scopedSensitivityScaler,            "cg_scopedSensitivityScaler",            "0.6",         CVAR_ARCHIVE,                 0 },           // per atvi req
 	{ &cg_teamChatTime,                       "cg_teamChatTime",                       "8000",        CVAR_ARCHIVE,                 0 },
 	{ &cg_teamChatMention,                    "cg_teamChatMention",                    "1",           CVAR_ARCHIVE,                 0 },
+	{ &cg_disableComplaints,                  "cg_disableComplaints",                  "0",           CVAR_ARCHIVE,                 0 }, // Disable complaint popup prompts and status popups
 	{ &cg_coronafardist,                      "cg_coronafardist",                      "1536",        CVAR_ARCHIVE,                 0 },
 	{ &cg_coronas,                            "cg_coronas",                            "1",           CVAR_ARCHIVE,                 0 },
 	{ &cg_predictItems,                       "cg_predictItems",                       "1",           CVAR_ARCHIVE,                 0 },

--- a/src/cgame/cg_cvars.h
+++ b/src/cgame/cg_cvars.h
@@ -113,6 +113,7 @@ extern vmCvar_t cg_synchronousClients;
 #endif // ALLOW_GSYNC
 extern vmCvar_t cg_teamChatTime;
 extern vmCvar_t cg_teamChatMention;
+extern vmCvar_t cg_disableComplaints;
 extern vmCvar_t cg_stats;
 extern vmCvar_t cg_coronafardist;
 extern vmCvar_t cg_coronas;

--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -2634,7 +2634,7 @@ void CG_DrawVote(hudComponent_t *comp)
 	const char *str = NULL;
 	char       str1[32], str2[32];
 
-	if (cgs.complaintEndTime > cg.time && !cg.demoPlayback && (comp->style & 1) && cgs.complaintClient >= 0)
+	if (!cg_disableComplaints.integer && cgs.complaintEndTime > cg.time && !cg.demoPlayback && (comp->style & 1) && cgs.complaintClient >= 0)
 	{
 		CG_GetBindingKeyForVote(str1, str2);
 
@@ -2811,7 +2811,7 @@ void CG_DrawVote(hudComponent_t *comp)
 		return;
 	}
 
-	if (cgs.complaintEndTime > cg.time && !cg.demoPlayback && (comp->style & 1) && cgs.complaintClient < 0)
+	if (!cg_disableComplaints.integer && cgs.complaintEndTime > cg.time && !cg.demoPlayback && (comp->style & 1) && cgs.complaintClient < 0)
 	{
 		switch (cgs.complaintClient)
 		{

--- a/src/cgame/cg_servercmds.c
+++ b/src/cgame/cg_servercmds.c
@@ -1256,12 +1256,12 @@ void CG_AddToTeamChat(const char *str, int clientnum) // FIXME: add disguise?
 			cgs.teamChatPos++;
 
 			cgs.teamChatStartLine[cgs.teamChatPos % chatHeight] = qfalse;
-			p    = cgs.teamChatMsgs[cgs.teamChatPos % chatHeight];
-			*p   = 0;
-			*p++ = Q_COLOR_ESCAPE;
-			*p++ = lastcolor;
-			len  = 0;
-			ls   = NULL;
+			p                                                   = cgs.teamChatMsgs[cgs.teamChatPos % chatHeight];
+			*p                                                  = 0;
+			*p++                                                = Q_COLOR_ESCAPE;
+			*p++                                                = lastcolor;
+			len                                                 = 0;
+			ls                                                  = NULL;
 		}
 
 		if (Q_IsColorString(str))
@@ -3594,6 +3594,14 @@ static void CG_ServerCommand(void)
 	case COMPLAINT_HASH:                                       // "complaint"
 		if (cgs.gamestate == GS_PLAYING)
 		{
+			// Client-side opt-out for all complaint popups.
+			if (cg_disableComplaints.integer)
+			{
+				cgs.complaintEndTime = 0;
+				cgs.complaintClient  = -1;
+				return;
+			}
+
 			if (!(CG_GetActiveHUD()->votetext.style & 1))
 			{
 				trap_SendClientCommand("vote no");


### PR DESCRIPTION
Introduce a new archived client cvar, cg_disableComplaints, to disable complaint popups entirely when set to 1.