### PR TITLE
game: fix char overflow in fireteam joinOrder

### DIFF
--- a/src/game/bg_public.h
+++ b/src/game/bg_public.h
@@ -2784,7 +2784,7 @@ extern const char *bg_fireteamNamesAxis[MAX_FIRETEAMS / 2];
 typedef struct
 {
 	int ident;
-	char joinOrder[MAX_CLIENTS];    ///< order in which clients joined the fire team (server), client uses to store if a client is on this fireteam
+	signed char joinOrder[MAX_CLIENTS];    ///< order in which clients joined the fire team (server), client uses to store if a client is on this fireteam
 	int leader;                     ///< leader = joinOrder[0] on server, stored here on client
 	qboolean inuse;
 	qboolean priv;


### PR DESCRIPTION
which causes crash on aarch64 when fireteam is disbanded ( `Server crashed: G_RemoveClientFromFireteams: invalid client` ) and possibly more fireteam operations

`-funsigned-char -Werror=tautological-constant-out-of-range-compare` Clang flags catch this, but I was only able run compilation of qagame with Clang. I can't figure out why Clion doesn't run clang for other cmake targets. Somebody else could try to find other places where this overflow can happen. 

```patch
diff --git a/cmake/ETLPlatform.cmake b/cmake/ETLPlatform.cmake
--- a/cmake/ETLPlatform.cmake	(revision 39b0957d60864edb49d2a78cfda2829fb774de31)
+++ b/cmake/ETLPlatform.cmake	(revision 22532641a4b39de35870e1ab2a1569dd5fc9057a)
@@ -36,6 +36,10 @@
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wdeclaration-after-statement -Wunused-but-set-variable")
 endif()
 
+if("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -funsigned-char -Werror=tautological-constant-out-of-range-compare")
+endif()
+
 # Color diagnostics for build systems other than make
 if(UNIX)
 	if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
```