### PR TITLE
Allow vsay_team for spectators

### DIFF
--- a/src/cgame/cg_consolecmds.c
+++ b/src/cgame/cg_consolecmds.c
@@ -632,17 +632,6 @@ static void CG_TeamVoiceChat_f(void)
 		return;
 	}
 
-	// don't let spectators voice chat
-	// NOTE - This cg.snap will be the person you are following, but its just for intermission test
-	if (cg.snap && (cg.snap->ps.pm_type != PM_INTERMISSION))
-	{
-		if (cgs.clientinfo[cg.clientNum].team == TEAM_SPECTATOR || cgs.clientinfo[cg.clientNum].team == TEAM_FREE)
-		{
-			CG_Printf("%s", CG_TranslateString("Can't team voice chat as a spectator.\n")); // FIXME? find a way to print this on screen
-			return;
-		}
-	}
-
 	trap_Argv(1, chatCmd, 64);
 
 	trap_SendConsoleCommand(va("cmd vsay_team %s\n", chatCmd));

--- a/src/game/g_cmds_ext.c
+++ b/src/game/g_cmds_ext.c
@@ -890,12 +890,6 @@ void G_vsay_cmd(gentity_t *ent, unsigned int dwCommand, int value)
  */
 void G_vsay_team_cmd(gentity_t *ent, unsigned int dwCommand, int value)
 {
-	if (ent->client->sess.sessionTeam == TEAM_SPECTATOR || ent->client->sess.sessionTeam == TEAM_FREE)
-	{
-		trap_SendServerCommand(ent - g_entities, "print \"Can't team chat as spectator\n\"");
-		return;
-	}
-
 	G_Voice_f(ent, SAY_TEAM, qfalse, qfalse);
 }
 


### PR DESCRIPTION
In ETPro you could vsay as spectator, don't know why this isn't enabled in legacy. Addresses: https://github.com/etlegacy/etlegacy/issues/2434