### PR TITLE
qcommon: enclose DEFAULT_SV_FRAMETIME macro in brackets

### DIFF
--- a/src/qcommon/q_shared.h
+++ b/src/qcommon/q_shared.h
@@ -504,7 +504,7 @@ typedef float net_float;
 #define DEFAULT_SV_FPS     20
 #define DEFAULT_SV_FPS_STR "20"
 // default server frametime at sv_fps 20, for framerate independent timings
-#define DEFAULT_SV_FRAMETIME 1000 / DEFAULT_SV_FPS
+#define DEFAULT_SV_FRAMETIME (1000 / DEFAULT_SV_FPS)
 
 extern char *GlobalGameTitle;
 


### PR DESCRIPTION
This not being in brackets broke flamechunk growth calculations, and could potentially break other expressions where it's used.

refs #3096