### PR TITLE
game: Use incoming damage direction for gibs

### DIFF
--- a/src/cgame/cg_effects.c
+++ b/src/cgame/cg_effects.c
@@ -576,11 +576,12 @@ int CG_GetOriginForTag(centity_t *cent, refEntity_t *parent, const char *tagName
  * @param[in] playerOrigin
  * @param[in] gdir
  */
-void CG_GibPlayer(centity_t *cent, vec3_t playerOrigin, vec3_t gdir, int damage)
+void CG_GibPlayer(centity_t *cent, vec3_t playerOrigin, vec3_t gdir, int damage, qboolean heavyDirectGib)
 {
 	if (cg_blood.integer && cg_bloodTime.integer)
 	{
 		vec3_t         origin;
+		vec3_t         launchDir;
 		trace_t        trace;
 		clientInfo_t   *ci;
 		bg_character_t *character;
@@ -593,6 +594,9 @@ void CG_GibPlayer(centity_t *cent, vec3_t playerOrigin, vec3_t gdir, int damage)
 		// vec4_t      color;
 		vec3_t      velocity, dir, angles;
 		refEntity_t *re = &cent->pe.bodyRefEnt;
+		float       directHeavyScale;
+		float       topDownLift;
+		qboolean    hasLaunchDir;
 		int         i, j, count = 0;
 		int         tagIndex, gibIndex, junction;
 		int         clientNum = cent->currentState.clientNum;
@@ -653,6 +657,18 @@ void CG_GibPlayer(centity_t *cent, vec3_t playerOrigin, vec3_t gdir, int damage)
 
 		ci        = &cgs.clientinfo[clientNum];
 		character = CG_CharacterForClientinfo(ci, cent);
+		// Direct heavy-projectile hits should throw gibs much harder.
+		directHeavyScale = heavyDirectGib ? 1.75f : 1.0f;
+		hasLaunchDir     = (VectorNormalize2(gdir, launchDir) > 0.f);
+		topDownLift      = 0.f;
+
+		if (hasLaunchDir && launchDir[2] < -0.45f)
+		{
+			// EV_GIB_PLAYER does not carry blast distance, so only steep
+			// downward impulses get a small lift to keep close overhead hits
+			// from driving every gib straight into the floor.
+			topDownLift = Com_Clamp(0.f, 1.f, (-launchDir[2] - 0.45f) / 0.55f) * GIB_VELOCITY * 0.75f;
+		}
 
 		// fetch the various positions of the tag_gib*'s
 		// and spawn the gibs from the correct places (especially the head)
@@ -668,12 +684,24 @@ void CG_GibPlayer(centity_t *cent, vec3_t playerOrigin, vec3_t gdir, int damage)
 				VectorSubtract(origin, re->origin, dir);
 				VectorNormalize(dir);
 
-				// spawn a gib
-				velocity[0] = dir[0] * (0.5f + random()) * GIB_VELOCITY * 0.3f;
-				velocity[1] = dir[1] * (0.5f + random()) * GIB_VELOCITY * 0.3f;
-				velocity[2] = GIB_JUMP + dir[2] * (0.5f + random()) * GIB_VELOCITY * 0.5f;
+				if (hasLaunchDir)
+				{
+					// Keep the transmitted damage direction as the dominant launch
+					// vector and only use tag offsets as a small cone spread.
+					// Direct heavy-projectile hits get a much stronger shove.
+					VectorScale(launchDir, directHeavyScale * (GIB_JUMP + (0.5f + random()) * GIB_VELOCITY), velocity);
+					VectorMA(velocity, (0.15f + 0.15f * random()) * GIB_VELOCITY, dir, velocity);
+					velocity[2] += topDownLift;
+				}
+				else
+				{
+					// Fall back to the legacy outward/upward spray when the event
+					// did not carry a usable damage direction.
+					velocity[0] = dir[0] * (0.5f + random()) * GIB_VELOCITY * 0.3f;
+					velocity[1] = dir[1] * (0.5f + random()) * GIB_VELOCITY * 0.3f;
+					velocity[2] = GIB_JUMP + dir[2] * (0.5f + random()) * GIB_VELOCITY * 0.5f;
+				}
 
-				VectorMA(velocity, GIB_VELOCITY, gdir, velocity);
 				AxisToAngles(axis, angles);
 
 				CG_LaunchGib(cent, origin, angles, velocity, character->gibModels[gibIndex], 1.0, 0);

--- a/src/cgame/cg_event.c
+++ b/src/cgame/cg_event.c
@@ -2608,7 +2608,8 @@ void CG_EntityEvent(centity_t *cent, vec3_t position)
 
 		trap_S_StartSound(es->pos.trBase, -1, CHAN_AUTO, cgs.media.gibSound);
 		ByteToDir(es->eventParm, dir);
-		CG_GibPlayer(bodyCent, bodyCent->lerpOrigin, dir, es->effect3Time);
+		// EV_GIB_PLAYER reuses the weapon byte as a 0/1 heavy-direct gib flag.
+		CG_GibPlayer(bodyCent, bodyCent->lerpOrigin, dir, es->effect3Time, (qboolean)es->weapon);
 	}
 	break;
 	// particles

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -3305,7 +3305,7 @@ localEntity_t *CG_SmokePuff(const vec3_t p,
 
 void CG_BubbleTrail(vec3_t start, vec3_t end, float size, float spacing);
 
-void CG_GibPlayer(centity_t *cent, vec3_t playerOrigin, vec3_t gdir, int damage);
+void CG_GibPlayer(centity_t *cent, vec3_t playerOrigin, vec3_t gdir, int damage, qboolean heavyDirectGib);
 void CG_LoseHat(centity_t *cent, vec3_t dir);
 
 void CG_Bleed(vec3_t origin, int entityNum);

--- a/src/game/g_combat.c
+++ b/src/game/g_combat.c
@@ -223,34 +223,98 @@ void LookAtKiller(gentity_t *self, gentity_t *inflictor, gentity_t *attacker)
 }
 
 /**
- * @brief GibEntity
- * @param[in,out] self
- * @param[in] killer
+ * @brief Resolve the gib push from the latest damage impulse whenever possible.
+ * @param[in] self
+ * @param[in] inflictor
+ * @param[in] attacker
+ * @param[out] dir
  */
-void GibEntity(gentity_t *self, int killer, int damage)
+static void G_GetGibDirection(gentity_t *self, gentity_t *inflictor, gentity_t *attacker, vec3_t dir)
 {
-	gentity_t *te;
-	gentity_t *other = &g_entities[killer];
-	vec3_t    dir;
+	gentity_t *source = NULL;
 
 	VectorClear(dir);
-	if (other->inuse)
+
+	// Reuse the exact damage direction captured by G_Damage so explosive gibs
+	// keep travelling with the incoming blast instead of guessing from positions.
+	if (self->client &&
+	    self->client->lasthurt_time == level.time &&
+	    !self->client->damage_fromWorld &&
+	    !VectorCompare(self->client->damage_from, vec3_origin))
 	{
-		if (other->client)
-		{
-			VectorSubtract(self->r.currentOrigin, other->r.currentOrigin, dir);
-			VectorNormalize(dir);
-		}
-		else if (!VectorCompare(other->s.pos.trDelta, vec3_origin))
-		{
-			VectorNormalize2(other->s.pos.trDelta, dir);
-		}
+		VectorNormalize2(self->client->damage_from, dir);
+		return;
 	}
+
+	if (inflictor && inflictor->inuse && inflictor->s.number != ENTITYNUM_WORLD)
+	{
+		source = inflictor;
+	}
+	else if (attacker && attacker->inuse && attacker->s.number != ENTITYNUM_WORLD)
+	{
+		source = attacker;
+	}
+
+	if (!source)
+	{
+		return;
+	}
+
+	if (source->client)
+	{
+		VectorSubtract(self->r.currentOrigin, source->r.currentOrigin, dir);
+		VectorNormalize(dir);
+	}
+	else if (!VectorCompare(source->s.pos.trDelta, vec3_origin))
+	{
+		VectorNormalize2(source->s.pos.trDelta, dir);
+	}
+}
+
+/**
+ * @brief Check whether this gib should use the heavy direct-hit launch boost.
+ * @param[in] meansOfDeath
+ * @param[in] radiusDamage
+ * @return qtrue for direct panzer, bazooka, or mortar gib hits.
+ */
+static qboolean G_IsHeavyDirectGib(meansOfDeath_t meansOfDeath, qboolean radiusDamage)
+{
+	if (radiusDamage)
+	{
+		return qfalse;
+	}
+
+	switch (meansOfDeath)
+	{
+	case MOD_PANZERFAUST:
+	case MOD_BAZOOKA:
+	case MOD_MORTAR:
+	case MOD_MORTAR2:
+		return qtrue;
+	default:
+		return qfalse;
+	}
+}
+
+/**
+ * @brief GibEntity
+ * @param[in,out] self
+ * @param[in] inflictor
+ * @param[in] attacker
+ */
+void GibEntity(gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int damage, qboolean heavyDirectGib)
+{
+	gentity_t *te;
+	vec3_t    dir;
+
+	G_GetGibDirection(self, inflictor, attacker, dir);
 
 	te                   = G_TempEntity(self->r.currentOrigin, EV_GIB_PLAYER);
 	te->s.otherEntityNum = self->s.number;
 	te->s.eventParm      = DirToByte(dir);
 	te->s.effect3Time    = damage;
+	// Reuse the temp entity weapon byte as a compact heavy-direct gib flag.
+	te->s.weapon = heavyDirectGib;
 
 	self->takedamage = qfalse;
 	self->s.eType    = ET_INVISIBLE;
@@ -260,16 +324,16 @@ void GibEntity(gentity_t *self, int killer, int damage)
 /**
  * @brief body_die
  * @param[in,out] self
- * @param inflictor - unused
- * @param attacker - unused
- * @param damage - unused
- * @param meansOfDeath - unused
+ * @param[in] inflictor
+ * @param[in] attacker
+ * @param[in] damage
+ * @param[in] meansOfDeath - unused
  */
 void body_die(gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int damage, meansOfDeath_t meansOfDeath)
 {
 	if (self->health <= GIB_HEALTH)
 	{
-		GibEntity(self, ENTITYNUM_WORLD, damage);
+		GibEntity(self, inflictor, attacker, damage, G_IsHeavyDirectGib(meansOfDeath, self->sound2to3 != 0));
 	}
 }
 
@@ -746,7 +810,7 @@ void player_die(gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int 
 	// FIXME: contents is always 0 here
 	if (self->health <= GIB_HEALTH && !(contents & CONTENTS_NODROP))
 	{
-		GibEntity(self, killer, damage);
+		GibEntity(self, inflictor, attacker, damage, G_IsHeavyDirectGib(meansOfDeath, self->sound2to3 != 0));
 	}
 	else if (meansOfDeath != MOD_SWAP_PLACES)
 	{
@@ -1846,7 +1910,7 @@ void G_DamageExt(gentity_t *targ, gentity_t *inflictor, gentity_t *attacker, vec
 				}
 				if (targ->health <= GIB_HEALTH)
 				{
-					GibEntity(targ, 0, damage);
+					GibEntity(targ, inflictor, attacker, damage, G_IsHeavyDirectGib(mod, (dflags & DAMAGE_RADIUS) != 0));
 				}
 			}
 			else

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1655,6 +1655,7 @@ void G_Damage(gentity_t *targ, gentity_t *inflictor, gentity_t *attacker, vec3_t
 void G_DamageExt(gentity_t *targ, gentity_t *inflictor, gentity_t *attacker, vec3_t dir, vec3_t point, int damage, int dflags, meansOfDeath_t mod, int *hitEventType);
 qboolean G_RadiusDamage(vec3_t origin, gentity_t *inflictor, gentity_t *attacker, float damage, float radius, gentity_t *ignore, meansOfDeath_t mod);
 qboolean etpro_RadiusDamage(vec3_t origin, gentity_t *inflictor, gentity_t *attacker, float damage, float radius, gentity_t *ignore, meansOfDeath_t mod, qboolean clientsonly);
+void GibEntity(gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int damage, qboolean heavyDirectGib);
 void body_die(gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int damage, meansOfDeath_t meansOfDeath);
 void TossWeapons(gentity_t *self);
 gentity_t *G_BuildHead(gentity_t *ent, grefEntity_t *refent, qboolean newRefent);

--- a/src/game/g_mover.c
+++ b/src/game/g_mover.c
@@ -485,7 +485,6 @@ qboolean G_TryPushingEntity(gentity_t *check, gentity_t *pusher, vec3_t move, ve
 
 // referenced in G_MoverPush()
 extern void LandMineTrigger(gentity_t *self);
-extern void GibEntity(gentity_t *self, int killer, int damage);
 
 /**
  * @brief Objects need to be moved back on a failed push,
@@ -645,7 +644,7 @@ qboolean G_MoverPush(gentity_t *pusher, vec3_t move, vec3_t amove, gentity_t **o
 		{
 		case ET_CORPSE: // always gib corpses ...
 			trap_LinkEntity(check);
-			GibEntity(check, ENTITYNUM_WORLD, 0);
+			GibEntity(check, &g_entities[ENTITYNUM_WORLD], &g_entities[ENTITYNUM_WORLD], 0, qfalse);
 			moveList[e] = ENTITYNUM_NONE; // prevent re-linking later on
 			continue;
 		default:


### PR DESCRIPTION
Prefer the exact damage vector captured during G_Damage when emitting EV_GIB_PLAYER so explosive gibs keep travelling with the incoming blast direction.

Make CG_GibPlayer treat the transmitted gib direction as the primary launch vector instead of layering it on top of a fixed upward kick.

Also add a small upward correction for steep downward gib directions so close overhead explosions do not drive every gib straight into the floor.

Also tag EV_GIB_PLAYER with a heavy-projectile weapon only for direct (non-radius) panzer, bazooka, and mortar gib kills, then use that tag client-side to scale the launch speed up significantly.