### PR TITLE
sys: add desktop crash stack traces

### DIFF
--- a/cmake/ETLPlatform.cmake
+++ b/cmake/ETLPlatform.cmake
@@ -201,7 +201,7 @@ elseif(WIN32)
 		target_compile_definitions(shared_libraries INTERFACE C_ONLY)
 	endif()
 
-	target_link_libraries(os_libraries INTERFACE wsock32 ws2_32 psapi winmm)
+	target_link_libraries(os_libraries INTERFACE wsock32 ws2_32 psapi winmm dbghelp)
 
 	if(FEATURE_SSL)
 		target_link_libraries(os_libraries INTERFACE Crypt32)

--- a/src/qcommon/qcommon.h
+++ b/src/qcommon/qcommon.h
@@ -1400,7 +1400,7 @@ qboolean IN_IsNumLockDown(void);
 #endif
 
 qboolean Sys_DllExtension(const char *name);
-void Sys_Backtrace(int sig);
+void Sys_Backtrace(int sig, void *context);
 
 char *Sys_GetCurrentUser(void);
 

--- a/src/sys/sys_local.h
+++ b/src/sys/sys_local.h
@@ -77,6 +77,8 @@ NORETURN_MSVC void Sys_PlatformExit(int code) _attribute((noreturn));
 #endif
 
 void Sys_SigHandler(int signal);
+void Sys_HandleCrash(int signal, void *context);
+void Sys_InstallCrashHandler(void);
 void Sys_ErrorDialog(const char *error);
 void Sys_AnsiColorPrint(const char *msg);
 

--- a/src/sys/sys_main.c
+++ b/src/sys/sys_main.c
@@ -49,6 +49,9 @@
 #include <string.h>
 #include <ctype.h>
 #include <errno.h>
+#ifndef _WIN32
+#include <unistd.h>
+#endif
 
 #include "sys_local.h"
 #include "sys_loadlib.h"
@@ -1216,22 +1219,52 @@ void Sys_BuildCommandLine(int argc, char **argv, char *buffer, size_t bufferSize
 #       define DEFAULT_BASEDIR Sys_BinaryPath()
 #endif
 
+static volatile sig_atomic_t sys_crashSignalCaught;
+static volatile sig_atomic_t sys_signalCaught;
+
+/**
+ * @brief Common crash dispatch shared by the platform-specific handlers.
+ * @param[in] signal Signal number or platform exception code.
+ * @param[in] context Platform-specific crash context.
+ */
+void Sys_HandleCrash(int signal, void *context)
+{
+	if (sys_crashSignalCaught)
+	{
+		fprintf(stderr, "DOUBLE CRASH FAULT: Received signal %d, exiting immediately...\n",
+		        signal);
+#ifdef _WIN32
+		TerminateProcess(GetCurrentProcess(), 3);
+#else
+		_exit(128 + signal);
+#endif
+	}
+
+	sys_crashSignalCaught = 1;
+	Sys_Backtrace(signal, context);
+
+#ifdef _WIN32
+	TerminateProcess(GetCurrentProcess(), 3);
+#else
+	_exit(128 + signal);
+#endif
+}
+
 /**
  * @brief Sys_SigHandler
  * @param[in] signal
  */
 void Sys_SigHandler(int signal)
 {
-	static qboolean signalcaught = qfalse;
-
-	if (signalcaught)
+	if (sys_signalCaught)
 	{
 		fprintf(stderr, "DOUBLE SIGNAL FAULT: Received signal %d, exiting...\n",
 		        signal);
+		Sys_PlatformExit(2);
 	}
 	else
 	{
-		signalcaught = qtrue;
+		sys_signalCaught = 1;
 #ifndef DEDICATED
 		CL_Shutdown();
 #endif
@@ -1241,15 +1274,6 @@ void Sys_SigHandler(int signal)
 	if (signal == SIGTERM || signal == SIGINT)
 	{
 		Sys_Exit(1);
-	}
-	else if (signal == SIGSEGV)
-	{
-#if defined(__linux__) && !defined(__ANDROID__)
-		Sys_Backtrace(signal);
-		// NOTE : must not exit here, otherwise OS might not create coredumps
-#else
-		Sys_Exit(signal);
-#endif
 	}
 	else
 	{
@@ -1262,18 +1286,27 @@ void Sys_SigHandler(int signal)
  */
 void Sys_SetUpConsoleAndSignals(void)
 {
+	static qboolean initialized = qfalse;
+
+	if (initialized)
+	{
+		return;
+	}
+
+	initialized = qtrue;
+
 #ifndef USE_WINDOWS_CONSOLE
 	CON_Init();
 #endif
 
-// don't set signal handlers for anything that will generate coredump (in DEBUG builds)
-#if !defined(ETLEGACY_DEBUG)
-	signal(SIGILL, Sys_SigHandler);
-	signal(SIGFPE, Sys_SigHandler);
-	signal(SIGSEGV, Sys_SigHandler);
-#endif
 	signal(SIGINT, Sys_SigHandler);
 	signal(SIGTERM, Sys_SigHandler);
+#ifdef SIGHUP
+	signal(SIGHUP, Sys_SigHandler);
+#endif
+#ifdef SIGQUIT
+	signal(SIGQUIT, Sys_SigHandler);
+#endif
 }
 
 /**

--- a/src/sys/sys_unix.c
+++ b/src/sys/sys_unix.c
@@ -64,6 +64,73 @@ qboolean stdinIsATTY;
 // Used to determine where to store user-specific files
 static char homePath[MAX_OSPATH] = { 0 };
 
+/**
+ * @brief Convert a fatal Unix signal into a readable name for crash reports.
+ * @param[in] signal Signal number.
+ * @return Static signal name string.
+ */
+static const char *Sys_UnixSignalName(int signal)
+{
+	switch (signal)
+	{
+	case SIGABRT: return "SIGABRT";
+	case SIGFPE:  return "SIGFPE";
+	case SIGILL:  return "SIGILL";
+	case SIGINT:  return "SIGINT";
+	case SIGSEGV: return "SIGSEGV";
+	case SIGTERM: return "SIGTERM";
+#ifdef SIGBUS
+	case SIGBUS:  return "SIGBUS";
+#endif
+#ifdef SIGHUP
+	case SIGHUP:  return "SIGHUP";
+#endif
+#ifdef SIGQUIT
+	case SIGQUIT: return "SIGQUIT";
+#endif
+#ifdef SIGTRAP
+	case SIGTRAP: return "SIGTRAP";
+#endif
+	default:      return "UNKNOWN";
+	}
+}
+
+/**
+ * @brief Unix fatal signal trampoline used to preserve kernel signal data.
+ * @param[in] signal Signal number.
+ * @param[in] info Signal information provided by the kernel.
+ * @param[in] context Platform context pointer.
+ */
+static void Sys_UnixCrashHandler(int signal, siginfo_t *info, void *context)
+{
+	(void)context;
+	Sys_HandleCrash(signal, info);
+}
+
+/**
+ * @brief Install the fatal Unix signal handlers used for crash reporting.
+ */
+void Sys_InstallCrashHandler(void)
+{
+	struct sigaction action;
+
+	memset(&action, 0, sizeof(action));
+	sigemptyset(&action.sa_mask);
+	action.sa_sigaction = Sys_UnixCrashHandler;
+	action.sa_flags     = SA_SIGINFO | SA_RESETHAND;
+
+	sigaction(SIGABRT, &action, NULL);
+	sigaction(SIGFPE, &action, NULL);
+	sigaction(SIGILL, &action, NULL);
+	sigaction(SIGSEGV, &action, NULL);
+#ifdef SIGBUS
+	sigaction(SIGBUS, &action, NULL);
+#endif
+#if defined(SIGTRAP) && !defined(ETLEGACY_DEBUG)
+	sigaction(SIGTRAP, &action, NULL);
+#endif
+}
+
 #ifdef  __ANDROID__
 char *Sys_CdToExtStorage(void)
 {
@@ -1179,14 +1246,7 @@ void Sys_PlatformInit(void)
 {
 	const char *term = getenv("TERM");
 
-// don't set signal handlers for anything that will generate coredump (in DEBUG builds)
-#if !defined(ETLEGACY_DEBUG)
-	signal(SIGTRAP, Sys_SigHandler);
-	signal(SIGBUS, Sys_SigHandler);
-#endif
-	signal(SIGHUP, Sys_SigHandler);
-	signal(SIGABRT, Sys_SigHandler);
-	signal(SIGQUIT, Sys_SigHandler);
+	Sys_InstallCrashHandler();
 
 	stdinIsATTY = isatty(STDIN_FILENO) &&
 	              !(term && (!strcmp(term, "raw") || !strcmp(term, "dumb")));
@@ -1273,25 +1333,35 @@ qboolean Sys_DllExtension(const char *name)
 	return qfalse;
 }
 
-void Sys_Backtrace(int sig)
+void Sys_Backtrace(int sig, void *context)
 {
-	void   *syms[32];
-	size_t size;
+	const char      *signalName = Sys_UnixSignalName(sig);
+	const siginfo_t *info       = (const siginfo_t *)context;
+	void            *syms[32];
+	int             size = 0;
 
 	// Get the backtrace and write it to stderr
 #ifndef __ANDROID__
-	size = backtrace(syms, 32);
+	size = backtrace(syms, ARRAY_LEN(syms));
 #endif
 	fprintf(stderr, "--- Report this to the project - START ---\n");
-	fprintf(stderr, "ERROR: Caught SIGSEGV(%d)\n", sig);
+	fprintf(stderr, "ERROR: Caught %s (%d)\n", signalName, sig);
+	if (info != NULL)
+	{
+		fprintf(stderr, "FAULT ADDRESS: %p\n", info->si_addr);
+	}
 	fprintf(stderr, "VERSION: %s (%s)\n", ETLEGACY_VERSION, ETLEGACY_VERSION_SHORT);
 	fprintf(stderr, "BTIME: %s\n", PRODUCT_BUILD_TIME);
 	fprintf(stderr, "BACKTRACE:\n");
 #ifndef __ANDROID__
 	backtrace_symbols_fd(syms, size, STDERR_FILENO);
+#else
+	fprintf(stderr, "backtrace unavailable on this build\n");
 #endif
 	fprintf(stderr, "--- Report this to the project -  END  ---\n");
+	fflush(stderr);
 
 	signal(sig, SIG_DFL);
 	kill(getpid(), sig);
+	_exit(128 + sig);
 }

--- a/src/sys/sys_win32.c
+++ b/src/sys/sys_win32.c
@@ -44,11 +44,13 @@
 #include "sys_win32.h"
 
 #include <windows.h>
+#include <dbghelp.h>
 #include <lmerr.h>
 #include <lmcons.h>
 #include <lmwksta.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <signal.h>
 #include <stdio.h>
 #include <direct.h>
 #include <io.h>
@@ -67,6 +69,136 @@ static char homePath[MAX_OSPATH] = { 0 };
 //static jmp_buf sys_exitframe;
 //static int     sys_retcode;
 //static char    sys_exitstr[MAX_STRING_CHARS];
+
+/**
+ * @brief Convert a Win32 exception code into a readable name.
+ * @param[in] exceptionCode Structured exception code.
+ * @return Static exception name string.
+ */
+static const char *Sys_WinExceptionName(DWORD exceptionCode)
+{
+	switch (exceptionCode)
+	{
+	case EXCEPTION_ACCESS_VIOLATION:          return "EXCEPTION_ACCESS_VIOLATION";
+	case EXCEPTION_ARRAY_BOUNDS_EXCEEDED:    return "EXCEPTION_ARRAY_BOUNDS_EXCEEDED";
+	case EXCEPTION_BREAKPOINT:               return "EXCEPTION_BREAKPOINT";
+	case EXCEPTION_DATATYPE_MISALIGNMENT:    return "EXCEPTION_DATATYPE_MISALIGNMENT";
+	case EXCEPTION_FLT_DENORMAL_OPERAND:     return "EXCEPTION_FLT_DENORMAL_OPERAND";
+	case EXCEPTION_FLT_DIVIDE_BY_ZERO:       return "EXCEPTION_FLT_DIVIDE_BY_ZERO";
+	case EXCEPTION_FLT_INVALID_OPERATION:    return "EXCEPTION_FLT_INVALID_OPERATION";
+	case EXCEPTION_FLT_OVERFLOW:             return "EXCEPTION_FLT_OVERFLOW";
+	case EXCEPTION_FLT_STACK_CHECK:          return "EXCEPTION_FLT_STACK_CHECK";
+	case EXCEPTION_FLT_UNDERFLOW:            return "EXCEPTION_FLT_UNDERFLOW";
+	case EXCEPTION_ILLEGAL_INSTRUCTION:      return "EXCEPTION_ILLEGAL_INSTRUCTION";
+	case EXCEPTION_IN_PAGE_ERROR:            return "EXCEPTION_IN_PAGE_ERROR";
+	case EXCEPTION_INT_DIVIDE_BY_ZERO:       return "EXCEPTION_INT_DIVIDE_BY_ZERO";
+	case EXCEPTION_INT_OVERFLOW:             return "EXCEPTION_INT_OVERFLOW";
+	case EXCEPTION_INVALID_DISPOSITION:      return "EXCEPTION_INVALID_DISPOSITION";
+	case EXCEPTION_NONCONTINUABLE_EXCEPTION: return "EXCEPTION_NONCONTINUABLE_EXCEPTION";
+	case EXCEPTION_PRIV_INSTRUCTION:         return "EXCEPTION_PRIV_INSTRUCTION";
+	case EXCEPTION_SINGLE_STEP:              return "EXCEPTION_SINGLE_STEP";
+	case EXCEPTION_STACK_OVERFLOW:           return "EXCEPTION_STACK_OVERFLOW";
+	default:                                 return "UNKNOWN_EXCEPTION";
+	}
+}
+
+/**
+ * @brief Convert a CRT signal into a readable name.
+ * @param[in] signal Signal number.
+ * @return Static signal name string.
+ */
+static const char *Sys_WinSignalName(int signal)
+{
+	switch (signal)
+	{
+	case SIGABRT: return "SIGABRT";
+	case SIGFPE:  return "SIGFPE";
+	case SIGILL:  return "SIGILL";
+	case SIGINT:  return "SIGINT";
+	case SIGSEGV: return "SIGSEGV";
+	case SIGTERM: return "SIGTERM";
+	default:      return "UNKNOWN_SIGNAL";
+	}
+}
+
+/**
+ * @brief Redirect the standard streams to the active Windows console.
+ */
+static void Sys_WinBindConsoleStreams(void)
+{
+	int                        hConHandle;
+	intptr_t                   stdHandleValue;
+	CONSOLE_SCREEN_BUFFER_INFO coninfo;
+	FILE                       *fp;
+	HANDLE                     stdHandle;
+
+	stdHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+	if (stdHandle != INVALID_HANDLE_VALUE && GetConsoleScreenBufferInfo(stdHandle, &coninfo))
+	{
+		coninfo.dwSize.Y = 9999;
+		SetConsoleScreenBufferSize(stdHandle, coninfo.dwSize);
+	}
+
+	stdHandleValue = (intptr_t)GetStdHandle(STD_OUTPUT_HANDLE);
+	hConHandle     = _open_osfhandle(stdHandleValue, _O_TEXT);
+	fp             = _fdopen(hConHandle, "w");
+	if (fp != NULL)
+	{
+		*stdout = *fp;
+		setvbuf(stdout, NULL, _IONBF, 0);
+	}
+
+	stdHandleValue = (intptr_t)GetStdHandle(STD_INPUT_HANDLE);
+	hConHandle     = _open_osfhandle(stdHandleValue, _O_TEXT);
+	fp             = _fdopen(hConHandle, "r");
+	if (fp != NULL)
+	{
+		*stdin = *fp;
+		setvbuf(stdin, NULL, _IONBF, 0);
+	}
+
+	stdHandleValue = (intptr_t)GetStdHandle(STD_ERROR_HANDLE);
+	hConHandle     = _open_osfhandle(stdHandleValue, _O_TEXT);
+	fp             = _fdopen(hConHandle, "w");
+	if (fp != NULL)
+	{
+		*stderr = *fp;
+		setvbuf(stderr, NULL, _IONBF, 0);
+	}
+}
+
+/**
+ * @brief CRT signal adapter for the shared crash handler.
+ * @param[in] signal Signal number.
+ */
+static void Sys_WinSignalHandler(int signal)
+{
+	Sys_HandleCrash(signal, NULL);
+}
+
+/**
+ * @brief Top-level Win32 exception filter used for crash reporting.
+ * @param[in] exceptionInfo Structured exception information.
+ * @return Win32 exception handling result.
+ */
+static LONG WINAPI Sys_WinExceptionHandler(EXCEPTION_POINTERS *exceptionInfo)
+{
+	Sys_HandleCrash((int)exceptionInfo->ExceptionRecord->ExceptionCode, exceptionInfo);
+	return EXCEPTION_EXECUTE_HANDLER;
+}
+
+/**
+ * @brief Install the Windows crash handlers for structured exceptions and CRT signals.
+ */
+void Sys_InstallCrashHandler(void)
+{
+	SetUnhandledExceptionFilter(Sys_WinExceptionHandler);
+
+	signal(SIGABRT, Sys_WinSignalHandler);
+	signal(SIGFPE, Sys_WinSignalHandler);
+	signal(SIGILL, Sys_WinSignalHandler);
+	signal(SIGSEGV, Sys_WinSignalHandler);
+}
 
 size_t Sys_WideCharArrayToString(wchar_t *array, char *buffer, size_t len)
 {
@@ -1011,62 +1143,27 @@ void Sys_OpenURL(const char *url, qboolean doexit)
  */
 void Sys_CreateConsoleWindow(void)
 {
-#ifndef DEDICATED
-	int                        hConHandle;
-	long                       lStdHandle;
-	CONSOLE_SCREEN_BUFFER_INFO coninfo;
-	FILE                       *fp;
+	HWND consoleWindow;
 
-	static qboolean consoleIsOpen = qfalse;
+	consoleWindow = GetConsoleWindow();
 
-	if (consoleIsOpen)
+	if (!consoleWindow)
 	{
-		FreeConsole();
-		consoleIsOpen = qtrue;
-		return;
-	}
-	else
-	{
-		consoleIsOpen = qtrue;
+		if (!AttachConsole(ATTACH_PARENT_PROCESS) && !AllocConsole())
+		{
+			return;
+		}
+
+		Sys_WinBindConsoleStreams();
+		Sys_SetUpConsoleAndSignals();
+		consoleWindow = GetConsoleWindow();
 	}
 
-	// allocate a console for this app
-	AllocConsole();
-
-	// set the screen buffer to be big enough to let us scroll text
-	if (GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &coninfo))
+	if (consoleWindow)
 	{
-		coninfo.dwSize.Y = 9999;
-		SetConsoleScreenBufferSize(GetStdHandle(STD_OUTPUT_HANDLE), coninfo.dwSize);
+		ShowWindow(consoleWindow, SW_SHOWNORMAL);
+		SetForegroundWindow(consoleWindow);
 	}
-
-	// redirect unbuffered STDOUT to the console
-	lStdHandle = (long)(GetStdHandle(STD_OUTPUT_HANDLE));
-	hConHandle = _open_osfhandle(lStdHandle, _O_TEXT);
-	fp         = _fdopen(hConHandle, "w");
-	*stdout    = *fp;
-	setvbuf(stdout, NULL, _IONBF, 0);
-
-	// redirect unbuffered STDIN to the console
-	lStdHandle = (long)(GetStdHandle(STD_INPUT_HANDLE));
-	hConHandle = _open_osfhandle(lStdHandle, _O_TEXT);
-	fp         = _fdopen(hConHandle, "r");
-	*stdin     = *fp;
-
-	setvbuf(stdin, NULL, _IONBF, 0);
-
-	// redirect unbuffered STDERR to the console
-	lStdHandle = (long)(GetStdHandle(STD_ERROR_HANDLE));
-	hConHandle = _open_osfhandle(lStdHandle, _O_TEXT);
-	fp         = _fdopen(hConHandle, "w");
-	*stderr    = *fp;
-
-	setvbuf(stderr, NULL, _IONBF, 0);
-
-	//SetConsoleTitle(WINDOWNAME);
-
-	Sys_SetUpConsoleAndSignals();
-#endif
 }
 
 // TODO: This could be enabled in the future
@@ -1132,6 +1229,7 @@ WinVars_t g_wv;
 void Sys_PlatformInit(void)
 {
 	g_wv.hInstance = GetModuleHandle(NULL);
+	Sys_InstallCrashHandler();
 
 #ifdef EXCEPTION_HANDLER
 	WinSetExceptionVersion(Q3_VERSION);
@@ -1163,7 +1261,7 @@ void Sys_PlatformInit(void)
 #endif
 
 	// no abort/retry/fail errors
-	SetErrorMode(SEM_FAILCRITICALERRORS);
+	SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
 }
 
 NORETURN_MSVC void _attribute((noreturn)) Sys_PlatformExit(int code)
@@ -1181,4 +1279,161 @@ NORETURN_MSVC void _attribute((noreturn)) Sys_PlatformExit(int code)
 qboolean Sys_DllExtension(const char *name)
 {
 	return COM_CompareExtension(name, DLL_EXT);
+}
+
+/**
+ * @brief Write a stack trace for the current Win32 crash context.
+ * @param[in] sig CRT signal number or exception code.
+ * @param[in] context Structured exception information when available.
+ */
+void Sys_Backtrace(int sig, void *context)
+{
+	DWORD              exceptionCode;
+	DWORD              imageType;
+	DWORD              lineDisplacement;
+	DWORD64            address;
+	DWORD64            displacement64;
+	DWORD64            moduleBase;
+	HANDLE             process;
+	HANDLE             thread;
+	STACKFRAME64       stackFrame;
+	CONTEXT            localContext;
+	CONTEXT            *stackContext;
+	EXCEPTION_POINTERS *exceptionInfo;
+	IMAGEHLP_LINE64    lineInfo;
+	PSYMBOL_INFO       symbolInfo;
+	unsigned int       frameIndex;
+	char               modulePath[MAX_OSPATH];
+	char               symbolBuffer[sizeof(SYMBOL_INFO) + MAX_SYM_NAME * sizeof(TCHAR)];
+	const char         *exceptionName;
+	const char         *moduleName;
+	char               *separator;
+
+	exceptionInfo = (EXCEPTION_POINTERS *)context;
+	process       = GetCurrentProcess();
+	thread        = GetCurrentThread();
+	imageType     = 0;
+	exceptionCode = (DWORD)sig;
+	address       = 0;
+	moduleName    = "<unknown>";
+
+	Sys_CreateConsoleWindow();
+
+	if (exceptionInfo != NULL && exceptionInfo->ContextRecord != NULL)
+	{
+		localContext  = *exceptionInfo->ContextRecord;
+		stackContext  = &localContext;
+		exceptionCode = exceptionInfo->ExceptionRecord->ExceptionCode;
+		address       = (DWORD64)(ULONG_PTR)exceptionInfo->ExceptionRecord->ExceptionAddress;
+		exceptionName = Sys_WinExceptionName(exceptionCode);
+	}
+	else
+	{
+		RtlCaptureContext(&localContext);
+		stackContext  = &localContext;
+		exceptionName = Sys_WinSignalName(sig);
+	}
+
+	ZeroMemory(&stackFrame, sizeof(stackFrame));
+#if defined(_M_X64)
+	imageType                   = IMAGE_FILE_MACHINE_AMD64;
+	stackFrame.AddrPC.Offset    = stackContext->Rip;
+	stackFrame.AddrFrame.Offset = stackContext->Rbp;
+	stackFrame.AddrStack.Offset = stackContext->Rsp;
+#elif defined(_M_IX86)
+	imageType                   = IMAGE_FILE_MACHINE_I386;
+	stackFrame.AddrPC.Offset    = stackContext->Eip;
+	stackFrame.AddrFrame.Offset = stackContext->Ebp;
+	stackFrame.AddrStack.Offset = stackContext->Esp;
+#elif defined(_M_ARM64)
+	imageType                   = IMAGE_FILE_MACHINE_ARM64;
+	stackFrame.AddrPC.Offset    = stackContext->Pc;
+	stackFrame.AddrFrame.Offset = stackContext->Fp;
+	stackFrame.AddrStack.Offset = stackContext->Sp;
+#endif
+	stackFrame.AddrPC.Mode    = AddrModeFlat;
+	stackFrame.AddrFrame.Mode = AddrModeFlat;
+	stackFrame.AddrStack.Mode = AddrModeFlat;
+
+	SymSetOptions(SYMOPT_DEFERRED_LOADS | SYMOPT_LOAD_LINES | SYMOPT_UNDNAME);
+	SymInitialize(process, NULL, TRUE);
+
+	fprintf(stderr, "--- Report this to the project - START ---\n");
+	fprintf(stderr, "ERROR: Caught %s (0x%08lx)\n", exceptionName, (unsigned long)exceptionCode);
+	if (address != 0)
+	{
+		fprintf(stderr, "FAULT ADDRESS: %p\n", (void *)(ULONG_PTR)address);
+	}
+	fprintf(stderr, "VERSION: %s (%s)\n", ETLEGACY_VERSION, ETLEGACY_VERSION_SHORT);
+	fprintf(stderr, "BTIME: %s\n", PRODUCT_BUILD_TIME);
+	fprintf(stderr, "BACKTRACE:\n");
+
+	if (imageType == 0)
+	{
+		fprintf(stderr, "Unsupported Windows architecture for stack walking.\n");
+	}
+	else
+	{
+		for (frameIndex = 0; frameIndex < 64; frameIndex++)
+		{
+			address = stackFrame.AddrPC.Offset;
+			if (address == 0)
+			{
+				break;
+			}
+
+			ZeroMemory(symbolBuffer, sizeof(symbolBuffer));
+			symbolInfo               = (PSYMBOL_INFO)symbolBuffer;
+			symbolInfo->SizeOfStruct = sizeof(SYMBOL_INFO);
+			symbolInfo->MaxNameLen   = MAX_SYM_NAME;
+			displacement64           = 0;
+			moduleBase               = SymGetModuleBase64(process, address);
+			modulePath[0]            = '\0';
+
+			if (moduleBase != 0 && GetModuleFileNameA((HMODULE)(ULONG_PTR)moduleBase, modulePath, sizeof(modulePath)) > 0)
+			{
+				separator = strrchr(modulePath, '\\');
+				if (separator == NULL)
+				{
+					separator = strrchr(modulePath, '/');
+				}
+				moduleName = separator != NULL ? separator + 1 : modulePath;
+			}
+			else
+			{
+				moduleName = "<unknown>";
+			}
+
+			fprintf(stderr, "  %02u %p %s!", frameIndex, (void *)(ULONG_PTR)address, moduleName);
+
+			if (SymFromAddr(process, address, &displacement64, symbolInfo))
+			{
+				fprintf(stderr, "%s+0x%llx", symbolInfo->Name, (unsigned long long)displacement64);
+			}
+			else
+			{
+				fprintf(stderr, "<unknown> (error %lu)", GetLastError());
+			}
+
+			ZeroMemory(&lineInfo, sizeof(lineInfo));
+			lineInfo.SizeOfStruct = sizeof(lineInfo);
+			lineDisplacement      = 0;
+			if (SymGetLineFromAddr64(process, address, &lineDisplacement, &lineInfo))
+			{
+				fprintf(stderr, " [%s:%lu]", lineInfo.FileName, (unsigned long)lineInfo.LineNumber);
+			}
+
+			fprintf(stderr, "\n");
+
+			if (!StackWalk64(imageType, process, thread, &stackFrame, stackContext, NULL,
+			                 SymFunctionTableAccess64, SymGetModuleBase64, NULL))
+			{
+				break;
+			}
+		}
+	}
+
+	fprintf(stderr, "--- Report this to the project -  END  ---\n");
+	fflush(stderr);
+	SymCleanup(process);
 }


### PR DESCRIPTION
Install a dedicated fatal crash path for the supported desktop platforms instead of routing crash signals through the graceful shutdown handler.

On Unix-like builds this moves fatal signal registration into sys_unix.c, uses sigaction with SA_SIGINFO so the handler retains fault metadata, expands reporting beyond Linux-only SIGSEGV handling, and prints a consistent developer-facing backtrace header before re-raising the original signal.

On Windows this installs a process-wide unhandled exception filter, keeps CRT fatal signals wired into the same crash path, forces up a real console when needed, and walks the crashing thread stack through DbgHelp so the console output includes symbol, module, and optional line information.

The shared sys_main.c logic now separates graceful termination signals from fatal crashes, guards against double-fault recursion, and keeps crash teardown minimal so stack reporting is attempted before the process is terminated.

The Windows platform libraries now link against dbghelp so the stack walker resolves symbols on supported builds.