### PR TITLE
mod: fix client detection on cgame/ui

### DIFF
--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -2198,7 +2198,7 @@ void CG_Init(int serverMessageNum, int serverCommandSequence, int clientNum, qbo
 
 	cg.demoPlayback = demoPlayback;
 
-	MOD_CHECK_ETLEGACY(etLegacyClient, clientVersion, cg.etLegacyClient);
+	MOD_CHECK_ETLEGACY(clientVersion, cg.etLegacyClient);
 
 	// get the rendering configuration from the client system
 	trap_GetGlconfig(&cgs.glconfig);

--- a/src/qcommon/q_shared.h
+++ b/src/qcommon/q_shared.h
@@ -103,8 +103,28 @@
 #define SLASH_COMMAND 1        ///< Will the client require a '/' sign in front of commands
 
 // ET: Legacy specific - used by mod code
+// NOTE: this is not a perfect and reliable solution - vanilla client sends garbage data to VM calls
+// for unused arguments, which makes the arguments used to detect ET: Legacy clients unreliable.
+// A more reliable method on cgame/ui is to check for 'etVersion' cvar, although this is not
+// fool proof either, as old clients may just set this themselves as 'CVAR_USER_CREATED'.
+#ifdef GAMEDLL
 #define MOD_CHECK_ETLEGACY(isETLegacy, versionNum, outputValue) outputValue = (isETLegacy == qtrue ? qtrue : qfalse); \
 		if (outputValue) { outputValue = versionNum; }
+#else
+#define MOD_CHECK_ETLEGACY(clientVersion, outVersion) \
+		{ \
+			char versionString[128]; \
+			char versionStringCmp[128]; \
+\
+			trap_Cvar_VariableStringBuffer("etVersion", versionString, sizeof(versionString)); \
+			Com_sprintf(versionStringCmp, sizeof(versionStringCmp), "%s %s", PRODUCT_LABEL, ETLEGACY_VERSION); \
+\
+			if (!Q_stricmpn(versionString, versionStringCmp, 13)) /* "ET Legacy v2." */ \
+			{ \
+				outVersion = clientVersion; \
+			} \
+		}
+#endif
 
 #ifdef _MSC_VER
 #pragma warning(disable : 4018) // signed/unsigned mismatch

--- a/src/ui/ui_main.c
+++ b/src/ui/ui_main.c
@@ -8735,7 +8735,7 @@ void UI_Init(int etLegacyClient, int clientVersion)
 		uiInfo.uiDC.bias = 0;
 	}
 
-	MOD_CHECK_ETLEGACY(etLegacyClient, clientVersion, uiInfo.etLegacyClient);
+	MOD_CHECK_ETLEGACY(clientVersion, uiInfo.etLegacyClient);
 
 	uiInfo.uiDC.etLegacyClient = uiInfo.etLegacyClient;
 


### PR DESCRIPTION
Using the vm arguments to detect the client that the user has is not reliable as 2.60b sends garbage data to unused vm arguments, which make the mod think that 2.60b client is in fact ET: Legacy client, as the client version is not 0.