### PR TITLE
ui: fix linking on non-Linux platforms

### DIFF
--- a/src/ui/ui_main.c
+++ b/src/ui/ui_main.c
@@ -8854,6 +8854,8 @@ void UI_Init(int etLegacyClient, int clientVersion)
 	uiInfo.uiDC.getHunkData            = &trap_GetHunkData;
 	uiInfo.uiDC.getConfigString        = &trap_GetConfigString;
 
+	uiInfo.uiDC.demoStepUpDirectory = &UI_DemoStepUpDirectory;
+
 	Init_Display(&uiInfo.uiDC);
 
 	String_Init();

--- a/src/ui/ui_menu.c
+++ b/src/ui/ui_menu.c
@@ -1131,7 +1131,7 @@ void Menu_HandleKey(menuDef_t *menu, int key, qboolean down)
 	// step back out of nested folders without leaving the keyboard flow.
 	if (menu != NULL && down && key == K_BACKSPACE && !g_waitingForKey && !g_editingField &&
 	    menu->window.name && !Q_stricmp(menu->window.name, "viewreplay") &&
-	    UI_DemoStepUpDirectory())
+	    DC->demoStepUpDirectory())
 	{
 		Item_SetFocus(Menu_FindItemByName(menu, "demoList"), DC->cursorx, DC->cursory);
 		return;

--- a/src/ui/ui_shared.h
+++ b/src/ui/ui_shared.h
@@ -555,6 +555,8 @@ typedef struct
 	void (*getHunkData)(int *hunkused, int *hunkexpected);
 	int (*getConfigString)(int index, char *buff, size_t buffsize);
 
+	qboolean (*demoStepUpDirectory)(void);
+
 	float yscale;
 	float xscale;
 	float bias;


### PR DESCRIPTION
`ui_menu.c` is included in cgame as well, unlike `ui_main.c`, so calling functions directly that live there from `ui_menu.c` will fail to link on most platforms. Call via function pointer in `displayContextDef_t` instead so that everything links correctly.

refs #3406