### PR TITLE
cgame: fix potential buffer overflow in awards parsing

### DIFF
--- a/src/cgame/cg_debriefing.c
+++ b/src/cgame/cg_debriefing.c
@@ -2479,7 +2479,7 @@ void CG_Debriefing_ParseAwards(void)
 		cgs.dbAwardNames[i] = s;
 
 		len   = strlen(s);
-		size -= len;
+		size -= len + 1;
 		s    += len + 1;
 
 		// team


### PR DESCRIPTION
When awards were copied to the awards buffer, the remaining space didn't account for the null terminator in the copied string, causing an off-by-one error in the size remaining in the buffer, which could potentially cause a buffer overflow once the buffer was close to being full.