### PR TITLE
cgame: fix incorrect health color range in ft overlay

### DIFF
--- a/src/cgame/cg_fireteamoverlay.c
+++ b/src/cgame/cg_fireteamoverlay.c
@@ -816,7 +816,7 @@ static void CG_FTOverlay_DrawWeaponIcon(fireteamOverlay_t *fto)
 }
 
 #define FT_HEALTH_NORMAL 80
-#define FT_HEALTH_YELLOW 10
+#define FT_HEALTH_YELLOW 1
 
 static void CG_FTOverlay_DrawHealth(fireteamOverlay_t *fto, hudComponent_t *comp)
 {
@@ -1317,18 +1317,13 @@ static vec4_t * CG_FireTeamHealthColor(clientInfo_t *ci, hudComponent_t *comp)
 		return &colorYellow;
 	}
 
-	if (ci->health > 0)
-	{
-		return &colorRed;
-	}
-
 	// wounded
 	if (ci->health == 0)
 	{
 		return (cg.time % 500) > 250 ? &colorWhite : &colorRed;
 	}
 
-	// limbo (-1 health)
+	// limbo (< 0 health)
 	return &colorRed;
 }
 


### PR DESCRIPTION
Yellow health is supposed to be 1-80, not 10-80. Red is only for dead players.

refs #3217 