### PR TITLE
cgame: add cg_allowSelfKillSpawnProtection cvar, fixes #3321

### DIFF
--- a/src/cgame/cg_consolecmds.c
+++ b/src/cgame/cg_consolecmds.c
@@ -1290,6 +1290,25 @@ void CG_ForceTapOut_f(void)
 }
 
 /**
+ * @brief Client-side handler for the /kill command.
+ */
+static void CG_Kill_f(void)
+{
+	if (!cg.snap)
+	{
+		return;
+	}
+
+	if (cgs.gamestate == GS_PLAYING && !cg_allowSelfKillSpawnProtection.integer && cg.spawnInvulnerability && cg.snap->ps.powerups[PW_INVULNERABLE] > cg.time)
+	{
+		CG_CenterPrint("You are invulnerable - ^3/kill^7 is disabled.");
+		return;
+	}
+
+	trap_SendClientCommand("kill");
+}
+
+/**
  * @brief Shows a popup message.
  */
 static void CG_CPM_f(void)
@@ -3577,6 +3596,7 @@ static consoleCommand_t commands[] =
 	{ "undoSpeaker",            CG_UndoSpeaker_f             },
 	{ "cpm",                    CG_CPM_f                     },
 	{ "forcetapout",            CG_ForceTapOut_f             },
+	{ "kill",                   CG_Kill_f                    },
 	{ "timerSet",               CG_TimerSet_f                },
 	{ "timerReset",             CG_TimerReset_f              },
 	{ "resetTimer",             CG_TimerReset_f              }, // keep ETPro compatibility
@@ -3703,7 +3723,6 @@ static const char *gameCommand[] =
 	"imwa",
 	"imws",
 	//   "invite",
-	"kill",
 	"lock",
 	"mapvote",
 #ifdef FEATURE_MULTIVIEW

--- a/src/cgame/cg_consolecmds.c
+++ b/src/cgame/cg_consolecmds.c
@@ -1294,7 +1294,7 @@ void CG_ForceTapOut_f(void)
  */
 static void CG_Kill_f(void)
 {
-	if (!cg.snap)
+	if (cg.demoPlayback || !cg.snap || (cg.snap->ps.pm_flags & PMF_FOLLOW))
 	{
 		return;
 	}

--- a/src/cgame/cg_cvars.c
+++ b/src/cgame/cg_cvars.c
@@ -201,6 +201,7 @@ vmCvar_t cg_refereePassword;
 vmCvar_t cg_atmosphericEffects;
 
 vmCvar_t cg_instanttapout;
+vmCvar_t cg_allowSelfKillSpawnProtection;
 
 vmCvar_t cg_debugSkills;
 
@@ -522,6 +523,7 @@ static cvarTable_t cvarTable[] =
 	{ &cg_refereePassword,                    "auth_refereePassword",                  "",            CVAR_TEMP,                    0 },
 
 	{ &cg_instanttapout,                      "cg_instanttapout",                      "0",           CVAR_ARCHIVE,                 0 },
+	{ &cg_allowSelfKillSpawnProtection,       "cg_allowSelfKillSpawnProtection",       "0",           CVAR_ARCHIVE,                 0 },
 	{ &cg_debugSkills,                        "cg_debugSkills",                        "0",           0,                            0 },
 	{ NULL,                                   "cg_etVersion",                          "",            CVAR_USERINFO | CVAR_ROM,     0 },
 #if 0

--- a/src/cgame/cg_cvars.h
+++ b/src/cgame/cg_cvars.h
@@ -206,6 +206,7 @@ extern vmCvar_t cg_debugSkills;
 
 // some optimization cvars
 extern vmCvar_t cg_instanttapout;
+extern vmCvar_t cg_allowSelfKillSpawnProtection;
 
 // demo recording cvars
 extern vmCvar_t cl_demorecording;

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1353,6 +1353,7 @@ typedef struct
 	int grenLastTime;
 	int lastBeingRevivedTime;
 	int lastReviveTime;
+	qboolean spawnInvulnerability;
 
 	int switchbackWeapon;
 	int lastFiredWeapon;

--- a/src/cgame/cg_playerstate.c
+++ b/src/cgame/cg_playerstate.c
@@ -158,6 +158,7 @@ void CG_Respawn(qboolean revived)
 	cg.predictedPlayerState.weapAnim    = ((cg.predictedPlayerState.weapAnim & ANIM_TOGGLEBIT) ^ ANIM_TOGGLEBIT) | WEAP_IDLE1;      // reset weapon animations
 	cg.predictedPlayerState.weaponstate = WEAPON_READY;      // hmm, set this?  what to?
 	cg.predictedPlayerEntity.firedTime  = 0; // reset weapon smoke
+	cg.spawnInvulnerability             = !revived;
 
 	// display weapons available
 	cg.weaponSelectTime = cg.time;

--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -1274,12 +1274,6 @@ void Cmd_Kill_f(gentity_t *ent, unsigned int dwCommand, int value)
 		return;
 	}
 
-	if (g_gamestate.integer == GS_PLAYING && ent->client->isSpawnInvulnerability && ent->client->ps.powerups[PW_INVULNERABLE] > level.time && !g_cheats.value)
-	{
-		trap_SendServerCommand(ent - g_entities, "cp \"You are invulnerable - ^3/kill^7 is disabled.\"");
-		return;
-	}
-
 	if (ent->health <= 0)
 	{
 		limbo(ent, qtrue);


### PR DESCRIPTION
This PR moves PW_INVULNERABLE self kill check to client side and adds `cg_allowSelfKillSpawnProtection` cvar that allows clients to self kill during protection if they choose to do so.