### PR TITLE
etltv: add tv zone for tv server queue memory allocations, refs #229

### DIFF
--- a/src/qcommon/common.c
+++ b/src/qcommon/common.c
@@ -1219,9 +1219,6 @@ void *Z_TagMalloc(size_t size, int tag)
 	{
 		if (rover == start)
 		{
-#ifdef ZONE_DEBUG
-			Z_LogHeap();
-
 			char *zoneName;
 
 			switch (tag)
@@ -1230,6 +1227,9 @@ void *Z_TagMalloc(size_t size, int tag)
 			case TAG_TVSERVER: zoneName = "tv";    break;
 			default:           zoneName = "main";  break;
 			}
+
+#ifdef ZONE_DEBUG
+			Z_LogHeap();
 
 			Com_Error(ERR_FATAL, "Z_Malloc: failed on allocation of %zu bytes from the %s zone: %s, line: %d (%s)",
 			          size, zoneName, file, line, label);

--- a/src/qcommon/common.c
+++ b/src/qcommon/common.c
@@ -1025,6 +1025,8 @@ static memzone_t *mainzone;
 /// We also have a small zone for small allocations that would only
 /// fragment the main zone (think of cvar and cmd strings)
 static memzone_t *smallzone;
+/// zone for all tv server queue memory allocations
+static memzone_t *tvzone;
 
 static void Z_CheckHeap(void);
 
@@ -1052,6 +1054,21 @@ static void Z_ClearZone(memzone_t *zone, int size)
 	block->tag  = 0;        // free block
 	block->id   = ZONEID;
 	block->size = size - sizeof(memzone_t);
+}
+
+/**
+ * @brief GetZoneFromTag
+ * @param[int] tag
+ * return
+ */
+static memzone_t *GetZoneFromTag(memtag_t tag)
+{
+	switch (tag)
+	{
+	case TAG_SMALL:    return smallzone;
+	case TAG_TVSERVER: return tvzone;
+	default:           return mainzone;
+	}
 }
 
 /**
@@ -1089,14 +1106,7 @@ void Z_Free(void *ptr)
 		Com_Error(ERR_FATAL, "Z_Free: memory block wrote past end");
 	}
 
-	if (block->tag == TAG_SMALL)
-	{
-		zone = smallzone;
-	}
-	else
-	{
-		zone = mainzone;
-	}
+	zone = GetZoneFromTag(block->tag);
 
 	zone->used -= block->size;
 	// set the block to something that should cause problems
@@ -1143,14 +1153,7 @@ void Z_FreeTags(int tag)
 {
 	memzone_t *zone;
 
-	if (tag == TAG_SMALL)
-	{
-		zone = smallzone;
-	}
-	else
-	{
-		zone = mainzone;
-	}
+	zone = GetZoneFromTag(tag);
 
 	// use the rover as our pointer, because
 	// Z_Free automatically adjusts it
@@ -1196,14 +1199,7 @@ void *Z_TagMalloc(size_t size, int tag)
 		Com_Error(ERR_FATAL, "Z_TagMalloc: tried to use a 0 tag");
 	}
 
-	if (tag == TAG_SMALL)
-	{
-		zone = smallzone;
-	}
-	else
-	{
-		zone = mainzone;
-	}
+	zone = GetZoneFromTag(tag);
 
 #ifdef ZONE_DEBUG
 	allocSize = size;
@@ -1226,11 +1222,20 @@ void *Z_TagMalloc(size_t size, int tag)
 #ifdef ZONE_DEBUG
 			Z_LogHeap();
 
+			char *zoneName;
+
+			switch (tag)
+			{
+			case TAG_SMALL:    zoneName = "small"; break;
+			case TAG_TVSERVER: zoneName = "tv";    break;
+			default:           zoneName = "main";  break;
+			}
+
 			Com_Error(ERR_FATAL, "Z_Malloc: failed on allocation of %zu bytes from the %s zone: %s, line: %d (%s)",
-			          size, zone == smallzone ? "small" : "main", file, line, label);
+			          size, zoneName, file, line, label);
 #else
 			Com_Error(ERR_FATAL, "Z_Malloc: failed on allocation of %zu bytes from the %s zone",
-			          size, zone == smallzone ? "small" : "main");
+			          size, zoneName);
 #endif
 			return NULL;
 		}
@@ -1325,15 +1330,38 @@ static void Z_CheckHeap(void)
 		}
 		if ((byte *)block + block->size != (byte *)block->next)
 		{
-			Com_Error(ERR_FATAL, "Z_CheckHeap: block size does not touch the next block");
+			Com_Error(ERR_FATAL, "Z_CheckHeap: (mainzone) block size does not touch the next block");
 		}
 		if (block->next->prev != block)
 		{
-			Com_Error(ERR_FATAL, "Z_CheckHeap: next block doesn't have proper back link");
+			Com_Error(ERR_FATAL, "Z_CheckHeap: (mainzone) next block doesn't have proper back link");
 		}
 		if (!block->tag && !block->next->tag)
 		{
-			Com_Error(ERR_FATAL, "Z_CheckHeap: two consecutive free blocks");
+			Com_Error(ERR_FATAL, "Z_CheckHeap: (mainzone) two consecutive free blocks");
+		}
+	}
+
+	if (tvzone)
+	{
+		for (block = tvzone->blocklist.next; ; block = block->next)
+		{
+			if (block->next == &tvzone->blocklist)
+			{
+				break;          // all blocks have been hit
+			}
+			if ((byte *)block + block->size != (byte *)block->next)
+			{
+				Com_Error(ERR_FATAL, "Z_CheckHeap: (tvzone) block size does not touch the next block");
+			}
+			if (block->next->prev != block)
+			{
+				Com_Error(ERR_FATAL, "Z_CheckHeap: (tvzone) next block doesn't have proper back link");
+			}
+			if (!block->tag && !block->next->tag)
+			{
+				Com_Error(ERR_FATAL, "Z_CheckHeap: (tvzone) two consecutive free blocks");
+			}
 		}
 	}
 }
@@ -1406,6 +1434,7 @@ void Z_LogHeap(void)
 {
 	Z_LogZoneHeap(mainzone, "MAIN");
 	Z_LogZoneHeap(smallzone, "SMALL");
+	Z_LogZoneHeap(tvzone, "TV");
 }
 
 // static mem blocks to reduce a lot of small zone overhead
@@ -1542,6 +1571,7 @@ static int  s_hunkTotal;
 
 static int s_zoneTotal;
 static int s_smallZoneTotal;
+static int s_tvZoneTotal;
 
 /**
  * @brief Com_Meminfo_f
@@ -1552,6 +1582,7 @@ void Com_Meminfo_f(void)
 	int        zoneBytes = 0, zoneBlocks = 0;
 	int        smallZoneBytes, smallZoneBlocks;
 	int        botlibBytes = 0, rendererBytes = 0;
+	int        tvZoneBytes = 0, tvZoneBlocks = 0;
 	int        unused;
 
 	for (block = mainzone->blocklist.next ; ; block = block->next)
@@ -1609,9 +1640,32 @@ void Com_Meminfo_f(void)
 		}
 	}
 
+	if (tvzone)
+	{
+		for (block = tvzone->blocklist.next; ; block = block->next)
+		{
+			if (block->tag)
+			{
+				tvZoneBytes += block->size;
+				tvZoneBlocks++;
+			}
+
+			if (block->next == &tvzone->blocklist)
+			{
+				break;          // all blocks have been hit
+			}
+		}
+	}
+
 	Com_Printf("%9i bytes (%6.2f MB) total hunk\n", s_hunkTotal, s_hunkTotal / Square(1024.f));
 	Com_Printf("%9i bytes (%6.2f MB) total zone\n", s_zoneTotal, s_zoneTotal / Square(1024.f));
+	Com_Printf("%9i bytes (%6.2f MB) total small zone\n", s_smallZoneTotal, s_smallZoneTotal / Square(1024.f));
+	if (tvzone)
+	{
+		Com_Printf("%9i bytes (%6.2f MB) total tv zone\n", s_tvZoneTotal, s_tvZoneTotal / Square(1024.f));
+	}
 	Com_Printf("\n");
+
 	Com_Printf("%9i bytes (%6.2f MB) low mark\n", hunk_low.mark, hunk_low.mark / Square(1024.f));
 	Com_Printf("%9i bytes (%6.2f MB) low permanent\n", hunk_low.permanent, hunk_low.permanent / Square(1024.f));
 	if (hunk_low.temp != hunk_low.permanent)
@@ -1644,7 +1698,13 @@ void Com_Meminfo_f(void)
 	Com_Printf("        %9i bytes (%6.2f MB) in dynamic botlib\n", botlibBytes, botlibBytes / Square(1024.f));
 	Com_Printf("        %9i bytes (%6.2f MB) in dynamic renderer\n", rendererBytes, rendererBytes / Square(1024.f));
 	Com_Printf("        %9i bytes (%6.2f MB) in dynamic other\n", zoneBytes - (botlibBytes + rendererBytes), (zoneBytes - (botlibBytes + rendererBytes)) / Square(1024.f));
-	Com_Printf("        %9i bytes (%6.2f MB) in small Zone memory (%i) blocks\n", smallZoneBytes, smallZoneBytes / Square(1024.f), smallZoneBlocks);
+	Com_Printf("\n");
+
+	Com_Printf("%9i bytes (%6.2f MB) in small Zone memory (%i) blocks\n", smallZoneBytes, smallZoneBytes / Square(1024.f), smallZoneBlocks);
+	if (tvzone)
+	{
+		Com_Printf("%9i bytes (%6.2f MB) in tv Zone memory (%i) blocks\n", tvZoneBytes, tvZoneBytes / Square(1024.f), tvZoneBlocks);
+	}
 }
 
 /**
@@ -1687,6 +1747,25 @@ void Com_TouchMemory(void)
 		if (block->next == &mainzone->blocklist)
 		{
 			break;          // all blocks have been hit
+		}
+	}
+
+	if (tvzone)
+	{
+		for (block = tvzone->blocklist.next; ; block = block->next)
+		{
+			if (block->tag)
+			{
+				j = block->size >> 2;
+				for (i = 0; i < j; i += 64)                 // only need to touch each page
+				{
+					sum += ((int *)block)[i];
+				}
+			}
+			if (block->next == &tvzone->blocklist)
+			{
+				break;          // all blocks have been hit
+			}
 		}
 	}
 
@@ -1743,6 +1822,47 @@ void Com_InitZoneMemory(void)
 	}
 	Z_ClearZone(mainzone, s_zoneTotal);
 }
+
+#ifdef DEDICATED
+
+/**
+ * @brief Com_InitTVZoneMemory tv server queue memory zone
+ */
+void Com_InitTVZoneMemory(void)
+{
+	cvar_t *cv;
+
+	cv = Cvar_Get("sv_etltv_delay", "0", 0);
+
+	// no delay means no queue memory zone needed
+	if (!cv->integer)
+	{
+		return;
+	}
+
+	cv = Cvar_Get("sv_etltv_zoneMegs", DEF_TVZONEMEGS_S, 0);
+
+	Com_Printf("TV Zone megs: %d\n", cv->integer);
+	if (cv->integer < DEF_TVZONEMEGS)
+	{
+		Cvar_Set("sv_etltv_zoneMegs", DEF_TVZONEMEGS_S);
+		s_tvZoneTotal = 1024 * 1024 * DEF_TVZONEMEGS;
+	}
+	else
+	{
+		s_tvZoneTotal = 1024 * 1024 * cv->integer;
+	}
+
+	tvzone = calloc(s_tvZoneTotal, 1);
+	if (!tvzone)
+	{
+		Com_Error(ERR_FATAL, "TV Zone data failed to allocate %i megs", s_tvZoneTotal / (1024 * 1024));
+	}
+
+	Z_ClearZone(tvzone, s_tvZoneTotal);
+}
+
+#endif
 
 /**
  * @brief Hunk_Log
@@ -2965,6 +3085,10 @@ void Com_Init(char *commandLine)
 #endif
 	// allocate the stack based hunk allocator
 	Com_InitHunkMemory();
+
+#ifdef DEDICATED
+	Com_InitTVZoneMemory();
+#endif
 
 	// if any archived cvars are modified after this, we will trigger a writing
 	// of the config file

--- a/src/qcommon/qcommon.h
+++ b/src/qcommon/qcommon.h
@@ -1152,7 +1152,8 @@ typedef enum
 	TAG_BOTLIB,
 	TAG_RENDERER,
 	TAG_SMALL,
-	TAG_STATIC
+	TAG_STATIC,
+	TAG_TVSERVER
 } memtag_t;
 
 /*
@@ -1171,6 +1172,9 @@ renderer models
 temp file loading
 --- high memory ---
 */
+
+#define DEF_TVZONEMEGS   24
+#define DEF_TVZONEMEGS_S XSTRING(DEF_TVZONEMEGS)
 
 #if defined(ETLEGACY_DEBUG) && !defined(ZONE_DEBUG)
 #define ZONE_DEBUG

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -653,7 +653,7 @@ typedef struct
 	int lastRunFrameTime;           ///< last server GAME_RUN_FRAME time
 	int lastRunFrameSysTime;        ///< last server GAME_RUN_FRAME system time
 
-	qboolean isTVGame;              ///< is it tv server
+	qboolean TVServer;              ///< is it tv server
 	qboolean isDelayed;             ///< is the master server feed delayed
 	qboolean isGamestateParsed;     ///< was the first gamestate server message parsed when the master server feed is delayed
 	qboolean firstSnap;             ///< did we parse first snapshot after new gamestate

--- a/src/server/sv_cl_main.c
+++ b/src/server/sv_cl_main.c
@@ -1380,9 +1380,10 @@ void SV_CL_FlushMemory(void)
 		// clear collision map data
 		CM_ClearMap();
 
-		while (svMsgQueueHead)
+		if (svMsgQueueHead)
 		{
-			SV_CL_FreeServerMessage();
+			Z_FreeTags(TAG_TVSERVER);
+			svMsgQueueHead = svMsgQueueTail = NULL;
 		}
 	}
 	else

--- a/src/server/sv_cl_main.c
+++ b/src/server/sv_cl_main.c
@@ -1286,7 +1286,7 @@ static void SV_CL_PacketEvent(const netadr_t *from, msg_t *msg)
 
 	if (!NET_CompareAdr(from, &svclc.serverAddress))
 	{
-		if (svcls.isTVGame)
+		if (svcls.TVServer)
 		{
 			SV_PacketEvent(from, msg);
 		}
@@ -1409,7 +1409,7 @@ void SV_CL_ClearState(void)
  */
 int SV_CL_GetPlayerstate(int clientNum, playerState_t *ps)
 {
-	if (!svcls.isTVGame)
+	if (!svcls.TVServer)
 	{
 		Com_Error(ERR_FATAL, "SV_CL_GetPlayerstate: TVGame not loaded");
 	}

--- a/src/server/sv_cl_parse.c
+++ b/src/server/sv_cl_parse.c
@@ -472,7 +472,7 @@ void SV_CL_DeltaEntity(msg_t *msg, svclSnapshot_t *frame, int newnum, entityStat
 		MSG_ETTV_ReadDeltaEntityShared(msg, oldShared, stateShared);
 	}
 
-	if (svcls.isTVGame && sv.gentities)
+	if (svcls.TVServer && sv.gentities)
 	{
 		gEnt = SV_GentityNum(newnum);
 
@@ -1112,7 +1112,7 @@ void SV_CL_ParseServerMessage(msg_t *msg, int headerBytes)
 
 	SV_CL_ParseBinaryMessage(msg);
 
-	if (svcls.isTVGame)
+	if (svcls.TVServer)
 	{
 		SV_CL_RunFrame();
 	}

--- a/src/server/sv_cl_parse.c
+++ b/src/server/sv_cl_parse.c
@@ -1128,21 +1128,12 @@ void SV_CL_ParseServerMessage(msg_t *msg, int headerBytes)
  */
 static void *SV_CL_Allocate(int size)
 {
-	void *data;
-
 	if (size > MAX_MSGLEN)
 	{
 		Com_Error(ERR_FATAL, "SV_CL_Allocate: Oversized allocation of [%d].", size);
 	}
 
-	data = Com_Allocate(size);
-
-	if (!data)
-	{
-		Com_Error(ERR_FATAL, "SV_CL_Allocate: Couldn't allocate size [%d].", size);
-	}
-
-	return data;
+	return Z_TagMalloc(size, TAG_TVSERVER);
 }
 
 /**
@@ -1151,12 +1142,7 @@ static void *SV_CL_Allocate(int size)
  */
 static serverMessageQueue_t *SV_CL_NewMessage(void)
 {
-	serverMessageQueue_t *newMessage = Com_Allocate(sizeof(serverMessageQueue_t));
-
-	if (!newMessage)
-	{
-		Com_Error(ERR_FATAL, "SV_CL_NewMessage: Couldn't allocate new message.");
-	}
+	serverMessageQueue_t *newMessage = Z_TagMalloc(sizeof(serverMessageQueue_t), TAG_TVSERVER);
 
 	Com_Memset(newMessage, 0, sizeof(serverMessageQueue_t));
 
@@ -1184,11 +1170,11 @@ static void SV_CL_FreeMessage(serverMessageQueue_t *svMsg)
 
 	for (i = 0; i < svMsg->numServerCommand; i++)
 	{
-		free(svMsg->serverCommands[i]);
+		Z_Free(svMsg->serverCommands[i]);
 	}
 
-	free(svMsg->msg.data);
-	free(svMsg);
+	Z_Free(svMsg->msg.data);
+	Z_Free(svMsg);
 }
 
 /**

--- a/src/server/sv_client.c
+++ b/src/server/sv_client.c
@@ -605,7 +605,7 @@ gotnewcl:
 	*newcl    = temp;
 	clientNum = newcl - svs.clients;
 
-	if (!svcls.isTVGame)
+	if (!svcls.TVServer)
 	{
 		newcl->gentity            = SV_GentityNum(clientNum);
 		newcl->gentity->r.svFlags = 0; // clear client flags on new connection.
@@ -684,7 +684,7 @@ gotnewcl:
 	{
 		int clients = sv_maxclients->integer;
 
-		if (svcls.isTVGame)
+		if (svcls.TVServer)
 		{
 			clients = MAX_CLIENTS;
 		}
@@ -920,7 +920,7 @@ void SV_SendClientGameState(client_t *client)
 
 	MSG_WriteByte(&msg, svc_EOF);
 
-	if (svcls.isTVGame)
+	if (svcls.TVServer)
 	{
 		MSG_WriteLong(&msg, svclc.clientNum);
 	}

--- a/src/server/sv_client.c
+++ b/src/server/sv_client.c
@@ -969,9 +969,15 @@ void SV_ClientEnterWorld(client_t *client, usercmd_t *cmd)
 	}
 
 	// set up the entity for the client
-	ent           = SV_GentityNum(clientNum);
-	ent->s.number = clientNum;
-
+	if (svcls.TVServer)
+	{
+		ent = SV_GentityNum(svclc.clientNum);
+	}
+	else
+	{
+		ent           = SV_GentityNum(clientNum);
+		ent->s.number = clientNum;
+	}
 	// Differentiate between players and bots to properly replay gamestates
 	if (client->demoClient && strlen(client->userinfo) && strlen(Info_ValueForKey(client->userinfo, "cg_etVersion")))
 	{

--- a/src/server/sv_cvars.c
+++ b/src/server/sv_cvars.c
@@ -121,6 +121,7 @@ cvar_t *sv_etltv_autorecord;
 cvar_t *sv_etltv_autoplay;
 cvar_t *sv_etltv_clientname;
 cvar_t *sv_etltv_delay;
+cvar_t *sv_etltv_zoneMegs;
 cvar_t *sv_etltv_shownet;
 cvar_t *sv_etltv_queue_ms;
 cvar_t *sv_etltv_netblast;

--- a/src/server/sv_cvars.h
+++ b/src/server/sv_cvars.h
@@ -127,6 +127,7 @@ extern cvar_t *sv_etltv_autorecord;
 extern cvar_t *sv_etltv_autoplay;
 extern cvar_t *sv_etltv_clientname;
 extern cvar_t *sv_etltv_delay;
+extern cvar_t *sv_etltv_zoneMegs;
 extern cvar_t *sv_etltv_shownet;
 extern cvar_t *sv_etltv_queue_ms;
 extern cvar_t *sv_etltv_netblast;

--- a/src/server/sv_game.c
+++ b/src/server/sv_game.c
@@ -746,7 +746,7 @@ void SV_ShutdownGameProgs(void)
 	VM_Free(gvm);
 	gvm = NULL;
 
-	svcls.isTVGame = qfalse;
+	svcls.TVServer = qfalse;
 }
 
 /**
@@ -767,7 +767,7 @@ static void SV_InitGameVM(qboolean restart)
 		svs.clients[i].gentity = NULL;
 	}
 
-	if (svcls.isTVGame && !restart)
+	if (svcls.TVServer && !restart)
 	{
 		for (i = 0; i < MAX_CONFIGSTRINGS; i++)
 		{
@@ -825,7 +825,7 @@ void SV_InitGameProgs(void)
 	if (svcls.state >= CA_AUTHORIZING)
 	{
 		gvm            = VM_Create("tvgame", qfalse, SV_GameSystemCalls, VMI_NATIVE);
-		svcls.isTVGame = gvm != NULL;
+		svcls.TVServer = gvm != NULL;
 	}
 	else
 	{

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -1237,6 +1237,7 @@ void SV_Init(void)
 	sv_etltv_autoplay   = Cvar_Get("sv_etltv_autoplay", "0", CVAR_ARCHIVE_ND);
 	sv_etltv_clientname = Cvar_GetAndDescribe("sv_etltv_clientname", "ETLTV", CVAR_ARCHIVE_ND, "Name of the ETLTV client.");
 	sv_etltv_delay      = Cvar_GetAndDescribe("sv_etltv_delay", "0", CVAR_INIT, "Delay feed by number of seconds.");
+	sv_etltv_zoneMegs   = Cvar_GetAndDescribe("sv_etltv_zoneMegs", DEF_TVZONEMEGS_S, CVAR_INIT, "TV server queue memory zone. (in MB)");
 	sv_etltv_shownet    = Cvar_Get("sv_etltv_shownet", "0", CVAR_ARCHIVE_ND);
 	sv_etltv_queue_ms   = Cvar_Get("ettv_queue_ms", "-1", CVAR_ROM);    // ettv_queue_ms for ettv backward compatibility
 	sv_etltv_netblast   = Cvar_GetAndDescribe("sv_etltv_netblast", "1", CVAR_ARCHIVE_ND, "Send all message fragments at once.");

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -98,7 +98,7 @@ void SV_SetConfigstring(int index, const char *val)
 	sv.configstrings[index]         = CopyString(val);
 	sv.configstringsmodified[index] = qtrue;
 
-	if (svcls.isTVGame && svcls.state != CA_LOADING &&
+	if (svcls.TVServer && svcls.state != CA_LOADING &&
 	    (index == CS_SERVERINFO || index == CS_WOLFINFO))
 	{
 		SV_CL_ConfigstringInfoChanged(index);
@@ -306,7 +306,7 @@ void SV_CreateBaseline(void)
 	sharedEntity_t *svent;
 	int            entnum;
 
-	if (svcls.isTVGame)
+	if (svcls.TVServer)
 	{
 		for (entnum = 0; entnum < MAX_GENTITIES; entnum++)
 		{
@@ -866,7 +866,7 @@ void SV_SpawnServer(const char *server)
 
 					client        = &svs.clients[i];
 					client->state = CS_ACTIVE;
-					if (!svcls.isTVGame)
+					if (!svcls.TVServer)
 					{
 						ent             = SV_GentityNum(i);
 						ent->s.number   = i;

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -1237,10 +1237,11 @@ void SV_Init(void)
 	sv_etltv_autoplay   = Cvar_Get("sv_etltv_autoplay", "0", CVAR_ARCHIVE_ND);
 	sv_etltv_clientname = Cvar_GetAndDescribe("sv_etltv_clientname", "ETLTV", CVAR_ARCHIVE_ND, "Name of the ETLTV client.");
 	sv_etltv_delay      = Cvar_GetAndDescribe("sv_etltv_delay", "0", CVAR_INIT, "Delay feed by number of seconds.");
-	sv_etltv_zoneMegs   = Cvar_GetAndDescribe("sv_etltv_zoneMegs", DEF_TVZONEMEGS_S, CVAR_INIT, "TV server queue memory zone. (in MB)");
-	sv_etltv_shownet    = Cvar_Get("sv_etltv_shownet", "0", CVAR_ARCHIVE_ND);
-	sv_etltv_queue_ms   = Cvar_Get("ettv_queue_ms", "-1", CVAR_ROM);    // ettv_queue_ms for ettv backward compatibility
-	sv_etltv_netblast   = Cvar_GetAndDescribe("sv_etltv_netblast", "1", CVAR_ARCHIVE_ND, "Send all message fragments at once.");
+	sv_etltv_zoneMegs   = Cvar_GetAndDescribe("sv_etltv_zoneMegs", DEF_TVZONEMEGS_S, CVAR_INIT, "Amount of memory (in MB) allocated for tv server when 'sv_etltv_delay' cvar is set.\n"
+	                                                                                            "This zone is used to store each incoming packet from master server for 'sv_etltv_delay' seconds.");
+	sv_etltv_shownet  = Cvar_Get("sv_etltv_shownet", "0", CVAR_ARCHIVE_ND);
+	sv_etltv_queue_ms = Cvar_Get("ettv_queue_ms", "-1", CVAR_ROM);      // ettv_queue_ms for ettv backward compatibility
+	sv_etltv_netblast = Cvar_GetAndDescribe("sv_etltv_netblast", "1", CVAR_ARCHIVE_ND, "Send all message fragments at once.");
 
 #if defined(FEATURE_IRC_SERVER) && defined(DEDICATED)
 	IRC_Init();

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -1225,7 +1225,7 @@ void SV_PacketEvent(const netadr_t *from, msg_t *msg)
 		return;
 	}
 
-	if (svcls.isTVGame && svcls.state == CA_DISCONNECTED)
+	if (svcls.TVServer && svcls.state == CA_DISCONNECTED)
 	{
 		return;
 	}
@@ -1502,7 +1502,7 @@ static qboolean SV_CheckPaused(void)
  */
 int64_t SV_FrameMsec()
 {
-	if (svcls.isTVGame)
+	if (svcls.TVServer)
 	{
 		return 8;
 	}
@@ -1719,7 +1719,7 @@ void SV_Frame(int msec)
 		return;
 	}
 
-	if (svcls.isTVGame)
+	if (svcls.TVServer)
 	{
 		SV_CL_Frame(frameMsec);
 	}

--- a/src/server/sv_snapshot.c
+++ b/src/server/sv_snapshot.c
@@ -266,7 +266,7 @@ static void SV_ETTV_EmitPlayerstates(client_t *client, msg_t *msg)
 
 	MSG_WriteByte(msg, svc_ettv_playerstates);
 
-	if (!svcls.isTVGame)
+	if (!svcls.TVServer)
 	{
 		for (i = 0; i < sv_maxclients->integer; i++)
 		{
@@ -668,7 +668,7 @@ static void SV_AddEntitiesVisibleFromPoint(client_t *cl, vec3_t origin, clientSn
 			continue;
 		}
 
-		if (cl->ettvClient || (svcls.isTVGame && ent->s.number < MAX_CLIENTS))
+		if (cl->ettvClient || (svcls.TVServer && ent->s.number < MAX_CLIENTS))
 		{
 			SV_AddEntToSnapshot(cl, playerEnt, svEnt, ent, eNums);
 			continue;

--- a/src/server/sv_world.c
+++ b/src/server/sv_world.c
@@ -231,14 +231,14 @@ void SV_LinkEntity(sharedEntity_t *gEnt)
 
 	ent = SV_SvEntityForGentity(gEnt);
 
-	if (svcls.isTVGame && gEnt->s.solid == SOLID_BMODEL)
+	if (svcls.TVServer && gEnt->s.solid == SOLID_BMODEL)
 	{
 		gEnt->r.bmodel = qtrue;
 	}
 
 	// sanity check for possible currentOrigin being reset bug
 	if (!gEnt->r.bmodel && vec3_compare(gEnt->r.currentOrigin, vec3_origin)
-	    && !svcls.isTVGame
+	    && !svcls.TVServer
 	    )
 	{
 		// I've seen this warning a lot - let map makers know which entity is affected.


### PR DESCRIPTION
- zone is added only to dedicated server and if server is delayed (`sv_etltv_delay` is set)
  zone minimum default size is 24MB
  added cvar `sv_etltv_zoneMegs` for increasing the default size (setable only in commandline)
  1 player per 1 minute of delay uses around 0.2MB, so for example 12 players with 5 minute delay should use around 12-13MB (tested only on bots)
  added debugging info to `meminfo` and `zonelog` command accordingly
- rename member variable
- set client entity to tv server entity - fixes a bug where if the entities on master server are bots then players joining tv server would inherit `SVF_BOT` flag if they connect on the same server slot as bot from master server, which would make tv server think they are a bot and never send a snapshot to such client

refs #229