### PR TITLE
misc: fix Windows subprocess decoding

### DIFF
--- a/misc/check-changes.py
+++ b/misc/check-changes.py
@@ -5,7 +5,6 @@
 # REQUIRES: python uncrustify git
 import os
 import sys
-import subprocess
 import difflib
 from pathlib import Path
 from dataclasses import dataclass, field
@@ -46,12 +45,7 @@ class Error:
 
 def check_black(path: Path, errors: List[Error]):
     try:
-        result = subprocess.run(
-            ["black", "--check", "--diff", str(path)],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
+        result = run_command(["black", "--check", "--diff", str(path)], check=False)
         if result.returncode != 0:
             errors.append(
                 Error(
@@ -65,11 +59,9 @@ def check_black(path: Path, errors: List[Error]):
 
 
 def check_uncrustify(path: Path, errors: List[Error]):
-    result = subprocess.run(
+    result = run_command(
         ["uncrustify", "-c", str(ROOT_DIR / "uncrustify.cfg"), "-f", str(path)],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
+        check=False,
     )
 
     if result.returncode != 0:
@@ -95,12 +87,7 @@ def check_uncrustify(path: Path, errors: List[Error]):
 
 def check_sh(path: Path, errors: List[Error]):
     # shellcheck
-    result = subprocess.run(
-        ["shellcheck", str(path)],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
+    result = run_command(["shellcheck", str(path)], check=False)
 
     if result.returncode != 0:
         errors.append(
@@ -112,12 +99,7 @@ def check_sh(path: Path, errors: List[Error]):
         )
 
     # shfmt
-    result = subprocess.run(
-        ["shfmt", "--diff", str(path)],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
+    result = run_command(["shfmt", "--diff", str(path)], check=False)
 
     if result.returncode != 0:
         errors.append(

--- a/misc/etl_lib.py
+++ b/misc/etl_lib.py
@@ -1,3 +1,4 @@
+import locale
 import os
 import sys
 import subprocess
@@ -10,13 +11,29 @@ ROOT_DIR = Path(__file__).resolve().parent.parent
 CWD = Path.cwd()
 
 
+def decode_subprocess_output(data: bytes) -> str:
+    # Most tool output in this repo is UTF-8, but Windows helper text can still
+    # arrive in the active locale encoding.
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError:
+        return data.decode(
+            locale.getpreferredencoding(False) or "utf-8", errors="replace"
+        )
+
+
 def run_command(cmd: List[str], check=True) -> subprocess.CompletedProcess:
-    result = subprocess.run(
+    raw_result = subprocess.run(
         cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        text=True,
         check=False,
+    )
+    result = subprocess.CompletedProcess(
+        raw_result.args,
+        raw_result.returncode,
+        decode_subprocess_output(raw_result.stdout or b""),
+        decode_subprocess_output(raw_result.stderr or b""),
     )
     if check and result.returncode:
         msg = f"$ {" ".join([str(x) for x in cmd])}\nreturncode: {result.returncode}"
@@ -29,9 +46,7 @@ def run_command(cmd: List[str], check=True) -> subprocess.CompletedProcess:
 
 
 def run_git_command(cmd: List[str]) -> List[str]:
-    result = subprocess.run(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True
-    )
+    result = run_command(cmd, check=True)
     return result.stdout.strip().splitlines()
 
 

--- a/misc/update-changelog.py
+++ b/misc/update-changelog.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import locale
 import os
 import re
 import subprocess
@@ -21,6 +22,17 @@ def log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
 
 
+def decode_subprocess_output(data: bytes) -> str:
+    # Repo content is expected to be UTF-8, but helper stderr can still use the
+    # platform encoding on Windows.
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError:
+        return data.decode(
+            locale.getpreferredencoding(False) or "utf-8", errors="replace"
+        )
+
+
 def run_fetch(script_dir: Path) -> str:
     """
     Runs ./fetch-single-file-from-git-repo.py "<repo>" "<file>" in script_dir.
@@ -36,20 +48,21 @@ def run_fetch(script_dir: Path) -> str:
     proc = subprocess.run(
         cmd,
         cwd=str(script_dir),
-        text=True,
         capture_output=True,
     )
+    stdout_text = decode_subprocess_output(proc.stdout or b"")
+    stderr_text = decode_subprocess_output(proc.stderr or b"")
     if proc.returncode != 0:
         # Preserve stderr for debugging; also include stdout in case it matters.
         log("[!] Fetch failed. Output follows:")
-        if proc.stdout:
-            print(proc.stdout, end="", file=sys.stderr)
-        if proc.stderr:
-            print(proc.stderr, end="", file=sys.stderr)
+        if stdout_text:
+            print(stdout_text, end="", file=sys.stderr)
+        if stderr_text:
+            print(stderr_text, end="", file=sys.stderr)
         raise SystemExit(proc.returncode)
 
-    log(f"[1/4] Fetch OK ({len(proc.stdout)} bytes).")
-    return proc.stdout
+    log(f"[1/4] Fetch OK ({len(proc.stdout or b'')} bytes).")
+    return stdout_text
 
 
 _heading_re = re.compile(r"^##\s+(.+?)\s*$")


### PR DESCRIPTION
Capture subprocess output in misc Python helpers as raw bytes and apply explicit decoding instead of relying on Python text mode.

This fixes the Windows failure mode where UTF-8 output from git or other tools is decoded with the active code page, which can raise a decode error and leave follow-up code working with missing output.

The combined change covers update-changelog.py plus the shared misc helper and check-changes.py so the scripts use one consistent, Windows-safe decoding path.