### PR TITLE
cgame: fix round timer visual bug with timelimit 0, fix #3447

### DIFF
--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -3279,7 +3279,12 @@ static char *CG_RoundTimerText()
 		return "WARMUP";
 	}
 
-	if (CG_RoundTime(&qt) < 0 && cgs.timelimit > 0.0f)
+	if (cgs.timelimit <= 0.0f)
+	{
+		return "";
+	}
+
+	if (CG_RoundTime(&qt) < 0)
 	{
 		return "00:00"; // round ended
 	}


### PR DESCRIPTION
Like in vanilla, don't draw the round timer when timelimit is set to 0