### PR TITLE
cgame: don't overwrite valid text with noise generator

### DIFF
--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -4762,13 +4762,22 @@ static void CG_NoiseGenerator()
 	trap_Cvar_Set("cl_noprint", "1");
 
 	// banner
-	CG_AddToBannerPrint("Iaculatores coniunctis: incesserit servitium castrensi post velut et deinde virgae.");
+	if (!cg.bannerPrintTime)
+	{
+		CG_AddToBannerPrint(NOISE_BANNER_TEXT);
+	}
 
 	// center print
-	CG_CenterPrint("Insulari sufficiente postulatus aut nullo delatus hostiles iniecto aut suos.");
+	if (!cg.centerPrintTime)
+	{
+		CG_CenterPrint(NOISE_CENTER_TEXT);
+	}
 
-	// objevive print
-	CG_ObjectivePrint("You are near an amazing place and everyone envy you.");
+	// objective print
+	if (!cg.oidPrintTime)
+	{
+		CG_ObjectivePrint(NOISE_OBJECTIVE_TEXT);
+	}
 
 	// chat
 	CG_AddToTeamChat("Lorem ipsum dolor sit amet, consectetuer adipiscing elit.", cg.snap->ps.clientNum);
@@ -4812,8 +4821,11 @@ static void CG_NoiseGenerator()
 	cg.flagIndicator |= (1 << PW_NUM_POWERUPS);
 
 	// vote
-	cgs.voteTime = cg.time - VOTE_TIME + 1;
-	Q_strncpyz(cgs.voteString, "Do you want cast a vote ?", sizeof(cgs.voteString));
+	if (!cgs.voteTime)
+	{
+		cgs.voteTime = cg.time;
+		Q_strncpyz(cgs.voteString, NOISE_VOTE_TEXT, sizeof(cgs.voteString));
+	}
 
 	// missile camera
 	cg.latestMissile = &cg_entities[cg.snap->ps.clientNum];

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2925,6 +2925,11 @@ void CG_EventHandling(int type, qboolean fForced);
 int CG_RoundTime(qtime_t *qtime);
 qboolean CG_IsDemoVersionBelow(int major, int minor, int patch);
 
+#define NOISE_BANNER_TEXT "Iaculatores coniunctis: incesserit servitium castrensi post velut et deinde virgae."
+#define NOISE_CENTER_TEXT "Insulari sufficiente postulatus aut nullo delatus hostiles iniecto aut suos."
+#define NOISE_OBJECTIVE_TEXT "You are near an amazing place and everyone envy you."
+#define NOISE_VOTE_TEXT "Do you want cast a vote ?"
+
 void CG_HudEditor_Cleanup();
 
 qboolean CG_GetTag(int clientNum, const char *tagname, orientation_t *orientation);

--- a/src/cgame/cg_newDraw.c
+++ b/src/cgame/cg_newDraw.c
@@ -809,12 +809,32 @@ void CG_HudEditor_Cleanup(void)
 	int i;
 
 	CG_InitPM();
-	cg.bannerPrintTime  = 0;
-	cg.centerPrintTime  = 0;
-	cgs.voteTime        = 0;
 	cg.cursorHintTime   = 0;
 	cg.crosshairEntTime = 0;
-	cg.oidPrintTime     = 0;
+
+	// overwrite on noise banner print
+	if (!Q_strncmp(cg.bannerPrint, NOISE_BANNER_TEXT, sizeof(cg.bannerPrint)))
+	{
+		cg.bannerPrintTime = 0;
+	}
+
+	// overwrite on noise center print
+	if (!Q_strncmp(cg.centerPrint, NOISE_CENTER_TEXT, sizeof(cg.centerPrint)))
+	{
+		cg.centerPrintTime = 0;
+	}
+
+	// overwrite on noise objective print
+	if (!Q_strncmp(cg.oidPrint, NOISE_OBJECTIVE_TEXT, sizeof(cg.oidPrint)))
+	{
+		cg.oidPrintTime = 0;
+	}
+
+	// overwrite on noise vote
+	if (!Q_strncmp(cgs.voteString, NOISE_VOTE_TEXT, sizeof(cgs.voteString)))
+	{
+		cgs.voteTime = 0;
+	}
 
 	for (i = 0; i < TEAMCHAT_MSG_MAX; i++)
 	{


### PR DESCRIPTION
Don't overwrite message text such as vote, banner, center print or objective print if a valide texte message is displayed