### PR TITLE
cgame: fix misleading FPS drop in FPS meter, fix #3443

### DIFF
--- a/src/cgame/cg_draw_hud.c
+++ b/src/cgame/cg_draw_hud.c
@@ -40,6 +40,7 @@ hudData_t      hudData;
 hudComponent_t *showOnlyHudComponent = NULL;
 
 static lagometer_t lagometer;
+static int         fps;
 
 /**
 * @var hudComponentFields
@@ -3067,20 +3068,19 @@ void CG_DrawSpeed(hudComponent_t *comp)
 #define MAX_FPS_FRAMES  500
 
 /**
- * @brief CG_DrawFPS
- * @param[in] comp
- * @return
+ * @brief CG_ComputeFPS
  */
-void CG_DrawFPS(hudComponent_t *comp)
+void CG_ComputeFPS(void)
 {
 	static int          previousTimes[MAX_FPS_FRAMES];
 	static int          previous;
 	static unsigned int index;
-	const char          *s;
 	int                 t;
 	int                 frameTime;
 
-	t = trap_Milliseconds(); // don't use serverTime, because that will be drifting to correct for internet lag changes, timescales, timedemos, etc
+	// don't use serverTime, because that will be drifting
+	// to correct for internet lag changes, timescales, timedemos, etc
+	t = trap_Milliseconds();
 
 	frameTime = t - previous;
 	previous  = t;
@@ -3090,11 +3090,11 @@ void CG_DrawFPS(hudComponent_t *comp)
 
 	if (index > MAX_FPS_FRAMES)
 	{
-		int i, fps;
+		unsigned int i;
 		// average multiple frames together to smooth changes out a bit
 		int total = 0;
 
-		for (i = 0 ; i < MAX_FPS_FRAMES ; ++i)
+		for (i = 0; i < MAX_FPS_FRAMES; ++i)
 		{
 			total += previousTimes[i];
 		}
@@ -3102,15 +3102,22 @@ void CG_DrawFPS(hudComponent_t *comp)
 		total = total ? total : 1;
 
 		fps = 1000 * MAX_FPS_FRAMES / total;
-
-		s = va("%i FPS", fps);
 	}
 	else
 	{
-		s = "estimating";
+		fps = -1;
 	}
+}
 
-	CG_DrawCompText(comp, s, comp->colorMain, comp->styleText, &cgs.media.limboFont1);
+/**
+ * @brief CG_DrawFPS
+ * @param[in] comp
+ * @return
+ */
+void CG_DrawFPS(hudComponent_t *comp)
+{
+	CG_DrawCompText(comp, (fps == -1) ? "estimating" : va("%i FPS", fps),
+	                comp->colorMain, comp->styleText, &cgs.media.limboFont1);
 }
 
 /**

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -3049,6 +3049,7 @@ void CG_InitStatsDebug(void);
 void CG_StatsDebugAddText(const char *text);
 void CG_DrawDebugArtillery(centity_t *cent);
 
+void CG_ComputeFPS(void);
 void CG_AddLagometerFrameInfo(void);
 void CG_AddLagometerSnapshotInfo(snapshot_t *snap);
 void CG_CenterPrint(const char *str);

--- a/src/cgame/cg_view.c
+++ b/src/cgame/cg_view.c
@@ -2806,6 +2806,9 @@ void CG_DrawActiveFrame(int serverTime, qboolean demoPlayback)
 		Com_Memcpy(cg.refdef.areamask, cg.snap->areamask, sizeof(cg.refdef.areamask));
 
 		DEBUGTIME
+		
+		//fps sample
+		CG_ComputeFPS();
 
 		//lagometer sample
 		CG_AddLagometerFrameInfo();

--- a/src/cgame/cg_view.c
+++ b/src/cgame/cg_view.c
@@ -2806,7 +2806,7 @@ void CG_DrawActiveFrame(int serverTime, qboolean demoPlayback)
 		Com_Memcpy(cg.refdef.areamask, cg.snap->areamask, sizeof(cg.refdef.areamask));
 
 		DEBUGTIME
-		
+
 		//fps sample
 		CG_ComputeFPS();
 


### PR DESCRIPTION
Move the FPS sampling outside the FPS meter draw function to ensure FPS sampling is always refresh each frame