### PR TITLE
refactor: `net_uint8_t` for DirToByte, AddEvent

### DIFF
--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1577,7 +1577,7 @@ void G_ClientSound(gentity_t *ent, int soundIndex);
 void G_TouchTriggers(gentity_t *ent);
 
 void G_AddPredictableEvent(gentity_t *ent, int event, int eventParm);
-void G_AddEvent(gentity_t *ent, int event, int eventParm);
+void G_AddEvent(gentity_t *ent, int event, net_uint8_t eventParm);
 void G_SetOrigin(gentity_t *ent, vec3_t origin);
 void AddRemap(const char *oldShader, const char *newShader, float timeOffset);
 void G_ResetRemappedShaders(void);

--- a/src/game/g_missile.c
+++ b/src/game/g_missile.c
@@ -171,8 +171,9 @@ void G_MissileImpact(gentity_t *ent, trace_t *trace, int impactDamage)
 	gentity_t      *other = &g_entities[trace->entityNum];
 	gentity_t      *temp;
 	vec3_t         velocity;
-	entity_event_t event = EV_NONE;
-	int            param = 0, otherentnum = 0;
+	entity_event_t event       = EV_NONE;
+	net_uint8_t    param       = 0;
+	int            otherentnum = 0;
 
 	// handle func_explosives
 	if (other->classname && Q_stricmp(other->classname, "func_explosive") == 0)

--- a/src/qcommon/q_math.c
+++ b/src/qcommon/q_math.c
@@ -303,7 +303,7 @@ void ClampColor(vec4_t color)
  *
  * @note This isn't a real cheap function to call!
  */
-int DirToByte(vec3_t dir)
+net_uint8_t DirToByte(vec3_t dir)
 {
 	int   i, best;
 	float d, bestd;
@@ -333,7 +333,7 @@ int DirToByte(vec3_t dir)
  * @param[in] b
  * @param[out] dir
  */
-void ByteToDir(int b, vec3_t dir)
+void ByteToDir(net_uint8_t b, vec3_t dir)
 {
 	if (b < 0 || b >= NUMVERTEXNORMALS)
 	{


### PR DESCRIPTION
The point of `DirToByte` is to use it for `eventParm`,
which is `net_uint8_t`.

I didn't try to compile this, only ran my linter.