### PR TITLE
misc: use uname -m for arm64 detection in easybuild.sh

### DIFF
--- a/easybuild.sh
+++ b/easybuild.sh
@@ -280,7 +280,7 @@ setup_sensible_defaults() {
         x86_build=false
 
         # Detect Apple Silicon (arm64) and set architecture accordingly
-        if [[ "$PLATFORMARCH" == "arm64" ]]; then
+        if [[ $(uname -m) == "arm64" ]]; then
             # Default to arm64 unless user overrides with --osx-arc
             MACOS_ARCHITECTURES=${MACOS_ARCHITECTURES:-arm64}
             einfo "Detected Apple Silicon (arm64). Defaulting to arm64 build."


### PR DESCRIPTION
The detection of the OS (and arch) runs after this particular check. So on macOS (arm64) it throws this output:

```
ET: Legacy version: v2.84.0-17-ge30ddb4

~~> Detected Intel Mac (x86_64). Defaulting to x86_64 build.`
```

(....)

```
~~> Checking for needed apps to compile...

  running on: macOS arm64 - 26.5.1 <--- this one is right tho.

  autoconf   found:
  libtoolize not found
  cmake      found:
  gcc        found:
  g++        found:
  clang      found:
  clang++    found:
  git        found:
  zip        found:
  nasm       found:
  entr       not found but no problem
```
(...)

```
~~> Authentication is enabled, defaulting to bundled curl

~~> Configuring ET: Legacy...

~~> Building for macOS architecture(s): x86_64
using:
   -DCMAKE_BUILD_TYPE=Release
   -DCROSS_COMPILE32=0
   -DZIP_ONLY=0
   (...)
   -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0
   -DCMAKE_OSX_ARCHITECTURES=x86_64

~~> Default build...
```

So this fix does a direct uname arch check in the macOS sectiion of the build script.