### PR TITLE
client: skip rewind backup allocations for other mods

### DIFF
--- a/src/client/cl_demo.c
+++ b/src/client/cl_demo.c
@@ -926,6 +926,12 @@ void CL_FreeDemoPoints(void)
  */
 void CL_AllocateDemoPoints(void)
 {
+	// only legacy mod supports rewinding, don't try to allocate anything if we're not running it
+	if (!IS_DEFAULT_MOD)
+	{
+		return;
+	}
+
 	CL_FreeDemoPoints();
 
 	maxRewindBackups = cl_maxRewindBackups->integer;


### PR DESCRIPTION
Since `CL_RewindDemo()` does nothing if we're not running the default mod, don't bother allocating rewind backups in such case either.