### PR TITLE
Fix server lag spike on flag/objective capture

### DIFF
--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -2161,6 +2161,10 @@ void ClientUserinfoChanged(int clientNum)
 	}
 #endif
 
+	// the full CS_PLAYERS rebuild below includes the current 'sp'/'msp' values,
+	// so any pending targeted spawn info update (G_FlushSpawnPointInfoChanges) is supercession
+	client->pers.spawnInfoChangePending = qfalse;
+
 	trap_GetConfigstring(CS_PLAYERS + clientNum, oldname, sizeof(oldname));
 	trap_SetConfigstring(CS_PLAYERS + clientNum, configStr);
 
@@ -2177,6 +2181,85 @@ void ClientUserinfoChanged(int clientNum)
 
 	G_LogPrintf("ClientUserinfoChanged: %i %s\n", clientNum, configStr);
 	G_DPrintf("ClientUserinfoChanged: %i :: %s\n", clientNum, configStr);
+}
+
+/// max targeted CS_PLAYERS spawn info updates pushed per server frame; at sv_fps 20 a
+/// value of 8 flushes a 64-player burst in <= 8 frames (400ms) instead of one frame
+#define MAX_SPAWN_INFO_UPDATES_PER_FRAME 8
+
+/**
+ * @brief Applies pending spawn point info updates to the CS_PLAYERS configstrings.
+ *
+ * @details When an objective or flag changes ownership, G_UpdateSpawnPointStatePlayerCounts()
+ * re-checks every player's resolved spawn point in one pass.
+ *
+ * The old approach called ClientUserinfoChanged() for each affected player during that pass.
+ * That works, but it also rebuilds and broadcasts the full CS_PLAYERS configstring for much
+ * of the server in a single frame. With enough clients, this can create a
+ * burst of reliable messages, which shows up as a server-side lag spike whenever a flag is
+ * captured.
+ *
+ * Instead, affected clients are marked with pers.spawnInfoChangePending. This function is
+ * then called once per server frame from G_RunFrame() and updates only the spawn-related
+ * keys, 'sp' and 'msp', in the existing CS_PLAYERS configstring.
+ *
+ * To avoid doing too much work in one frame, only up to MAX_SPAWN_INFO_UPDATES_PER_FRAME
+ * clients are processed per frame. The written keys and values match what
+ * ClientUserinfoChanged() would produce, so existing client features such as fireteam
+ * overlay spawn numbers continue to behave the same.
+ *
+ * Since the engine only broadcasts configstrings that actually changed, this also becomes
+ * a no-op when the resolved spawn values end up matching the previous values.
+ */
+
+void G_FlushSpawnPointInfoChanges(void)
+{
+	static char cs[MAX_STRING_CHARS];
+	gclient_t   *client;
+	int         i, clientNum, updates = 0;
+
+	for (i = 0; i < level.numConnectedClients; i++)
+	{
+		client = &level.clients[level.sortedClients[i]];
+
+		if (!client->pers.spawnInfoChangePending)
+		{
+			continue;
+		}
+
+		// budget exhausted - remaining clients keep their pending flag
+		// and are flushed over the following frames
+		if (updates >= MAX_SPAWN_INFO_UPDATES_PER_FRAME)
+		{
+			break;
+		}
+
+		client->pers.spawnInfoChangePending = qfalse;
+
+		// not fully connected yet: ClientBegin -> ClientUserinfoChanged writes
+		// the full configstring (including sp/msp) anyway
+		if (client->pers.connected != CON_CONNECTED)
+		{
+			continue;
+		}
+
+		clientNum = client - level.clients;
+
+		trap_GetConfigstring(CS_PLAYERS + clientNum, cs, sizeof(cs));
+
+		if (!cs[0])
+		{
+			continue;
+		}
+
+		// same keys/values as the full rebuild in ClientUserinfoChanged()
+		Info_SetValueForKey(cs, "sp", va("%i", Com_Clamp(0, (level.numSpawnPoints - 1), client->sess.resolvedSpawnPointIndex) + 1));
+		Info_SetValueForKey(cs, "msp", va("%i", client->sess.resolvedMinorSpawnPointIndex));
+
+		trap_SetConfigstring(CS_PLAYERS + clientNum, cs);
+
+		updates++;
+	}
 }
 
 extern const char *country_name[MAX_COUNTRY_NUM];

--- a/src/game/g_cmds_ext.c
+++ b/src/game/g_cmds_ext.c
@@ -152,7 +152,7 @@ static const cmd_reference_t aCommandInfo[] =
 	{ "scores",         CMD_USAGE_ANY_TIME,          qtrue,       qfalse, G_scores_cmd,                        ":^7 Displays current match stat info"                                                       },
 	{ "setviewpos",     CMD_USAGE_NO_INTERMISSION,   qtrue,       qfalse, Cmd_SetViewpos_f,                    " x y z pitch yaw roll useViewHeight(0/1):^7 Set the current player position and view angle" },
 	{ "getspawnpt",     CMD_USAGE_NO_INTERMISSION,   qtrue,       qfalse, Cmd_GetSpawnPoint_f,                 ":^7 Get Selected Spawnpoint"                                                                },
-	{ "setspawnpt",     CMD_USAGE_NO_INTERMISSION,   qtrue,       qfalse, Cmd_SetSpawnPoint_f,                 " [majorSpawn] [minorSpawn]:^7 Select a spawn point"                                         },
+	{ "setspawnpt",     CMD_USAGE_NO_INTERMISSION,   qtrue,       qtrue, Cmd_SetSpawnPoint_f,                 " [majorSpawn] [minorSpawn]:^7 Select a spawn point"                                         },
 	{ "sgstats",        CMD_USAGE_ANY_TIME,          qtrue,       qfalse, Cmd_sgStats_f,                       ""                                                                                           },
 
 	{ "showstats",      CMD_USAGE_ANY_TIME,          qtrue,       qfalse, G_PrintAccuracyLog,                  ":^7 Shows weapon accuracy stats"                                                            },

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -859,6 +859,8 @@ typedef struct
 	int savedClassWeaponTimeCvop;
 	int savedClassWeaponTime;
 
+	qboolean spawnInfoChangePending;    ///< resolved spawn point changed; CS_PLAYERS 'sp'/'msp' keys need a defered update
+
 } clientPersistant_t;
 
 /**
@@ -1842,6 +1844,7 @@ qboolean G_DemoRunFrame(void);
 // g_client.c
 char *ClientConnect(int clientNum, qboolean firstTime, qboolean isBot);
 void ClientUserinfoChanged(int clientNum);
+void G_FlushSpawnPointInfoChanges(void);
 void ClientDisconnect(int clientNum);
 void ClientBegin(int clientNum);
 void ClientCommand(int clientNum);

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -4654,6 +4654,9 @@ void G_RunFrame(int levelTime)
 
 	G_UpdateTeamMapData();
 
+	// push deferred CS_PLAYERS 'sp'/'msp' updates (rate-limited, see g_client.c)
+	G_FlushSpawnPointInfoChanges();
+
 	if (level.gameManager)
 	{
 		level.gameManager->s.otherEntityNum  = MAX(0, team_maxLandmines.integer - G_CountTeamLandmines(TEAM_AXIS));

--- a/src/game/g_team.c
+++ b/src/game/g_team.c
@@ -2401,7 +2401,13 @@ void G_UpdateSpawnPointStatePlayerCounts()
 		{
 			client->sess.resolvedSpawnPointIndex      = resolvedSpawn.major;
 			client->sess.resolvedMinorSpawnPointIndex = resolvedMinorSpawnPt;
-			ClientUserinfoChanged(client - level.clients);
+			// don't call ClientUserinfoChanged() here: on objective/flag capture the resolved
+			// spawn point changes for most of the server at once, and rebuilding and broadcasting
+			// the full CS_PLAYERS configstring for every client in a single frame causes a
+			// noticeable server lag spike (reliable messages in thousands). Instead flag the
+			// client and let G_FlushSpawnPointInfoChanges() (G_RunFrame) push a targeted,
+			// rate-limited update of just the 'sp'/'msp' keys.
+			client->pers.spawnInfoChangePending = qtrue;
 		}
 	}
 	// update configstring, if necessary


### PR DESCRIPTION
G_UpdateSpawnPointStatePlayerCounts() was calling ClientUserinfoChanged() for every client whose resolved spawn point changed. On an objective or flag capture, that can be most of the server in a single frame. Each call rebuilds and reliably broadcasts the full CS_PLAYERS configstring to all clients, creating a burst of reliable messages in one tick.

In practice, this showed up as a server hitch that got worse as player count increased. This was a regression from the fireteam spawnpoint feature (upstream cec44f70, PR #3155); 2.82.0 only performed an assignment here.

Instead, changed clients are now marked with pers.spawnInfoChangePending and drained from G_RunFrame() through G_FlushSpawnPointInfoChanges(). That path updates only the 'sp' and 'msp' keys in the existing CS_PLAYERS configstring and limits the work to 8 clients per frame.

The keys and values written here match what ClientUserinfoChanged() writes, so existing 2.84 clients continue to support fireteam overlay spawn numbers without any client-side changes. ClientUserinfoChanged() also clears the pending flag, since its full rebuild already includes the current values.

This also initializes sess.previousUserMinorSpawnPointValue to -1 in both session init paths, G_InitGame and G_InitSessionData. Previously it was left uninitialized, which caused the first player-count pass to flag a false update for every client.