### PR TITLE
client: Fix cl_shownet printing wrong entity num

### DIFF
--- a/src/qcommon/msg.c
+++ b/src/qcommon/msg.c
@@ -4,6 +4,7 @@
  *
  * ET: Legacy
  * Copyright (C) 2012-2024 ET:Legacy team <mail@etlegacy.com>
+ * Copyright (C) 2016 Eugene
  *
  * This file is part of ET: Legacy - http://www.etlegacy.com
  *
@@ -1469,6 +1470,8 @@ void MSG_ReadDeltaEntity(msg_t *msg, entityState_t *from, entityState_t *to,
 		Com_Error(ERR_DROP, "invalid entityState field count");
 	}
 
+	to->number = number;
+
 	// shownet 2/3 will interleave with other printed info, -1 will
 	// just print the delta records`
 	if (cl_shownet && (cl_shownet->integer >= 2 || cl_shownet->integer == -1))
@@ -1480,8 +1483,6 @@ void MSG_ReadDeltaEntity(msg_t *msg, entityState_t *from, entityState_t *to,
 	{
 		print = 0;
 	}
-
-	to->number = number;
 
 	for (i = 0, field = entityStateFields ; i < lc ; i++, field++)
 	{


### PR DESCRIPTION
Cherry-picked from
https://github.com/ec-/Quake3e/commit/76da681398c030bfe3db5fb76411a07b0b20ab9b.

I did not test this on ETLegacy specifically,
only on Quake3e itself.

The license is compatible (GPLv2 or later).
