### PR TITLE
dont trigger additional minimize for macos on focus lost event

### DIFF
--- a/src/sdl/sdl_input.c
+++ b/src/sdl/sdl_input.c
@@ -1718,7 +1718,9 @@ static void IN_ProcessEvents(void)
 				{
 					break;
 				}
+#ifndef __APPLE__
 				IN_WindowFocusLost();
+#endif
 			// fall through
 			case SDL_WINDOWEVENT_LEAVE:
 				Key_ClearStates();


### PR DESCRIPTION
When I alt-tab etlegacy on my mac it's super clunky and etlegacy appears in recently opened apps.

I've made some research and I think that this is because etlegacy manually executes minimize inside custom method IN_WindowFocusLost() which fights with how sdl resolves it for macos.
Alt-tabing in macos is focus lost event from what I tested.

I've tested this solution on my PC but tbh I'm not sure if it's really correct.