### PR TITLE
game: fix a visual bug which caused fireteam to display incorrect spa…

### DIFF
--- a/src/game/g_team.c
+++ b/src/game/g_team.c
@@ -2268,8 +2268,8 @@ static int G_ResolveSpawnPointIndex(team_t team, const vec_t *target_origin)
 }
 
 /**
- * @brief Finds suitable spawn point index for the given team.
- *        If auto selected spawn point is invalid, fallback to standard resolving method.
+ * @brief Return existing default spawn point for a team.
+ *				Can be inactive and doesn't have to belong to the team.
  * @param[in] team
  * @param[in] targetSpawnPt Player selected spawn point.
  * @return Spawn point index or -1.
@@ -2278,14 +2278,11 @@ static int G_ResolveAutoSpawnPointIndex(team_t team, int targetSpawnPt)
 {
 	if (targetSpawnPt >= 0 && targetSpawnPt < level.numSpawnPoints)
 	{
-		const spawnPointState_t *targetSpawnPointState = &level.spawnPointStates[targetSpawnPt];
-		// if this spawn point is already owned by the team, no further actions necessary
-		if (targetSpawnPointState->isActive && targetSpawnPointState->team == team)
-		{
-			return targetSpawnPt;
-		}
+		// if mapscript is set up incorrectly this spawn might not belong to the team or be inactive,
+		// in that case it should be resolved later
+		return targetSpawnPt;
 	}
-	// fallback:
+	// fallback, return any valid spawnpoint
 	return G_ResolveSpawnPointIndex(team, NULL);
 }
 
@@ -2326,13 +2323,13 @@ playerSpawn_t G_GetSpawnForClient(const gclient_t *client, const int resolvedAut
 		return (playerSpawn_t) { -1, -1 };
 	}
 	teamAutoSpawnPt = resolvedAutoSpawnPts[(client->sess.sessionTeam == TEAM_AXIS) ? 0 : 1];
-	// no spawn points are found for the given team
+	// no spawn points on the map
 	if (teamAutoSpawnPt == -1)
 	{
 		return (playerSpawn_t) { -1, -1 };
 	}
 	targetSpawnPt = G_ConvertToSpawnPointIndex(client->sess.userSpawnPointValue, teamAutoSpawnPt);
-	// selected spawn point is owned by the opposite team, find closest team spawn point
+	// selected spawn point is owned by the opposite team or is inactive, find the closest team spawn point
 	if (level.spawnPointStates[targetSpawnPt].team != client->sess.sessionTeam ||
 	    level.spawnPointStates[targetSpawnPt].isActive != 1)
 	{


### PR DESCRIPTION
…wn point when default map spawn for a team was invalid.

My previous updates to the fireteam spawn point display introduced a small bug: when a map (or its mapscript) sets a team's default spawn point to one that's invalid - belonging to the enemy team, or inactive - the fireteam overlay would display an arbitrary spawn point instead of the closest valid one to the intended target. This fix makes it correctly display the closest spawn point instead.

Below I'm pasting my tests on how whole feature works divided by: This PR, current Master amd commit just before my first change.
For supply there is no issue on master as supply has correct default spawnpoints for teams:
<img width="1138" height="224" alt="image" src="https://github.com/user-attachments/assets/f727f88c-ca68-4625-a56a-2ac04a12bb63" />

For operation though, we can see the bug I've introduced. 
<img width="1140" height="97" alt="image" src="https://github.com/user-attachments/assets/e065b7ae-f95f-451b-b4ab-3bdf4cef5539" />
As we can see default spawnpoint for allies on mapstart is actually pointing to axis spawn.

<img width="224" height="81" alt="image" src="https://github.com/user-attachments/assets/c06a8500-8ea6-436b-ae96-2c433ed452c1" />
