### PR TITLE
Fix hit detection: antilag rewind time and dropped usercmds under antiwarp

### DIFF
--- a/src/game/et-antiwarp.c
+++ b/src/game/et-antiwarp.c
@@ -193,6 +193,11 @@ void DoClientThinks(gentity_t *ent)
 		serverTime = cmd->serverTime;
 		totalDelta = latestTime - cmd->serverTime;
 
+		// remember the command time the client actually authored - antilag
+		// must rewind to this time, since cmd->serverTime may be rewritten
+		// below (deltahax) to enforce the movement budget
+		ent->client->realCmdServerTime = cmd->serverTime;
+
 		if (pmove_fixed.integer || ent->client->pers.pmoveFixed)
 		{
 			serverTime = ((serverTime + pmove_msec.integer - 1) / pmove_msec.integer) * pmove_msec.integer;

--- a/src/game/et-antiwarp.c
+++ b/src/game/et-antiwarp.c
@@ -57,18 +57,19 @@ void etpro_AddUsercmd(int clientNum, usercmd_t *cmd)
 	gentity_t *ent = g_entities + clientNum;
 	int       idx  = (ent->client->cmdhead + ent->client->cmdcount) % LAG_MAX_COMMANDS;
 
-	ent->client->cmds[idx] = *cmd;
-
 	if (ent->client->cmdcount < LAG_MAX_COMMANDS)
 	{
+		ent->client->cmds[idx] = *cmd;
 		ent->client->cmdcount++;
 	}
 	else
 	{
 		// queue full, the oldest command is overwritten - rescue its button
-		// presses so they are not silently lost (refs #1408)
+		// presses before overwriting so they are not silently lost (refs #1408)
+		// (note: with a full queue, idx == cmdhead)
 		ent->client->droppedButtons  |= ent->client->cmds[ent->client->cmdhead].buttons;
 		ent->client->droppedWButtons |= ent->client->cmds[ent->client->cmdhead].wbuttons;
+		ent->client->cmds[idx]        = *cmd;
 		ent->client->cmdhead          = (ent->client->cmdhead + 1) % LAG_MAX_COMMANDS;
 	}
 }

--- a/src/game/et-antiwarp.c
+++ b/src/game/et-antiwarp.c
@@ -65,7 +65,11 @@ void etpro_AddUsercmd(int clientNum, usercmd_t *cmd)
 	}
 	else
 	{
-		ent->client->cmdhead = (ent->client->cmdhead + 1) % LAG_MAX_COMMANDS;
+		// queue full, the oldest command is overwritten - rescue its button
+		// presses so they are not silently lost (refs #1408)
+		ent->client->droppedButtons  |= ent->client->cmds[ent->client->cmdhead].buttons;
+		ent->client->droppedWButtons |= ent->client->cmds[ent->client->cmdhead].wbuttons;
+		ent->client->cmdhead          = (ent->client->cmdhead + 1) % LAG_MAX_COMMANDS;
 	}
 }
 
@@ -210,18 +214,31 @@ void DoClientThinks(gentity_t *ent)
 			// whoops. too lagged.
 			drop_threshold = LAG_MIN_DROP_THRESHOLD;
 			lastTime       = ent->client->ps.commandTime = cmd->serverTime;
+
+			// don't lose button presses of dropped commands - merge them into
+			// the next processed command (a dropped attack press would
+			// otherwise never fire server-side, refs #1408)
+			ent->client->droppedButtons  |= cmd->buttons;
+			ent->client->droppedWButtons |= cmd->wbuttons;
+
 			goto drop_packet;
 		}
 
 		if (totalDelta < 0)
 		{
 			// oro? packet from the future
+			ent->client->droppedButtons  |= cmd->buttons;
+			ent->client->droppedWButtons |= cmd->wbuttons;
+
 			goto drop_packet;
 		}
 
 		if (timeDelta <= 0)
 		{
 			// packet from the past
+			ent->client->droppedButtons  |= cmd->buttons;
+			ent->client->droppedWButtons |= cmd->wbuttons;
+
 			goto drop_packet;
 		}
 
@@ -288,6 +305,20 @@ void DoClientThinks(gentity_t *ent)
 
 		// erh.  hack, really. make it run for the proper amount of time.
 		ent->client->ps.commandTime = lastTime;
+
+		// merge in button presses of commands dropped above, so they still
+		// take effect (delayed) instead of being silently lost. Weapon fire
+		// is level-triggered on cmd.buttons with pmext->releasedFire as the
+		// semi-auto edge, so a merged press fires at most once.
+		if (ent->client->droppedButtons || ent->client->droppedWButtons)
+		{
+			cmd->buttons  |= ent->client->droppedButtons;
+			cmd->wbuttons |= ent->client->droppedWButtons;
+
+			ent->client->droppedButtons  = 0;
+			ent->client->droppedWButtons = 0;
+		}
+
 		ClientThink_cmd(ent, cmd);
 		lastTime = ent->client->ps.commandTime;
 

--- a/src/game/g_active.c
+++ b/src/game/g_active.c
@@ -1711,6 +1711,7 @@ void ClientThink(int clientNum)
 		}
 		else
 		{
+			ent->client->realCmdServerTime = newcmd.serverTime;
 			ClientThink_cmd(ent, &newcmd);
 		}
 	}

--- a/src/game/g_antilag.c
+++ b/src/game/g_antilag.c
@@ -225,10 +225,12 @@ static qboolean G_AdjustSingleClientPosition(gentity_t *ent, int time)
 	}
 	while (i != ent->client->topMarker);
 
-	if (i == j)     // oops, no valid stored markers
-	{
-		return qfalse;
-	}
+	// if the requested time is newer than our newest marker, the loop above
+	// breaks immediately with i == j == topMarker - this is the normal case
+	// for low-ping shooters, whose command time is newer than the last stored
+	// frame. Don't bail out here: clamp to the newest marker instead of not
+	// rewinding at all. The copy branch below (i == topMarker) applies the
+	// newest stored position.
 
 	// save current position to backup if we have not already done so ( no need to re-save )
 	if (ent->client->backupMarker.time != level.time)
@@ -766,7 +768,7 @@ void G_HistoricalTrace(gentity_t *ent, trace_t *results, const vec3_t start, con
 		return;
 	}
 
-	G_AdjustClientPositions(ent, ent->client->pers.cmd.serverTime, qtrue);
+	G_AdjustClientPositions(ent, ent->client->realCmdServerTime, qtrue);
 
 	G_Trace(ent, results, start, mins, maxs, end, passEntityNum, contentmask);
 
@@ -784,7 +786,7 @@ void G_HistoricalTraceBegin(gentity_t *ent)
 	{
 		return;
 	}
-	G_AdjustClientPositions(ent, ent->client->pers.cmd.serverTime, qtrue);
+	G_AdjustClientPositions(ent, ent->client->realCmdServerTime, qtrue);
 }
 
 /**

--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -3479,6 +3479,7 @@ void ClientSpawn(gentity_t *ent, qboolean revived, qboolean teamChange, qboolean
 	// initialize animations and other things
 	client->ps.commandTime           = level.time - 100;
 	ent->client->pers.cmd.serverTime = level.time;
+	ent->client->realCmdServerTime   = level.time;
 
 	ClientThink(ent - g_entities);
 

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1033,6 +1033,7 @@ struct gclient_s
 	qboolean warping;
 	qboolean warped;
 	int lastCmdRealTime;
+	int realCmdServerTime;                  ///< serverTime of the usercmd currently being processed, as authored by the client (never rewritten by antiwarp) - used as the antilag rewind time
 	int cmdhead;                            ///< antiwarp command queue head
 	int cmdcount;                           ///< antiwarp command queue # valid commands
 	float cmddelta;                         ///< antiwarp command queue # valid commands

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1034,6 +1034,8 @@ struct gclient_s
 	qboolean warped;
 	int lastCmdRealTime;
 	int realCmdServerTime;                  ///< serverTime of the usercmd currently being processed, as authored by the client (never rewritten by antiwarp) - used as the antilag rewind time
+	int droppedButtons;                     ///< buttons of usercmds dropped by antiwarp, merged into the next processed command so presses are not lost
+	int droppedWButtons;                    ///< wbuttons of usercmds dropped by antiwarp, merged into the next processed command so presses are not lost
 	int cmdhead;                            ///< antiwarp command queue head
 	int cmdcount;                           ///< antiwarp command queue # valid commands
 	float cmddelta;                         ///< antiwarp command queue # valid commands


### PR DESCRIPTION
Fixes #1408

Hit registration felt delayed, and hits sometimes didn't register at all. Both symptoms trace to the interaction
between zinx's antiwarp port (et-antiwarp.c) and antilag (g_antilag.c), and both are compounded by antiwarp
silently discarding usercmds. Two commits, three distinct root causes:

1. Antiwarp fabricated serverTime fed the antilag rewind (d3147ec02)

DoClientThinks() enforces its movement budget by capping/splitting usercmds, rewriting cmd->serverTime to a
fabricated, earlier time (deltahax) before ClientThink_cmd() latches it into pers.cmd and fires weapon events.
Antilag then rewound all other clients to pers.cmd.serverTime — the fabricated time, always older than what the
shooter actually saw. Targets were tested against a past further back than the shooter's view, so hits missed or
registered "late". Under sustained antiwarping, ps.commandTime effectively freezes while level.time advances,
pushing the rewind time outside the marker window entirely.

Fix: latch the client-authored serverTime into gclient_s.realCmdServerTime before antiwarp can rewrite it, and use
it as the rewind time in G_HistoricalTrace/G_HistoricalTraceBegin. (Note: 72bed4f16 attempted this ETPub-style in
2020 but snapshotted after the rewrite, capturing the fabricated time too; reverted in b9d645fd7. This captures it
before antiwarp touches it. The whole lineage — stock WET SDK antilag, rtcwPro — shares the flaw via
pers.cmd.serverTime.)

2. Low-ping shooters got no compensation at all (d3147ec02)

G_AdjustSingleClientPosition() bailed with return qfalse ("oops, no valid stored markers") whenever the rewind time
was newer than the newest marker — the normal case for any shooter with ping below one server frame. Their shots
traced against target positions up to a full server frame (~50 ms at sv_fps 20) ahead of what they saw, with zero
backward reconciliation. i == j after the marker walk can only mean "newer than newest marker" with i == j ==
topMarker, so falling through to the existing copy branch now clamps to the newest marker; backup/restore symmetry
is preserved.

3. Antiwarp silently swallowed button presses (b9ad853ec)

DoClientThinks() discards whole usercmds in four places (>800 ms backlog drop, "future" packets, "past" packets
after a resync jump, queue overflow overwrite), losing their buttons/wbuttons along with the movement. Weapon fire
is level-triggered on cmd.buttons & BUTTON_ATTACK inside Pmove — if the entire press window is dropped, the shot
never exists server-side.

Fix: accumulate the buttons of every discarded cmd into droppedButtons/droppedWButtons and OR-merge them into the
next cmd actually processed. A swallowed click becomes a late shot instead of no shot — and thanks to fix 1, the
late shot still rewinds to what the player saw. Movement/drop semantics and the clock-cheat protection are
unchanged; only button state is forwarded, never movement.

Testing

- [x] Compile
- [ ] Playtest with a high-ping / packet-lossy client: semi-auto spam during loss bursts, g_antiwarp 16|32 debug
output, g_debugBullets/g_debugPlayerHitboxes to eyeball rewound hitboxes
- [ ] A/B against g_antiwarp 0 to confirm no regression for non-warping players
- [ ] Low-ping / LAN match to verify compensation for sub-frame pings

Known limitations

- Timing analysis of the merged press vs. stock semantics (PM_Weapon, including the semi-auto quickfire clamp at weaponTime <= 150 ms) shows the merge reproduces stock fire/no-fire outcomes in virtually all press/release timings. The one divergent artifact is a possible "ghost shot": a click released just before the quickfire window, fully dropped, can fire when the merged press lands inside the window — stock would not have fired, and the client never predicted the shot. Rare and benign; suppressing it (forwarding press/release edges instead of button levels) would reintroduce the lost clicks this fix exists to prevent.
- Shots from within a fully-dropped full-auto hold are inherently unrecoverable; the merge restores one shot rather than the full burst.
- Weapon switches (cmd.weapon) of dropped cmds are still not forwarded.
- Original etpro's reconciliation of antiwarp/antilag could not be checked: etpro source is not publicly available (closed source; antiwarp was a private handoff from zinx, a2139bb15).