### PR TITLE
cgame: fix forced mono colored UFT-8 name display

### DIFF
--- a/src/cgame/cg_draw.c
+++ b/src/cgame/cg_draw.c
@@ -2382,34 +2382,6 @@ void CG_DrawCrosshairHealthBar(hudComponent_t *comp)
 }
 
 /**
- * @brief CG_GetCrosshairNameString
- * @param[in] comp
- * @param[in] clientNum
- * @return a colorized or single color name string for crosshair info
- */
-static const char *CG_GetCrosshairNameString(hudComponent_t *comp, int clientNum)
-{
-	char colorized[MAX_NAME_LENGTH + 2] = { 0 };
-
-	// ensure the client is valid
-	if (!cgs.clientinfo[clientNum].infoValid)
-	{
-		return va("unknown");
-	}
-
-	if (comp->style & 1)
-	{
-		// Draw them with full colors
-		return cgs.clientinfo[clientNum].name;
-	}
-
-	// Draw them with a single color
-	Q_ColorizeString('*', cgs.clientinfo[clientNum].cleanname, colorized, MAX_NAME_LENGTH + 2);
-
-	return va("%s", colorized);
-}
-
-/**
  * @brief CG_DrawCrosshairNames
  * @param[in] comp
  */
@@ -2485,7 +2457,7 @@ void CG_DrawCrosshairNames(hudComponent_t *comp)
 						break;
 					}
 
-					s = va(CG_TranslateString("%s^*\'s %s"), CG_GetCrosshairNameString(comp, es->otherEntityNum), weaponText);
+					s = va(CG_TranslateString("%s^*\'s %s"), CG_GetClientNameString(es->otherEntityNum, comp->style & 1), weaponText);
 				}
 				break;
 			default:
@@ -2539,7 +2511,7 @@ void CG_DrawCrosshairNames(hudComponent_t *comp)
 	{
 		textColor[3] = color[3];
 
-		s = CG_GetCrosshairNameString(comp, clientNum);
+		s = CG_GetClientNameString(clientNum, comp->style & 1);
 		CG_DrawCompText(comp, s, textColor, comp->styleText, &cgs.media.limboFont2);
 	}
 }

--- a/src/cgame/cg_drawtools.c
+++ b/src/cgame/cg_drawtools.c
@@ -1844,3 +1844,31 @@ qhandle_t CG_GetTeamFlag(team_t team)
 	default: return 0;
 	}
 }
+
+/**
+ * @brief CG_GetClientNameString
+ * @param[in] clientNum
+ * @param[in] isFullcolor
+ * @return a colorized or single color name string from selected client
+ */
+char *CG_GetClientNameString(int clientNum, qboolean isFullcolor)
+{
+	char colorized[MAX_NAME_LENGTH + 2] = { 0 };
+
+	// ensure the client is valid
+	if (!cgs.clientinfo[clientNum].infoValid)
+	{
+		return va("unknown");
+	}
+
+	if (isFullcolor)
+	{
+		// Draw them with full colors
+		return cgs.clientinfo[clientNum].name;
+	}
+
+	// Draw them with a single color
+	Q_ColorizeString('*', cgs.clientinfo[clientNum].name, colorized, MAX_NAME_LENGTH + 2);
+
+	return va("%s", colorized);
+}

--- a/src/cgame/cg_fireteamoverlay.c
+++ b/src/cgame/cg_fireteamoverlay.c
@@ -498,20 +498,10 @@ static void CG_FTOverlay_SetColors(fireteamOverlay_t *fto, const float alpha)
 
 static void CG_FTOverlay_StorePlayerName(fireteamOverlay_t *fto, const int row, const hudComponent_t *comp)
 {
-	if (comp->style & FT_COLORLESS_NAME || (comp->style & FT_STATUS_COLOR_NAME && (fto->ci->health <= 0 || fto->ci->ping >= 999)))
-	{
-		char escapedName[MAX_NAME_LENGTH];
+	qboolean isFullcolor = !(comp->style & FT_COLORLESS_NAME
+	                         || (comp->style & FT_STATUS_COLOR_NAME && (fto->ci->health <= 0 || fto->ci->ping >= 999)));
 
-		// use NULL color here rather than 'fto->ci->cleanname' directly,
-		// to make sure that a name with visible carets in it doesn't get colorized when drawing,
-		// and works as expected with colorless names/status colored names
-		Q_ColorizeString('*', fto->ci->cleanname, escapedName, sizeof(escapedName));
-		Q_strncpyz(fto->name[row], escapedName, sizeof(fto->name[row]));
-	}
-	else
-	{
-		Q_strncpyz(fto->name[row], fto->ci->name, sizeof(fto->name[row]));
-	}
+	Q_strncpyz(fto->name[row], CG_GetClientNameString(fto->ci->clientNum, isFullcolor), sizeof(fto->name[row]));
 
 	// truncate name if max chars is set
 	if (cg_fireteamNameMaxChars.integer > 0)

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -4455,5 +4455,7 @@ void CG_DrawCursor(float x, float y);
 
 qhandle_t CG_GetTeamFlag(team_t team);
 
+char *CG_GetClientNameString(int clientNum, qboolean isFullcolor);
+
 void CG_DemoBackwardsCompatInit();
 #endif // #ifndef INCLUDE_CG_LOCAL_H

--- a/src/cgame/cg_players.c
+++ b/src/cgame/cg_players.c
@@ -2255,7 +2255,7 @@ static void CG_PlayerSprites(centity_t *cent)
 
 		if (cg_drawSpectatorNames.integer > 0)
 		{
-			name = cg_drawSpectatorNames.integer == 1 ? ci->cleanname : ci->name;
+			name = CG_GetClientNameString(cent->currentState.clientNum, cg_drawSpectatorNames.integer);
 
 			if (cg_shoutcastDrawHealth.integer == 1 && cgs.clientinfo[cg.clientNum].shoutcaster)
 			{
@@ -2292,7 +2292,7 @@ static void CG_PlayerSprites(centity_t *cent)
 
 	if (cg.demoPlayback && cg_drawSpectatorNames.integer > 0)
 	{
-		CG_PlayerFloatText(cent, cg_drawSpectatorNames.integer == 1 ? ci->cleanname : ci->name, height + 8);
+		CG_PlayerFloatText(cent, CG_GetClientNameString(cent->currentState.clientNum, cg_drawSpectatorNames.integer == 1), height + 8);
 	}
 
 	if (cent->currentState.powerups & (1 << PW_INVULNERABLE))

--- a/src/cgame/cg_shoutcastoverlay.c
+++ b/src/cgame/cg_shoutcastoverlay.c
@@ -211,8 +211,8 @@ static void CG_DrawShoutcastPlayerOverlayAxis(hudComponent_t *comp, clientInfo_t
 		CG_DrawPic(topRowX + (statusWidth / 2) - 10, y + (height / 2) - 10, 20, 20, cgs.media.scoreEliminatedShader);
 	}
 
-	// draw name limit 20 chars
-	Q_ColorizeString(player->health < 0 ? '9' : '7', player->cleanname, name, MAX_NAME_LENGTH + 2);
+	// draw name
+	Q_ColorizeString(player->health < 0 ? '9' : '7', player->name, name, MAX_NAME_LENGTH + 2);
 	textHeight = CG_Text_Height_Ext(name, 0.16f, 0, FONT_TEXT);
 	CG_Text_Paint_Ext(comp->location.x + statusWidth + 1, y + (height / 4) + (textHeight / 2), 0.16f, 0.16f, comp->colorMain, name, 0, 20, comp->styleText, FONT_TEXT);
 
@@ -367,8 +367,8 @@ static void CG_DrawShoutcastPlayerOverlayAllies(hudComponent_t *comp, clientInfo
 		CG_DrawPic(topRowX - (statusWidth / 2) - 10, y + (height / 2) - 10, 20, 20, cgs.media.scoreEliminatedShader);
 	}
 
-	// draw name limit 20 chars
-	Q_ColorizeString(player->health < 0 ? '9' : '7', player->cleanname, name, MAX_NAME_LENGTH + 2);
+	// draw name
+	Q_ColorizeString(player->health < 0 ? '9' : '7', player->name, name, MAX_NAME_LENGTH + 2);
 	textWidth  = CG_Text_Width_Ext(name, 0.16f, 0, FONT_TEXT);
 	textHeight = CG_Text_Height_Ext(name, 0.16f, 0, FONT_TEXT);
 	if (textWidth > 116)
@@ -768,8 +768,8 @@ void CG_DrawShoutcastPlayerStatus(hudComponent_t *comp)
 	// draw team flag
 	CG_DrawPic(nameBoxX + 4, nameBoxY + (nameBoxHeight / 2) - 4.5f, 14, 9, CG_GetTeamFlag(player->team));
 
-	// draw name limit 20 chars, width 110
-	Q_ColorizeString('7', player->cleanname, name, MAX_NAME_LENGTH + 2);
+	// draw name, width 110
+	Q_ColorizeString('7', player->name, name, MAX_NAME_LENGTH + 2);
 	textWidth  = CG_Text_Width_Ext(name, scale, 0, FONT_TEXT);
 	textHeight = CG_Text_Height_Ext(name, scale, 0, FONT_TEXT);
 	if (textWidth > 110)

--- a/src/qcommon/q_shared.c
+++ b/src/qcommon/q_shared.c
@@ -2020,15 +2020,12 @@ void Q_EscapeColorCodes(char *string, char escapeColor)
 }
 
 /**
- * @brief Takes a plain "un-colored" string, and then colorizes it so the string is displayed in the given color.
+ * @brief Takes a plain string, and then colorizes it so the string is displayed in the given color.
  * If given a string such as "Bob" and asked to colorize to '1' (red)', the output would be "^1Bob". If given
- * "John^^7Candy" the output is "^1John^^1^^17Candy"  -- Note that when drawn, this would literally show
- * the text "John^^7Candy" in red.
- *
- * If the desired result is to see "John^Candy" in red, then create a clean un-colored string before calling this.
+ * "John^^7Candy" the output is "^1John^^1^^1Candy".
  *
  * REQUIREMENTS:
- *	- Callers must pass in a buffer that is *at least* 3 bytes long.
+ *  - Callers must pass in a buffer that is *at least* 3 bytes long.
  *  - inStr and outStr cannot overlap
  *
  * @param[in] colorCode
@@ -2068,9 +2065,17 @@ void Q_ColorizeString(char colorCode, const char *inStr, char *outStr, size_t ou
 			// chars plus possible terminator char
 			if (outOffset + 4 < outBufferLen)
 			{
-				outStr[outOffset++] = c;
-				outStr[outOffset++] = Q_COLOR_ESCAPE;
-				outStr[outOffset++] = colorCode;
+				if (inOffset + 1 < inLen && inStr[inOffset + 1] == '^')
+				{
+					outStr[outOffset++] = c;
+					outStr[outOffset++] = Q_COLOR_ESCAPE;
+					outStr[outOffset++] = colorCode;
+				}
+				else
+				{
+					// skip color escaped
+					inOffset += 1;
+				}
 			}
 			else
 			{


### PR DESCRIPTION
On crosshair, fireteam and shoutcaster overlay, the players name containing UTF-8 char were not printed properly and literrally skipped. This was due to the usage of `cleanname` retuned from `Q_CleanStr` function which skip UTF-8 char.