### PR TITLE
game: reset time_played in skill rating warmup reset, refs #1422

### DIFF
--- a/src/game/g_skillrating.c
+++ b/src/game/g_skillrating.c
@@ -532,6 +532,7 @@ void G_SkillRatingGetClientRating(gclient_t *cl)
 		{
 			cl->sess.time_axis   = 0;
 			cl->sess.time_allies = 0;
+			cl->sess.time_played = 0;
 		}
 
 		// prepare delta rating


### PR DESCRIPTION
G_SkillRatingGetClientRating() cleared sess.time_axis and
sess.time_allies on warmup reconnects but left sess.time_played,
so Time played (100 * time_played / (time_axis + time_allies))
could exceed 100% when the leftover value survives (forced
restarts, no-warmup configs). Reset it with the team counters.
Stopwatch is unaffected: skill rating is disabled there.
