### PR TITLE
game: skip skill rating updates for maps without decisive winner, refs #3066

### DIFF
--- a/src/game/g_skillrating.c
+++ b/src/game/g_skillrating.c
@@ -717,7 +717,7 @@ float G_SkillRatingGetMapRating(char *mapname)
 
 			G_Printf("G_SkillRatingGetMapRating: sqlite3_step failed: %s\n", err_msg);
 			sqlite3_free(err_msg);
-			return 1;
+			return 0.5f;
 		}
 	}
 
@@ -851,6 +851,13 @@ void G_CalculateSkillRatings(void)
 	// log
 	G_LogPrintf("SkillRating: Map: %s, Winner: %d, Time: %d, Timelimit: %d\n",
 	            level.rawmapname, winner, level.intermissionQueued - level.startTime - level.timeDelta, g_timelimit.integer * 60000);
+
+	// skip maps without decisive winner (draw or admin forced end)
+	if (winner != TEAM_AXIS && winner != TEAM_ALLIES)
+	{
+		G_LogPrintf("SkillRating: no decisive winner, map and player ratings not updated\n");
+		return;
+	}
 
 	// update map rating
 	if (g_skillRating.integer > 1)


### PR DESCRIPTION
Drawn or admin force-ended maps (winner -1) were processed as Axis
wins, twice over: the map bias recorded a spurious Axis victory, and
the non-draw model (EPSILON = 0) gave every player rankFactor -1,
decreasing all ratings.

G_CalculateSkillRatings now returns early without a decisive winner,
skipping both updates and logging the skip. Proper draw support
(draw-variant V/W functions) remains a separate feature.

Also return fair 0.5 bias instead of 1.0 on db errors in
G_SkillRatingGetMapRating.
