### PR TITLE
game: reset player stats on console map_restart, refs #1812

### DIFF
--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -1957,6 +1957,12 @@ void G_ShutdownGame(int restart)
 	mdx_cleanup();
 #endif
 
+	// reset stats on any mid-match restart that didn't already handle them (e.g. console map_restart)
+	if (restart && !level.fResetStats && !trap_Cvar_VariableIntegerValue("g_restarted") && g_gamestate.integer == GS_PLAYING)
+	{
+		level.fResetStats = qtrue;
+	}
+
 	// write all the client session data so we can get it back
 	G_WriteSessionData(restart);
 }


### PR DESCRIPTION
A map_restart from the server console never passes through
Svcmd_ResetMatch_f, so level.fResetStats was never set and player
stats persisted across the restart.

G_ShutdownGame now flags stats for reset on any restart during a
match that hasn't already handled them (fResetStats set, or the
g_restarted warmup-countdown restart) matching vote maprestart
behaviour. Mod restarts back to warmup mid-match (empty team,
config load) now reset stats too, consistent with that.

Mod-initiated restarts that must keep stats are unaffected:
- vote/reset_match restarts set fResetStats themselves
- the warmup countdown restart sets g_restarted first
- LMS rounds and the nextmap fallback run at GS_INTERMISSION
