### PR TITLE
game: prevent session data inheritance across clients on slot reuse, refs #2612

### DIFF
--- a/src/game/g_client.c
+++ b/src/game/g_client.c
@@ -2434,7 +2434,12 @@ char *ClientConnect(int clientNum, qboolean firstTime, qboolean isBot)
 	}
 	else
 	{
-		G_ReadSessionData(client);
+		// read the session data, or initialize a fresh session
+		// if the stored session belongs to a different client
+		if (!G_ReadSessionData(client))
+		{
+			G_InitSessionData(client, userinfo);
+		}
 	}
 
 	// GeoIP

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1873,7 +1873,7 @@ void G_InitMemory(void);
 void Svcmd_GameMem_f(void);
 
 // g_session.c
-void G_ReadSessionData(gclient_t *client);
+qboolean G_ReadSessionData(gclient_t *client);
 void G_InitSessionData(gclient_t *client, const char *userinfo);
 
 void G_InitWorldSession(void);

--- a/src/game/g_session.c
+++ b/src/game/g_session.c
@@ -70,6 +70,7 @@ void G_WriteClientSessionData(gclient_t *client, qboolean restart)
 		Com_Error(ERR_FATAL, "Could not allocate memory for session data\n");
 	}
 
+	cJSON_AddStringToObject(root, "guid", client->pers.cl_guid);
 	cJSON_AddNumberToObject(root, "sessionTeam", client->sess.sessionTeam);
 	cJSON_AddNumberToObject(root, "spectatorTime", client->sess.spectatorTime);
 	cJSON_AddNumberToObject(root, "spectatorState", client->sess.spectatorState);
@@ -302,18 +303,38 @@ void G_CalcRank(gclient_t *client)
 /**
  * @brief Called on a reconnect
  * @param[in] client
+ * @return qtrue if the session data was restored, qfalse if there is no
+ *         session file or it belongs to a different client (guid mismatch)
  */
-void G_ReadSessionData(gclient_t *client)
+qboolean G_ReadSessionData(gclient_t *client)
 {
-	char     fileName[MAX_QPATH] = { 0 };
-	cJSON    *root = NULL, *wstats = NULL, *campaign = NULL;
-	qboolean test, restoreStats = qtrue;
-	int      i = 0;
+	char       fileName[MAX_QPATH] = { 0 };
+	const char *guid;
+	cJSON      *root = NULL, *wstats = NULL, *campaign = NULL;
+	qboolean   test, restoreStats = qtrue;
+	int        i = 0;
 
 	Com_sprintf(fileName, sizeof(fileName), "session/client%02i.json", (int)(client - level.clients));
 	Com_Printf("Reading session file %s\n", fileName);
 
 	root = Q_FSReadJsonFrom(fileName);
+
+	// no session file (or unreadable/corrupt) - start with a fresh session
+	if (!root)
+	{
+		return qfalse;
+	}
+
+	// session files are stored per client slot - ensure the stored session
+	// actually belongs to this client (e.g. not to the previous slot occupant)
+	guid = Q_ReadStringValueJson(root, "guid");
+
+	if (!guid || Q_stricmp(guid, client->pers.cl_guid))
+	{
+		G_LogPrintf("G_ReadSessionData: guid mismatch for client %i, skipping session restore\n", (int)(client - level.clients));
+		cJSON_Delete(root);
+		return qfalse;
+	}
 
 	if (level.fResetStats)
 	{
@@ -543,6 +564,8 @@ void G_ReadSessionData(gclient_t *client)
 		client->sess.startskillpoints[i] = client->sess.skillpoints[i];
 		client->sess.startxptotal       += client->sess.skillpoints[i];
 	}
+
+	return qtrue;
 }
 
 /**


### PR DESCRIPTION
Session files are stored per client slot and were restored without
any ownership check, so a new occupant (e.g. a bot filling a freed
slot) inherited the previous client's skill rating, prestige and
stats, which were then written to rating_match under the bot's guid
and skewed the original player's rating via G_UpdateSkillRating.

Store the client guid in the session file and fall back to a fresh
session on guid mismatch.

Bots keep their stable per-slot fake guid (OMNIBOTxx) so they still
participate in skill rating: their rating feeds the team strength
behind individual deltas, so excluding them would misestimate every
bot matchup. With the guid check, a bot can no longer pick up a
human's session, so the rows it writes are genuinely its own.
