### PR TITLE
game: use connect-time guid for SR/XP db access, refs #1493

### DIFF
--- a/src/game/g_skillrating.c
+++ b/src/game/g_skillrating.c
@@ -483,9 +483,6 @@ int G_SkillRatingSetUserRating(srData_t *sr_data)
  */
 void G_SkillRatingGetClientRating(gclient_t *cl)
 {
-	char     userinfo[MAX_INFO_STRING];
-	char     *guid;
-	int      clientNum;
 	srData_t sr_data;
 
 	// disable for these game types
@@ -505,14 +502,15 @@ void G_SkillRatingGetClientRating(gclient_t *cl)
 		return;
 	}
 
-	clientNum = cl - level.clients;
-
-	// retrieve guid
-	trap_GetUserinfo(clientNum, userinfo, sizeof(userinfo));
-	guid = Info_ValueForKey(userinfo, "cl_guid");
+	// skip clients without a usable GUID (e.g. ETLTV slaves)
+	// pers.cl_guid is set at connect time (format-validated when g_guidCheck is enabled); userinfo may be stale on slot reuse
+	if (strlen(cl->pers.cl_guid) < MAX_GUID_LENGTH)
+	{
+		return;
+	}
 
 	// assign guid
-	sr_data.guid = (const unsigned char *)guid;
+	sr_data.guid = (const unsigned char *)cl->pers.cl_guid;
 
 	// retrieve current rating or assign default values
 	if (level.warmupTime || level.intermissionQueued || level.intermissiontime)
@@ -579,9 +577,6 @@ void G_SkillRatingGetClientRating(gclient_t *cl)
  */
 void G_SkillRatingSetClientRating(gclient_t *cl)
 {
-	char     userinfo[MAX_INFO_STRING];
-	char     *guid;
-	int      clientNum;
 	srData_t sr_data;
 
 	// disable for these game types
@@ -607,14 +602,15 @@ void G_SkillRatingSetClientRating(gclient_t *cl)
 		return;
 	}
 
-	clientNum = cl - level.clients;
-
-	// retrieve guid
-	trap_GetUserinfo(clientNum, userinfo, sizeof(userinfo));
-	guid = Info_ValueForKey(userinfo, "cl_guid");
+	// skip clients without a usable GUID (e.g. ETLTV slaves)
+	// pers.cl_guid is set at connect time (format-validated when g_guidCheck is enabled); userinfo may be stale on slot reuse
+	if (strlen(cl->pers.cl_guid) < MAX_GUID_LENGTH)
+	{
+		return;
+	}
 
 	// assign match data
-	sr_data.guid        = (const unsigned char *)guid;
+	sr_data.guid        = (const unsigned char *)cl->pers.cl_guid;
 	sr_data.mu          = cl->sess.mu;
 	sr_data.sigma       = cl->sess.sigma;
 	sr_data.time_axis   = cl->sess.time_axis;

--- a/src/game/g_xp_saver.c
+++ b/src/game/g_xp_saver.c
@@ -152,8 +152,6 @@ int G_XPSaver_CheckDB(char *db_path, int db_mode)
  */
 void G_XPSaver_Load(gclient_t *cl)
 {
-	char      userinfo[MAX_INFO_STRING];
-	char      *guid;
 	int       clientNum, i;
 	xpData_t  xp_data;
 	gentity_t *ent;
@@ -179,12 +177,15 @@ void G_XPSaver_Load(gclient_t *cl)
 		return;
 	}
 
-	// retrieve guid
-	trap_GetUserinfo(clientNum, userinfo, sizeof(userinfo));
-	guid = Info_ValueForKey(userinfo, "cl_guid");
+	// skip clients without a usable GUID (e.g. ETLTV slaves)
+	// pers.cl_guid is set at connect time (format-validated when g_guidCheck is enabled); userinfo may be stale on slot reuse
+	if (strlen(cl->pers.cl_guid) < MAX_GUID_LENGTH)
+	{
+		return;
+	}
 
 	// assign guid
-	xp_data.guid = (const unsigned char *)guid;
+	xp_data.guid = (const unsigned char *)cl->pers.cl_guid;
 
 	// retrieve current xp or assign default values
 	if (G_XPSaver_Read(&xp_data))
@@ -209,8 +210,6 @@ void G_XPSaver_Load(gclient_t *cl)
  */
 void G_XPSaver_Store(gclient_t *cl)
 {
-	char      userinfo[MAX_INFO_STRING];
-	char      *guid;
 	int       clientNum, i;
 	xpData_t  xp_data;
 	gentity_t *ent;
@@ -242,11 +241,14 @@ void G_XPSaver_Store(gclient_t *cl)
 		return;
 	}
 
-	// retrieve guid
-	trap_GetUserinfo(clientNum, userinfo, sizeof(userinfo));
-	guid = Info_ValueForKey(userinfo, "cl_guid");
+	// skip clients without a usable GUID (e.g. ETLTV slaves)
+	// pers.cl_guid is set at connect time (format-validated when g_guidCheck is enabled); userinfo may be stale on slot reuse
+	if (strlen(cl->pers.cl_guid) < MAX_GUID_LENGTH)
+	{
+		return;
+	}
 
-	xp_data.guid = (const unsigned char *)guid;
+	xp_data.guid = (const unsigned char *)cl->pers.cl_guid;
 
 	for (i = 0; i < SK_NUM_SKILLS; i++)
 	{


### PR DESCRIPTION
The store/load functions re-read cl_guid from engine userinfo at write
time and never validated it. On client slot reuse the engine replaces
the userinfo before the game runs the forced disconnect of the previous
occupant, so a rating could be recorded under an empty guid, producing
blank unmatched rows in the database.

Use client->pers.cl_guid (validated in ClientConnect) instead and skip
clients without a valid guid.
