### PR TITLE
cgame: copy HUD.dat instead of move for compatibility

### DIFF
--- a/src/cgame/cg_hud_io.c
+++ b/src/cgame/cg_hud_io.c
@@ -234,6 +234,127 @@ static qboolean CG_ReadHudFileVersion(const char *filename, int *version)
 }
 
 /**
+ * @brief CG_CopyHudFile
+ * @details HUD migration intentionally avoids filesystem rename semantics because the
+ * cgame VM only has portable read, write, close, list, and delete syscalls.
+ *
+ * 1. Refuse to start when the target path already exists. This keeps from
+ *    accidentally overwriting existing HUDs, timestamped backups, and
+ *    timestamped invalid files.
+ * 2. Copy the complete source file into the target path and close both files.
+ *    Closing first makes sure a later validation read sees what was written.
+ * 3. Re-open the target and validate it. Normal HUD moves validate the JSON
+ *    version field against the expected version. Invalid HUD preservation
+ *    cannot parse JSON by definition, so it validates that the copied size
+ *    matches the original source size.
+ *
+ * @param[in] source
+ * @param[in] target
+ * @param[in] expectedVersion
+ * @return
+ */
+static qboolean CG_CopyHudFile(const char *source, const char *target, int expectedVersion)
+{
+	fileHandle_t sourceFile;
+	fileHandle_t targetFile;
+	byte         buffer[16384];
+	int          sourceLen;
+	int          targetLen;
+	int          remaining;
+	int          chunk;
+	int          written;
+	int          targetVersion;
+
+	// Do the collision check before opening the source. A pre-existing target
+	// means the migration would overwrite user data, so the move must abort.
+	if (CG_HudFileExists(target))
+	{
+		CG_Printf(S_COLOR_RED "ERROR CG_CopyHudFile: target already exists '%s'\n", target);
+		return qfalse;
+	}
+
+	// Open the source first so failures never create an empty target file.
+	{
+		sourceFile = 0;
+		sourceLen  = trap_FS_FOpenFile(source, &sourceFile, FS_READ);
+		if (sourceLen < 0 || !sourceFile)
+		{
+			if (sourceFile)
+			{
+				trap_FS_FCloseFile(sourceFile);
+			}
+			CG_Printf(S_COLOR_RED "ERROR CG_CopyHudFile: failed to read source '%s'\n", source);
+			return qfalse;
+		}
+	}
+
+	// Only open the target after the source is known to be readable.
+	targetFile = 0;
+	if (trap_FS_FOpenFile(target, &targetFile, FS_WRITE) < 0 || !targetFile)
+	{
+		trap_FS_FCloseFile(sourceFile);
+		CG_Printf(S_COLOR_RED "ERROR CG_CopyHudFile: failed to write target '%s'\n", target);
+		return qfalse;
+	}
+
+	// Copy in fixed-size chunks to avoid allocating a buffer sized to the HUD.
+	remaining = sourceLen;
+	while (remaining > 0)
+	{
+		chunk = remaining > (int)sizeof(buffer) ? (int)sizeof(buffer) : remaining;
+		trap_FS_Read(buffer, chunk, sourceFile);
+		written = trap_FS_Write(buffer, chunk, targetFile);
+		if (written != chunk)
+		{
+			trap_FS_FCloseFile(sourceFile);
+			trap_FS_FCloseFile(targetFile);
+			trap_FS_Delete(target);
+			CG_Printf(S_COLOR_RED "ERROR CG_CopyHudFile: short write while moving '%s' to '%s'\n", source, target);
+			return qfalse;
+		}
+		remaining -= chunk;
+	}
+
+	// Validation is done through a new read handle, so close the write handle
+	// first and make the just-written target visible to the filesystem layer.
+	trap_FS_FCloseFile(sourceFile);
+	trap_FS_FCloseFile(targetFile);
+
+	// Valid HUD migrations re-read the copied JSON. Invalid HUD preservation
+	// can only validate that the copied file exists with the expected size.
+	if (expectedVersion > 0)
+	{
+		if (!CG_ReadHudFileVersion(target, &targetVersion) || targetVersion != expectedVersion)
+		{
+			trap_FS_Delete(target);
+			CG_Printf(S_COLOR_RED "ERROR CG_CopyHudFile: target validation failed '%s'\n", target);
+			return qfalse;
+		}
+	}
+	else
+	{
+		// Invalid HUD files cannot be parsed, so the only meaningful
+		// post-copy validation is that the target has the same byte length.
+		targetFile = 0;
+		targetLen  = trap_FS_FOpenFile(target, &targetFile, FS_READ);
+		if (targetFile)
+		{
+			trap_FS_FCloseFile(targetFile);
+		}
+
+		if (targetLen != sourceLen)
+		{
+			trap_FS_Delete(target);
+			CG_Printf(S_COLOR_RED "ERROR CG_CopyHudFile: target size validation failed '%s'\n", target);
+			return qfalse;
+		}
+	}
+
+	CG_Printf(S_COLOR_CYAN "Copied HUD file '%s' to '%s'\n", source, target);
+	return qtrue;
+}
+
+/**
  * @brief CG_MoveHudFile
  * @details HUD migration intentionally avoids filesystem rename semantics because the
  * cgame VM only has portable read, write, close, list, and delete syscalls.
@@ -260,99 +381,10 @@ static qboolean CG_ReadHudFileVersion(const char *filename, int *version)
  */
 static qboolean CG_MoveHudFile(const char *source, const char *target, int expectedVersion)
 {
-	fileHandle_t sourceFile;
-	fileHandle_t targetFile;
-	byte         buffer[16384];
-	int          sourceLen;
-	int          targetLen;
-	int          remaining;
-	int          chunk;
-	int          written;
-	int          targetVersion;
-
-	// Do the collision check before opening the source. A pre-existing target
-	// means the migration would overwrite user data, so the move must abort.
-	if (CG_HudFileExists(target))
+	if (!CG_CopyHudFile(source, target, expectedVersion))
 	{
-		CG_Printf(S_COLOR_RED "ERROR CG_MoveHudFile: target already exists '%s'\n", target);
+		CG_Printf(S_COLOR_RED "ERROR CG_MoveHudFile: failed to copy hud file '%s'\n", source);
 		return qfalse;
-	}
-
-	// Open the source first so failures never create an empty target file.
-	{
-		sourceFile = 0;
-		sourceLen  = trap_FS_FOpenFile(source, &sourceFile, FS_READ);
-		if (sourceLen < 0 || !sourceFile)
-		{
-			if (sourceFile)
-			{
-				trap_FS_FCloseFile(sourceFile);
-			}
-			CG_Printf(S_COLOR_RED "ERROR CG_MoveHudFile: failed to read source '%s'\n", source);
-			return qfalse;
-		}
-	}
-
-	// Only open the target after the source is known to be readable.
-	targetFile = 0;
-	if (trap_FS_FOpenFile(target, &targetFile, FS_WRITE) < 0 || !targetFile)
-	{
-		trap_FS_FCloseFile(sourceFile);
-		CG_Printf(S_COLOR_RED "ERROR CG_MoveHudFile: failed to write target '%s'\n", target);
-		return qfalse;
-	}
-
-	// Copy in fixed-size chunks to avoid allocating a buffer sized to the HUD.
-	remaining = sourceLen;
-	while (remaining > 0)
-	{
-		chunk = remaining > (int)sizeof(buffer) ? (int)sizeof(buffer) : remaining;
-		trap_FS_Read(buffer, chunk, sourceFile);
-		written = trap_FS_Write(buffer, chunk, targetFile);
-		if (written != chunk)
-		{
-			trap_FS_FCloseFile(sourceFile);
-			trap_FS_FCloseFile(targetFile);
-			trap_FS_Delete(target);
-			CG_Printf(S_COLOR_RED "ERROR CG_MoveHudFile: short write while moving '%s' to '%s'\n", source, target);
-			return qfalse;
-		}
-		remaining -= chunk;
-	}
-
-	// Validation is done through a new read handle, so close the write handle
-	// first and make the just-written target visible to the filesystem layer.
-	trap_FS_FCloseFile(sourceFile);
-	trap_FS_FCloseFile(targetFile);
-
-	// Valid HUD migrations re-read the copied JSON. Invalid HUD preservation
-	// can only validate that the copied file exists with the expected size.
-	if (expectedVersion > 0)
-	{
-		if (!CG_ReadHudFileVersion(target, &targetVersion) || targetVersion != expectedVersion)
-		{
-			trap_FS_Delete(target);
-			CG_Printf(S_COLOR_RED "ERROR CG_MoveHudFile: target validation failed '%s'\n", target);
-			return qfalse;
-		}
-	}
-	else
-	{
-		// Invalid HUD files cannot be parsed, so the only meaningful
-		// post-copy validation is that the target has the same byte length.
-		targetFile = 0;
-		targetLen  = trap_FS_FOpenFile(target, &targetFile, FS_READ);
-		if (targetFile)
-		{
-			trap_FS_FCloseFile(targetFile);
-		}
-
-		if (targetLen != sourceLen)
-		{
-			trap_FS_Delete(target);
-			CG_Printf(S_COLOR_RED "ERROR CG_MoveHudFile: target size validation failed '%s'\n", target);
-			return qfalse;
-		}
 	}
 
 	// Source deletion is the final step. Every earlier failure path returns
@@ -2264,6 +2296,14 @@ qboolean CG_TryReadHudFromFile(const char *filename, qboolean isEditable)
 
 /**
  * @brief CG_ReadHudsFromFile
+ * 
+ * @todo Once all server will do the transition to newer mod version
+ * we shall remove the HUD legacyPath copy back to move function.
+ * This is done on purpose to ease the migration process for players 
+ * and server owner where players playing on different server with different version
+ * may encounter annoyance if the hud.dat is moved from where it is supposed to be
+ * on older mod version
+ * 
  */
 void CG_ReadHudsFromFile(void)
 {
@@ -2313,17 +2353,19 @@ void CG_ReadHudsFromFile(void)
 				CG_HudFilePathForVersion(targetPath, sizeof(targetPath), parsedVersion);
 				if (CG_HudFileExists(targetPath))
 				{
-					// A versioned HUD already exists, so keep both files by moving
+					// TODO : see @todo in header function
+					// A versioned HUD already exists, so keep both files by copying
 					// the legacy file to a timestamped backup for its JSON version.
+					/*
 					CG_HudBackupFilePathForVersion(backupPath, sizeof(backupPath), parsedVersion);
-					if (!CG_MoveHudFile(legacyPath, backupPath, parsedVersion))
+					if (!CG_CopyHudFile(legacyPath, backupPath, parsedVersion))
 					{
 						CG_Printf(S_COLOR_RED "ERROR CG_ReadHudsFromFile: failed to preserve legacy HUD '%s'\n", legacyPath);
-					}
+					}*/
 				}
 				else
 				{
-					if (!CG_MoveHudFile(legacyPath, targetPath, parsedVersion))
+					if (!CG_CopyHudFile(legacyPath, targetPath, parsedVersion))
 					{
 						// Keep the user's HUD active for this session even if
 						// the filesystem refused the canonical migration.

--- a/src/cgame/cg_hud_io.c
+++ b/src/cgame/cg_hud_io.c
@@ -2296,14 +2296,13 @@ qboolean CG_TryReadHudFromFile(const char *filename, qboolean isEditable)
 
 /**
  * @brief CG_ReadHudsFromFile
- * 
- * @todo Once all server will do the transition to newer mod version
- * we shall remove the HUD legacyPath copy back to move function.
- * This is done on purpose to ease the migration process for players 
- * and server owner where players playing on different server with different version
- * may encounter annoyance if the hud.dat is moved from where it is supposed to be
- * on older mod version
- * 
+ *
+ * @todo Once all servers transition to the newer mod version,
+ * we will remove the HUD legacyPath copy-back logic and restore the move function.
+ * This is done intentionally to ease the migration process for players
+ * and server owners, as players playing across servers with different versions
+ * may experience issues if hud.dat is moved from where older mod versions
+ * expect it to be.
  */
 void CG_ReadHudsFromFile(void)
 {


### PR DESCRIPTION
Once all servers transition to the newer mod version, we will remove the HUD legacyPath copy-back logic and restore the move function. This is done intentionally to ease the migration process for players and server owners, as players playing across servers with different versions may experience issues if hud.dat is moved from where older mod versions expect it to be.