### PR TITLE
engine: fix cm_optimizePatchPlanes not correctly applying on first load

### DIFF
--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -586,6 +586,8 @@ void CL_Disconnect(qboolean showMainMenu)
 	SCR_StopCinematic();
 	S_ClearSoundBuffer(qtrue);    // modified
 
+	Cvar_ForceReset("cm_optimizePatchPlanes");
+
 	// send a disconnect message to the server
 	// send it a few times in case one is dropped
 	if (cls.state >= CA_CONNECTED)
@@ -615,6 +617,8 @@ void CL_Disconnect(qboolean showMainMenu)
 	// not connected to a pure server anymore
 	cl_connectedToPureServer = qfalse;
 
+	cl_optimizedPatchServer = qfalse;
+
 	// don't try a restart if uivm is NULL, as we might be in the middle of a restart already
 	if (uivm && cls.state > CA_DISCONNECTED)
 	{
@@ -630,12 +634,6 @@ void CL_Disconnect(qboolean showMainMenu)
 	else
 	{
 		cls.state = CA_DISCONNECTED;
-	}
-
-	// reset patch collision to default incase it was modified by server
-	if (cls.state < CA_CONNECTING)
-	{
-		Cvar_Set("cm_optimizePatchPlanes", "0");
 	}
 }
 
@@ -940,12 +938,6 @@ static void CL_Connect_f(void)
 	// server connection string
 	Cvar_Set("cl_currentServerAddress", server);
 	Cvar_Set("cl_currentServerIP", ip_port);
-
-	// if we are not compatible, likely 2.60b server - use vanilla patch collision
-	if (!Com_IsCompatible(&clc.agent, 0x1))
-	{
-		Cvar_Set("cm_optimizePatchPlanes", "1");
-	}
 
 #ifdef FEATURE_IRC_CLIENT
 	if (irc_mode->integer & IRCM_AUTO_CONNECT)

--- a/src/client/cl_parse.c
+++ b/src/client/cl_parse.c
@@ -587,8 +587,9 @@ void CL_ParseSnapshot(msg_t *msg)
 
 //=====================================================================
 
-int cl_connectedToPureServer;
-int cl_connectedToCheatServer;
+int      cl_connectedToPureServer;
+int      cl_connectedToCheatServer;
+qboolean cl_optimizedPatchServer;
 
 void CL_PurgeCache(void);
 
@@ -658,6 +659,8 @@ void CL_SystemInfoChanged(void)
 	CL_SetPurePaks(qfalse);
 
 	gameSet = qfalse;
+	// assume vanilla patch collision
+	cl_optimizedPatchServer = qtrue;
 	// scan through all the variables in the systeminfo and locally set cvars to match
 	s = systemInfo;
 	while (s)
@@ -668,6 +671,11 @@ void CL_SystemInfoChanged(void)
 		if (!key[0])
 		{
 			break;
+		}
+
+		if (!Q_stricmp(key, "cm_optimizePatchPlanes"))
+		{
+			cl_optimizedPatchServer = Q_atoi(value) ? qtrue : qfalse;
 		}
 
 		// ehw!

--- a/src/qcommon/cm_load.c
+++ b/src/qcommon/cm_load.c
@@ -669,7 +669,7 @@ void CM_LoadMap(const char *name, qboolean clientload, unsigned int *checksum)
 	cm_playerCurveClip = Cvar_Get("cm_playerCurveClip", "1", CVAR_ARCHIVE_ND | CVAR_CHEAT);
 	cm_optimize        = Cvar_Get("cm_optimize", "1", CVAR_CHEAT);
 
-	// pure client and not self hosted (to avoid mixing flags on local play)
+	// only server may set this, client just reads whatever the server communicates
 	if (clientload && !com_sv_running->integer)
 	{
 		cm_optimizePatchPlanes = Cvar_Get("cm_optimizePatchPlanes", "0", CVAR_ROM | CVAR_SYSTEMINFO);

--- a/src/qcommon/cm_patch.c
+++ b/src/qcommon/cm_patch.c
@@ -956,6 +956,22 @@ static qboolean CM_ValidateFacet(facet_t *facet)
 }
 
 /**
+ * @brief Whether we should enable VET patch plane optimizations or not
+ * @return qtrue if vanilla optimizations are enabled
+ */
+static ID_INLINE qboolean CM_UseVanillaOptimization(void)
+{
+#ifdef DEDICATED
+	return cm_optimizePatchPlanes->integer;
+#else
+	// if running local server, trust the cvar
+	return com_sv_running->integer
+	    ? cm_optimizePatchPlanes->integer
+	    : cl_optimizedPatchServer;
+#endif
+}
+
+/**
  * @brief CM_AddFacetBevels
  * @param[in,out] facet
  */
@@ -1021,7 +1037,7 @@ void CM_AddFacetBevels(facet_t *facet)
 			// see if the plane is already present
 			for (i = 0; i < facet->numBorders; i++)
 			{
-				if (!cm_optimizePatchPlanes->integer)
+				if (!CM_UseVanillaOptimization())
 				{
 					if (CM_PlaneEqual(&planes[facet->borderPlanes[i]], plane, &flipped))
 					{

--- a/src/qcommon/qcommon.h
+++ b/src/qcommon/qcommon.h
@@ -1141,6 +1141,10 @@ extern cvar_t *com_downloadURL;
 extern fileHandle_t com_journalFile;
 extern fileHandle_t com_journalDataFile;
 
+#ifndef DEDICATED
+extern qboolean cl_optimizedPatchServer;
+#endif
+
 /**
  * @enum memtag_t
  * @brief
@@ -1449,7 +1453,7 @@ double Sys_GetWindowsVer(void);
 
 #define sys_stat_t struct _stat
 int Sys_Stat(const char *path, void *stat);
-#define Sys_S_IsDir(m) ((m) & _S_IFDIR)
+#define Sys_S_IsDir(m) ((m)&_S_IFDIR)
 
 int Sys_Rename(const char *from, const char *to);
 char *Sys_RealPath(const char *path);


### PR DESCRIPTION
The check for whether the server was "compatible" was done too early, which always set this to 1 on initial connect, before the server had a chance to communicate the desired setting.

This is now reworked such that the client doesn't ever use the cvar, only server does - client simply reads the cvar from systeminfo string, and sets an internal variable to `qtrue/qfalse`, depending on if patch optimizations are enabled or not.

refs #1590 