### PR TITLE
game: fix map win probability prior usage in skill rating, refs #3524

### DIFF
--- a/src/game/g_skillrating.c
+++ b/src/game/g_skillrating.c
@@ -1005,24 +1005,20 @@ float W(float t, float epsilon)
 
 /**
  * @brief Map winning probability
- * @details Get wining parameter bias of the played map
+ * @details Get winning probability for the given team from the Axis map bias
  * @param[in] team
+ * @param[in] mapAxisProb Axis win probability for the map
  * @return map win probability
  */
-float G_MapWinProb(int team)
+float G_MapWinProb(int team, float mapAxisProb)
 {
-	if (!level.mapProb)
-	{
-		level.mapProb = 0.5f;
-	}
-
 	if (team == TEAM_AXIS)
 	{
-		return level.mapProb;
+		return mapAxisProb;
 	}
 	else
 	{
-		return 1.0f - level.mapProb;
+		return 1.0f - mapAxisProb;
 	}
 }
 
@@ -1065,8 +1061,7 @@ void G_UpdateSkillRating(int winner)
 	// map side parameter (read prior map bias)
 	if (g_skillRating.integer > 1)
 	{
-		mapProb  = G_SkillRatingGetMapRating(level.rawmapname);
-		mapProb  = (winner == TEAM_AXIS) ? mapProb : 1.0f - mapProb;
+		mapProb  = G_MapWinProb(winner, G_SkillRatingGetMapRating(level.rawmapname));
 		mapMu    = 2 * MU * mapProb;
 		mapSigma = 2 * MU * sqrtf(mapProb * (1.0f - mapProb));
 		mapBeta  = mapSigma / 2;
@@ -1298,7 +1293,7 @@ float G_CalculateWinProbability(int team)
 	// map side parameter
 	if (g_skillRating.integer > 1)
 	{
-		mapProb  = G_MapWinProb(team);
+		mapProb  = G_MapWinProb(team, level.mapProb ? level.mapProb : 0.5f);
 		mapMu    = 2 * MU * mapProb;
 		mapSigma = 2 * MU * sqrtf(mapProb * (1.0f - mapProb));
 		mapBeta  = mapSigma / 2;

--- a/src/game/g_skillrating.c
+++ b/src/game/g_skillrating.c
@@ -935,6 +935,12 @@ void G_CalculateSkillRatings(void)
 		return;
 	}
 
+	// log last estimated win probability
+	G_LogPrintf("SkillRating: Win probability X/L: %.6f/%.6f\n", level.axisProb, level.alliesProb);
+
+	// update player ratings using the prior map bias
+	G_UpdateSkillRating(winner);
+
 	// update map rating
 	if (g_skillRating.integer > 1)
 	{
@@ -948,11 +954,6 @@ void G_CalculateSkillRatings(void)
 		Info_SetValueForKey(cs, "M", va("%f", level.mapProb));
 		trap_SetConfigstring(CS_MODINFO, cs);
 	}
-
-	// log last estimated win probability
-	G_LogPrintf("SkillRating: Win probability X/L: %.6f/%.6f\n", level.axisProb, level.alliesProb);
-
-	G_UpdateSkillRating(winner);
 }
 
 /**
@@ -1028,7 +1029,7 @@ float G_MapWinProb(int team)
 /**
  * @brief Update skill rating
  * @details Update player's skill rating based on team performance
- * @param[in] team
+ * @param[in] winner
  */
 void G_UpdateSkillRating(int winner)
 {
@@ -1061,10 +1062,11 @@ void G_UpdateSkillRating(int winner)
 		return;
 	}
 
-	// map side parameter
+	// map side parameter (read prior map bias)
 	if (g_skillRating.integer > 1)
 	{
-		mapProb  = G_MapWinProb(winner);
+		mapProb  = G_SkillRatingGetMapRating(level.rawmapname);
+		mapProb  = (winner == TEAM_AXIS) ? mapProb : 1.0f - mapProb;
 		mapMu    = 2 * MU * mapProb;
 		mapSigma = 2 * MU * sqrtf(mapProb * (1.0f - mapProb));
 		mapBeta  = mapSigma / 2;


### PR DESCRIPTION
- **game: use prior map bias when updating player skill ratings, refs #3524**
- **game: parameterize G_MapWinProb with explicit probability, refs #3524**
