### PR TITLE
mod: remove broken g_resetXPMapCount and mapvote XP reset display, refs #2803

### DIFF
--- a/src/cgame/cg_debriefing.c
+++ b/src/cgame/cg_debriefing.c
@@ -1060,20 +1060,6 @@ void CG_MapVoteList_Draw(panel_button_t *button)
 	int   i;
 	float y = button->rect.y + 12;
 
-	// display map number if server is configured
-	// to reset XP after certain number of maps
-	if (cgs.mapVoteMapY > 0)
-	{
-		const char *s;
-		float      w;
-
-		s = va("Map %d of %d", cgs.mapVoteMapX + 1, cgs.mapVoteMapY);
-		w = CG_Text_Width_Ext(s, button->font->scalex, 0, button->font->font);
-		CG_Text_Paint_Ext(DB_MAPNAME_X + 10 + cgs.wideXoffset + DB_MAPVOTE_X * 0.5f - w * 0.5f, DB_MAPVOTE_Y,
-		                  button->font->scalex, button->font->scaley, button->font->colour,
-		                  s, 0, 0, 0, button->font->font);
-	}
-
 	for (i = 0; i + cgs.dbMapVoteListOffset < cgs.dbNumMaps && i < 16; i++)
 	{
 		int    j       = 0;

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2775,8 +2775,6 @@ typedef struct cgs_s
 	qboolean dbMapMultiVote;
 	int dbMapVotedFor[3];
 	sortedVotedMapByTotal_s dbSortedVotedMapsByTotal[MAX_VOTE_MAPS];
-	int mapVoteMapX;
-	int mapVoteMapY;
 
 	int fixedphysics;
 	int fixedphysicsfps;

--- a/src/cgame/cg_scoreboard.c
+++ b/src/cgame/cg_scoreboard.c
@@ -377,7 +377,7 @@ int WM_DrawObjectives(int x, int y, int width, float fade)
 			s = va(CG_TranslateString("MAP %i of %i"), cgs.currentCampaignMap + 1, cgs.campaignData.mapCount);
 			break;
 		case GT_WOLF_MAPVOTE:
-			s = (cgs.mapVoteMapY ? va(CG_TranslateString("MAP %i of %i"), cgs.mapVoteMapX + 1, cgs.mapVoteMapY) : "MAP");
+			s = "MAP";
 			break;
 		default:
 			s = "MAP";

--- a/src/cgame/cg_servercmds.c
+++ b/src/cgame/cg_servercmds.c
@@ -356,8 +356,6 @@ void CG_ParseModInfo(void)
 
 	info = CG_ConfigString(CS_MODINFO);
 
-	cgs.mapVoteMapX = Q_atoi(Info_ValueForKey(info, "X"));
-	cgs.mapVoteMapY = Q_atoi(Info_ValueForKey(info, "Y"));
 #ifdef FEATURE_RATING
 	cgs.skillRating = Q_atoi(Info_ValueForKey(info, "R"));
 	if (cgs.skillRating > 1)

--- a/src/game/g_cvars.c
+++ b/src/game/g_cvars.c
@@ -244,7 +244,6 @@ vmCvar_t g_mapVoteFlags;
 vmCvar_t g_maxMapsVotedFor;
 vmCvar_t g_minMapAge;
 vmCvar_t g_excludedMaps;
-vmCvar_t g_resetXPMapCount;
 
 vmCvar_t g_campaignFile;
 
@@ -591,7 +590,6 @@ cvarTable_t gameCvarTable[] =
 	{ &g_maxMapsVotedFor,                 "g_maxMapsVotedFor",                 "6",                          0,                                               0, qfalse, qfalse },
 	{ &g_minMapAge,                       "g_minMapAge",                       "3",                          0,                                               0, qfalse, qfalse },
 	{ &g_excludedMaps,                    "g_excludedMaps",                    "",                           0,                                               0, qfalse, qfalse },
-	{ &g_resetXPMapCount,                 "g_resetXPMapCount",                 "0",                          0,                                               0, qfalse, qfalse },
 
 	{ &g_campaignFile,                    "g_campaignFile",                    "",                           0,                                               0, qfalse, qfalse },
 
@@ -914,14 +912,6 @@ void G_UpdateCvars(void)
 					char cs[MAX_INFO_STRING];
 
 					cs[0] = '\0';
-
-					// MAPVOTE
-					// FIXME: mapvote & xp
-					if (g_gametype.integer == GT_WOLF_MAPVOTE)
-					{
-						Info_SetValueForKey(cs, "X", va("%i", (level.mapsSinceLastXPReset >= g_resetXPMapCount.integer) ? 0 : level.mapsSinceLastXPReset));
-						Info_SetValueForKey(cs, "Y", (va("%i", g_resetXPMapCount.integer)));
-					}
 
 #ifdef FEATURE_RATING
 					Info_SetValueForKey(cs, "R", va("%i", g_skillRating.integer));

--- a/src/game/g_cvars.h
+++ b/src/game/g_cvars.h
@@ -235,7 +235,6 @@ extern vmCvar_t g_mapVoteFlags;
 extern vmCvar_t g_maxMapsVotedFor;
 extern vmCvar_t g_minMapAge;
 extern vmCvar_t g_excludedMaps;
-extern vmCvar_t g_resetXPMapCount;
 
 extern vmCvar_t g_campaignFile;
 

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1379,7 +1379,6 @@ typedef struct level_locals_s
 	int mapvotehistorycount;
 	char lastVotedMap[MAX_VOTE_MAPS];
 	int mapVoteNumMaps;
-	int mapsSinceLastXPReset;
 	qboolean mapVotePlayersCount;
 
 	// sv_cvars

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -1643,35 +1643,6 @@ void G_InitGame(int levelTime, int randomSeed, int restart, int etLegacyServer, 
 	// MAPVOTE
 	if (g_gametype.integer == GT_WOLF_MAPVOTE)
 	{
-		char mapConfig[MAX_STRING_CHARS];
-
-		//trap_Cvar_Set("C", va("%d,%d",
-		//        ((level.mapsSinceLastXPReset >= g_resetXPMapCount.integer) ?
-		//               0 : level.mapsSinceLastXPReset)+1,
-		//       g_resetXPMapCount.integer));
-
-		if (g_mapConfigs.string[0] && g_resetXPMapCount.integer)
-		{
-			Q_strncpyz(mapConfig, "exec ", sizeof(mapConfig));
-			Q_strcat(mapConfig, sizeof(mapConfig), g_mapConfigs.string);
-			i = level.mapsSinceLastXPReset;
-			if (i == 0 || i == g_resetXPMapCount.integer)
-			{
-				i = 2;
-			}
-			else if (i + 2 <= g_resetXPMapCount.integer)
-			{
-				i += 2;
-			}
-			else
-			{
-				i = 1;
-			}
-			Q_strcat(mapConfig, sizeof(mapConfig), va("/vote_%d.cfg", i));
-
-			trap_SendConsoleCommand(EXEC_APPEND, mapConfig);
-		}
-
 		level.mapVotePlayersCount = CG_ParseMapVotePlayersCountConfig();
 	}
 
@@ -1731,9 +1702,6 @@ void G_InitGame(int levelTime, int randomSeed, int restart, int etLegacyServer, 
 
 	numSplinePaths = 0 ;
 	numPathCorners = 0;
-
-	// MAPVOTE
-	level.mapsSinceLastXPReset = 0;
 
 	// init objective indicator
 	level.flagIndicator   = 0;
@@ -2801,11 +2769,6 @@ void ExitLevel(void)
 	case GT_WOLF_MAPVOTE:
 	{
 		int nextMap = -1, highMapVote = 0, curMapVotes = 0, maxMaps, highMapAge = 0, curMapAge = 0;
-
-		if (g_resetXPMapCount.integer)
-		{
-			level.mapsSinceLastXPReset++;
-		}
 
 		maxMaps = Com_Clamp(0, level.mapVoteNumMaps, g_maxMapsVotedFor.integer);
 


### PR DESCRIPTION
The g_resetXPMapCount cvar and the mapsSinceLastXPReset counter were never
wired to the actual XP reset logic. Stats were reset every map via
level.fResetStats, while the scoreboard displayed a meaningless
'Map X of Y' counter. Remove the dead code to establish a clean
'no XP save' baseline for mapvote before the database-backed
xpsave system is implemented.
