### PR TITLE
mod: add configurable XP save reset policy for Objective and Mapvote, refs #3520

### DIFF
--- a/misc/etmain/legacy.cfg
+++ b/misc/etmain/legacy.cfg
@@ -142,6 +142,8 @@ set vote_allow_cointoss "1"                     // allow coin toss by vote
 
 // XP SAVE
 //set g_xpSave "0"                              // toggle XP save system
+//set g_xpSaveResetMode "1"                     // XP save reset mode: 0 = never, 1 = maps, 2 = time, 3 = decay
+//set g_xpSaveResetThreshold "8"                // threshold for reset mode (maps / hours / half-life days)
 
 // LUA
 

--- a/src/cgame/cg_debriefing.c
+++ b/src/cgame/cg_debriefing.c
@@ -40,6 +40,10 @@ team_t CG_Debriefing_FindWinningTeamForPos(int pos);
 
 int QDECL CG_SortPlayersByXP(const void *a, const void *b);
 
+#ifdef FEATURE_XPSAVE
+static qboolean xpSaveResetButtonConfirmation = qfalse;
+#endif
+
 static panel_button_text_t debriefPlayerHeadingSmallerFont =
 {
 	0.2f,                  0.2f,
@@ -683,6 +687,22 @@ static panel_button_t debriefPlayerInfoHitRegions =
 	0
 };
 
+#ifdef FEATURE_XPSAVE
+static panel_button_t debriefPlayerXPSaveResetButton =
+{
+	NULL,
+	"RESET XP",
+	{ 110,                               138,88, 16 },
+	{ 0,                                 0,  0,  0, 0, 0, 0, 0},
+	&debriefPlayerInfoFont,              // font
+	CG_Debriefing_XPSaveResetButton_KeyDown,// keyDown
+	NULL,                                // keyUp
+	CG_Debriefing_XPSaveResetButton_Draw,
+	NULL,
+	0
+};
+#endif
+
 #define PLAYERHEADER_SKILLS(number)           \
 		static panel_button_t debriefPlayerInfoSkills ## number = {      \
 			NULL,                                       \
@@ -726,6 +746,9 @@ static panel_button_t *debriefPanelButtons[] =
 	&debriefPlayerInfoSkills5,
 	&debriefPlayerInfoSkills6,
 	&debriefPlayerInfoHitRegions,
+#ifdef FEATURE_XPSAVE
+	&debriefPlayerXPSaveResetButton,
+#endif
 	&debriefPlayerWeaponStatsHeader,    &debriefPlayerWeaponStatsNameHeader,   &debriefPlayerWeaponStatsShotsHeader,
 	&debriefPlayerWeaponStatsHitsHeader,&debriefPlayerWeaponStatsKillsHeader,
 	&debriefPlayerWeaponStatsList,      &debriefPlayerWeaponStatsListScroll,
@@ -3268,6 +3291,104 @@ qboolean CG_Debriefing_NextButton_KeyDown(panel_button_t *button, int key)
 
 	return qfalse;
 }
+
+#ifdef FEATURE_XPSAVE
+/**
+ * @brief CG_Debriefing_XPSaveResetButton_KeyDown
+ * @param button - unused
+ * @param[in] key
+ * @return
+ */
+qboolean CG_Debriefing_XPSaveResetButton_KeyDown(panel_button_t *button, int key)
+{
+	if (key == K_MOUSE1)
+	{
+		// on first click on the button, display confirmation message
+		// then accept reset on second click
+		if (!xpSaveResetButtonConfirmation)
+		{
+			xpSaveResetButtonConfirmation = qtrue;
+			return qfalse;
+		}
+
+		trap_SendClientCommand("imxpsavereset");
+
+		// clear local xp display immediately to hide the button
+		Com_Memset(cgs.clientinfo[cg.clientNum].skillpoints, 0, sizeof(cgs.clientinfo[cg.clientNum].skillpoints));
+		Com_Memset(cgs.clientinfo[cg.clientNum].medals, 0, sizeof(cgs.clientinfo[cg.clientNum].medals));
+		Com_Memset(cgs.clientinfo[cg.clientNum].skill, 0, sizeof(cgs.clientinfo[cg.clientNum].skill));
+
+		xpSaveResetButtonConfirmation = qfalse;
+
+		return qtrue;
+	}
+
+	return qfalse;
+}
+
+/**
+ * @brief CG_Debriefing_XPSaveResetButton_Draw
+ * @param[in] button
+ */
+void CG_Debriefing_XPSaveResetButton_Draw(panel_button_t *button)
+{
+	int i, totalXP = 0;
+
+	if (cgs.gametype != GT_WOLF && cgs.gametype != GT_WOLF_MAPVOTE)
+	{
+		return;
+	}
+
+	if (cgs.dbSelectedClient != cg.clientNum)
+	{
+		return;
+	}
+
+	for (i = 0; i < SK_NUM_SKILLS; i++)
+	{
+		totalXP += cgs.clientinfo[cg.clientNum].skillpoints[i];
+	}
+
+	if (totalXP <= 0)
+	{
+		return;
+	}
+
+	CG_PanelButtonsRender_Button(button);
+
+	if (BG_CursorInRect(&button->rect))
+	{
+		float  h;
+		char   *text;
+		vec4_t *color;
+		vec4_t clrBdr = { 0.5f, 0.5f, 0.5f, 0.5f };
+		vec4_t clrBck = { 0.0f, 0.0f, 0.0f, 0.8f };
+
+		h = CG_Text_Height_Ext("A", button->font->scalex, 0, button->font->font);
+
+		if (xpSaveResetButtonConfirmation)
+		{
+			CG_FillRect(button->rect.x + button->rect.w + 18, button->rect.y - h * 2, button->rect.w * 1.6f, h * 5, clrBck);
+			CG_DrawRect_FixedBorder(button->rect.x + button->rect.w + 18, button->rect.y - h * 2, button->rect.w * 1.6f, h * 5, 1, clrBdr);
+
+			text  = "Are you sure?\nClick again to confirm.";
+			color = &colorYellow;
+		}
+		else
+		{
+			CG_FillRect(button->rect.x + button->rect.w + 18, button->rect.y - h * 2, button->rect.w * 1.6f, h * 8, clrBck);
+			CG_DrawRect_FixedBorder(button->rect.x + button->rect.w + 18, button->rect.y - h * 2, button->rect.w * 1.6f, h * 8, 1, clrBdr);
+
+			text  = "Reset saved XP.\nThis map's earned XP\nwill not carry over.";
+			color = &button->font->colour;
+		}
+
+		CG_DrawMultilineText(button->rect.x + button->rect.w + 20, button->rect.y, button->rect.w, button->font->scalex, button->font->scaley, *color,
+		                     CG_TranslateString(text),
+		                     2 * h, 0, 0, ITEM_TEXTSTYLE_SHADOWED, ITEM_ALIGN_LEFT, button->font->font);
+	}
+}
+#endif
 
 /**
  * @brief CG_Debriefing_VoteButton_Draw

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -3979,6 +3979,10 @@ qboolean CG_Debriefing_ReadyButton_KeyDown(panel_button_t *button, int key);
 qboolean CG_Debriefing_QCButton_KeyDown(panel_button_t *button, int key);
 qboolean CG_Debriefing_PanelButton_KeyDown(panel_button_t *button, int key);
 qboolean CG_Debriefing_NextButton_KeyDown(panel_button_t *button, int key);
+#ifdef FEATURE_XPSAVE
+qboolean CG_Debriefing_XPSaveResetButton_KeyDown(panel_button_t *button, int key);
+void CG_Debriefing_XPSaveResetButton_Draw(panel_button_t *button);
+#endif
 
 void CG_PanelButtonsRender_Button_Ext(rectDef_t *r, const char *text);
 

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2779,6 +2779,11 @@ typedef struct cgs_s
 	int fixedphysics;
 	int fixedphysicsfps;
 	int pronedelay;
+#ifdef FEATURE_XPSAVE
+	int xpSaveResetValue;
+	int xpSaveResetThreshold;
+	int xpSaveResetMode;
+#endif
 #ifdef FEATURE_RATING
 	int skillRating;
 	float mapProb;

--- a/src/cgame/cg_scoreboard.c
+++ b/src/cgame/cg_scoreboard.c
@@ -35,6 +35,7 @@
 
 #include "cg_local.h"
 
+#include <math.h>
 #include <time.h>
 
 char *Binding_FromName(const char *cvar);
@@ -401,6 +402,13 @@ int WM_DrawObjectives(int x, int y, int width, float fade)
 				minutes = (remaining % 3600) / 60;
 
 				s = va(CG_TranslateString("XP RESET IN %ih %im"), hours, minutes);
+			}
+			else if (cgs.xpSaveResetMode == 3 && cgs.xpSaveResetThreshold > 0)
+			{
+				int halfLife = cgs.xpSaveResetThreshold;
+				int dailyPct = (int)round((1.0 - pow(0.5, 1.0 / halfLife)) * 100.0);
+
+				s = va(CG_TranslateString("XP DECAY %i%%/DAY (λ %iD)"), dailyPct, halfLife);
 			}
 			else
 #endif

--- a/src/cgame/cg_scoreboard.c
+++ b/src/cgame/cg_scoreboard.c
@@ -376,8 +376,18 @@ int WM_DrawObjectives(int x, int y, int width, float fade)
 		case GT_WOLF_CAMPAIGN:
 			s = va(CG_TranslateString("MAP %i of %i"), cgs.currentCampaignMap + 1, cgs.campaignData.mapCount);
 			break;
+		case GT_WOLF:
 		case GT_WOLF_MAPVOTE:
-			s = "MAP";
+#ifdef FEATURE_XPSAVE
+			if (cgs.xpSaveResetMode == 1 && cgs.xpSaveResetThreshold > 0)
+			{
+				s = va(CG_TranslateString("MAP %i of %i"), cgs.xpSaveResetValue + 1, cgs.xpSaveResetThreshold);
+			}
+			else
+#endif
+			{
+				s = "MAP";
+			}
 			break;
 		default:
 			s = "MAP";

--- a/src/cgame/cg_scoreboard.c
+++ b/src/cgame/cg_scoreboard.c
@@ -35,6 +35,8 @@
 
 #include "cg_local.h"
 
+#include <time.h>
+
 char *Binding_FromName(const char *cvar);
 
 // colors and fonts for overlays
@@ -382,6 +384,23 @@ int WM_DrawObjectives(int x, int y, int width, float fade)
 			if (cgs.xpSaveResetMode == 1 && cgs.xpSaveResetThreshold > 0)
 			{
 				s = va(CG_TranslateString("MAP %i of %i"), cgs.xpSaveResetValue + 1, cgs.xpSaveResetThreshold);
+			}
+			else if (cgs.xpSaveResetMode == 2 && cgs.xpSaveResetThreshold > 0)
+			{
+				time_t now        = time(NULL);
+				time_t last_reset = (time_t)cgs.xpSaveResetValue;
+				int    remaining  = cgs.xpSaveResetThreshold * 3600 - (int)difftime(now, last_reset);
+				int    hours, minutes;
+
+				if (remaining < 0)
+				{
+					remaining = 0;
+				}
+
+				hours   = remaining / 3600;
+				minutes = (remaining % 3600) / 60;
+
+				s = va(CG_TranslateString("XP RESET IN %ih %im"), hours, minutes);
 			}
 			else
 #endif

--- a/src/cgame/cg_servercmds.c
+++ b/src/cgame/cg_servercmds.c
@@ -356,6 +356,12 @@ void CG_ParseModInfo(void)
 
 	info = CG_ConfigString(CS_MODINFO);
 
+#ifdef FEATURE_XPSAVE
+	cgs.xpSaveResetValue     = Q_atoi(Info_ValueForKey(info, "X"));
+	cgs.xpSaveResetThreshold = Q_atoi(Info_ValueForKey(info, "Y"));
+	cgs.xpSaveResetMode      = Q_atoi(Info_ValueForKey(info, "Z"));
+#endif
+
 #ifdef FEATURE_RATING
 	cgs.skillRating = Q_atoi(Info_ValueForKey(info, "R"));
 	if (cgs.skillRating > 1)

--- a/src/cgame/cg_servercmds.c
+++ b/src/cgame/cg_servercmds.c
@@ -563,6 +563,7 @@ void CG_ParseWolfinfo(void)
 	{
 		CG_ParseWarmup();
 	}
+
 }
 
 /**

--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -4901,6 +4901,61 @@ void Cmd_IntermissionPlayerTime_f(gentity_t *ent, unsigned int dwCommand, int va
 	trap_SendServerCommand(ent - g_entities, buffer);
 }
 
+#ifdef FEATURE_XPSAVE
+/**
+ * @brief Cmd_IntermissionXPSaveReset_f
+ * @param[in,out] ent
+ * @param dwCommand - unused
+ * @param value    - unused
+ */
+void Cmd_IntermissionXPSaveReset_f(gentity_t *ent, unsigned int dwCommand, int value)
+{
+	char userinfo[MAX_INFO_STRING];
+	char *guid;
+	int i;
+	gclient_t *cl;
+
+	if (!ent || !ent->client)
+	{
+		return;
+	}
+
+	if (!g_xpSave.integer)
+	{
+		return;
+	}
+
+	if (g_gametype.integer != GT_WOLF && g_gametype.integer != GT_WOLF_MAPVOTE)
+	{
+		return;
+	}
+
+	cl = ent->client;
+
+	trap_GetUserinfo(ent - g_entities, userinfo, sizeof(userinfo));
+	guid = Info_ValueForKey(userinfo, "cl_guid");
+
+	if (G_XPSave_Reset((const unsigned char *)guid) != 0)
+	{
+		return;
+	}
+
+	// reset current session xp so the debriefing display updates immediately
+	Com_Memset(cl->sess.skillpoints, 0, sizeof(cl->sess.skillpoints));
+	Com_Memset(cl->sess.startskillpoints, 0, sizeof(cl->sess.startskillpoints));
+	Com_Memset(cl->sess.medals, 0, sizeof(cl->sess.medals));
+	cl->sess.startxptotal = 0;
+	cl->sess.rank         = 0;
+
+	for (i = 0; i < SK_NUM_SKILLS; i++)
+	{
+		cl->sess.skill[i] = 0;
+	}
+
+	trap_SendServerCommand(ent - g_entities, "print \"XP save data reset.\\n\"");
+}
+#endif
+
 #ifdef FEATURE_RATING
 /**
  * @brief Cmd_IntermissionSkillRating_f

--- a/src/game/g_cmds_ext.c
+++ b/src/game/g_cmds_ext.c
@@ -112,6 +112,9 @@ static const cmd_reference_t aCommandInfo[] =
 	{ "imsr",           CMD_USAGE_INTERMISSION_ONLY, qtrue,       qfalse, Cmd_IntermissionSkillRating_f,       ""                                                                                           },
 #endif
 	{ "imvotetally",    CMD_USAGE_INTERMISSION_ONLY, qtrue,       qfalse, G_IntermissionVoteTally_cmd,         ""                                                                                           },
+#ifdef FEATURE_XPSAVE
+	{ "imxpsavereset",  CMD_USAGE_INTERMISSION_ONLY, qtrue,       qfalse, Cmd_IntermissionXPSaveReset_f,       ""                                                                                           },
+#endif
 	{ "imwa",           CMD_USAGE_INTERMISSION_ONLY, qtrue,       qfalse, Cmd_IntermissionWeaponAccuracies_f,  ""                                                                                           },
 	{ "imws",           CMD_USAGE_INTERMISSION_ONLY, qtrue,       qfalse, Cmd_IntermissionWeaponStats_f,       ""                                                                                           },
 //  { "invite",         CMD_USAGE_ANY_TIME,  qtrue,        NULL,                                " <player_ID>:^7 Invites a player to join a team" },

--- a/src/game/g_cvars.c
+++ b/src/game/g_cvars.c
@@ -324,6 +324,9 @@ vmCvar_t g_stickyCharge;
 
 #ifdef FEATURE_XPSAVE
 vmCvar_t g_xpSave;
+vmCvar_t g_xpSaveResetMode;
+vmCvar_t g_xpSaveResetThreshold;
+vmCvar_t g_xpSaveResetValue;
 #endif
 
 vmCvar_t g_debugForSingleClient;
@@ -651,6 +654,9 @@ cvarTable_t gameCvarTable[] =
 	{ &g_stickyCharge,                    "g_stickyCharge",                    "0",                          CVAR_ARCHIVE,                                    0, qfalse, qfalse },
 #ifdef FEATURE_XPSAVE
 	{ &g_xpSave,                          "g_xpSave",                          "0",                          CVAR_ARCHIVE,                                    0, qfalse, qfalse },
+	{ &g_xpSaveResetMode,                 "g_xpSaveResetMode",                 "0",                          CVAR_ARCHIVE,                                    0, qfalse, qfalse },
+	{ &g_xpSaveResetThreshold,            "g_xpSaveResetThreshold",            "0",                          CVAR_ARCHIVE,                                    0, qfalse, qfalse },
+	{ &g_xpSaveResetValue,                "g_xpSaveResetValue",                "0",                          CVAR_ARCHIVE,                                    0, qfalse, qfalse },
 #endif
 	{ &g_suddenDeath,                     "g_suddenDeath",                     "0",                          CVAR_ARCHIVE,                                    0, qtrue,  qfalse },
 	{ &g_dropObjDelay,                    "g_dropObjDelay",                    "3000",                       CVAR_ARCHIVE,                                    0, qtrue,  qfalse },
@@ -912,6 +918,12 @@ void G_UpdateCvars(void)
 					char cs[MAX_INFO_STRING];
 
 					cs[0] = '\0';
+
+#ifdef FEATURE_XPSAVE
+					Info_SetValueForKey(cs, "X", va("%i", g_xpSaveResetValue.integer));
+					Info_SetValueForKey(cs, "Y", va("%i", g_xpSaveResetThreshold.integer));
+					Info_SetValueForKey(cs, "Z", va("%i", g_xpSaveResetMode.integer));
+#endif
 
 #ifdef FEATURE_RATING
 					Info_SetValueForKey(cs, "R", va("%i", g_skillRating.integer));

--- a/src/game/g_cvars.c
+++ b/src/game/g_cvars.c
@@ -31,6 +31,8 @@
 
 #include "g_local.h"
 
+#include <time.h>
+
 #ifdef FEATURE_LUA
 #include "g_lua.h"
 #endif
@@ -743,6 +745,9 @@ void G_UpdateCvars(void)
 	qboolean    chargetimechanged  = qfalse;
 	qboolean    clsweaprestriction = qfalse;
 	qboolean    skillLevelPoints   = qfalse;
+#ifdef FEATURE_XPSAVE
+	static qboolean xpSaveResetModeInitialized = qfalse;
+#endif
 
 	for (i = 0, cv = gameCvarTable ; i < gameCvarTableSize ; i++, cv++)
 	{
@@ -906,6 +911,23 @@ void G_UpdateCvars(void)
 						G_RemoveAllShoutcasters();
 					}
 				}
+#ifdef FEATURE_XPSAVE
+				else if (cv->vmCvar == &g_xpSaveResetMode)
+				{
+					if (xpSaveResetModeInitialized)
+					{
+						if (g_xpSaveResetMode.integer == 1)
+						{
+							trap_Cvar_Set("g_xpSaveResetValue", "0");
+						}
+						else if (g_xpSaveResetMode.integer == 2)
+						{
+							trap_Cvar_Set("g_xpSaveResetValue", va("%i", (int)time(NULL)));
+						}
+					}
+					xpSaveResetModeInitialized = qtrue;
+				}
+#endif
 #ifdef FEATURE_LUA
 				else if (cv->vmCvar == &lua_modules || cv->vmCvar == &lua_allowedModules)
 				{

--- a/src/game/g_cvars.h
+++ b/src/game/g_cvars.h
@@ -306,6 +306,9 @@ extern vmCvar_t g_stickyCharge;
 
 #ifdef FEATURE_XPSAVE
 extern vmCvar_t g_xpSave;
+extern vmCvar_t g_xpSaveResetMode;
+extern vmCvar_t g_xpSaveResetThreshold;
+extern vmCvar_t g_xpSaveResetValue;
 #endif
 
 extern vmCvar_t g_debugForSingleClient;

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -1468,6 +1468,9 @@ void Cmd_UnIgnore_f(gentity_t *ent, unsigned int dwCommand, int value);
 void Cmd_SelectedObjective_f(gentity_t *ent, unsigned int dwCommand, int value);
 void Cmd_IntermissionPlayerKillsDeaths_f(gentity_t *ent, unsigned int dwCommand, int value);
 void Cmd_IntermissionPlayerTime_f(gentity_t *ent, unsigned int dwCommand, int value);
+#ifdef FEATURE_XPSAVE
+void Cmd_IntermissionXPSaveReset_f(gentity_t *ent, unsigned int dwCommand, int value);
+#endif
 void Cmd_IntermissionSkillRating_f(gentity_t *ent, unsigned int dwCommand, int value);
 void Cmd_IntermissionWeaponAccuracies_f(gentity_t *ent, unsigned int dwCommand, int value);
 void Cmd_IntermissionWeaponStats_f(gentity_t *ent, unsigned int dwCommand, int value);
@@ -2367,6 +2370,7 @@ int G_XPSave_CheckDB(char *db_path, int db_mode);
 void G_XPSave_Load(gclient_t *cl);
 void G_XPSave_Store(gclient_t *cl);
 int G_XPSave_Clear();
+int G_XPSave_Reset(const unsigned char *guid);
 #endif
 
 // g_stats.c

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -1755,6 +1755,32 @@ void G_InitGame(int levelTime, int randomSeed, int restart, int etLegacyServer, 
 			G_XPSave_Clear();
 		}
 	}
+	else if (g_xpSave.integer && (g_gametype.integer == GT_WOLF || g_gametype.integer == GT_WOLF_MAPVOTE))
+	{
+		// keep reset cvars sane
+		if (g_xpSaveResetThreshold.integer < 0)
+		{
+			trap_Cvar_Set("g_xpSaveResetThreshold", "0");
+		}
+
+		if (g_xpSaveResetValue.integer < 0)
+		{
+			trap_Cvar_Set("g_xpSaveResetValue", "0");
+		}
+
+		// maps-based auto-reset
+		if (g_xpSaveResetMode.integer == 1 &&
+		    g_xpSaveResetThreshold.integer > 0 &&
+		    g_xpSaveResetValue.integer >= g_xpSaveResetThreshold.integer)
+		{
+			G_Printf("XP save: auto-reset triggered after %i maps\n", g_xpSaveResetValue.integer);
+
+			if (G_XPSave_Clear() == 0)
+			{
+				trap_Cvar_Set("g_xpSaveResetValue", "0");
+			}
+		}
+	}
 #endif
 
 	// disable server engine flood protection if we have mod-sided flood protection enabled
@@ -2842,6 +2868,17 @@ void ExitLevel(void)
 			cl->ps.persistant[PERS_SCORE] = 0;
 		}
 	}
+
+#ifdef FEATURE_XPSAVE
+	// increment the global map counter for maps-based XP save reset
+	if (g_xpSave.integer &&
+	    g_xpSaveResetMode.integer == 1 &&
+	    g_xpSaveResetThreshold.integer > 0 &&
+	    (g_gametype.integer == GT_WOLF || g_gametype.integer == GT_WOLF_MAPVOTE))
+	{
+		trap_Cvar_Set("g_xpSaveResetValue", va("%i", g_xpSaveResetValue.integer + 1));
+	}
+#endif
 
 	// we need to do this here before changing to CON_CONNECTING
 	G_WriteSessionData(qfalse);

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -34,6 +34,8 @@
 
 #include "g_local.h"
 
+#include <time.h>
+
 #ifdef FEATURE_OMNIBOT
 #include "g_etbot_interface.h"
 #endif
@@ -1768,6 +1770,17 @@ void G_InitGame(int levelTime, int randomSeed, int restart, int etLegacyServer, 
 			trap_Cvar_Set("g_xpSaveResetValue", "0");
 		}
 
+		// if the value looks like it belongs to a different mode, reinitialize it
+		// (e.g. after a config change and server restart)
+		if (g_xpSaveResetMode.integer == 1 && g_xpSaveResetValue.integer > 1000000000)
+		{
+			trap_Cvar_Set("g_xpSaveResetValue", "0");
+		}
+		else if (g_xpSaveResetMode.integer == 2 && (g_xpSaveResetValue.integer <= 0 || g_xpSaveResetValue.integer < 1000000000))
+		{
+			trap_Cvar_Set("g_xpSaveResetValue", va("%i", (int)time(NULL)));
+		}
+
 		// maps-based auto-reset
 		if (g_xpSaveResetMode.integer == 1 &&
 		    g_xpSaveResetThreshold.integer > 0 &&
@@ -1778,6 +1791,23 @@ void G_InitGame(int levelTime, int randomSeed, int restart, int etLegacyServer, 
 			if (G_XPSave_Clear() == 0)
 			{
 				trap_Cvar_Set("g_xpSaveResetValue", "0");
+			}
+		}
+		// time-based auto-reset (threshold is in hours)
+		else if (g_xpSaveResetMode.integer == 2 &&
+		         g_xpSaveResetThreshold.integer > 0)
+		{
+			time_t now        = time(NULL);
+			time_t last_reset = (time_t)g_xpSaveResetValue.integer;
+
+			if (difftime(now, last_reset) >= (double)(g_xpSaveResetThreshold.integer * 3600))
+			{
+				G_Printf("XP save: time-based auto-reset triggered\n");
+
+				if (G_XPSave_Clear() == 0)
+				{
+					trap_Cvar_Set("g_xpSaveResetValue", va("%i", (int)now));
+				}
 			}
 		}
 	}

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -1770,6 +1770,15 @@ void G_InitGame(int levelTime, int randomSeed, int restart, int etLegacyServer, 
 			trap_Cvar_Set("g_xpSaveResetValue", "0");
 		}
 
+		if (g_xpSaveResetMode.integer < 0)
+		{
+			trap_Cvar_Set("g_xpSaveResetMode", "0");
+		}
+		else if (g_xpSaveResetMode.integer > 3)
+		{
+			trap_Cvar_Set("g_xpSaveResetMode", "0");
+		}
+
 		// if the value looks like it belongs to a different mode, reinitialize it
 		// (e.g. after a config change and server restart)
 		if (g_xpSaveResetMode.integer == 1 && g_xpSaveResetValue.integer > 1000000000)

--- a/src/game/g_svcmds.c
+++ b/src/game/g_svcmds.c
@@ -36,6 +36,8 @@
 
 #include "g_local.h"
 
+#include <time.h>
+
 #ifdef FEATURE_OMNIBOT
 #include "g_etbot_interface.h"
 #endif

--- a/src/game/g_svcmds.c
+++ b/src/game/g_svcmds.c
@@ -892,6 +892,37 @@ void Svcmd_ResetMatch(void)
 	Svcmd_ResetMatch_f(qtrue, qtrue);
 }
 
+#ifdef FEATURE_XPSAVE
+/**
+ * @brief Svcmd_ResetXPSave_f
+ * @details <code>reset_xpsave</code>: resets all persisted XP save data.
+ */
+void Svcmd_ResetXPSave_f(void)
+{
+	if (!g_xpSave.integer)
+	{
+		G_Printf("reset_xpsave: g_xpSave is disabled\n");
+		return;
+	}
+
+	if (g_gametype.integer != GT_WOLF && g_gametype.integer != GT_WOLF_MAPVOTE)
+	{
+		G_Printf("reset_xpsave: only available in Objective and Mapvote gametypes\n");
+		return;
+	}
+
+	if (G_XPSave_Clear() != 0)
+	{
+		G_Printf("reset_xpsave: failed to clear persisted XP\n");
+		return;
+	}
+
+	trap_Cvar_Set("g_xpSaveResetValue", "0");
+
+	G_Printf("reset_xpsave: all persisted XP has been reset\n");
+}
+#endif
+
 /**
  * @brief swaps all clients to opposite team
  */
@@ -2556,6 +2587,9 @@ static consoleCommandTable_t consoleCommandTable[] =
 	{ "listmaxlivesip",             PrintMaxLivesGUID             },
 	{ "start_match",                Svcmd_StartMatch_f            },
 	{ "reset_match",                Svcmd_ResetMatch              },
+#ifdef FEATURE_XPSAVE
+	{ "reset_xpsave",               Svcmd_ResetXPSave_f           },
+#endif
 	{ "swap_teams",                 Svcmd_SwapTeams_f             },
 	{ "shuffle_teams",              Svcmd_ShuffleTeamsXP          },
 	{ "shuffle_teams_norestart",    Svcmd_ShuffleTeamsXPNoRestart },

--- a/src/game/g_xpsave.c
+++ b/src/game/g_xpsave.c
@@ -61,6 +61,7 @@ static int G_XPSave_Write(xpData_t *xp_data);
 #define XPUSERS_SQLWRAP_INSERT "INSERT INTO xpsave_users (guid, skills, medals, created, updated) VALUES ('%s', ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);"
 #define XPUSERS_SQLWRAP_UPDATE "UPDATE xpsave_users SET skills = ?, medals = ?, updated = CURRENT_TIMESTAMP WHERE guid = '%s';"
 #define XPUSERS_SQLWRAP_DELETE "DELETE FROM xpsave_users"
+#define XPUSERS_SQLWRAP_DELETE_GUID "DELETE FROM xpsave_users WHERE guid = '%s';"
 
 /**
  * @brief Checks if database exists, if tables exist and if schemas are correct
@@ -409,6 +410,40 @@ static int G_XPSave_Write(xpData_t *xp_data)
 
 	result = sqlite3_finalize(sqlstmt);
 	assert_return(result == SQLITE_OK, 1, sqlite3_errmsg(level.database.db));
+
+	return 0;
+}
+
+/**
+ * @brief Removes xp data for a single player from the table
+ * @param[in] guid
+ * @return 0 if successful, 1 otherwise.
+ */
+int G_XPSave_Reset(const unsigned char *guid)
+{
+	int  result;
+	char *err_msg = NULL;
+
+	if (!level.database.initialized)
+	{
+		G_Printf("G_XPSave_Reset: access to non-initialized database\n");
+		return 1;
+	}
+
+	if (!guid || guid[0] == '\0')
+	{
+		G_Printf("G_XPSave_Reset: invalid guid\n");
+		return 1;
+	}
+
+	result = sqlite3_exec(level.database.db, va(XPUSERS_SQLWRAP_DELETE_GUID, guid), 0, 0, &err_msg);
+
+	if (result != SQLITE_OK)
+	{
+		G_Printf("G_XPSave_Reset: sqlite3_exec failed: %s\n", err_msg);
+		sqlite3_free(err_msg);
+		return 1;
+	}
 
 	return 0;
 }

--- a/src/game/g_xpsave.c
+++ b/src/game/g_xpsave.c
@@ -25,6 +25,9 @@
 
 #include "g_local.h"
 
+#include <math.h>
+#include <time.h>
+
 #ifdef FEATURE_DBMS
 #include <sqlite3.h>
 #else
@@ -50,14 +53,16 @@ typedef struct xpData_s
 	const unsigned char *guid;
 	int skillpoints[SK_NUM_SKILLS];
 	int medals[SK_NUM_SKILLS];
+	time_t updated;
 } xpData_t;
 
 static int G_XPSave_Read(xpData_t *xp_data);
 static int G_XPSave_Write(xpData_t *xp_data);
+static void G_XPSave_ApplyDecay(xpData_t *xp_data);
 
 #define XPCHECK_SQLWRAP_TABLES "SELECT * FROM xpsave_users;"
 #define XPCHECK_SQLWRAP_SCHEMA "SELECT guid, skills, medals, created, updated FROM xpsave_users;"
-#define XPUSERS_SQLWRAP_SELECT "SELECT * FROM xpsave_users WHERE guid = '%s';"
+#define XPUSERS_SQLWRAP_SELECT "SELECT guid, skills, medals, created, strftime('%%s', updated) FROM xpsave_users WHERE guid = '%s';"
 #define XPUSERS_SQLWRAP_INSERT "INSERT INTO xpsave_users (guid, skills, medals, created, updated) VALUES ('%s', ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);"
 #define XPUSERS_SQLWRAP_UPDATE "UPDATE xpsave_users SET skills = ?, medals = ?, updated = CURRENT_TIMESTAMP WHERE guid = '%s';"
 #define XPUSERS_SQLWRAP_DELETE "DELETE FROM xpsave_users"
@@ -189,6 +194,15 @@ void G_XPSave_Load(gclient_t *cl)
 		return;
 	}
 
+	// apply decay to inactive players
+	G_XPSave_ApplyDecay(&xp_data);
+
+	// persist decayed values so the next connect does not re-decay
+	if (xp_data.updated != 0 && g_xpSaveResetMode.integer == 3 && g_xpSaveResetThreshold.integer > 0)
+	{
+		G_XPSave_Write(&xp_data);
+	}
+
 	// assign user data to session
 	cl->sess.startxptotal = 0;
 	for (i = 0; i < SK_NUM_SKILLS; i++)
@@ -296,6 +310,7 @@ static int G_XPSave_Read(xpData_t *xp_data)
 
 	Com_Memset(xp_data->skillpoints, 0, sizeof(xp_data->skillpoints));
 	Com_Memset(xp_data->medals, 0, sizeof(xp_data->medals));
+	xp_data->updated = 0;
 
 	if (!level.database.initialized)
 	{
@@ -322,6 +337,8 @@ static int G_XPSave_Read(xpData_t *xp_data)
 			bf_read(pSkills, int, xp_data->skillpoints[i]);
 			bf_read(pMedals, int, xp_data->medals[i]);
 		}
+
+		xp_data->updated = (time_t)sqlite3_column_int64(sqlstmt, 4);
 	}
 	// no entry found or other failure
 	else if (result != SQLITE_DONE)
@@ -473,6 +490,71 @@ int G_XPSave_Clear()
 	}
 
 	return 0;
+}
+
+/**
+ * @brief Applies exponential decay to skillpoints based on inactivity.
+ *        g_xpSaveResetThreshold is interpreted as the half-life in days.
+ *        Medals are not decayed.
+ * @param[in,out] xp_data
+ */
+static void G_XPSave_ApplyDecay(xpData_t *xp_data)
+{
+	time_t now;
+	double days, halfLife, factor;
+	int    i, newXp, decayed = qfalse;
+
+	if (g_xpSaveResetMode.integer != 3)
+	{
+		return;
+	}
+
+	if (g_xpSaveResetThreshold.integer <= 0)
+	{
+		return;
+	}
+
+	if (xp_data->updated == 0)
+	{
+		return;
+	}
+
+	now      = time(NULL);
+	days     = difftime(now, xp_data->updated) / 86400.0;
+	halfLife = (double)g_xpSaveResetThreshold.integer;
+
+	if (days <= 0.0 || halfLife <= 0.0)
+	{
+		return;
+	}
+
+	factor = pow(0.5, days / halfLife);
+
+	for (i = 0; i < SK_NUM_SKILLS; i++)
+	{
+		if (xp_data->skillpoints[i] == 0)
+		{
+			continue;
+		}
+
+		newXp = (int)(xp_data->skillpoints[i] * factor);
+
+		if (newXp < 0)
+		{
+			newXp = 0;
+		}
+
+		if (newXp != xp_data->skillpoints[i])
+		{
+			xp_data->skillpoints[i] = newXp;
+			decayed                 = qtrue;
+		}
+	}
+
+	if (decayed)
+	{
+		G_DPrintf("XP save: decayed skills after %.2f days of inactivity (half-life %.0f days)\n", days, halfLife);
+	}
 }
 
 #endif


### PR DESCRIPTION
- **mod: add Reset XP button on intermission screen, refs #3520**
- **game: add maps-based XP save reset mode, refs #3520**
- **game: add time-based XP save reset mode, refs #3520**
- **game: add decay XP save reset mode, refs #3520**
- **game: clamp g_xpSaveResetMode to valid range, refs #3520**
- **game: add reset_xpsave server command, refs #3520**
- **misc: add g_xpSaveReset cvars to legacy config, refs #3520**
