### PR TITLE
game: fix artillery shot counter decremented on dead bodies, refs #3521

### DIFF
--- a/src/game/g_match.c
+++ b/src/game/g_match.c
@@ -301,18 +301,16 @@ void G_addStats(gentity_t *targ, gentity_t *attacker, int damage, meansOfDeath_t
 	{
 		if (attacker && attacker->client)
 		{
-			weapon_t weap = GetMODTableData(mod)->weaponIcon;
-
 			// don't count hits/shots for hitscan weapons
-			if (!GetWeaponTableData(weap)->splashDamage)
+			// Keep flamethrower out as well: it is not flagged explosive, but it
+			// has splash-like continuous damage and should not lose a shot for
+			// every corpse it touches.
+			if (!GetMODTableData(mod)->isExplosive && mod != MOD_FLAMETHROWER)
 			{
-				int x;
-
-				x = attacker->client->sess.aWeaponStats[GetMODTableData(mod)->indexWeaponStat].atts--;
-
-				if (x < 1)
+				// Only decrement if there is a shot to take back
+				if (attacker->client->sess.aWeaponStats[GetMODTableData(mod)->indexWeaponStat].atts > 0)
 				{
-					attacker->client->sess.aWeaponStats[GetMODTableData(mod)->indexWeaponStat].atts = 1;
+					attacker->client->sess.aWeaponStats[GetMODTableData(mod)->indexWeaponStat].atts--;
 				}
 			}
 


### PR DESCRIPTION
The dead-body/gibbage branch in G_addStats tried to detect hitscan weapons by
checking splashDamage on the MOD table's weaponIcon. For MOD_ARTY that icon is
WP_BINOCULARS, which has splashDamage 0, so artillery shells hitting corpses
decremented the WS_ARTILLERY shot counter and could drive it to zero.
Use the MOD table's isExplosive flag instead, which correctly classifies
artillery and other splash weapons as explosive. Flamethrower is kept excluded
from the decrement because it has continuous splash-like damage and was
previously protected by its splashDamage value. Only decrement the counter when
it is positive, so a zero value remains visible as a sign of another bug instead
of being masked by a clamp to 1.
