### PR TITLE
mod: improve XP save decay and reset display, refs #3520

### DIFF
--- a/misc/etmain/legacy.cfg
+++ b/misc/etmain/legacy.cfg
@@ -141,9 +141,9 @@ set vote_allow_cointoss "1"                     // allow coin toss by vote
 //set g_minMapAge "3"
 
 // XP SAVE
-//set g_xpSave "0"                              // toggle XP save system
-//set g_xpSaveResetMode "1"                     // XP save reset mode: 0 = never, 1 = maps, 2 = time, 3 = decay
-//set g_xpSaveResetThreshold "8"                // threshold for reset mode (maps / hours / half-life days)
+set g_xpSave "0"                                // toggle XP save system
+set g_xpSaveResetMode "1"                       // XP save reset mode: 0 = never, 1 = maps, 2 = time, 3 = decay
+set g_xpSaveResetThreshold "8"                  // threshold for reset mode (maps / hours / half-life hours)
 
 // LUA
 

--- a/src/cgame/cg_scoreboard.c
+++ b/src/cgame/cg_scoreboard.c
@@ -393,15 +393,17 @@ int WM_DrawObjectives(int x, int y, int width, float fade)
 				int    remaining  = cgs.xpSaveResetThreshold * 3600 - (int)difftime(now, last_reset);
 				int    hours, minutes;
 
-				if (remaining < 0)
+				if (remaining <= 0)
 				{
-					remaining = 0;
+					s = CG_TranslateString("XP RESET AT NEXT MAP");
 				}
+				else
+				{
+					hours   = remaining / 3600;
+					minutes = (remaining % 3600) / 60;
 
-				hours   = remaining / 3600;
-				minutes = (remaining % 3600) / 60;
-
-				s = va(CG_TranslateString("XP RESET IN %ih %im"), hours, minutes);
+					s = va(CG_TranslateString("XP RESET IN %ih %im"), hours, minutes);
+				}
 			}
 			else if (cgs.xpSaveResetMode == 3 && cgs.xpSaveResetThreshold > 0)
 			{

--- a/src/cgame/cg_scoreboard.c
+++ b/src/cgame/cg_scoreboard.c
@@ -407,10 +407,22 @@ int WM_DrawObjectives(int x, int y, int width, float fade)
 			}
 			else if (cgs.xpSaveResetMode == 3 && cgs.xpSaveResetThreshold > 0)
 			{
-				int halfLife = cgs.xpSaveResetThreshold;
-				int dailyPct = (int)round((1.0 - pow(0.5, 1.0 / halfLife)) * 100.0);
+				int halfLifeHours = cgs.xpSaveResetThreshold;
+				int days          = halfLifeHours / 24;
+				int hours         = halfLifeHours % 24;
 
-				s = va(CG_TranslateString("XP DECAY %i%%/DAY (λ %iD)"), dailyPct, halfLife);
+				if (days > 0 && hours > 0)
+				{
+					s = va(CG_TranslateString("XP DECAY λ %id %ih"), days, hours);
+				}
+				else if (days > 0)
+				{
+					s = va(CG_TranslateString("XP DECAY λ %id"), days);
+				}
+				else
+				{
+					s = va(CG_TranslateString("XP DECAY λ %ih"), hours);
+				}
 			}
 			else
 #endif

--- a/src/game/g_xpsave.c
+++ b/src/game/g_xpsave.c
@@ -474,14 +474,14 @@ int G_XPSave_Clear()
 
 /**
  * @brief Applies exponential decay to skillpoints based on inactivity.
- *        g_xpSaveResetThreshold is interpreted as the half-life in days.
+ *        g_xpSaveResetThreshold is interpreted as the half-life in hours.
  *        Medals are not decayed.
  * @param[in,out] xp_data
  */
 static void G_XPSave_ApplyDecay(xpData_t *xp_data)
 {
 	time_t now;
-	double days, halfLife, factor;
+	double hours, halfLife, factor;
 	int    i, newXp, decayed = qfalse;
 
 	if (g_xpSaveResetMode.integer != 3 ||
@@ -492,15 +492,15 @@ static void G_XPSave_ApplyDecay(xpData_t *xp_data)
 	}
 
 	now      = time(NULL);
-	days     = difftime(now, xp_data->updated) / 86400.0;
+	hours    = difftime(now, xp_data->updated) / 3600.0;
 	halfLife = (double)g_xpSaveResetThreshold.integer;
 
-	if (days <= 0.0)
+	if (hours <= 0.0)
 	{
 		return;
 	}
 
-	factor = pow(0.5, days / halfLife);
+	factor = pow(0.5, hours / halfLife);
 
 	for (i = 0; i < SK_NUM_SKILLS; i++)
 	{
@@ -520,7 +520,7 @@ static void G_XPSave_ApplyDecay(xpData_t *xp_data)
 
 	if (decayed)
 	{
-		G_DPrintf("XP save: decayed skills after %.2f days of inactivity (half-life %.0f days)\n", days, halfLife);
+		G_DPrintf("XP save: decayed skills after %.2f hours of inactivity (half-life %.0f hours)\n", hours, halfLife);
 	}
 }
 

--- a/src/game/g_xpsave.c
+++ b/src/game/g_xpsave.c
@@ -484,17 +484,9 @@ static void G_XPSave_ApplyDecay(xpData_t *xp_data)
 	double days, halfLife, factor;
 	int    i, newXp, decayed = qfalse;
 
-	if (g_xpSaveResetMode.integer != 3)
-	{
-		return;
-	}
-
-	if (g_xpSaveResetThreshold.integer <= 0)
-	{
-		return;
-	}
-
-	if (xp_data->updated == 0)
+	if (g_xpSaveResetMode.integer != 3 ||
+	    g_xpSaveResetThreshold.integer <= 0 ||
+	    xp_data->updated == 0)
 	{
 		return;
 	}
@@ -503,7 +495,7 @@ static void G_XPSave_ApplyDecay(xpData_t *xp_data)
 	days     = difftime(now, xp_data->updated) / 86400.0;
 	halfLife = (double)g_xpSaveResetThreshold.integer;
 
-	if (days <= 0.0 || halfLife <= 0.0)
+	if (days <= 0.0)
 	{
 		return;
 	}
@@ -518,11 +510,6 @@ static void G_XPSave_ApplyDecay(xpData_t *xp_data)
 		}
 
 		newXp = (int)round(xp_data->skillpoints[i] * factor);
-
-		if (newXp < 0)
-		{
-			newXp = 0;
-		}
 
 		if (newXp != xp_data->skillpoints[i])
 		{

--- a/src/game/g_xpsave.c
+++ b/src/game/g_xpsave.c
@@ -517,7 +517,7 @@ static void G_XPSave_ApplyDecay(xpData_t *xp_data)
 			continue;
 		}
 
-		newXp = (int)(xp_data->skillpoints[i] * factor);
+		newXp = (int)round(xp_data->skillpoints[i] * factor);
 
 		if (newXp < 0)
 		{


### PR DESCRIPTION
- **cgame: show 'XP RESET AT NEXT MAP' when time-based reset expired, refs #3520**
- **game: use round() instead of truncation for XP decay, refs #3520**
- **game: simplify XP decay guard checks, refs #3520**
- **mod: use hours for XP decay half-life and improve scoreboard display, refs #3520**
