### PR TITLE
game: Expose sess.kill_assists to Lua API

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -2,6 +2,10 @@
 # Intended for player consumption, in one shape or form.
 
 upcoming:
+  - title: Expose kill assists to Lua API
+    categ: lua
+    descr: |
+      `sess.kill_assists` can now be read and set via `et.gentity_get` / `et.gentity_set`.
   - title: Fade in first-person weapon when being revived
     categ: cgame
     descr: |

--- a/src/game/g_lua.c
+++ b/src/game/g_lua.c
@@ -1326,6 +1326,7 @@ static const gentity_field_t gclient_fields[] =
 	_et_gclient_addfield(sess.spec_invite,                  FIELD_INT,                 0),
 	_et_gclient_addfield(sess.spec_team,                    FIELD_INT,                 0),
 	_et_gclient_addfield(sess.kills,                        FIELD_INT,                 0),
+	_et_gclient_addfield(sess.kill_assists,                 FIELD_INT,                 0),
 	_et_gclient_addfield(sess.deaths,                       FIELD_INT,                 0),
 	_et_gclient_addfield(sess.gibs,                         FIELD_INT,                 0),
 	_et_gclient_addfield(sess.self_kills,                   FIELD_INT,                 0),


### PR DESCRIPTION
This pull request introduces support for accessing and modifying the `sess.kill_assists` field through the Lua API, allowing scripts to read and set player kill assists:

* Exposed the `sess.kill_assists` field to Lua via `et.gentity_get` and `et.gentity_set`, enabling Lua scripts to read and modify player kill assists (`src/game/g_lua.c`).

* Updated the `CHANGELOG.yml` to announce the new Lua API support for kill assists.